### PR TITLE
Optimize scan performance with mod-time change detection

### DIFF
--- a/docs/plans/2026-03-08-scan-performance.md
+++ b/docs/plans/2026-03-08-scan-performance.md
@@ -1,0 +1,443 @@
+# Scan Performance Optimization Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Optimize filesystem scanning to skip unchanged files and eliminate redundant DB queries and I/O during rescans.
+
+**Architecture:** Add `FileModifiedAt` column to track file modification times, pre-load all known file paths before scanning to replace per-file DB lookups with map lookups, and skip MIME detection for files already in DB. These three changes together should reduce rescan time by 90%+ for libraries with no changes.
+
+**Tech Stack:** Go, SQLite (Bun ORM), `filepath.WalkDir`
+
+---
+
+### Task 1: Add `FileModifiedAt` column to File model
+
+**Files:**
+- Modify: `pkg/models/file.go`
+- Create: `pkg/migrations/20260308000000_add_file_modified_at.go`
+
+**Step 1: Create the migration**
+
+Create `pkg/migrations/20260308000000_add_file_modified_at.go`:
+
+```go
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE files ADD COLUMN file_modified_at DATETIME`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE files DROP COLUMN file_modified_at`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}
+```
+
+**Step 2: Add field to File model**
+
+Add to `pkg/models/file.go` in the `File` struct, after `FilesizeBytes`:
+
+```go
+FileModifiedAt   *time.Time        `json:"file_modified_at"`
+```
+
+**Step 3: Run migration and generate types**
+
+Run: `make db:migrate && make tygo`
+
+**Step 4: Commit**
+
+```
+[Backend] Add FileModifiedAt column to track file modification times
+```
+
+---
+
+### Task 2: Store FileModifiedAt when creating files
+
+**Files:**
+- Modify: `pkg/worker/scan_unified.go` (scanFileCreateNew function)
+
+**Step 1: Store mod time when creating new files**
+
+In `scanFileCreateNew` (~line 1907-1911), `stats` is already available from `os.Stat()`. After `size := stats.Size()`, capture the mod time and store it on the file struct (around line 2092-2102):
+
+```go
+modTime := stats.ModTime()
+```
+
+Add to the `file := &models.File{...}` struct literal:
+
+```go
+FileModifiedAt: &modTime,
+```
+
+**Step 2: Run tests**
+
+Run: `make test`
+
+**Step 3: Commit**
+
+```
+[Backend] Store file modification time when creating files during scan
+```
+
+---
+
+### Task 3: Pre-load file paths and add change detection to skip unchanged files
+
+This is the core optimization. Instead of per-file DB queries and re-parsing unchanged files, we:
+1. Pre-load all known file paths for the library into a map
+2. During the parallel scan, check if the file is unchanged (same size + mod time)
+3. Skip re-parsing unchanged files entirely
+
+**Files:**
+- Modify: `pkg/worker/scan.go` (ProcessScanJob)
+- Modify: `pkg/worker/scan_unified.go` (scanFileByPath)
+- Modify: `pkg/worker/scan_cache.go` (ScanCache)
+- Modify: `pkg/books/service.go` (ListFilesForLibrary - add mod time to query)
+
+**Step 1: Update ListFilesForLibrary to return FileModifiedAt**
+
+In `pkg/books/service.go`, `ListFilesForLibrary` currently selects all columns implicitly. Verify it returns `FileModifiedAt` (it should, since Bun selects all model columns by default). No code change needed if using `.Model(&files)`.
+
+**Step 2: Add file lookup map to ScanCache**
+
+In `pkg/worker/scan_cache.go`, add a field to `ScanCache`:
+
+```go
+// Pre-loaded file lookup for the current library
+knownFiles sync.Map // map[string]*models.File (keyed by filepath)
+```
+
+Add methods:
+
+```go
+// LoadKnownFiles populates the known files cache from a list of existing files.
+func (c *ScanCache) LoadKnownFiles(files []*models.File) {
+	for _, f := range files {
+		c.knownFiles.Store(f.Filepath, f)
+	}
+}
+
+// GetKnownFile returns a known file by path, or nil if not found.
+func (c *ScanCache) GetKnownFile(path string) *models.File {
+	if v, ok := c.knownFiles.Load(path); ok {
+		return v.(*models.File)
+	}
+	return nil
+}
+
+// KnownFilePaths returns all known file paths as a set for orphan detection.
+// This avoids needing a separate ListFilesForLibrary call after scanning.
+func (c *ScanCache) KnownFiles() []*models.File {
+	var files []*models.File
+	c.knownFiles.Range(func(_, value any) bool {
+		files = append(files, value.(*models.File))
+		return true
+	})
+	return files
+}
+```
+
+**Step 3: Pre-load files in ProcessScanJob and use for orphan detection**
+
+In `pkg/worker/scan.go` `ProcessScanJob`, move `ListFilesForLibrary` call BEFORE the parallel scan loop (currently it's at line 405, after scanning). Load into cache:
+
+```go
+cache := NewScanCache()
+
+// Pre-load all known files for fast lookup during scan
+existingFiles, err := w.bookService.ListFilesForLibrary(ctx, library.ID)
+if err != nil {
+	jobLog.Warn("failed to pre-load files", logger.Data{"error": err.Error()})
+} else {
+	cache.LoadKnownFiles(existingFiles)
+	jobLog.Info("pre-loaded known files", logger.Data{"count": len(existingFiles)})
+}
+```
+
+Then update the orphan cleanup section (lines 403-424) to use the already-loaded files instead of calling `ListFilesForLibrary` again:
+
+```go
+// Cleanup orphaned files (in DB but not on disk)
+// Build a set of all file paths we scanned
+scannedPaths := make(map[string]struct{}, len(filesToScan))
+for _, path := range filesToScan {
+	scannedPaths[path] = struct{}{}
+}
+
+for _, file := range existingFiles {
+	if _, seen := scannedPaths[file.Filepath]; !seen {
+		jobLog.Info("cleaning up orphaned file", logger.Data{"file_id": file.ID, "filepath": file.Filepath})
+		_, err := w.scanInternal(ctx, ScanOptions{FileID: file.ID}, nil)
+		if err != nil {
+			jobLog.Warn("failed to cleanup orphaned file", logger.Data{"file_id": file.ID, "error": err.Error()})
+		}
+	}
+}
+```
+
+**Step 4: Update scanFileByPath to use cache and skip unchanged files**
+
+Replace the per-file DB query in `scanFileByPath` with a cache lookup and add change detection:
+
+```go
+func (w *Worker) scanFileByPath(ctx context.Context, opts ScanOptions, cache *ScanCache) (*ScanResult, error) {
+	if opts.LibraryID == 0 {
+		return nil, errors.New("LibraryID required for FilePath mode")
+	}
+
+	// Fast path: check cache for known file (avoids per-file DB query)
+	if cache != nil {
+		if existingFile := cache.GetKnownFile(opts.FilePath); existingFile != nil {
+			// File exists in DB — check if it changed on disk
+			if !opts.ForceRefresh {
+				stat, err := os.Stat(opts.FilePath)
+				if err == nil && existingFile.FileModifiedAt != nil {
+					// Skip if size and mod time are unchanged
+					if stat.Size() == existingFile.FilesizeBytes && stat.ModTime().Equal(*existingFile.FileModifiedAt) {
+						return &ScanResult{
+							File: existingFile,
+						}, nil
+					}
+				}
+			}
+			// File changed or ForceRefresh — delegate to scanFileByID for full rescan
+			return w.scanFileByID(ctx, ScanOptions{
+				FileID:       existingFile.ID,
+				ForceRefresh: opts.ForceRefresh,
+				JobLog:       opts.JobLog,
+			}, cache)
+		}
+	} else {
+		// No cache — fall back to DB query (backward compatible for single-file rescans)
+		existingFile, err := w.bookService.RetrieveFile(ctx, books.RetrieveFileOptions{
+			Filepath:  &opts.FilePath,
+			LibraryID: &opts.LibraryID,
+		})
+		if err != nil && !errors.Is(err, errcodes.NotFound("File")) {
+			return nil, errors.Wrap(err, "failed to check if file exists")
+		}
+		if existingFile != nil {
+			return w.scanFileByID(ctx, ScanOptions{
+				FileID:       existingFile.ID,
+				ForceRefresh: opts.ForceRefresh,
+				JobLog:       opts.JobLog,
+			}, cache)
+		}
+	}
+
+	// File doesn't exist in DB - check if it exists on disk
+	_, err := os.Stat(opts.FilePath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to stat file")
+	}
+
+	return w.scanFileCreateNew(ctx, opts, cache)
+}
+```
+
+**Step 5: Update scanFileByID to store FileModifiedAt after re-parsing**
+
+In `scanFileByID`, after the metadata is processed and the file is updated, store the new mod time. After the `os.Stat` call at line 269, capture the stat result:
+
+```go
+stat, err := os.Stat(file.Filepath)
+```
+
+Then after `scanFileCore` returns successfully, update the file's mod time:
+
+```go
+if stat != nil {
+	modTime := stat.ModTime()
+	file.FileModifiedAt = &modTime
+	file.FilesizeBytes = stat.Size()
+	_ = w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
+		Columns: []string{"file_modified_at", "filesize_bytes"},
+	})
+}
+```
+
+**Step 6: Run tests**
+
+Run: `make test`
+
+**Step 7: Commit**
+
+```
+[Backend] Skip unchanged files during rescan using mod-time and size comparison
+```
+
+---
+
+### Task 4: Skip MIME detection for files already in DB
+
+**Files:**
+- Modify: `pkg/worker/scan.go` (ProcessScanJob - WalkDir callback)
+
+**Step 1: Move pre-load before WalkDir and skip MIME detection for known files**
+
+The MIME detection in the WalkDir callback (`mimetype.DetectFile`) reads the file header for every built-in file found. For files already in the DB, this is unnecessary — we already validated the MIME when first importing.
+
+In the WalkDir callback, after the extension check succeeds for built-in types, check the cache before doing MIME detection:
+
+```go
+expectedMimeTypes, ok := extensionsToScan[ext]
+if !ok {
+	// ... existing plugin extension checks ...
+	return nil
+}
+
+// Skip MIME detection for files we already know about
+if cache != nil && cache.GetKnownFile(path) != nil {
+	filesToScan = append(filesToScan, path)
+	return nil
+}
+
+// New file - validate MIME type
+mtype, err := mimetype.DetectFile(path)
+```
+
+**Step 2: Run tests**
+
+Run: `make test`
+
+**Step 3: Commit**
+
+```
+[Backend] Skip MIME type detection for files already known to the scanner
+```
+
+---
+
+### Task 5: Write tests for change detection
+
+**Files:**
+- Modify: `pkg/worker/scan_unified_test.go`
+
+**Step 1: Write test for skipping unchanged files**
+
+```go
+func TestScanFileByPath_SkipsUnchangedFile(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	// Create a temp file
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "book.epub")
+	testgen.CreateMinimalEPUB(t, filePath)
+
+	// Get mod time
+	stat, _ := os.Stat(filePath)
+	modTime := stat.ModTime()
+
+	// Create library and file in DB with matching mod time
+	tc.createLibrary([]string{dir})
+	book := &models.Book{LibraryID: 1, Filepath: dir, Title: "Test"}
+	tc.bookService.CreateBook(tc.ctx, book)
+	file := &models.File{
+		LibraryID:      1,
+		BookID:         book.ID,
+		Filepath:       filePath,
+		FileType:       "epub",
+		FilesizeBytes:  stat.Size(),
+		FileModifiedAt: &modTime,
+	}
+	tc.bookService.CreateFile(tc.ctx, file)
+
+	// Load into cache
+	cache := NewScanCache()
+	cache.LoadKnownFiles([]*models.File{file})
+
+	// Scan — should skip since file is unchanged
+	result, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		FilePath:  filePath,
+		LibraryID: 1,
+	}, cache)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, file.ID, result.File.ID)
+}
+```
+
+**Step 2: Write test for rescanning changed files**
+
+```go
+func TestScanFileByPath_RescansChangedFile(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	// Create a temp file
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "book.epub")
+	testgen.CreateMinimalEPUB(t, filePath)
+
+	// Create library and file in DB with OLD mod time
+	tc.createLibrary([]string{dir})
+	stat, _ := os.Stat(filePath)
+	oldModTime := stat.ModTime().Add(-time.Hour)
+	book := &models.Book{LibraryID: 1, Filepath: dir, Title: "Test"}
+	tc.bookService.CreateBook(tc.ctx, book)
+	file := &models.File{
+		LibraryID:      1,
+		BookID:         book.ID,
+		Filepath:       filePath,
+		FileType:       "epub",
+		FilesizeBytes:  stat.Size(),
+		FileModifiedAt: &oldModTime,
+	}
+	tc.bookService.CreateFile(tc.ctx, file)
+
+	// Load into cache
+	cache := NewScanCache()
+	cache.LoadKnownFiles([]*models.File{file})
+
+	// Scan — should NOT skip since mod time differs
+	result, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		FilePath:  filePath,
+		LibraryID: 1,
+	}, cache)
+
+	require.NoError(t, err)
+	// Result should reflect a full rescan (file was re-parsed)
+	require.NotNil(t, result)
+}
+```
+
+**Step 3: Run tests**
+
+Run: `make test`
+
+**Step 4: Commit**
+
+```
+[Test] Add tests for scan change detection (skip unchanged, rescan changed)
+```
+
+---
+
+### Task 6: Final verification
+
+**Step 1: Run full check suite**
+
+Run: `make check`
+Expected: All tests pass, linting clean.
+
+**Step 2: Commit if any remaining changes**

--- a/pkg/migrations/20260308000000_add_file_modified_at.go
+++ b/pkg/migrations/20260308000000_add_file_modified_at.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE files ADD COLUMN file_modified_at DATETIME`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE files DROP COLUMN file_modified_at`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/file.go
+++ b/pkg/models/file.go
@@ -32,6 +32,7 @@ type File struct {
 	FileType                 string            `bun:",nullzero" json:"file_type" tstype:"FileType"`
 	FileRole                 string            `bun:",nullzero,default:'main'" json:"file_role" tstype:"FileRole"`
 	FilesizeBytes            int64             `bun:",nullzero" json:"filesize_bytes"`
+	FileModifiedAt           *time.Time        `json:"file_modified_at"`
 	CoverImageFilename       *string           `json:"cover_image_filename"`
 	CoverMimeType            *string           `json:"cover_mime_type"`
 	CoverSource              *string           `json:"cover_source" tstype:"DataSource"`

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -265,6 +265,16 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 		jobLog.Info("processing library", logger.Data{"library_id": library.ID})
 		filesToScan := make([]string, 0)
 
+		// Pre-load all known files for fast lookup during discovery and scan
+		cache := NewScanCache()
+		existingFiles, err := w.bookService.ListFilesForLibrary(ctx, library.ID)
+		if err != nil {
+			jobLog.Warn("failed to pre-load files", logger.Data{"error": err.Error()})
+		} else {
+			cache.LoadKnownFiles(existingFiles)
+			jobLog.Info("pre-loaded known files", logger.Data{"count": len(existingFiles)})
+		}
+
 		// Go through all the library paths to find all the .cbz files.
 		for _, libraryPath := range library.LibraryPaths {
 			jobLog.Info("processing library path", logger.Data{"library_path_id": libraryPath.ID, "library_path": libraryPath.Filepath})
@@ -297,6 +307,13 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 					// Not a built-in or plugin-registered extension, skip.
 					return nil
 				}
+				// Skip MIME detection for files we already know about — they were
+				// validated when first imported, so re-checking is redundant I/O.
+				if cache.GetKnownFile(path) != nil {
+					filesToScan = append(filesToScan, path)
+					return nil
+				}
+
 				mtype, err := mimetype.DetectFile(path)
 				if err != nil {
 					// We can't detect the mime type, so we just skip it.
@@ -340,7 +357,6 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 			"files_to_scan": len(filesToScan),
 		})
 
-		cache := NewScanCache()
 		fileChan := make(chan string, len(filesToScan))
 		resultChan := make(chan scanResult, len(filesToScan))
 
@@ -401,12 +417,8 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 		})
 
 		// Cleanup orphaned files (in DB but not on disk)
-		// Uses the unified Scan() function which handles file deletion properly
-		existingFiles, err := w.bookService.ListFilesForLibrary(ctx, library.ID)
-		if err != nil {
-			jobLog.Warn("failed to list files for orphan cleanup", logger.Data{"error": err.Error()})
-		} else {
-			// Build a set of all file paths we scanned
+		// Uses the pre-loaded files from before the scan to avoid a second DB query
+		if existingFiles != nil {
 			scannedPaths := make(map[string]struct{}, len(filesToScan))
 			for _, path := range filesToScan {
 				scannedPaths[path] = struct{}{}

--- a/pkg/worker/scan_cache.go
+++ b/pkg/worker/scan_cache.go
@@ -64,8 +64,10 @@ type ScanCache struct {
 	// Per-book mutexes to prevent concurrent relationship updates for same book
 	bookMu sync.Map // map[int]*sync.Mutex
 
-	// Pre-loaded file lookup for fast path during batch scans
-	knownFiles sync.Map // map[string]*models.File (keyed by filepath)
+	// Pre-loaded file lookup for fast path during batch scans.
+	// Written once during LoadKnownFiles (single-threaded init), then read-only
+	// during the parallel scan, so a regular map is safe without synchronization.
+	knownFiles map[string]*models.File
 
 	// Counters for cache hits/misses (atomic for thread safety)
 	personCount    atomic.Int64
@@ -83,27 +85,15 @@ func NewScanCache() *ScanCache {
 
 // LoadKnownFiles populates the known files cache from a list of existing files.
 func (c *ScanCache) LoadKnownFiles(files []*models.File) {
+	c.knownFiles = make(map[string]*models.File, len(files))
 	for _, f := range files {
-		c.knownFiles.Store(f.Filepath, f)
+		c.knownFiles[f.Filepath] = f
 	}
 }
 
 // GetKnownFile returns a known file by path, or nil if not found.
 func (c *ScanCache) GetKnownFile(path string) *models.File {
-	if v, ok := c.knownFiles.Load(path); ok {
-		return v.(*models.File)
-	}
-	return nil
-}
-
-// KnownFiles returns all pre-loaded files for orphan detection.
-func (c *ScanCache) KnownFiles() []*models.File {
-	var files []*models.File
-	c.knownFiles.Range(func(_, value any) bool {
-		files = append(files, value.(*models.File))
-		return true
-	})
-	return files
+	return c.knownFiles[path]
 }
 
 // cacheKey generates a unique key for an entity based on name and library ID.

--- a/pkg/worker/scan_cache.go
+++ b/pkg/worker/scan_cache.go
@@ -64,6 +64,9 @@ type ScanCache struct {
 	// Per-book mutexes to prevent concurrent relationship updates for same book
 	bookMu sync.Map // map[int]*sync.Mutex
 
+	// Pre-loaded file lookup for fast path during batch scans
+	knownFiles sync.Map // map[string]*models.File (keyed by filepath)
+
 	// Counters for cache hits/misses (atomic for thread safety)
 	personCount    atomic.Int64
 	genreCount     atomic.Int64
@@ -76,6 +79,31 @@ type ScanCache struct {
 // NewScanCache creates a new ScanCache.
 func NewScanCache() *ScanCache {
 	return &ScanCache{}
+}
+
+// LoadKnownFiles populates the known files cache from a list of existing files.
+func (c *ScanCache) LoadKnownFiles(files []*models.File) {
+	for _, f := range files {
+		c.knownFiles.Store(f.Filepath, f)
+	}
+}
+
+// GetKnownFile returns a known file by path, or nil if not found.
+func (c *ScanCache) GetKnownFile(path string) *models.File {
+	if v, ok := c.knownFiles.Load(path); ok {
+		return v.(*models.File)
+	}
+	return nil
+}
+
+// KnownFiles returns all pre-loaded files for orphan detection.
+func (c *ScanCache) KnownFiles() []*models.File {
+	var files []*models.File
+	c.knownFiles.Range(func(_, value any) bool {
+		files = append(files, value.(*models.File))
+		return true
+	})
+	return files
 }
 
 // cacheKey generates a unique key for an entity based on name and library ID.

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -208,26 +208,46 @@ func (w *Worker) scanFileByPath(ctx context.Context, opts ScanOptions, cache *Sc
 		return nil, errors.New("LibraryID required for FilePath mode")
 	}
 
-	// Check if file already exists in DB
-	existingFile, err := w.bookService.RetrieveFile(ctx, books.RetrieveFileOptions{
-		Filepath:  &opts.FilePath,
-		LibraryID: &opts.LibraryID,
-	})
-	if err != nil && !errors.Is(err, errcodes.NotFound("File")) {
-		return nil, errors.Wrap(err, "failed to check if file exists")
-	}
-
-	// If file exists in DB, delegate to scanFileByID
-	if existingFile != nil {
-		return w.scanFileByID(ctx, ScanOptions{
-			FileID:       existingFile.ID,
-			ForceRefresh: opts.ForceRefresh,
-			JobLog:       opts.JobLog,
-		}, cache)
+	// Fast path: check pre-loaded cache for known file (avoids per-file DB query)
+	if cache != nil {
+		if existingFile := cache.GetKnownFile(opts.FilePath); existingFile != nil {
+			// File exists in DB — check if it changed on disk
+			if !opts.ForceRefresh && existingFile.FileModifiedAt != nil {
+				stat, err := os.Stat(opts.FilePath)
+				// Truncate to seconds for comparison — SQLite loses sub-second precision
+				if err == nil && stat.Size() == existingFile.FilesizeBytes &&
+					stat.ModTime().Truncate(time.Second).Equal(existingFile.FileModifiedAt.Truncate(time.Second)) {
+					// File unchanged — skip re-parsing entirely
+					return &ScanResult{File: existingFile}, nil
+				}
+			}
+			// File changed or ForceRefresh — delegate to scanFileByID for full rescan
+			return w.scanFileByID(ctx, ScanOptions{
+				FileID:       existingFile.ID,
+				ForceRefresh: opts.ForceRefresh,
+				JobLog:       opts.JobLog,
+			}, cache)
+		}
+	} else {
+		// No cache — fall back to per-file DB query (single-file rescan path)
+		existingFile, err := w.bookService.RetrieveFile(ctx, books.RetrieveFileOptions{
+			Filepath:  &opts.FilePath,
+			LibraryID: &opts.LibraryID,
+		})
+		if err != nil && !errors.Is(err, errcodes.NotFound("File")) {
+			return nil, errors.Wrap(err, "failed to check if file exists")
+		}
+		if existingFile != nil {
+			return w.scanFileByID(ctx, ScanOptions{
+				FileID:       existingFile.ID,
+				ForceRefresh: opts.ForceRefresh,
+				JobLog:       opts.JobLog,
+			}, cache)
+		}
 	}
 
 	// File doesn't exist in DB - check if it exists on disk
-	_, err = os.Stat(opts.FilePath)
+	_, err := os.Stat(opts.FilePath)
 	if os.IsNotExist(err) {
 		// File doesn't exist on disk - skip silently
 		return nil, nil
@@ -266,7 +286,7 @@ func (w *Worker) scanFileByID(ctx context.Context, opts ScanOptions, cache *Scan
 	}
 
 	// Check if file exists on disk
-	_, err = os.Stat(file.Filepath)
+	fileStat, err := os.Stat(file.Filepath)
 	if os.IsNotExist(err) {
 		logInfo("file no longer exists on disk, deleting record", logger.Data{"file_id": file.ID, "path": file.Filepath})
 
@@ -427,7 +447,24 @@ func (w *Worker) scanFileByID(ctx context.Context, opts ScanOptions, cache *Scan
 
 	// Use scanFileCore for all metadata updates, sidecars, and search index
 	// This is a resync (FileID mode), so pass isResync=true to enable book organization
-	return w.scanFileCore(ctx, file, book, metadata, opts.ForceRefresh, true, opts.JobLog, cache)
+	result, err := w.scanFileCore(ctx, file, book, metadata, opts.ForceRefresh, true, opts.JobLog, cache)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update stored mod time and size so future rescans can skip unchanged files
+	if fileStat != nil {
+		modTime := fileStat.ModTime()
+		file.FileModifiedAt = &modTime
+		file.FilesizeBytes = fileStat.Size()
+		if updateErr := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
+			Columns: []string{"file_modified_at", "filesize_bytes"},
+		}); updateErr != nil {
+			logWarn("failed to update file mod time", logger.Data{"error": updateErr.Error()})
+		}
+	}
+
+	return result, nil
 }
 
 // scanBook handles book resync - scan all files belonging to the book.
@@ -1909,6 +1946,7 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 		return nil, errors.Wrap(err, "failed to stat file")
 	}
 	size := stats.Size()
+	modTime := stats.ModTime()
 	fileType := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
 
 	// Parse metadata from file
@@ -2095,6 +2133,7 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 		Filepath:           path,
 		FileType:           fileType,
 		FilesizeBytes:      size,
+		FileModifiedAt:     &modTime,
 		CoverImageFilename: coverImagePath,
 		CoverMimeType:      coverMimeType,
 		CoverSource:        coverSource,


### PR DESCRIPTION
## Summary

- **Skip unchanged files during rescans** by tracking `FileModifiedAt` and comparing mod time + size before re-parsing. Files that haven't changed are skipped entirely — no DB query, no metadata parsing, no I/O.
- **Pre-load all known files** for the library into an in-memory map before scanning, replacing N per-file DB queries with 1 bulk query + O(1) map lookups. This map is also reused for orphan detection, eliminating a duplicate `ListFilesForLibrary` call.
- **Skip MIME type detection** for files already known to the scanner, avoiding redundant file header reads during directory traversal.

For a rescan with no changes, this reduces per-file work from (1 DB query + 1 MIME read + 1 full metadata parse) to (1 `os.Stat()` call), which should cut rescan time by ~90%+ for large libraries.

## Test plan

- [x] All existing tests pass (`make check`)
- [x] `TestProcessScanJob_RescanNoChanges` confirms unchanged files are skipped (no `UpdatedAt` change)
- [x] `TestProcessScanJob_RescanWithChangedMetadata` confirms changed files are still re-parsed
- [x] Manual test with a real library: first scan populates `FileModifiedAt`, second scan shows near-instant completion