### PR TITLE
Plugin System v2: UX and architecture revamp

### DIFF
--- a/app/components/pages/AdminPlugins.tsx
+++ b/app/components/pages/AdminPlugins.tsx
@@ -35,6 +35,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  PluginStatusActive,
   useAddRepository,
   useInstallPlugin,
   usePluginOrder,
@@ -211,10 +212,12 @@ const InstalledTab = () => {
                       className="text-xs text-muted-foreground"
                       htmlFor={`enable-${plugin.scope}-${plugin.id}`}
                     >
-                      {plugin.enabled ? "Enabled" : "Disabled"}
+                      {plugin.status === PluginStatusActive
+                        ? "Enabled"
+                        : "Disabled"}
                     </Label>
                     <Switch
-                      checked={plugin.enabled}
+                      checked={plugin.status === PluginStatusActive}
                       id={`enable-${plugin.scope}-${plugin.id}`}
                       onCheckedChange={(checked) => {
                         updatePlugin.mutate({
@@ -225,7 +228,7 @@ const InstalledTab = () => {
                       }}
                     />
                   </div>
-                  {plugin.enabled && (
+                  {plugin.status === PluginStatusActive && (
                     <>
                       <Button
                         disabled={reloadPlugin.isPending}

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -186,6 +186,11 @@ const AdminSettings = () => {
               value={config.plugin_dir}
             />
             <ConfigRow
+              description="Directory where plugin persistent data is stored"
+              label="Plugin Data Directory"
+              value={config.plugin_data_dir}
+            />
+            <ConfigRow
               description="File patterns excluded from supplement discovery"
               label="Supplement Exclude Patterns"
               value={config.supplement_exclude_patterns.join(", ")}

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -1,51 +1,32 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { API, type ShishoAPIError } from "@/libraries/api";
-import type { PluginIdentifierType } from "@/types/generated/models";
+import type {
+  Plugin,
+  PluginIdentifierType,
+  PluginOrder,
+  PluginRepository,
+} from "@/types/generated/models";
 
-// --- Types ---
-
-export interface Plugin {
-  scope: string;
-  id: string;
-  name: string;
-  version: string;
-  description?: string | null;
-  author?: string | null;
-  homepage?: string | null;
-  enabled: boolean;
-  installed_at: string;
-  updated_at?: string | null;
-  load_error?: string | null;
-  update_available_version?: string | null;
-}
-
-export interface PluginRepository {
-  url: string;
-  scope: string;
-  name?: string | null;
-  is_official: boolean;
-  enabled: boolean;
-  last_fetched_at?: string | null;
-  fetch_error?: string | null;
-}
-
-export interface PluginOrder {
-  hook_type: string;
-  scope: string;
-  plugin_id: string;
-  position: number;
-}
-
-export type PluginHookType =
-  | "inputConverter"
-  | "fileParser"
-  | "outputGenerator"
-  | "metadataEnricher";
+// Re-export generated types so consumers can import from this module
+export type {
+  Plugin,
+  PluginHookType,
+  PluginOrder,
+  PluginRepository,
+  PluginStatus,
+} from "@/types/generated/models";
+export {
+  PluginStatusActive,
+  PluginStatusDisabled,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+} from "@/types/generated/models";
 
 export interface PluginVersion {
   version: string;
   min_app_version: string;
+  changelog: string;
   download_url: string;
   sha256: string;
   manifest_version: number;
@@ -55,9 +36,11 @@ export interface AvailablePlugin {
   scope: string;
   id: string;
   name: string;
+  overview: string;
   description: string;
   author: string;
   homepage: string;
+  imageUrl: string;
   versions: PluginVersion[];
 }
 
@@ -510,6 +493,67 @@ export const useResetAllLibraryPluginOrders = () => {
       queryClient.invalidateQueries({
         queryKey: ["libraries", variables.libraryId, "plugins", "order"],
       });
+    },
+  });
+};
+
+// --- Metadata Search & Enrich ---
+
+export interface PluginSearchResult {
+  title: string;
+  authors?: string[];
+  description?: string;
+  image_url?: string;
+  release_date?: string;
+  publisher?: string;
+  identifiers?: { type: string; value: string }[];
+  provider_data?: unknown;
+  plugin_scope: string;
+  plugin_id: string;
+}
+
+export interface PluginSearchResponse {
+  results: PluginSearchResult[];
+}
+
+export const usePluginSearch = () => {
+  return useMutation<
+    PluginSearchResponse,
+    ShishoAPIError,
+    { query: string; bookId: number }
+  >({
+    mutationFn: ({ query, bookId }) => {
+      return API.request<PluginSearchResponse>("POST", "/plugins/search", {
+        query,
+        book_id: bookId,
+      });
+    },
+  });
+};
+
+export const usePluginEnrich = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    { modified: boolean; metadata?: Record<string, unknown> },
+    ShishoAPIError,
+    {
+      pluginScope: string;
+      pluginId: string;
+      bookId: number;
+      providerData: unknown;
+    }
+  >({
+    mutationFn: ({ pluginScope, pluginId, bookId, providerData }) => {
+      return API.request("POST", "/plugins/enrich", {
+        plugin_scope: pluginScope,
+        plugin_id: pluginId,
+        book_id: bookId,
+        provider_data: providerData,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["books"] });
     },
   });
 };

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	// Plugin system
 	pluginService := plugins.NewService(db)
-	pluginManager := plugins.NewManager(pluginService, cfg.PluginDir)
+	pluginManager := plugins.NewManager(pluginService, cfg.PluginDir, cfg.PluginDataDir)
 	if err := pluginManager.LoadAll(ctx); err != nil {
 		log.Warn("plugin load errors occurred", logger.Data{"error": err.Error()})
 	}

--- a/packages/plugin-types/hooks.d.ts
+++ b/packages/plugin-types/hooks.d.ts
@@ -24,37 +24,11 @@ export interface FileParserContext {
   fileType: string;
 }
 
-/** Context passed to metadataEnricher.enrich(). */
-export interface MetadataEnricherContext {
-  /** Metadata freshly parsed from the file on disk (e.g., from ComicInfo.xml, OPF, etc.). */
-  parsedMetadata: {
-    title?: string;
-    subtitle?: string;
-    series?: string;
-    seriesNumber?: number;
-    description?: string;
-    publisher?: string;
-    imprint?: string;
-    url?: string;
-    dataSource?: string;
-    authors?: Array<{ name: string; role?: string }>;
-    narrators?: string[];
-    genres?: string[];
-    tags?: string[];
-    releaseDate?: string;
-    identifiers?: Array<{ type: string; value: string }>;
-  };
-  /** File information from the database. */
-  file: {
-    id?: number;
-    filepath?: string;
-    fileType?: string;
-    fileRole?: string;
-    filesizeBytes?: number;
-    name?: string;
-    url?: string;
-  };
-  /** Current book state from the database, including manually-edited fields. */
+/** Context passed to metadataEnricher.search(). */
+export interface SearchContext {
+  /** Search query (book title for auto, user input for manual). */
+  query: string;
+  /** Current book state from the database. */
   book: {
     id?: number;
     title?: string;
@@ -66,6 +40,53 @@ export interface MetadataEnricherContext {
     tags?: string[];
     identifiers?: Array<{ type: string; value: string }>;
     publisher?: string;
+  };
+  /** File information. */
+  file: {
+    fileType?: string;
+    filePath?: string;
+  };
+}
+
+/** A single search result from metadataEnricher.search(). */
+export interface SearchResult {
+  title: string;
+  authors?: string[];
+  description?: string;
+  imageUrl?: string;
+  releaseDate?: string;
+  publisher?: string;
+  identifiers?: Array<{ type: string; value: string }>;
+  /** Opaque data passed back to enrich(). Use this to store internal IDs. */
+  providerData?: unknown;
+}
+
+/** Result returned from metadataEnricher.search(). */
+export interface SearchResponse {
+  results: SearchResult[];
+}
+
+/** Context passed to metadataEnricher.enrich(). */
+export interface EnrichContext {
+  /** The selected search result's providerData. */
+  selectedResult: unknown;
+  /** Current book state from the database. */
+  book: {
+    id?: number;
+    title?: string;
+    subtitle?: string;
+    description?: string;
+    series?: Array<{ name: string; number?: number }>;
+    authors?: Array<{ name: string; role?: string }>;
+    genres?: string[];
+    tags?: string[];
+    identifiers?: Array<{ type: string; value: string }>;
+    publisher?: string;
+  };
+  /** File information. */
+  file: {
+    fileType?: string;
+    filePath?: string;
   };
 }
 
@@ -131,7 +152,10 @@ export interface FileParserHook {
 
 /** Metadata enricher hook. */
 export interface MetadataEnricherHook {
-  enrich(context: MetadataEnricherContext): EnrichmentResult;
+  /** Search for candidate results from external sources. */
+  search(context: SearchContext): SearchResponse;
+  /** Enrich metadata from a selected search result. */
+  enrich(context: EnrichContext): EnrichmentResult;
 }
 
 /** Output generator hook. */
@@ -146,4 +170,11 @@ export interface ShishoPlugin {
   fileParser?: FileParserHook;
   metadataEnricher?: MetadataEnricherHook;
   outputGenerator?: OutputGeneratorHook;
+
+  /**
+   * Optional lifecycle hook called before the plugin is uninstalled.
+   * Use this to clean up resources (revoke tokens, delete caches, close connections).
+   * Errors in this hook do not prevent uninstall.
+   */
+  onUninstalling?: () => void;
 }

--- a/packages/plugin-types/host-api.d.ts
+++ b/packages/plugin-types/host-api.d.ts
@@ -343,6 +343,8 @@ export interface ShishoShell {
 
 /** Top-level host API object available as the global `shisho` variable. */
 export interface ShishoHostAPI {
+  /** Persistent data directory for this plugin. Created lazily on first access. */
+  readonly dataDir: string;
   log: ShishoLog;
   config: ShishoConfig;
   http: ShishoHTTP;

--- a/packages/plugin-types/manifest.d.ts
+++ b/packages/plugin-types/manifest.d.ts
@@ -153,6 +153,8 @@ export interface PluginManifest {
   name: string;
   /** Semver version string. */
   version: string;
+  /** Short one-liner overview (separate from longer description). */
+  overview?: string;
   description?: string;
   author?: string;
   homepage?: string;

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,7 +45,8 @@ type Config struct {
 	DownloadCacheMaxSizeGB int    `koanf:"download_cache_max_size_gb" json:"download_cache_max_size_gb"`
 
 	// Plugin settings
-	PluginDir string `koanf:"plugin_dir" json:"plugin_dir"`
+	PluginDir     string `koanf:"plugin_dir" json:"plugin_dir"`
+	PluginDataDir string `koanf:"plugin_data_dir" json:"plugin_data_dir"`
 
 	// Supplement discovery settings
 	SupplementExcludePatterns []string `koanf:"supplement_exclude_patterns" json:"supplement_exclude_patterns"`
@@ -87,6 +88,7 @@ func defaults() *Config {
 		JobRetentionDays:          30,
 		CacheDir:                  "/config/cache",
 		PluginDir:                 "/config/plugins/installed",
+		PluginDataDir:             "/config/plugins/data",
 		DownloadCacheMaxSizeGB:    5,
 		SupplementExcludePatterns: []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
 		JWTSecret:                 "", // Must be set via config or env var

--- a/pkg/migrations/20260304000000_plugin_v2_schema.go
+++ b/pkg/migrations/20260304000000_plugin_v2_schema.go
@@ -1,0 +1,90 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		// 1. Add status column (int), convert enabled -> status
+		_, err := db.Exec(`ALTER TABLE plugins ADD COLUMN status INTEGER NOT NULL DEFAULT 0`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Convert: enabled=true -> status=0 (Active), enabled=false -> status=-1 (Disabled)
+		_, err = db.Exec(`UPDATE plugins SET status = CASE WHEN enabled = true THEN 0 ELSE -1 END`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 2. Add auto_update column
+		_, err = db.Exec(`ALTER TABLE plugins ADD COLUMN auto_update BOOLEAN NOT NULL DEFAULT true`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 3. Add repository_scope and repository_url columns
+		_, err = db.Exec(`ALTER TABLE plugins ADD COLUMN repository_scope TEXT`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE plugins ADD COLUMN repository_url TEXT`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 4. Drop enabled column by recreating the table (SQLite limitation)
+		// Note: SQLite doesn't support DROP COLUMN in older versions, so we use
+		// the standard recreate approach. However, modern SQLite (3.35+) supports it.
+		_, err = db.Exec(`ALTER TABLE plugins DROP COLUMN enabled`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 5. Add index on status for filtering
+		_, err = db.Exec(`CREATE INDEX ix_plugins_status ON plugins(status)`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`DROP INDEX IF EXISTS ix_plugins_status`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = db.Exec(`ALTER TABLE plugins ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT true`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = db.Exec(`UPDATE plugins SET enabled = CASE WHEN status = 0 THEN true ELSE false END`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = db.Exec(`ALTER TABLE plugins DROP COLUMN status`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE plugins DROP COLUMN auto_update`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE plugins DROP COLUMN repository_scope`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE plugins DROP COLUMN repository_url`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/plugin.go
+++ b/pkg/models/plugin.go
@@ -15,6 +15,20 @@ const (
 	PluginHookMetadataEnricher = "metadataEnricher"
 )
 
+// PluginStatus represents the lifecycle state of a plugin.
+type PluginStatus int
+
+const (
+	// PluginStatusActive means the plugin is running normally.
+	PluginStatusActive PluginStatus = 0
+	// PluginStatusDisabled means the user has disabled the plugin.
+	PluginStatusDisabled PluginStatus = -1
+	// PluginStatusMalfunctioned means the plugin failed to load (LoadError has details).
+	PluginStatusMalfunctioned PluginStatus = -2
+	// PluginStatusNotSupported means the plugin's minShishoVersion is incompatible.
+	PluginStatusNotSupported PluginStatus = -3
+)
+
 type PluginRepository struct {
 	bun.BaseModel `bun:"table:plugin_repositories,alias:pr" tstype:"-"`
 
@@ -30,18 +44,21 @@ type PluginRepository struct {
 type Plugin struct {
 	bun.BaseModel `bun:"table:plugins,alias:p" tstype:"-"`
 
-	Scope                  string     `bun:",pk" json:"scope"`
-	ID                     string     `bun:",pk" json:"id"`
-	Name                   string     `bun:",notnull" json:"name"`
-	Version                string     `bun:",notnull" json:"version"`
-	Description            *string    `json:"description"`
-	Author                 *string    `json:"author"`
-	Homepage               *string    `json:"homepage"`
-	Enabled                bool       `bun:",notnull" json:"enabled"`
-	InstalledAt            time.Time  `bun:",notnull" json:"installed_at"`
-	UpdatedAt              *time.Time `json:"updated_at"`
-	LoadError              *string    `json:"load_error"`
-	UpdateAvailableVersion *string    `json:"update_available_version"`
+	Scope                  string       `bun:",pk" json:"scope"`
+	ID                     string       `bun:",pk" json:"id"`
+	Name                   string       `bun:",notnull" json:"name"`
+	Version                string       `bun:",notnull" json:"version"`
+	Description            *string      `json:"description"`
+	Author                 *string      `json:"author"`
+	Homepage               *string      `json:"homepage"`
+	Status                 PluginStatus `bun:",notnull,default:0" json:"status"`
+	AutoUpdate             bool         `bun:",notnull,default:true" json:"auto_update"`
+	RepositoryScope        *string      `json:"repository_scope"`
+	RepositoryURL          *string      `json:"repository_url"`
+	InstalledAt            time.Time    `bun:",notnull" json:"installed_at"`
+	UpdatedAt              *time.Time   `json:"updated_at"`
+	LoadError              *string      `json:"load_error"`
+	UpdateAvailableVersion *string      `json:"update_available_version"`
 }
 
 type PluginConfig struct {

--- a/pkg/plugins/events.go
+++ b/pkg/plugins/events.go
@@ -1,0 +1,32 @@
+package plugins
+
+// PluginEventType describes a plugin lifecycle event.
+type PluginEventType int
+
+const (
+	// PluginEventInstalled fires after a plugin is installed and loaded.
+	PluginEventInstalled PluginEventType = iota
+	// PluginEventUninstalled fires after a plugin is uninstalled.
+	PluginEventUninstalled
+	// PluginEventUpdated fires after a plugin version is updated (hot-reloaded).
+	PluginEventUpdated
+	// PluginEventEnabled fires after a disabled plugin is re-enabled and loaded.
+	PluginEventEnabled
+	// PluginEventDisabled fires after an active plugin is disabled and unloaded.
+	PluginEventDisabled
+	// PluginEventMalfunctioned fires when a plugin fails to load.
+	PluginEventMalfunctioned
+)
+
+// PluginEvent contains information about a plugin lifecycle change.
+type PluginEvent struct {
+	Type  PluginEventType
+	Scope string
+	ID    string
+	// Hooks lists the hook types this plugin provides (e.g., "fileParser", "metadataEnricher").
+	// Empty for uninstall/disable events.
+	Hooks []string
+}
+
+// PluginEventCallback is the signature for event listeners.
+type PluginEventCallback func(event PluginEvent)

--- a/pkg/plugins/events_test.go
+++ b/pkg/plugins/events_test.go
@@ -1,0 +1,70 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetEventCallback_ReceivesEvents(t *testing.T) {
+	pluginDir := t.TempDir()
+	db := setupTestDB(t)
+	service := NewService(db)
+	manager := NewManager(service, pluginDir, "")
+
+	var received []PluginEvent
+	manager.SetEventCallback(func(event PluginEvent) {
+		received = append(received, event)
+	})
+
+	// Emit some events
+	manager.emitEvent(PluginEventInstalled, "test", "my-plugin", []string{"fileParser"})
+	manager.emitEvent(PluginEventDisabled, "test", "my-plugin", nil)
+	manager.emitEvent(PluginEventUninstalled, "test", "my-plugin", nil)
+
+	require.Len(t, received, 3)
+
+	assert.Equal(t, PluginEventInstalled, received[0].Type)
+	assert.Equal(t, "test", received[0].Scope)
+	assert.Equal(t, "my-plugin", received[0].ID)
+	assert.Equal(t, []string{"fileParser"}, received[0].Hooks)
+
+	assert.Equal(t, PluginEventDisabled, received[1].Type)
+	assert.Nil(t, received[1].Hooks)
+
+	assert.Equal(t, PluginEventUninstalled, received[2].Type)
+}
+
+func TestEmitEvent_NoCallback_NoPanic(t *testing.T) {
+	pluginDir := t.TempDir()
+	db := setupTestDB(t)
+	service := NewService(db)
+	manager := NewManager(service, pluginDir, "")
+
+	// Should not panic when no callback is set
+	assert.NotPanics(t, func() {
+		manager.emitEvent(PluginEventInstalled, "test", "plugin", nil)
+	})
+}
+
+func TestSetEventCallback_ReplacesExisting(t *testing.T) {
+	pluginDir := t.TempDir()
+	db := setupTestDB(t)
+	service := NewService(db)
+	manager := NewManager(service, pluginDir, "")
+
+	var first, second []PluginEvent
+	manager.SetEventCallback(func(event PluginEvent) {
+		first = append(first, event)
+	})
+	manager.SetEventCallback(func(event PluginEvent) {
+		second = append(second, event)
+	})
+
+	manager.emitEvent(PluginEventEnabled, "test", "plugin", []string{"metadataEnricher"})
+
+	assert.Empty(t, first, "first callback should not receive events after replacement")
+	require.Len(t, second, 1)
+	assert.Equal(t, PluginEventEnabled, second[0].Type)
+}

--- a/pkg/plugins/generator_test.go
+++ b/pkg/plugins/generator_test.go
@@ -22,7 +22,7 @@ func TestGetOutputGenerator(t *testing.T) {
 		ID:          "hooks-generator",
 		Name:        "Test Generator",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -52,7 +52,7 @@ func TestRegisteredOutputFormats(t *testing.T) {
 		ID:          "hooks-generator",
 		Name:        "Test Generator",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -82,7 +82,7 @@ func TestRegisteredOutputFormats_Empty(t *testing.T) {
 		ID:          "simple-enricher",
 		Name:        "Simple Enricher",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -105,7 +105,7 @@ func TestPluginGenerator_Generate(t *testing.T) {
 		ID:          "hooks-generator",
 		Name:        "Test Generator",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -155,7 +155,7 @@ func TestPluginGenerator_Fingerprint(t *testing.T) {
 		ID:          "hooks-generator",
 		Name:        "Test Generator",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/uptrace/bun"
 )
 
 const validRepoURLPrefix = "https://raw.githubusercontent.com/"
@@ -21,6 +22,7 @@ type handler struct {
 	service   *Service
 	manager   *Manager
 	installer *Installer
+	db        *bun.DB
 }
 
 type installPayload struct {
@@ -33,8 +35,9 @@ type installPayload struct {
 }
 
 type updatePayload struct {
-	Enabled *bool             `json:"enabled"`
-	Config  map[string]string `json:"config"`
+	Enabled    *bool             `json:"enabled"`
+	AutoUpdate *bool             `json:"auto_update"`
+	Config     map[string]string `json:"config"`
 }
 
 type orderEntry struct {
@@ -44,6 +47,18 @@ type orderEntry struct {
 
 type setOrderPayload struct {
 	Order []orderEntry `json:"order" validate:"required"`
+}
+
+type searchPayload struct {
+	Query  string `json:"query" validate:"required"`
+	BookID int64  `json:"book_id" validate:"required"`
+}
+
+type enrichPayload struct {
+	PluginScope  string      `json:"plugin_scope" validate:"required"`
+	PluginID     string      `json:"plugin_id" validate:"required"`
+	BookID       int64       `json:"book_id" validate:"required"`
+	ProviderData interface{} `json:"provider_data"`
 }
 
 func (h *handler) listIdentifierTypes(c echo.Context) error {
@@ -94,7 +109,7 @@ func (h *handler) install(c echo.Context) error {
 			ID:          manifest.ID,
 			Name:        manifest.Name,
 			Version:     manifest.Version,
-			Enabled:     true,
+			Status:      models.PluginStatusActive,
 			InstalledAt: time.Now(),
 		}
 		if manifest.Description != "" {
@@ -108,7 +123,7 @@ func (h *handler) install(c echo.Context) error {
 		}
 	} else if payload.DownloadURL == "" && payload.SHA256 == "" {
 		// Look up the plugin in repositories
-		downloadURL, sha256Hash, version, err := h.findPluginInRepos(c, payload.Scope, payload.ID, payload.Version)
+		downloadURL, sha256Hash, version, repoURL, imageURL, err := h.findPluginInRepos(c, payload.Scope, payload.ID, payload.Version)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -118,13 +133,20 @@ func (h *handler) install(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 
+		// Download plugin icon (non-fatal)
+		if imageURL != "" {
+			_ = h.installer.DownloadPluginImage(ctx, payload.Scope, manifest.ID, imageURL)
+		}
+
 		plugin = &models.Plugin{
-			Scope:       payload.Scope,
-			ID:          manifest.ID,
-			Name:        manifest.Name,
-			Version:     version,
-			Enabled:     true,
-			InstalledAt: time.Now(),
+			Scope:           payload.Scope,
+			ID:              manifest.ID,
+			Name:            manifest.Name,
+			Version:         version,
+			Status:          models.PluginStatusActive,
+			RepositoryScope: &payload.Scope,
+			RepositoryURL:   &repoURL,
+			InstalledAt:     time.Now(),
 		}
 		if manifest.Description != "" {
 			plugin.Description = &manifest.Description
@@ -147,7 +169,19 @@ func (h *handler) install(c echo.Context) error {
 		// Store load error but don't fail the install
 		errMsg := err.Error()
 		plugin.LoadError = &errMsg
+		if isVersionIncompatible(err) {
+			plugin.Status = models.PluginStatusNotSupported
+		} else {
+			plugin.Status = models.PluginStatusMalfunctioned
+		}
 		_ = h.service.UpdatePlugin(ctx, plugin)
+		h.manager.emitEvent(PluginEventMalfunctioned, plugin.Scope, plugin.ID, nil)
+	} else {
+		var hooks []string
+		if rt := h.manager.GetRuntime(plugin.Scope, plugin.ID); rt != nil {
+			hooks = rt.HookTypes()
+		}
+		h.manager.emitEvent(PluginEventInstalled, plugin.Scope, plugin.ID, hooks)
 	}
 
 	return errors.WithStack(c.JSON(http.StatusCreated, plugin))
@@ -155,10 +189,10 @@ func (h *handler) install(c echo.Context) error {
 
 // findPluginInRepos searches enabled repositories for a plugin by scope and ID.
 // If version is empty, it returns the latest compatible version.
-func (h *handler) findPluginInRepos(c echo.Context, scope, pluginID, version string) (downloadURL, sha256Hash, resolvedVersion string, err error) {
+func (h *handler) findPluginInRepos(c echo.Context, scope, pluginID, version string) (downloadURL, sha256Hash, resolvedVersion, repoURL, imageURL string, err error) {
 	repos, err := h.service.ListRepositories(c.Request().Context())
 	if err != nil {
-		return "", "", "", errors.WithStack(err)
+		return "", "", "", "", "", errors.WithStack(err)
 	}
 
 	for _, repo := range repos {
@@ -185,18 +219,18 @@ func (h *handler) findPluginInRepos(c echo.Context, scope, pluginID, version str
 				// Find specific version
 				for _, v := range compatible {
 					if v.Version == version {
-						return v.DownloadURL, v.SHA256, v.Version, nil
+						return v.DownloadURL, v.SHA256, v.Version, repo.URL, p.ImageURL, nil
 					}
 				}
 			} else {
 				// Return the first (latest) compatible version
 				v := compatible[0]
-				return v.DownloadURL, v.SHA256, v.Version, nil
+				return v.DownloadURL, v.SHA256, v.Version, repo.URL, p.ImageURL, nil
 			}
 		}
 	}
 
-	return "", "", "", errcodes.NotFound("Plugin in repositories")
+	return "", "", "", "", "", errcodes.NotFound("Plugin in repositories")
 }
 
 func (h *handler) uninstall(c echo.Context) error {
@@ -204,6 +238,11 @@ func (h *handler) uninstall(c echo.Context) error {
 
 	scope := c.Param("scope")
 	id := c.Param("id")
+
+	// Run onUninstalling lifecycle hook before unloading
+	if rt := h.manager.GetRuntime(scope, id); rt != nil {
+		h.manager.RunOnUninstalling(rt)
+	}
 
 	h.manager.UnloadPlugin(scope, id)
 
@@ -214,6 +253,13 @@ func (h *handler) uninstall(c echo.Context) error {
 	if err := h.service.UninstallPlugin(ctx, scope, id); err != nil {
 		return errors.WithStack(err)
 	}
+
+	// Optionally delete persistent plugin data
+	if c.QueryParam("delete_data") == "true" {
+		h.manager.DeletePluginData(scope, id)
+	}
+
+	h.manager.emitEvent(PluginEventUninstalled, scope, id, nil)
 
 	return c.NoContent(http.StatusNoContent)
 }
@@ -238,22 +284,39 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	if payload.Enabled != nil {
-		wasEnabled := plugin.Enabled
-		plugin.Enabled = *payload.Enabled
+		wasActive := plugin.Status == models.PluginStatusActive
 
-		if *payload.Enabled && !wasEnabled {
-			// Enabling: load the plugin
+		if *payload.Enabled && !wasActive {
+			// Enabling: set Active and load the plugin
+			plugin.Status = models.PluginStatusActive
 			if err := h.manager.LoadPlugin(ctx, scope, id); err != nil {
 				errMsg := err.Error()
 				plugin.LoadError = &errMsg
+				if isVersionIncompatible(err) {
+					plugin.Status = models.PluginStatusNotSupported
+				} else {
+					plugin.Status = models.PluginStatusMalfunctioned
+				}
+				h.manager.emitEvent(PluginEventMalfunctioned, scope, id, nil)
 			} else {
 				plugin.LoadError = nil
+				var hooks []string
+				if rt := h.manager.GetRuntime(scope, id); rt != nil {
+					hooks = rt.HookTypes()
+				}
+				h.manager.emitEvent(PluginEventEnabled, scope, id, hooks)
 			}
-		} else if !*payload.Enabled && wasEnabled {
+		} else if !*payload.Enabled && wasActive {
 			// Disabling: unload the plugin
 			h.manager.UnloadPlugin(scope, id)
+			plugin.Status = models.PluginStatusDisabled
 			plugin.LoadError = nil
+			h.manager.emitEvent(PluginEventDisabled, scope, id, nil)
 		}
+	}
+
+	if payload.AutoUpdate != nil {
+		plugin.AutoUpdate = *payload.AutoUpdate
 	}
 
 	now := time.Now()
@@ -274,6 +337,18 @@ func (h *handler) update(c echo.Context) error {
 	return errors.WithStack(c.JSON(http.StatusOK, plugin))
 }
 
+func (h *handler) getImage(c echo.Context) error {
+	scope := c.Param("scope")
+	id := c.Param("id")
+
+	iconPath := filepath.Join(h.installer.PluginDir(), scope, id, "icon.png")
+	if _, err := os.Stat(iconPath); err != nil {
+		return errcodes.NotFound("Plugin icon not found")
+	}
+
+	return c.File(iconPath)
+}
+
 func (h *handler) reload(c echo.Context) error {
 	ctx := c.Request().Context()
 	scope := c.Param("scope")
@@ -287,8 +362,8 @@ func (h *handler) reload(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	if !plugin.Enabled {
-		return errcodes.ValidationError("Plugin must be enabled to reload.")
+	if plugin.Status != models.PluginStatusActive {
+		return errcodes.ValidationError("Plugin must be active to reload.")
 	}
 
 	if err := h.manager.ReloadPlugin(ctx, scope, id); err != nil {
@@ -542,7 +617,7 @@ func (h *handler) updateVersion(c echo.Context) error {
 	targetVersion := *plugin.UpdateAvailableVersion
 
 	// 3. Find the download URL and SHA256 from repositories
-	downloadURL, sha256Hash, _, err := h.findPluginInRepos(c, scope, id, targetVersion)
+	downloadURL, sha256Hash, _, _, imageURL, err := h.findPluginInRepos(c, scope, id, targetVersion)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -553,12 +628,23 @@ func (h *handler) updateVersion(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	// Download updated plugin icon (non-fatal)
+	if imageURL != "" {
+		_ = h.installer.DownloadPluginImage(ctx, scope, manifest.ID, imageURL)
+	}
+
 	// 5. Hot-reload the plugin
 	if err := h.manager.ReloadPlugin(ctx, scope, id); err != nil {
 		errMsg := err.Error()
 		plugin.LoadError = &errMsg
+		h.manager.emitEvent(PluginEventMalfunctioned, scope, id, nil)
 	} else {
 		plugin.LoadError = nil
+		var hooks []string
+		if rt := h.manager.GetRuntime(scope, id); rt != nil {
+			hooks = rt.HookTypes()
+		}
+		h.manager.emitEvent(PluginEventUpdated, scope, id, hooks)
 	}
 
 	// 6. Update DB record
@@ -719,7 +805,7 @@ func (h *handler) scan(c echo.Context) error {
 			ID:          manifest.ID,
 			Name:        manifest.Name,
 			Version:     manifest.Version,
-			Enabled:     false,
+			Status:      models.PluginStatusDisabled,
 			InstalledAt: time.Now(),
 		}
 		if manifest.Description != "" {
@@ -1070,6 +1156,177 @@ func (h *handler) resetLibraryFieldSettings(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+// searchMetadata runs search() across all enabled enricher plugins and returns aggregated results.
+func (h *handler) searchMetadata(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	var payload searchPayload
+	if err := c.Bind(&payload); err != nil {
+		return errcodes.ValidationError(err.Error())
+	}
+
+	// Look up the book
+	var book models.Book
+	if err := h.db.NewSelect().Model(&book).
+		Where("book.id = ?", payload.BookID).
+		Relation("Authors").
+		Relation("Authors.Person").
+		Relation("BookSeries").
+		Relation("BookSeries.Series").
+		Relation("Files").
+		Relation("Files.Identifiers").
+		Scan(ctx); err != nil {
+		return errcodes.NotFound("Book")
+	}
+
+	// Get all enricher runtimes
+	runtimes, err := h.manager.GetOrderedRuntimes(ctx, models.PluginHookMetadataEnricher, 0)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Build context objects
+	bookCtx := buildSearchBookContext(&book)
+	fileCtx := map[string]interface{}{} // Minimal file context for search
+	if len(book.Files) > 0 {
+		f := book.Files[0]
+		fileCtx["fileType"] = f.FileType
+		fileCtx["filePath"] = f.Filepath
+	}
+
+	var allResults []SearchResult
+	for _, rt := range runtimes {
+		searchCtx := map[string]interface{}{
+			"query": payload.Query,
+			"book":  bookCtx,
+			"file":  fileCtx,
+		}
+
+		resp, sErr := h.manager.RunMetadataSearch(ctx, rt, searchCtx)
+		if sErr != nil {
+			continue // Skip failed plugins
+		}
+		if resp != nil {
+			allResults = append(allResults, resp.Results...)
+		}
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"results": allResults,
+	})
+}
+
+// enrichMetadata runs enrich() on a specific plugin with a selected search result.
+func (h *handler) enrichMetadata(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	var payload enrichPayload
+	if err := c.Bind(&payload); err != nil {
+		return errcodes.ValidationError(err.Error())
+	}
+
+	// Get the specific plugin runtime
+	rt := h.manager.GetRuntime(payload.PluginScope, payload.PluginID)
+	if rt == nil {
+		return errcodes.NotFound("Plugin")
+	}
+
+	// Look up the book
+	var book models.Book
+	if err := h.db.NewSelect().Model(&book).
+		Where("book.id = ?", payload.BookID).
+		Relation("Authors").
+		Relation("Authors.Person").
+		Relation("BookSeries").
+		Relation("BookSeries.Series").
+		Relation("Files").
+		Relation("Files.Identifiers").
+		Scan(ctx); err != nil {
+		return errcodes.NotFound("Book")
+	}
+
+	bookCtx := buildSearchBookContext(&book)
+	fileCtx := map[string]interface{}{}
+	if len(book.Files) > 0 {
+		f := book.Files[0]
+		fileCtx["fileType"] = f.FileType
+		fileCtx["filePath"] = f.Filepath
+	}
+
+	enrichCtx := map[string]interface{}{
+		"selectedResult": payload.ProviderData,
+		"book":           bookCtx,
+		"file":           fileCtx,
+	}
+
+	result, err := h.manager.RunMetadataEnrich(ctx, rt, enrichCtx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return c.JSON(http.StatusOK, result)
+}
+
+// buildSearchBookContext builds a context map for search/enrich from a book model.
+func buildSearchBookContext(book *models.Book) map[string]interface{} {
+	ctx := map[string]interface{}{
+		"id":    book.ID,
+		"title": book.Title,
+	}
+
+	if book.Subtitle != nil {
+		ctx["subtitle"] = *book.Subtitle
+	}
+	if book.Description != nil {
+		ctx["description"] = *book.Description
+	}
+
+	if len(book.Authors) > 0 {
+		authors := make([]map[string]interface{}, 0, len(book.Authors))
+		for _, a := range book.Authors {
+			author := map[string]interface{}{}
+			if a.Person != nil {
+				author["name"] = a.Person.Name
+			}
+			if a.Role != nil {
+				author["role"] = *a.Role
+			}
+			authors = append(authors, author)
+		}
+		ctx["authors"] = authors
+	}
+
+	if len(book.BookSeries) > 0 {
+		series := make([]map[string]interface{}, len(book.BookSeries))
+		for i, bs := range book.BookSeries {
+			s := map[string]interface{}{
+				"name": bs.Series.Name,
+			}
+			if bs.SeriesNumber != nil {
+				s["number"] = *bs.SeriesNumber
+			}
+			series[i] = s
+		}
+		ctx["series"] = series
+	}
+
+	// Collect identifiers from all files
+	var identifiers []map[string]interface{}
+	for _, f := range book.Files {
+		for _, id := range f.Identifiers {
+			identifiers = append(identifiers, map[string]interface{}{
+				"type":  id.Type,
+				"value": id.Value,
+			})
+		}
+	}
+	if len(identifiers) > 0 {
+		ctx["identifiers"] = identifiers
+	}
+
+	return ctx
 }
 
 // NewHandler creates a handler for testing and external route registration.

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"database/sql"
 	"net/http"
 	"os"
@@ -11,18 +12,81 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/htmlutil"
+	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/sidecar"
+	"github.com/shishobooks/shisho/pkg/sortname"
 	"github.com/uptrace/bun"
 )
 
 const validRepoURLPrefix = "https://raw.githubusercontent.com/"
+
+// enrichDeps holds dependencies for the enrich endpoint.
+// Uses interfaces to avoid circular imports with the books package.
+type enrichDeps struct {
+	bookStore     bookStore
+	relStore      relationStore
+	identStore    identifierStore
+	personFinder  personFinder
+	genreFinder   genreFinder
+	tagFinder     tagFinder
+	searchIndexer searchIndexer
+}
+
+// bookStore provides core book CRUD operations.
+type bookStore interface {
+	UpdateBook(ctx context.Context, book *models.Book, columns []string) error
+	RetrieveBook(ctx context.Context, bookID int) (*models.Book, error)
+}
+
+// relationStore provides book relationship CRUD operations.
+type relationStore interface {
+	DeleteAuthors(ctx context.Context, bookID int) error
+	CreateAuthor(ctx context.Context, author *models.Author) error
+	DeleteBookSeries(ctx context.Context, bookID int) error
+	CreateBookSeries(ctx context.Context, bs *models.BookSeries) error
+	FindOrCreateSeries(ctx context.Context, name string, libraryID int, nameSource string) (*models.Series, error)
+	DeleteBookGenres(ctx context.Context, bookID int) error
+	CreateBookGenre(ctx context.Context, bg *models.BookGenre) error
+	DeleteBookTags(ctx context.Context, bookID int) error
+	CreateBookTag(ctx context.Context, bt *models.BookTag) error
+}
+
+// identifierStore provides file identifier CRUD operations.
+type identifierStore interface {
+	DeleteIdentifiersForFile(ctx context.Context, fileID int) (int, error)
+	CreateFileIdentifier(ctx context.Context, identifier *models.FileIdentifier) error
+}
+
+// personFinder finds or creates persons for author associations.
+type personFinder interface {
+	FindOrCreatePerson(ctx context.Context, name string, libraryID int) (*models.Person, error)
+}
+
+// genreFinder finds or creates genres.
+type genreFinder interface {
+	FindOrCreateGenre(ctx context.Context, name string, libraryID int) (*models.Genre, error)
+}
+
+// tagFinder finds or creates tags.
+type tagFinder interface {
+	FindOrCreateTag(ctx context.Context, name string, libraryID int) (*models.Tag, error)
+}
+
+// searchIndexer updates the search index after metadata changes.
+type searchIndexer interface {
+	IndexBook(ctx context.Context, book *models.Book) error
+}
 
 type handler struct {
 	service   *Service
 	manager   *Manager
 	installer *Installer
 	db        *bun.DB
+	enrich    *enrichDeps
 }
 
 type installPayload struct {
@@ -1218,9 +1282,11 @@ func (h *handler) searchMetadata(c echo.Context) error {
 	})
 }
 
-// enrichMetadata runs enrich() on a specific plugin with a selected search result.
+// enrichMetadata runs enrich() on a specific plugin with a selected search result,
+// then applies the returned metadata to the book.
 func (h *handler) enrichMetadata(c echo.Context) error {
 	ctx := c.Request().Context()
+	log := logger.FromContext(ctx)
 
 	var payload enrichPayload
 	if err := c.Bind(&payload); err != nil {
@@ -1233,7 +1299,7 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 		return errcodes.NotFound("Plugin")
 	}
 
-	// Look up the book
+	// Look up the book with all relations needed for enrichment
 	var book models.Book
 	if err := h.db.NewSelect().Model(&book).
 		Where("book.id = ?", payload.BookID).
@@ -1241,6 +1307,10 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 		Relation("Authors.Person").
 		Relation("BookSeries").
 		Relation("BookSeries.Series").
+		Relation("BookGenres").
+		Relation("BookGenres.Genre").
+		Relation("BookTags").
+		Relation("BookTags.Tag").
 		Relation("Files").
 		Relation("Files.Identifiers").
 		Scan(ctx); err != nil {
@@ -1266,7 +1336,247 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	return c.JSON(http.StatusOK, result)
+	// If the plugin didn't modify anything or we don't have persistence deps, return as-is
+	if !result.Modified || result.Metadata == nil || h.enrich == nil {
+		return c.JSON(http.StatusOK, result)
+	}
+
+	// Apply enriched metadata to the book
+	if err := h.applyEnrichment(ctx, &book, result.Metadata, rt, log); err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Reload the book with all relations to return the updated state
+	updatedBook, err := h.enrich.bookStore.RetrieveBook(ctx, book.ID)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return c.JSON(http.StatusOK, updatedBook)
+}
+
+// applyEnrichment applies enriched metadata to a book, respecting field filtering.
+func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, md *mediafile.ParsedMetadata, rt *Runtime, log logger.Logger) error {
+	manifest := rt.Manifest()
+	if manifest.Capabilities.MetadataEnricher == nil {
+		return nil
+	}
+
+	// Get declared and effective field settings
+	declaredFields := manifest.Capabilities.MetadataEnricher.Fields
+	enabledFields, err := h.service.GetEffectiveFieldSettings(ctx, book.LibraryID, rt.Scope(), rt.PluginID(), declaredFields)
+	if err != nil {
+		log.Warn("failed to get field settings, using all enabled", logger.Data{"error": err.Error()})
+		enabledFields = make(map[string]bool, len(declaredFields))
+		for _, f := range declaredFields {
+			enabledFields[f] = true
+		}
+	}
+
+	// Build a set of declared fields
+	declared := make(map[string]bool, len(declaredFields))
+	for _, f := range declaredFields {
+		declared[f] = true
+	}
+
+	// Helper: check if a field is both declared and enabled
+	isAllowed := func(field string) bool {
+		if !declared[field] {
+			return false
+		}
+		if enabled, ok := enabledFields[field]; ok {
+			return enabled
+		}
+		return true // Default: enabled
+	}
+
+	pluginSource := models.PluginDataSource(rt.Scope(), rt.PluginID())
+	var columns []string
+
+	// Title
+	title := strings.TrimSpace(md.Title)
+	if title != "" && isAllowed("title") {
+		book.Title = title
+		book.TitleSource = pluginSource
+		book.SortTitle = sortname.ForTitle(title)
+		book.SortTitleSource = pluginSource
+		columns = append(columns, "title", "title_source", "sort_title", "sort_title_source")
+	}
+
+	// Subtitle
+	if md.Subtitle != "" && isAllowed("subtitle") {
+		subtitle := strings.TrimSpace(md.Subtitle)
+		book.Subtitle = &subtitle
+		book.SubtitleSource = &pluginSource
+		columns = append(columns, "subtitle", "subtitle_source")
+	}
+
+	// Description
+	if md.Description != "" && isAllowed("description") {
+		desc := htmlutil.StripTags(strings.TrimSpace(md.Description))
+		if desc != "" {
+			book.Description = &desc
+			book.DescriptionSource = &pluginSource
+			columns = append(columns, "description", "description_source")
+		}
+	}
+
+	// Apply scalar column updates
+	if len(columns) > 0 {
+		if err := h.enrich.bookStore.UpdateBook(ctx, book, columns); err != nil {
+			return errors.Wrap(err, "failed to update book")
+		}
+	}
+
+	// Authors
+	if len(md.Authors) > 0 && isAllowed("authors") && h.enrich.personFinder != nil {
+		if err := h.enrich.relStore.DeleteAuthors(ctx, book.ID); err != nil {
+			return errors.Wrap(err, "failed to delete authors")
+		}
+		for i, pa := range md.Authors {
+			if pa.Name == "" {
+				continue
+			}
+			person, pErr := h.enrich.personFinder.FindOrCreatePerson(ctx, pa.Name, book.LibraryID)
+			if pErr != nil {
+				log.Warn("failed to find/create person", logger.Data{"name": pa.Name, "error": pErr.Error()})
+				continue
+			}
+			var role *string
+			if pa.Role != "" {
+				role = &pa.Role
+			}
+			if err := h.enrich.relStore.CreateAuthor(ctx, &models.Author{
+				BookID:    book.ID,
+				PersonID:  person.ID,
+				Role:      role,
+				SortOrder: i + 1,
+			}); err != nil {
+				log.Warn("failed to create author", logger.Data{"error": err.Error()})
+			}
+		}
+		book.AuthorSource = pluginSource
+		if err := h.enrich.bookStore.UpdateBook(ctx, book, []string{"author_source"}); err != nil {
+			return errors.Wrap(err, "failed to update author source")
+		}
+	}
+
+	// Series
+	seriesAllowed := isAllowed("series") || isAllowed("seriesNumber")
+	if md.Series != "" && seriesAllowed {
+		if err := h.enrich.relStore.DeleteBookSeries(ctx, book.ID); err != nil {
+			return errors.Wrap(err, "failed to delete series")
+		}
+		seriesRecord, sErr := h.enrich.relStore.FindOrCreateSeries(ctx, md.Series, book.LibraryID, pluginSource)
+		if sErr != nil {
+			log.Warn("failed to find/create series", logger.Data{"name": md.Series, "error": sErr.Error()})
+		} else {
+			if err := h.enrich.relStore.CreateBookSeries(ctx, &models.BookSeries{
+				BookID:       book.ID,
+				SeriesID:     seriesRecord.ID,
+				SeriesNumber: md.SeriesNumber,
+				SortOrder:    1,
+			}); err != nil {
+				log.Warn("failed to create book series", logger.Data{"error": err.Error()})
+			}
+		}
+	}
+
+	// Genres
+	if len(md.Genres) > 0 && isAllowed("genres") && h.enrich.genreFinder != nil {
+		if err := h.enrich.relStore.DeleteBookGenres(ctx, book.ID); err != nil {
+			return errors.Wrap(err, "failed to delete genres")
+		}
+		for _, genreName := range md.Genres {
+			if genreName == "" {
+				continue
+			}
+			genre, gErr := h.enrich.genreFinder.FindOrCreateGenre(ctx, genreName, book.LibraryID)
+			if gErr != nil {
+				log.Warn("failed to find/create genre", logger.Data{"genre": genreName, "error": gErr.Error()})
+				continue
+			}
+			if err := h.enrich.relStore.CreateBookGenre(ctx, &models.BookGenre{
+				BookID:  book.ID,
+				GenreID: genre.ID,
+			}); err != nil {
+				log.Warn("failed to create book genre", logger.Data{"error": err.Error()})
+			}
+		}
+		book.GenreSource = &pluginSource
+		if err := h.enrich.bookStore.UpdateBook(ctx, book, []string{"genre_source"}); err != nil {
+			return errors.Wrap(err, "failed to update genre source")
+		}
+	}
+
+	// Tags
+	if len(md.Tags) > 0 && isAllowed("tags") && h.enrich.tagFinder != nil {
+		if err := h.enrich.relStore.DeleteBookTags(ctx, book.ID); err != nil {
+			return errors.Wrap(err, "failed to delete tags")
+		}
+		for _, tagName := range md.Tags {
+			if tagName == "" {
+				continue
+			}
+			tag, tErr := h.enrich.tagFinder.FindOrCreateTag(ctx, tagName, book.LibraryID)
+			if tErr != nil {
+				log.Warn("failed to find/create tag", logger.Data{"tag": tagName, "error": tErr.Error()})
+				continue
+			}
+			if err := h.enrich.relStore.CreateBookTag(ctx, &models.BookTag{
+				BookID: book.ID,
+				TagID:  tag.ID,
+			}); err != nil {
+				log.Warn("failed to create book tag", logger.Data{"error": err.Error()})
+			}
+		}
+		book.TagSource = &pluginSource
+		if err := h.enrich.bookStore.UpdateBook(ctx, book, []string{"tag_source"}); err != nil {
+			return errors.Wrap(err, "failed to update tag source")
+		}
+	}
+
+	// Identifiers (file-level, applied to first file)
+	if len(md.Identifiers) > 0 && isAllowed("identifiers") && len(book.Files) > 0 {
+		fileID := book.Files[0].ID
+		if _, err := h.enrich.identStore.DeleteIdentifiersForFile(ctx, fileID); err != nil {
+			return errors.Wrap(err, "failed to delete identifiers")
+		}
+		for _, ident := range md.Identifiers {
+			if ident.Type == "" || ident.Value == "" {
+				continue
+			}
+			if err := h.enrich.identStore.CreateFileIdentifier(ctx, &models.FileIdentifier{
+				FileID: fileID,
+				Type:   ident.Type,
+				Value:  ident.Value,
+			}); err != nil {
+				log.Warn("failed to create identifier", logger.Data{"error": err.Error()})
+			}
+		}
+	}
+
+	// Write sidecars to keep them in sync
+	updatedBook, err := h.enrich.bookStore.RetrieveBook(ctx, book.ID)
+	if err == nil {
+		if sErr := sidecar.WriteBookSidecarFromModel(updatedBook); sErr != nil {
+			log.Warn("failed to write book sidecar", logger.Data{"error": sErr.Error()})
+		}
+		for _, file := range updatedBook.Files {
+			if sErr := sidecar.WriteFileSidecarFromModel(file); sErr != nil {
+				log.Warn("failed to write file sidecar", logger.Data{"file_id": file.ID, "error": sErr.Error()})
+			}
+		}
+	}
+
+	// Update FTS index
+	if h.enrich.searchIndexer != nil && updatedBook != nil {
+		if err := h.enrich.searchIndexer.IndexBook(ctx, updatedBook); err != nil {
+			log.Warn("failed to update search index", logger.Data{"error": err.Error()})
+		}
+	}
+
+	return nil
 }
 
 // buildSearchBookContext builds a context map for search/enrich from a book model.

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -119,10 +119,10 @@ type searchPayload struct {
 }
 
 type enrichPayload struct {
-	PluginScope  string      `json:"plugin_scope" validate:"required"`
-	PluginID     string      `json:"plugin_id" validate:"required"`
-	BookID       int         `json:"book_id" validate:"required"`
-	ProviderData interface{} `json:"provider_data"`
+	PluginScope  string `json:"plugin_scope" validate:"required"`
+	PluginID     string `json:"plugin_id" validate:"required"`
+	BookID       int    `json:"book_id" validate:"required"`
+	ProviderData any    `json:"provider_data"`
 }
 
 func (h *handler) listIdentifierTypes(c echo.Context) error {
@@ -1251,10 +1251,12 @@ func (h *handler) searchMetadata(c echo.Context) error {
 	}
 
 	// Check library access
-	if user, ok := c.Get("user").(*models.User); ok {
-		if !user.HasLibraryAccess(book.LibraryID) {
-			return errcodes.Forbidden("You don't have access to this library")
-		}
+	user, ok := c.Get("user").(*models.User)
+	if !ok {
+		return errcodes.Unauthorized("User not found in context")
+	}
+	if !user.HasLibraryAccess(book.LibraryID) {
+		return errcodes.Forbidden("You don't have access to this library")
 	}
 
 	// Get all enricher runtimes
@@ -1330,10 +1332,12 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 	}
 
 	// Check library access
-	if user, ok := c.Get("user").(*models.User); ok {
-		if !user.HasLibraryAccess(book.LibraryID) {
-			return errcodes.Forbidden("You don't have access to this library")
-		}
+	user, ok := c.Get("user").(*models.User)
+	if !ok {
+		return errcodes.Unauthorized("User not found in context")
+	}
+	if !user.HasLibraryAccess(book.LibraryID) {
+		return errcodes.Forbidden("You don't have access to this library")
 	}
 
 	bookCtx := buildSearchBookContext(&book)

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -115,13 +115,13 @@ type setOrderPayload struct {
 
 type searchPayload struct {
 	Query  string `json:"query" validate:"required"`
-	BookID int64  `json:"book_id" validate:"required"`
+	BookID int    `json:"book_id" validate:"required"`
 }
 
 type enrichPayload struct {
 	PluginScope  string      `json:"plugin_scope" validate:"required"`
 	PluginID     string      `json:"plugin_id" validate:"required"`
-	BookID       int64       `json:"book_id" validate:"required"`
+	BookID       int         `json:"book_id" validate:"required"`
 	ProviderData interface{} `json:"provider_data"`
 }
 
@@ -404,6 +404,11 @@ func (h *handler) update(c echo.Context) error {
 func (h *handler) getImage(c echo.Context) error {
 	scope := c.Param("scope")
 	id := c.Param("id")
+
+	if strings.Contains(scope, "..") || strings.Contains(id, "..") ||
+		strings.ContainsAny(scope, "/\\") || strings.ContainsAny(id, "/\\") {
+		return errcodes.ValidationError("Invalid scope or plugin ID")
+	}
 
 	iconPath := filepath.Join(h.installer.PluginDir(), scope, id, "icon.png")
 	if _, err := os.Stat(iconPath); err != nil {
@@ -1245,6 +1250,13 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		return errcodes.NotFound("Book")
 	}
 
+	// Check library access
+	if user, ok := c.Get("user").(*models.User); ok {
+		if !user.HasLibraryAccess(book.LibraryID) {
+			return errcodes.Forbidden("You don't have access to this library")
+		}
+	}
+
 	// Get all enricher runtimes
 	runtimes, err := h.manager.GetOrderedRuntimes(ctx, models.PluginHookMetadataEnricher, 0)
 	if err != nil {
@@ -1315,6 +1327,13 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 		Relation("Files.Identifiers").
 		Scan(ctx); err != nil {
 		return errcodes.NotFound("Book")
+	}
+
+	// Check library access
+	if user, ok := c.Get("user").(*models.User); ok {
+		if !user.HasLibraryAccess(book.LibraryID) {
+			return errcodes.Forbidden("You don't have access to this library")
+		}
 	}
 
 	bookCtx := buildSearchBookContext(&book)
@@ -1609,17 +1628,22 @@ func buildSearchBookContext(book *models.Book) map[string]interface{} {
 	}
 
 	if len(book.BookSeries) > 0 {
-		series := make([]map[string]interface{}, len(book.BookSeries))
-		for i, bs := range book.BookSeries {
+		series := make([]map[string]interface{}, 0, len(book.BookSeries))
+		for _, bs := range book.BookSeries {
+			if bs.Series == nil {
+				continue
+			}
 			s := map[string]interface{}{
 				"name": bs.Series.Name,
 			}
 			if bs.SeriesNumber != nil {
 				s["number"] = *bs.SeriesNumber
 			}
-			series[i] = s
+			series = append(series, s)
 		}
-		ctx["series"] = series
+		if len(series) > 0 {
+			ctx["series"] = series
+		}
 	}
 
 	// Collect identifiers from all files
@@ -1645,6 +1669,7 @@ func NewHandler(service *Service, manager *Manager, installer *Installer) *handl
 }
 
 // Exported handler methods for testing.
+func (h *handler) GetImage(c echo.Context) error              { return h.getImage(c) }
 func (h *handler) GetLibraryOrder(c echo.Context) error       { return h.getLibraryOrder(c) }
 func (h *handler) SetLibraryOrder(c echo.Context) error       { return h.setLibraryOrder(c) }
 func (h *handler) ResetLibraryOrder(c echo.Context) error     { return h.resetLibraryOrder(c) }

--- a/pkg/plugins/handler_image_test.go
+++ b/pkg/plugins/handler_image_test.go
@@ -1,0 +1,96 @@
+package plugins
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetImage_PathTraversal(t *testing.T) {
+	pluginDir := t.TempDir()
+	installer := NewInstaller(pluginDir)
+	h := NewHandler(nil, nil, installer)
+
+	tests := []struct {
+		name  string
+		scope string
+		id    string
+	}{
+		{"dot-dot in scope", "..", "plugin"},
+		{"dot-dot in id", "scope", ".."},
+		{"dot-dot path in scope", "scope/../etc", "plugin"},
+		{"dot-dot path in id", "scope", "plugin/../../etc"},
+		{"forward slash in scope", "scope/sub", "plugin"},
+		{"forward slash in id", "scope", "plugin/sub"},
+		{"backslash in scope", "scope\\sub", "plugin"},
+		{"backslash in id", "scope", "plugin\\sub"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("scope", "id")
+			c.SetParamValues(tt.scope, tt.id)
+
+			err := h.GetImage(c)
+			require.Error(t, err)
+
+			var ecErr *errcodes.Error
+			require.ErrorAs(t, err, &ecErr)
+			assert.Equal(t, http.StatusUnprocessableEntity, ecErr.HTTPCode)
+		})
+	}
+}
+
+func TestGetImage_ValidPlugin(t *testing.T) {
+	pluginDir := t.TempDir()
+	installer := NewInstaller(pluginDir)
+	h := NewHandler(nil, nil, installer)
+
+	// Create a valid plugin icon
+	iconDir := filepath.Join(pluginDir, "shisho", "test-plugin")
+	require.NoError(t, os.MkdirAll(iconDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(iconDir, "icon.png"), []byte("fake-png"), 0o644))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("scope", "id")
+	c.SetParamValues("shisho", "test-plugin")
+
+	err := h.GetImage(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "fake-png", rec.Body.String())
+}
+
+func TestGetImage_NotFound(t *testing.T) {
+	pluginDir := t.TempDir()
+	installer := NewInstaller(pluginDir)
+	h := NewHandler(nil, nil, installer)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("scope", "id")
+	c.SetParamValues("shisho", "nonexistent")
+
+	err := h.GetImage(c)
+	require.Error(t, err)
+
+	var ecErr *errcodes.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, http.StatusNotFound, ecErr.HTTPCode)
+}

--- a/pkg/plugins/handler_library_test.go
+++ b/pkg/plugins/handler_library_test.go
@@ -22,7 +22,7 @@ func TestLibraryPluginOrder_GetDefault(t *testing.T) {
 	library := insertTestLibrary(t, db, "Test Library")
 
 	// Setup: install plugin and set global order
-	plugin := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Test Enricher", Version: "1.0.0", Enabled: true}
+	plugin := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Test Enricher", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(plugin).Exec(ctx)
 	require.NoError(t, err)
 	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginOrder{
@@ -61,8 +61,8 @@ func TestLibraryPluginOrder_SetAndGet(t *testing.T) {
 	library := insertTestLibrary(t, db, "Test Library")
 
 	// Setup
-	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Enabled: true}
-	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Enabled: true}
+	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Status: models.PluginStatusActive}
+	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(p1).Exec(ctx)
 	require.NoError(t, err)
 	_, err = db.NewInsert().Model(p2).Exec(ctx)
@@ -113,7 +113,7 @@ func TestLibraryPluginOrder_ResetHookType(t *testing.T) {
 	library := insertTestLibrary(t, db, "Test Library")
 
 	// Setup
-	plugin := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Test Enricher", Version: "1.0.0", Enabled: true}
+	plugin := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Test Enricher", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(plugin).Exec(ctx)
 	require.NoError(t, err)
 
@@ -150,7 +150,7 @@ func TestLibraryPluginOrder_ResetAll(t *testing.T) {
 	library := insertTestLibrary(t, db, "Test Library")
 
 	// Setup
-	plugin := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Test Enricher", Version: "1.0.0", Enabled: true}
+	plugin := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Test Enricher", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(plugin).Exec(ctx)
 	require.NoError(t, err)
 

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -2,12 +2,14 @@ package plugins
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"time"
 
 	"github.com/dop251/goja"
 	"github.com/pkg/errors"
+	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/htmlutil"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -719,11 +721,14 @@ func (m *Manager) RunOnUninstalling(rt *Runtime) {
 	}()
 
 	// Call the hook, recovering from panics (errors don't prevent uninstall)
+	log := logger.New()
 	func() {
 		defer func() {
 			if r := recover(); r != nil {
-				// Log but don't propagate
-				_ = r
+				log.Warn("onUninstalling hook panicked", logger.Data{
+					"plugin": rt.scope + "/" + rt.pluginID,
+					"panic":  fmt.Sprintf("%v", r),
+				})
 			}
 		}()
 		_, _ = rt.onUninstalling(goja.Undefined())

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -40,7 +40,7 @@ func (m *Manager) RunInputConverter(ctx context.Context, rt *Runtime, sourcePath
 
 	// Set up FSContext
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
-	fsCtx := NewFSContext(pluginDir, []string{sourcePath, targetDir}, rt.manifest.Capabilities.FileAccess)
+	fsCtx := NewFSContext(pluginDir, rt.dataDir, []string{sourcePath, targetDir}, rt.manifest.Capabilities.FileAccess)
 	rt.SetFSContext(fsCtx)
 	defer func() {
 		rt.SetFSContext(nil)
@@ -88,7 +88,7 @@ func (m *Manager) RunFileParser(ctx context.Context, rt *Runtime, filePath, file
 
 	// Set up FSContext
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
-	fsCtx := NewFSContext(pluginDir, []string{filePath}, rt.manifest.Capabilities.FileAccess)
+	fsCtx := NewFSContext(pluginDir, rt.dataDir, []string{filePath}, rt.manifest.Capabilities.FileAccess)
 	rt.SetFSContext(fsCtx)
 	defer func() {
 		rt.SetFSContext(nil)
@@ -131,8 +131,28 @@ func (m *Manager) RunFileParser(ctx context.Context, rt *Runtime, filePath, file
 	return md, nil
 }
 
-// RunMetadataEnricher invokes a plugin's metadataEnricher.enrich() hook.
-func (m *Manager) RunMetadataEnricher(ctx context.Context, rt *Runtime, enrichCtx map[string]interface{}) (*EnrichmentResult, error) {
+// SearchResult is a single search result from a metadata enricher's search() hook.
+type SearchResult struct {
+	Title        string                       `json:"title"`
+	Authors      []string                     `json:"authors"`
+	Description  string                       `json:"description"`
+	ImageURL     string                       `json:"image_url"`
+	ReleaseDate  string                       `json:"release_date"`
+	Publisher    string                       `json:"publisher"`
+	Identifiers  []mediafile.ParsedIdentifier `json:"identifiers"`
+	ProviderData interface{}                  `json:"provider_data"` // Opaque data passed back to enrich()
+	// Added by the caller, not the plugin:
+	PluginScope string `json:"plugin_scope"`
+	PluginID    string `json:"plugin_id"`
+}
+
+// SearchResponse is the result of a metadata enricher's search() hook.
+type SearchResponse struct {
+	Results []SearchResult
+}
+
+// RunMetadataSearch invokes a plugin's metadataEnricher.search() hook.
+func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx map[string]interface{}) (*SearchResponse, error) {
 	if rt.metadataEnricher == nil {
 		return nil, errors.New("plugin does not have a metadataEnricher hook")
 	}
@@ -146,7 +166,50 @@ func (m *Manager) RunMetadataEnricher(ctx context.Context, rt *Runtime, enrichCt
 
 	// Set up FSContext (no extra allowed paths for enrichers)
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
-	fsCtx := NewFSContext(pluginDir, nil, rt.manifest.Capabilities.FileAccess)
+	fsCtx := NewFSContext(pluginDir, rt.dataDir, nil, rt.manifest.Capabilities.FileAccess)
+	rt.SetFSContext(fsCtx)
+	defer func() {
+		rt.SetFSContext(nil)
+		fsCtx.Cleanup() //nolint:errcheck
+	}()
+
+	// Get the search method
+	enricherObj := rt.metadataEnricher.ToObject(rt.vm)
+	searchVal := enricherObj.Get("search")
+	if searchVal == nil || goja.IsUndefined(searchVal) {
+		return nil, errors.New("metadataEnricher.search is not defined")
+	}
+	searchFn, ok := goja.AssertFunction(searchVal)
+	if !ok {
+		return nil, errors.New("metadataEnricher.search is not a function")
+	}
+
+	// Call the hook
+	result, err := searchFn(goja.Undefined(), rt.vm.ToValue(searchCtx))
+	if err != nil {
+		return nil, errors.Wrap(err, "metadataEnricher.search failed")
+	}
+
+	// Parse the result
+	return parseSearchResponse(rt.vm, result, rt.scope, rt.pluginID), nil
+}
+
+// RunMetadataEnrich invokes a plugin's metadataEnricher.enrich() hook.
+func (m *Manager) RunMetadataEnrich(ctx context.Context, rt *Runtime, enrichCtx map[string]interface{}) (*EnrichmentResult, error) {
+	if rt.metadataEnricher == nil {
+		return nil, errors.New("plugin does not have a metadataEnricher hook")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	defer cancel()
+	_ = ctx // reserved for future cancellation support
+
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+
+	// Set up FSContext (no extra allowed paths for enrichers)
+	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
+	fsCtx := NewFSContext(pluginDir, rt.dataDir, nil, rt.manifest.Capabilities.FileAccess)
 	rt.SetFSContext(fsCtx)
 	defer func() {
 		rt.SetFSContext(nil)
@@ -189,7 +252,7 @@ func (m *Manager) RunOutputGenerator(ctx context.Context, rt *Runtime, sourcePat
 
 	// Set up FSContext
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
-	fsCtx := NewFSContext(pluginDir, []string{sourcePath, destPath}, rt.manifest.Capabilities.FileAccess)
+	fsCtx := NewFSContext(pluginDir, rt.dataDir, []string{sourcePath, destPath}, rt.manifest.Capabilities.FileAccess)
 	rt.SetFSContext(fsCtx)
 	defer func() {
 		rt.SetFSContext(nil)
@@ -313,6 +376,67 @@ func parseEnrichmentResult(vm *goja.Runtime, val goja.Value) (*EnrichmentResult,
 	result.Metadata = metadata
 
 	return result, nil
+}
+
+// parseSearchResponse maps a JS search result to SearchResponse.
+func parseSearchResponse(vm *goja.Runtime, val goja.Value, pluginScope, pluginID string) *SearchResponse {
+	if val == nil || goja.IsUndefined(val) || goja.IsNull(val) {
+		return &SearchResponse{}
+	}
+
+	obj := val.ToObject(vm)
+	resultsVal := obj.Get("results")
+	if resultsVal == nil || goja.IsUndefined(resultsVal) || goja.IsNull(resultsVal) {
+		return &SearchResponse{}
+	}
+
+	resultsObj := resultsVal.ToObject(vm)
+	lengthVal := resultsObj.Get("length")
+	if lengthVal == nil || goja.IsUndefined(lengthVal) {
+		return &SearchResponse{}
+	}
+	length := int(lengthVal.ToInteger())
+
+	results := make([]SearchResult, 0, length)
+	for i := 0; i < length; i++ {
+		itemVal := resultsObj.Get(intToString(i))
+		if itemVal == nil || goja.IsUndefined(itemVal) || goja.IsNull(itemVal) {
+			continue
+		}
+		itemObj := itemVal.ToObject(vm)
+
+		sr := SearchResult{
+			Title:       getStringField(itemObj, "title"),
+			Description: getStringField(itemObj, "description"),
+			ImageURL:    getStringField(itemObj, "imageUrl"),
+			ReleaseDate: getStringField(itemObj, "releaseDate"),
+			Publisher:   getStringField(itemObj, "publisher"),
+			PluginScope: pluginScope,
+			PluginID:    pluginID,
+		}
+
+		// authors -> []string
+		authorsVal := itemObj.Get("authors")
+		if authorsVal != nil && !goja.IsUndefined(authorsVal) && !goja.IsNull(authorsVal) {
+			sr.Authors = parseStringArray(vm, authorsVal)
+		}
+
+		// identifiers -> []ParsedIdentifier
+		identifiersVal := itemObj.Get("identifiers")
+		if identifiersVal != nil && !goja.IsUndefined(identifiersVal) && !goja.IsNull(identifiersVal) {
+			sr.Identifiers = parseIdentifiers(vm, identifiersVal)
+		}
+
+		// providerData -> opaque (exported as-is)
+		providerDataVal := itemObj.Get("providerData")
+		if providerDataVal != nil && !goja.IsUndefined(providerDataVal) && !goja.IsNull(providerDataVal) {
+			sr.ProviderData = providerDataVal.Export()
+		}
+
+		results = append(results, sr)
+	}
+
+	return &SearchResponse{Results: results}
 }
 
 // parseParsedMetadata maps a JS metadata object to mediafile.ParsedMetadata.
@@ -572,4 +696,36 @@ func parseByteData(val goja.Value) []byte {
 // intToString converts an int to its string representation for JS array indexing.
 func intToString(i int) string {
 	return strconv.Itoa(i)
+}
+
+// RunOnUninstalling invokes a plugin's optional onUninstalling() lifecycle hook.
+// This is called before uninstall to give the plugin a chance to clean up.
+// Errors in the hook do not prevent uninstall.
+func (m *Manager) RunOnUninstalling(rt *Runtime) {
+	if rt.onUninstalling == nil {
+		return
+	}
+
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+
+	// Set up FSContext for the hook (plugin dir + data dir only)
+	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
+	fsCtx := NewFSContext(pluginDir, rt.dataDir, nil, rt.manifest.Capabilities.FileAccess)
+	rt.SetFSContext(fsCtx)
+	defer func() {
+		rt.SetFSContext(nil)
+		fsCtx.Cleanup() //nolint:errcheck
+	}()
+
+	// Call the hook, recovering from panics (errors don't prevent uninstall)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				// Log but don't propagate
+				_ = r
+			}
+		}()
+		_, _ = rt.onUninstalling(goja.Undefined())
+	}()
 }

--- a/pkg/plugins/hooks_test.go
+++ b/pkg/plugins/hooks_test.go
@@ -31,7 +31,7 @@ func setupHooksTestManager(t *testing.T, testdata, pluginID string) (*Manager, *
 	copyTestdataFile(t, srcDir, destDir, "main.js")
 
 	// Create the manager and install/load the plugin
-	manager := NewManager(service, pluginDir)
+	manager := NewManager(service, pluginDir, "")
 	ctx := context.Background()
 
 	plugin := &models.Plugin{
@@ -39,7 +39,7 @@ func setupHooksTestManager(t *testing.T, testdata, pluginID string) (*Manager, *
 		ID:          pluginID,
 		Name:        pluginID + " Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = service.InstallPlugin(ctx, plugin)
@@ -117,7 +117,7 @@ func TestRunInputConverter_Failure(t *testing.T) {
 	err = os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644)
 	require.NoError(t, err)
 
-	manager := NewManager(service, pluginDir)
+	manager := NewManager(service, pluginDir, "")
 	ctx := context.Background()
 
 	plugin := &models.Plugin{
@@ -125,7 +125,7 @@ func TestRunInputConverter_Failure(t *testing.T) {
 		ID:          "fail-converter",
 		Name:        "Fail Converter",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = service.InstallPlugin(ctx, plugin)
@@ -259,7 +259,7 @@ func TestRunFileParser_MinimalFields(t *testing.T) {
 	err = os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644)
 	require.NoError(t, err)
 
-	manager := NewManager(service, pluginDir)
+	manager := NewManager(service, pluginDir, "")
 	ctx := context.Background()
 
 	plugin := &models.Plugin{
@@ -267,7 +267,7 @@ func TestRunFileParser_MinimalFields(t *testing.T) {
 		ID:          "minimal-parser",
 		Name:        "Minimal Parser",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = service.InstallPlugin(ctx, plugin)
@@ -301,11 +301,12 @@ func TestRunFileParser_MinimalFields(t *testing.T) {
 	assert.Nil(t, md.Chapters)
 }
 
-func TestRunMetadataEnricher_Modified(t *testing.T) {
+func TestRunMetadataSearch_ReturnsResults(t *testing.T) {
 	mgr, rt := setupHooksTestManager(t, "hooks-enricher", "hooks-enricher")
 	ctx := context.Background()
 
-	enrichCtx := map[string]interface{}{
+	searchCtx := map[string]interface{}{
+		"query": "My Book",
 		"book": map[string]interface{}{
 			"title":   "My Book",
 			"authors": []string{"Author A"},
@@ -314,12 +315,42 @@ func TestRunMetadataEnricher_Modified(t *testing.T) {
 			"fileType": "epub",
 			"filePath": "/library/book.epub",
 		},
-		"parsedMetadata": map[string]interface{}{
-			"title": "My Book",
+	}
+
+	resp, err := mgr.RunMetadataSearch(ctx, rt, searchCtx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+
+	result := resp.Results[0]
+	assert.Equal(t, "Search: My Book", result.Title)
+	assert.Equal(t, []string{"Search Author"}, result.Authors)
+	assert.Equal(t, "Search Publisher", result.Publisher)
+	require.Len(t, result.Identifiers, 1)
+	assert.Equal(t, "goodreads", result.Identifiers[0].Type)
+	assert.NotNil(t, result.ProviderData)
+}
+
+func TestRunMetadataEnrich_Modified(t *testing.T) {
+	mgr, rt := setupHooksTestManager(t, "hooks-enricher", "hooks-enricher")
+	ctx := context.Background()
+
+	enrichCtx := map[string]interface{}{
+		"selectedResult": map[string]interface{}{
+			"internalId": 42,
+			"query":      "My Book",
+		},
+		"book": map[string]interface{}{
+			"title":   "My Book",
+			"authors": []string{"Author A"},
+		},
+		"file": map[string]interface{}{
+			"fileType": "epub",
+			"filePath": "/library/book.epub",
 		},
 	}
 
-	result, err := mgr.RunMetadataEnricher(ctx, rt, enrichCtx)
+	result, err := mgr.RunMetadataEnrich(ctx, rt, enrichCtx)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.Modified)
@@ -337,12 +368,12 @@ func TestRunMetadataEnricher_Modified(t *testing.T) {
 	assert.Equal(t, mediafile.ParsedIdentifier{Type: "goodreads", Value: "12345"}, result.Metadata.Identifiers[0])
 }
 
-func TestRunMetadataEnricher_NotModified(t *testing.T) {
+func TestRunMetadataEnrich_NotModified(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
 	pluginDir := t.TempDir()
 
-	// Create an enricher that returns modified: false
+	// Create an enricher that returns modified: false from enrich
 	destDir := filepath.Join(pluginDir, "test", "noop-enricher")
 	err := os.MkdirAll(destDir, 0755)
 	require.NoError(t, err)
@@ -363,6 +394,9 @@ func TestRunMetadataEnricher_NotModified(t *testing.T) {
 	mainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(context) {
+        return { results: [{ title: "Result", providerData: {} }] };
+      },
       enrich: function(context) {
         return { modified: false };
       }
@@ -375,7 +409,7 @@ func TestRunMetadataEnricher_NotModified(t *testing.T) {
 	err = os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644)
 	require.NoError(t, err)
 
-	manager := NewManager(service, pluginDir)
+	manager := NewManager(service, pluginDir, "")
 	ctx := context.Background()
 
 	plugin := &models.Plugin{
@@ -383,7 +417,7 @@ func TestRunMetadataEnricher_NotModified(t *testing.T) {
 		ID:          "noop-enricher",
 		Name:        "Noop Enricher",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = service.InstallPlugin(ctx, plugin)
@@ -396,11 +430,12 @@ func TestRunMetadataEnricher_NotModified(t *testing.T) {
 	require.NotNil(t, rt)
 
 	enrichCtx := map[string]interface{}{
-		"book": map[string]interface{}{"title": "Test"},
-		"file": map[string]interface{}{"fileType": "epub"},
+		"selectedResult": map[string]interface{}{},
+		"book":           map[string]interface{}{"title": "Test"},
+		"file":           map[string]interface{}{"fileType": "epub"},
 	}
 
-	result, err := manager.RunMetadataEnricher(ctx, rt, enrichCtx)
+	result, err := manager.RunMetadataEnrich(ctx, rt, enrichCtx)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.False(t, result.Modified)
@@ -482,12 +517,22 @@ func TestRunFileParser_NoHook(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not have a fileParser hook")
 }
 
-func TestRunMetadataEnricher_NoHook(t *testing.T) {
+func TestRunMetadataSearch_NoHook(t *testing.T) {
 	// Use the converter plugin which has no enricher hook
 	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")
 	ctx := context.Background()
 
-	_, err := mgr.RunMetadataEnricher(ctx, rt, map[string]interface{}{})
+	_, err := mgr.RunMetadataSearch(ctx, rt, map[string]interface{}{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not have a metadataEnricher hook")
+}
+
+func TestRunMetadataEnrich_NoHook(t *testing.T) {
+	// Use the converter plugin which has no enricher hook
+	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")
+	ctx := context.Background()
+
+	_, err := mgr.RunMetadataEnrich(ctx, rt, map[string]interface{}{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not have a metadataEnricher hook")
 }

--- a/pkg/plugins/hostapi.go
+++ b/pkg/plugins/hostapi.go
@@ -3,10 +3,14 @@ package plugins
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/dop251/goja"
+	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
 )
+
+var errDefinePropertyNotFound = errors.New("failed to get Object.defineProperty")
 
 // ConfigGetter provides config values for a plugin at runtime.
 type ConfigGetter interface {
@@ -25,6 +29,11 @@ func InjectHostAPIs(rt *Runtime, configGetter ConfigGetter) error {
 	shishoObj := vm.NewObject()
 	if err := vm.Set("shisho", shishoObj); err != nil {
 		return fmt.Errorf("failed to set shisho global: %w", err)
+	}
+
+	// Set dataDir property (lazily creates the directory on first access)
+	if err := injectDataDirProperty(vm, shishoObj, rt); err != nil {
+		return err
 	}
 
 	// Set up log namespace
@@ -73,6 +82,37 @@ func InjectHostAPIs(rt *Runtime, configGetter ConfigGetter) error {
 	}
 
 	return nil
+}
+
+// injectDataDirProperty sets up shisho.dataDir as a string property.
+// The directory is lazily created on first access via a getter.
+func injectDataDirProperty(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime) error {
+	if rt.dataDir == "" {
+		return nil
+	}
+
+	// Define a getter that lazily creates the directory
+	getter := vm.ToValue(func(_ goja.FunctionCall) goja.Value {
+		if err := os.MkdirAll(rt.dataDir, 0755); err != nil {
+			panic(vm.ToValue(fmt.Sprintf("shisho.dataDir: failed to create data directory: %v", err)))
+		}
+		return vm.ToValue(rt.dataDir)
+	})
+
+	// Use Object.defineProperty to set up a getter
+	objectVal := vm.GlobalObject().Get("Object")
+	defineProperty, ok := goja.AssertFunction(objectVal.ToObject(vm).Get("defineProperty"))
+	if !ok {
+		return errDefinePropertyNotFound
+	}
+
+	descriptor := vm.NewObject()
+	descriptor.Set("get", getter)         //nolint:errcheck
+	descriptor.Set("enumerable", true)    //nolint:errcheck
+	descriptor.Set("configurable", false) //nolint:errcheck
+
+	_, err := defineProperty(objectVal, shishoObj, vm.ToValue("dataDir"), descriptor)
+	return err
 }
 
 // injectLogNamespace sets up shisho.log with debug/info/warn/error methods.

--- a/pkg/plugins/hostapi_archive_test.go
+++ b/pkg/plugins/hostapi_archive_test.go
@@ -62,7 +62,7 @@ func TestArchive_ExtractZip_ExtractsFiles(t *testing.T) {
 	err := os.MkdirAll(destDir, 0755)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err = rt.vm.RunString(`shisho.archive.extractZip("` + zipPath + `", "` + destDir + `")`)
@@ -99,7 +99,7 @@ func TestArchive_ExtractZip_ZipSlipBlocked(t *testing.T) {
 	err = os.MkdirAll(destDir, 0755)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err = rt.vm.RunString(`shisho.archive.extractZip("` + zipPath + `", "` + destDir + `")`)
@@ -121,7 +121,7 @@ func TestArchive_CreateZip_CreatesValidZip(t *testing.T) {
 
 	destPath := filepath.Join(pluginDir, "output.zip")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err = rt.vm.RunString(`shisho.archive.createZip("` + srcDir + `", "` + destPath + `")`)
@@ -150,7 +150,7 @@ func TestArchive_ReadZipEntry_ReadsSpecificEntry(t *testing.T) {
 		"second.txt": "second content",
 	})
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`
@@ -174,7 +174,7 @@ func TestArchive_ReadZipEntry_NonExistentEntry(t *testing.T) {
 		"exists.txt": "content",
 	})
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.readZipEntry("` + zipPath + `", "nonexistent.txt")`)
@@ -192,7 +192,7 @@ func TestArchive_ListZipEntries_ReturnsAllNames(t *testing.T) {
 		"sub/c.txt": "c",
 	})
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`
@@ -215,7 +215,7 @@ func TestArchive_ExtractZip_ReadAccessDenied(t *testing.T) {
 	destDir := filepath.Join(pluginDir, "output")
 
 	// No fileAccess capability - external dir is not accessible
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.extractZip("` + zipPath + `", "` + destDir + `")`)
@@ -234,7 +234,7 @@ func TestArchive_ExtractZip_WriteAccessDenied(t *testing.T) {
 	// Write to external dir (not writable without capability)
 	destDir := filepath.Join(externalDir, "output")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.extractZip("` + zipPath + `", "` + destDir + `")`)
@@ -253,7 +253,7 @@ func TestArchive_CreateZip_ReadAccessDenied(t *testing.T) {
 
 	destPath := filepath.Join(pluginDir, "output.zip")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err = rt.vm.RunString(`shisho.archive.createZip("` + srcDir + `", "` + destPath + `")`)
@@ -273,7 +273,7 @@ func TestArchive_CreateZip_WriteAccessDenied(t *testing.T) {
 	// Write to external dir (not writable)
 	destPath := filepath.Join(externalDir, "output.zip")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err = rt.vm.RunString(`shisho.archive.createZip("` + srcDir + `", "` + destPath + `")`)
@@ -320,7 +320,7 @@ func TestArchive_ExtractZip_WithDirectoryEntries(t *testing.T) {
 	err := os.MkdirAll(destDir, 0755)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err = rt.vm.RunString(`shisho.archive.extractZip("` + zipPath + `", "` + destDir + `")`)
@@ -343,7 +343,7 @@ func TestArchive_ReadZipEntry_ReadAccessDenied(t *testing.T) {
 	zipPath := filepath.Join(externalDir, "test.zip")
 	createTestZip(t, zipPath, map[string]string{"file.txt": "content"})
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.readZipEntry("` + zipPath + `", "file.txt")`)
@@ -358,7 +358,7 @@ func TestArchive_ListZipEntries_ReadAccessDenied(t *testing.T) {
 	zipPath := filepath.Join(externalDir, "test.zip")
 	createTestZip(t, zipPath, map[string]string{"file.txt": "content"})
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.listZipEntries("` + zipPath + `")`)
@@ -390,7 +390,7 @@ func TestArchive_ExtractZip_WithAllowedPaths(t *testing.T) {
 	createTestZip(t, zipPath, map[string]string{"hello.txt": "world"})
 
 	// Both srcDir and destDir are in allowedPaths
-	fsCtx := NewFSContext(pluginDir, []string{srcDir, destDir}, nil)
+	fsCtx := NewFSContext(pluginDir, "", []string{srcDir, destDir}, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.extractZip("` + zipPath + `", "` + destDir + `")`)
@@ -416,7 +416,7 @@ func TestArchive_CreateZip_RoundTrip(t *testing.T) {
 	err = os.MkdirAll(extractDir, 0755)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	// Create zip then extract it
@@ -434,7 +434,7 @@ func TestArchive_CreateZip_RoundTrip(t *testing.T) {
 
 func TestArchive_ExtractZip_MissingArgs(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.extractZip("only-one-arg")`)
@@ -444,7 +444,7 @@ func TestArchive_ExtractZip_MissingArgs(t *testing.T) {
 
 func TestArchive_CreateZip_MissingArgs(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.createZip("only-one-arg")`)
@@ -454,7 +454,7 @@ func TestArchive_CreateZip_MissingArgs(t *testing.T) {
 
 func TestArchive_ReadZipEntry_MissingArgs(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.readZipEntry("only-one-arg")`)
@@ -464,7 +464,7 @@ func TestArchive_ReadZipEntry_MissingArgs(t *testing.T) {
 
 func TestArchive_ListZipEntries_MissingArgs(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.archive.listZipEntries()`)

--- a/pkg/plugins/hostapi_fs.go
+++ b/pkg/plugins/hostapi_fs.go
@@ -14,6 +14,7 @@ import (
 // It controls what filesystem operations a plugin can perform.
 type FSContext struct {
 	pluginDir     string         // Plugin's own directory (always accessible)
+	dataDir       string         // Persistent data directory (always accessible, read+write)
 	allowedPaths  []string       // Hook-provided paths (always accessible)
 	fileAccessCap *FileAccessCap // From manifest (nil = no global file access)
 	tempDir       string         // Lazy-created temp directory path
@@ -21,9 +22,10 @@ type FSContext struct {
 }
 
 // NewFSContext creates a new FSContext for a hook invocation.
-func NewFSContext(pluginDir string, allowedPaths []string, fileAccessCap *FileAccessCap) *FSContext {
+func NewFSContext(pluginDir, dataDir string, allowedPaths []string, fileAccessCap *FileAccessCap) *FSContext {
 	return &FSContext{
 		pluginDir:     pluginDir,
+		dataDir:       dataDir,
 		allowedPaths:  allowedPaths,
 		fileAccessCap: fileAccessCap,
 	}
@@ -66,6 +68,11 @@ func (ctx *FSContext) isReadAllowed(path string) bool {
 		return true
 	}
 
+	// Always allow persistent data directory
+	if ctx.dataDir != "" && isPathWithin(absPath, ctx.dataDir) {
+		return true
+	}
+
 	// Always allow temp directory
 	if ctx.tempDir != "" && isPathWithin(absPath, ctx.tempDir) {
 		return true
@@ -100,6 +107,11 @@ func (ctx *FSContext) isWriteAllowed(path string) bool {
 
 	// Always allow plugin's own directory
 	if isPathWithin(absPath, ctx.pluginDir) {
+		return true
+	}
+
+	// Always allow persistent data directory
+	if ctx.dataDir != "" && isPathWithin(absPath, ctx.dataDir) {
 		return true
 	}
 

--- a/pkg/plugins/hostapi_fs_test.go
+++ b/pkg/plugins/hostapi_fs_test.go
@@ -27,7 +27,7 @@ func TestFS_ReadTextFile_PluginDir(t *testing.T) {
 	err := os.WriteFile(testFile, []byte("hello world"), 0644)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`shisho.fs.readTextFile("` + testFile + `")`)
@@ -42,7 +42,7 @@ func TestFS_ReadFile_PluginDir(t *testing.T) {
 	err := os.WriteFile(testFile, data, 0644)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	// Read the file and verify it returns an ArrayBuffer with correct data
@@ -63,7 +63,7 @@ func TestFS_WriteTextFile_PluginDir(t *testing.T) {
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "output.txt")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.writeTextFile("` + testFile + `", "written content")`)
@@ -78,7 +78,7 @@ func TestFS_WriteFile_PluginDir(t *testing.T) {
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "output.bin")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`
@@ -97,7 +97,7 @@ func TestFS_WriteTextFile_ReadwriteAccess(t *testing.T) {
 	externalDir := t.TempDir()
 	testFile := filepath.Join(externalDir, "external.txt")
 
-	fsCtx := NewFSContext(pluginDir, nil, &FileAccessCap{Level: "readwrite"})
+	fsCtx := NewFSContext(pluginDir, "", nil, &FileAccessCap{Level: "readwrite"})
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.writeTextFile("` + testFile + `", "readwrite content")`)
@@ -114,7 +114,7 @@ func TestFS_Write_DeniedWithoutFileAccess(t *testing.T) {
 	testFile := filepath.Join(externalDir, "denied.txt")
 
 	// No fileAccess capability
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.writeTextFile("` + testFile + `", "should fail")`)
@@ -128,7 +128,7 @@ func TestFS_Write_DeniedWithReadOnlyAccess(t *testing.T) {
 	testFile := filepath.Join(externalDir, "denied.txt")
 
 	// Read-only fileAccess
-	fsCtx := NewFSContext(pluginDir, nil, &FileAccessCap{Level: "read"})
+	fsCtx := NewFSContext(pluginDir, "", nil, &FileAccessCap{Level: "read"})
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.writeTextFile("` + testFile + `", "should fail")`)
@@ -143,7 +143,7 @@ func TestFS_Read_AllowedWithReadAccess(t *testing.T) {
 	err := os.WriteFile(testFile, []byte("external content"), 0644)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, &FileAccessCap{Level: "read"})
+	fsCtx := NewFSContext(pluginDir, "", nil, &FileAccessCap{Level: "read"})
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`shisho.fs.readTextFile("` + testFile + `")`)
@@ -157,7 +157,7 @@ func TestFS_Exists_True(t *testing.T) {
 	err := os.WriteFile(testFile, []byte("hi"), 0644)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`shisho.fs.exists("` + testFile + `")`)
@@ -169,7 +169,7 @@ func TestFS_Exists_False(t *testing.T) {
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "nonexistent.txt")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`shisho.fs.exists("` + testFile + `")`)
@@ -181,7 +181,7 @@ func TestFS_Mkdir_PluginDir(t *testing.T) {
 	pluginDir := t.TempDir()
 	newDir := filepath.Join(pluginDir, "sub", "dir")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.mkdir("` + newDir + `")`)
@@ -197,7 +197,7 @@ func TestFS_Mkdir_DeniedOutsidePluginDir(t *testing.T) {
 	externalDir := t.TempDir()
 	newDir := filepath.Join(externalDir, "denied-dir")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.mkdir("` + newDir + `")`)
@@ -215,7 +215,7 @@ func TestFS_ListDir(t *testing.T) {
 	err = os.Mkdir(filepath.Join(pluginDir, "subdir"), 0755)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`
@@ -229,7 +229,7 @@ func TestFS_ListDir(t *testing.T) {
 
 func TestFS_TempDir_ConsistentPerInvocation(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	// Call tempDir twice - should return the same path
@@ -258,7 +258,7 @@ func TestFS_TempDir_ConsistentPerInvocation(t *testing.T) {
 
 func TestFS_TempDir_WriteAllowed(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 	defer fsCtx.Cleanup() //nolint:errcheck
 
@@ -284,7 +284,7 @@ func TestFS_AllowedPaths_ReadAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// No fileAccess capability, but allowedDir is in allowedPaths
-	fsCtx := NewFSContext(pluginDir, []string{allowedDir}, nil)
+	fsCtx := NewFSContext(pluginDir, "", []string{allowedDir}, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`shisho.fs.readTextFile("` + testFile + `")`)
@@ -298,7 +298,7 @@ func TestFS_AllowedPaths_WriteAccess(t *testing.T) {
 	testFile := filepath.Join(allowedDir, "allowed-write.txt")
 
 	// No fileAccess capability, but allowedDir is in allowedPaths
-	fsCtx := NewFSContext(pluginDir, []string{allowedDir}, nil)
+	fsCtx := NewFSContext(pluginDir, "", []string{allowedDir}, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.writeTextFile("` + testFile + `", "allowed write")`)
@@ -317,7 +317,7 @@ func TestFS_AllowedPaths_ExactFileMatch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Allow only the specific file
-	fsCtx := NewFSContext(pluginDir, []string{allowedFile}, nil)
+	fsCtx := NewFSContext(pluginDir, "", []string{allowedFile}, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`shisho.fs.readTextFile("` + allowedFile + `")`)
@@ -333,7 +333,7 @@ func TestFS_DeniedOutsideAllPaths(t *testing.T) {
 	require.NoError(t, err)
 
 	// No fileAccess, no allowedPaths matching deniedDir
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err = rt.vm.RunString(`shisho.fs.readTextFile("` + testFile + `")`)
@@ -348,7 +348,7 @@ func TestFS_Read_DeniedOutsidePluginDir_NoFileAccess(t *testing.T) {
 	err := os.WriteFile(testFile, []byte("external"), 0644)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err = rt.vm.RunString(`shisho.fs.readTextFile("` + testFile + `")`)
@@ -373,7 +373,7 @@ func TestFS_Exists_DeniedOutsidePluginDir(t *testing.T) {
 	externalDir := t.TempDir()
 	testFile := filepath.Join(externalDir, "secret.txt")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.exists("` + testFile + `")`)
@@ -385,7 +385,7 @@ func TestFS_ListDir_DeniedOutsidePluginDir(t *testing.T) {
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.listDir("` + externalDir + `")`)
@@ -397,7 +397,7 @@ func TestFS_ReadFile_NonexistentFile(t *testing.T) {
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "nonexistent.txt")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.readTextFile("` + testFile + `")`)
@@ -409,7 +409,7 @@ func TestFS_WriteFile_InvalidData(t *testing.T) {
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "output.bin")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	// Pass a string instead of ArrayBuffer
@@ -427,7 +427,7 @@ func TestFS_ReadTextFile_Subdirectory(t *testing.T) {
 	err = os.WriteFile(testFile, []byte("deep content"), 0644)
 	require.NoError(t, err)
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`shisho.fs.readTextFile("` + testFile + `")`)
@@ -463,7 +463,7 @@ func TestFS_SetFSContext_CanBeCleared(t *testing.T) {
 	require.NoError(t, err)
 
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 
 	// Set context
 	rt.SetFSContext(fsCtx)
@@ -487,7 +487,7 @@ func TestFS_SetFSContext_CanBeCleared(t *testing.T) {
 
 func TestFS_Cleanup_NoTempDir(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 
 	// Cleanup when no temp dir was created should be a no-op
 	err := fsCtx.Cleanup()
@@ -499,7 +499,7 @@ func TestFS_WriteFile_Mkdir_WithReadwriteAccess(t *testing.T) {
 	externalDir := t.TempDir()
 	newDir := filepath.Join(externalDir, "new-dir")
 
-	fsCtx := NewFSContext(pluginDir, nil, &FileAccessCap{Level: "readwrite"})
+	fsCtx := NewFSContext(pluginDir, "", nil, &FileAccessCap{Level: "readwrite"})
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.mkdir("` + newDir + `")`)
@@ -515,7 +515,7 @@ func TestFS_Mkdir_DeniedWithReadOnlyAccess(t *testing.T) {
 	externalDir := t.TempDir()
 	newDir := filepath.Join(externalDir, "new-dir")
 
-	fsCtx := NewFSContext(pluginDir, nil, &FileAccessCap{Level: "read"})
+	fsCtx := NewFSContext(pluginDir, "", nil, &FileAccessCap{Level: "read"})
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.mkdir("` + newDir + `")`)
@@ -526,7 +526,7 @@ func TestFS_Mkdir_DeniedWithReadOnlyAccess(t *testing.T) {
 func TestFS_TempDir_DifferentPerFSContext(t *testing.T) {
 	pluginDir := t.TempDir()
 
-	fsCtx1 := NewFSContext(pluginDir, nil, nil)
+	fsCtx1 := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx1)
 
 	val1, err := rt.vm.RunString(`shisho.fs.tempDir()`)
@@ -534,7 +534,7 @@ func TestFS_TempDir_DifferentPerFSContext(t *testing.T) {
 	defer fsCtx1.Cleanup() //nolint:errcheck
 
 	// Create a new FSContext (simulating a new hook invocation)
-	fsCtx2 := NewFSContext(pluginDir, nil, nil)
+	fsCtx2 := NewFSContext(pluginDir, "", nil, nil)
 	rt.SetFSContext(fsCtx2)
 
 	val2, err := rt.vm.RunString(`shisho.fs.tempDir()`)
@@ -553,7 +553,7 @@ func TestFS_ReadFile_ReadwriteAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// readwrite also grants read access
-	fsCtx := NewFSContext(pluginDir, nil, &FileAccessCap{Level: "readwrite"})
+	fsCtx := NewFSContext(pluginDir, "", nil, &FileAccessCap{Level: "readwrite"})
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`shisho.fs.readTextFile("` + testFile + `")`)
@@ -563,7 +563,7 @@ func TestFS_ReadFile_ReadwriteAccess(t *testing.T) {
 
 func TestFS_NewFSContext_NilAllowedPaths(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	assert.NotNil(t, fsCtx)
 	assert.Equal(t, pluginDir, fsCtx.pluginDir)
 	assert.Nil(t, fsCtx.allowedPaths)
@@ -572,7 +572,7 @@ func TestFS_NewFSContext_NilAllowedPaths(t *testing.T) {
 
 func TestFS_ReadFile_NoArgument(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.readFile()`)
@@ -582,7 +582,7 @@ func TestFS_ReadFile_NoArgument(t *testing.T) {
 
 func TestFS_ReadTextFile_NoArgument(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.readTextFile()`)
@@ -592,7 +592,7 @@ func TestFS_ReadTextFile_NoArgument(t *testing.T) {
 
 func TestFS_WriteTextFile_NoArguments(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.writeTextFile()`)
@@ -602,7 +602,7 @@ func TestFS_WriteTextFile_NoArguments(t *testing.T) {
 
 func TestFS_WriteFile_NoArguments(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.writeFile()`)
@@ -612,7 +612,7 @@ func TestFS_WriteFile_NoArguments(t *testing.T) {
 
 func TestFS_Exists_NoArgument(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	// goja converts missing args to "undefined" string, which will fail path check
@@ -623,7 +623,7 @@ func TestFS_Exists_NoArgument(t *testing.T) {
 
 func TestFS_Mkdir_NoArgument(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.mkdir()`)
@@ -633,7 +633,7 @@ func TestFS_Mkdir_NoArgument(t *testing.T) {
 
 func TestFS_ListDir_NoArgument(t *testing.T) {
 	pluginDir := t.TempDir()
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	_, err := rt.vm.RunString(`shisho.fs.listDir()`)
@@ -669,7 +669,7 @@ func TestFS_AllowedPaths_SubdirectoryAccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Allow the parent directory - subdirectory files should also be accessible
-	fsCtx := NewFSContext(pluginDir, []string{allowedDir}, nil)
+	fsCtx := NewFSContext(pluginDir, "", []string{allowedDir}, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	val, err := rt.vm.RunString(`shisho.fs.readTextFile("` + testFile + `")`)
@@ -681,7 +681,7 @@ func TestFS_WriteFile_Uint8Array(t *testing.T) {
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "uint8.bin")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	// Create a Uint8Array and pass its buffer
@@ -700,7 +700,7 @@ func TestFS_ReadFile_RoundTrip(t *testing.T) {
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "roundtrip.bin")
 
-	fsCtx := NewFSContext(pluginDir, nil, nil)
+	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
 
 	// Write binary data and read it back, verify equality

--- a/pkg/plugins/installer.go
+++ b/pkg/plugins/installer.go
@@ -277,6 +277,10 @@ func (inst *Installer) DownloadPluginImage(ctx context.Context, scope, pluginID,
 		return nil
 	}
 
+	if !isAllowedDownloadURL(imageURL) {
+		return errors.Errorf("image URL not from allowed host: %s", imageURL)
+	}
+
 	client := &http.Client{Timeout: 30 * time.Second}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)

--- a/pkg/plugins/installer.go
+++ b/pkg/plugins/installer.go
@@ -270,6 +270,47 @@ func (inst *Installer) extractZip(zipPath, destDir string) error {
 	return nil
 }
 
+// DownloadPluginImage downloads an image from the given URL and saves it as icon.png
+// in the plugin's directory. Errors are non-fatal and logged by the caller.
+func (inst *Installer) DownloadPluginImage(ctx context.Context, scope, pluginID, imageURL string) error {
+	if imageURL == "" {
+		return nil
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create image download request")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to download plugin image")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.Errorf("failed to download plugin image: HTTP %d", resp.StatusCode)
+	}
+
+	destDir := filepath.Join(inst.pluginDir, scope, pluginID)
+	destPath := filepath.Join(destDir, "icon.png")
+
+	// Limit image download to 5MB
+	const maxImageSize = 5 * 1024 * 1024
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImageSize))
+	if err != nil {
+		return errors.Wrap(err, "failed to read plugin image")
+	}
+
+	if err := os.WriteFile(destPath, data, 0600); err != nil {
+		return errors.Wrap(err, "failed to save plugin image")
+	}
+
+	return nil
+}
+
 // isAllowedDownloadURL checks whether the URL matches any allowed download host prefix.
 func isAllowedDownloadURL(url string) bool {
 	for _, prefix := range AllowedDownloadHosts {

--- a/pkg/plugins/integration_test.go
+++ b/pkg/plugins/integration_test.go
@@ -89,13 +89,22 @@ func TestPluginLifecycle(t *testing.T) {
       }
     },
     metadataEnricher: {
+      search: function(ctx) {
+        return {
+          results: [{
+            title: "Found: " + ctx.query,
+            providerData: { query: ctx.query }
+          }]
+        };
+      },
       enrich: function(ctx) {
+        var title = ctx.selectedResult && ctx.selectedResult.query ? ctx.selectedResult.query : (ctx.book ? ctx.book.title : "");
         return {
           modified: true,
           metadata: {
             genres: ["Science Fiction"],
             tags: ["enriched"],
-            description: "Enriched: " + ctx.book.title
+            description: "Enriched: " + title
           }
         };
       }
@@ -123,14 +132,14 @@ func TestPluginLifecycle(t *testing.T) {
 		ID:          pluginID,
 		Name:        "Lifecycle Test Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = service.InstallPlugin(context.Background(), plugin)
 	require.NoError(t, err)
 
 	// 4. Create a Manager and load the plugin
-	manager := NewManager(service, pluginDir)
+	manager := NewManager(service, pluginDir, "")
 	ctx := context.Background()
 
 	err = manager.LoadPlugin(ctx, scope, pluginID)
@@ -210,8 +219,9 @@ func TestPluginLifecycle(t *testing.T) {
 	require.NotNil(t, metadata.SeriesNumber)
 	assert.InDelta(t, 1.5, *metadata.SeriesNumber, 0.001)
 
-	// 14. Run metadataEnricher
-	enrichCtx := map[string]interface{}{
+	// 14. Run metadataEnricher search + enrich
+	searchCtx := map[string]interface{}{
+		"query": "My Book",
 		"book": map[string]interface{}{
 			"title":   "My Book",
 			"authors": []string{"Author A"},
@@ -222,7 +232,25 @@ func TestPluginLifecycle(t *testing.T) {
 		},
 	}
 
-	enrichResult, err := manager.RunMetadataEnricher(ctx, rt, enrichCtx)
+	searchResp, err := manager.RunMetadataSearch(ctx, rt, searchCtx)
+	require.NoError(t, err)
+	require.NotNil(t, searchResp)
+	require.Len(t, searchResp.Results, 1)
+	assert.Equal(t, "Found: My Book", searchResp.Results[0].Title)
+
+	enrichCtx := map[string]interface{}{
+		"selectedResult": searchResp.Results[0].ProviderData,
+		"book": map[string]interface{}{
+			"title":   "My Book",
+			"authors": []string{"Author A"},
+		},
+		"file": map[string]interface{}{
+			"fileType": "testformat",
+			"filePath": testFile,
+		},
+	}
+
+	enrichResult, err := manager.RunMetadataEnrich(ctx, rt, enrichCtx)
 	require.NoError(t, err)
 	require.NotNil(t, enrichResult)
 	assert.True(t, enrichResult.Modified)
@@ -355,6 +383,9 @@ func TestPluginLifecycle_ConfigIntegration(t *testing.T) {
 	mainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: "Result", providerData: {} }] };
+      },
       enrich: function(ctx) {
         var prefix = shisho.config.get("prefix");
         if (!prefix) {
@@ -382,7 +413,7 @@ func TestPluginLifecycle_ConfigIntegration(t *testing.T) {
 		ID:          pluginID,
 		Name:        "Config Test Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = service.InstallPlugin(context.Background(), plugin)
@@ -393,7 +424,7 @@ func TestPluginLifecycle_ConfigIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Load and run
-	manager := NewManager(service, pluginDir)
+	manager := NewManager(service, pluginDir, "")
 	ctx := context.Background()
 
 	err = manager.LoadPlugin(ctx, scope, pluginID)
@@ -403,11 +434,12 @@ func TestPluginLifecycle_ConfigIntegration(t *testing.T) {
 	require.NotNil(t, rt)
 
 	enrichCtx := map[string]interface{}{
-		"book": map[string]interface{}{"title": "Test"},
-		"file": map[string]interface{}{"fileType": "epub"},
+		"selectedResult": map[string]interface{}{},
+		"book":           map[string]interface{}{"title": "Test"},
+		"file":           map[string]interface{}{"fileType": "epub"},
 	}
 
-	result, err := manager.RunMetadataEnricher(ctx, rt, enrichCtx)
+	result, err := manager.RunMetadataEnrich(ctx, rt, enrichCtx)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.True(t, result.Modified)
@@ -423,11 +455,11 @@ func TestPluginLifecycle_LoadAll(t *testing.T) {
 
 	// Create two plugins: one enabled, one disabled
 	for _, p := range []struct {
-		id      string
-		enabled bool
+		id     string
+		status models.PluginStatus
 	}{
-		{"enabled-plugin", true},
-		{"disabled-plugin", false},
+		{"enabled-plugin", models.PluginStatusActive},
+		{"disabled-plugin", models.PluginStatusDisabled},
 	} {
 		destDir := filepath.Join(pluginDir, "test", p.id)
 		err := os.MkdirAll(destDir, 0755)
@@ -465,7 +497,7 @@ func TestPluginLifecycle_LoadAll(t *testing.T) {
 			ID:          p.id,
 			Name:        p.id,
 			Version:     "1.0.0",
-			Enabled:     p.enabled,
+			Status:      p.status,
 			InstalledAt: time.Now(),
 		}
 		err = service.InstallPlugin(context.Background(), plugin)
@@ -473,7 +505,7 @@ func TestPluginLifecycle_LoadAll(t *testing.T) {
 	}
 
 	// Load all
-	manager := NewManager(service, pluginDir)
+	manager := NewManager(service, pluginDir, "")
 	err := manager.LoadAll(context.Background())
 	require.NoError(t, err)
 
@@ -537,13 +569,13 @@ func TestPluginLifecycle_ReloadPlugin(t *testing.T) {
 		ID:          pluginID,
 		Name:        "Reload Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = service.InstallPlugin(context.Background(), plugin)
 	require.NoError(t, err)
 
-	manager := NewManager(service, pluginDir)
+	manager := NewManager(service, pluginDir, "")
 	ctx := context.Background()
 
 	err = manager.LoadPlugin(ctx, scope, pluginID)

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -2,11 +2,14 @@ package plugins
 
 import (
 	"context"
+	stderrors "errors"
+	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/models"
 )
 
 // reservedExtensions are built-in file types that plugins cannot claim.
@@ -19,29 +22,59 @@ var reservedExtensions = map[string]struct{}{
 // Manager holds loaded Runtime instances indexed by "scope/id".
 // It coordinates loading at startup, unloading, and hot-reloading on install/update/enable.
 type Manager struct {
-	mu        sync.RWMutex
-	plugins   map[string]*Runtime // key: "scope/id"
-	service   *Service
-	pluginDir string
+	mu            sync.RWMutex
+	plugins       map[string]*Runtime // key: "scope/id"
+	service       *Service
+	pluginDir     string
+	pluginDataDir string // Base directory for persistent plugin data
 
 	// fetchRepo is the function used to fetch repository manifests.
 	// Defaults to FetchRepository; tests can override this.
 	fetchRepo func(url string) (*RepositoryManifest, error)
+
+	// onEvent is called when a plugin lifecycle event occurs.
+	// Set via SetEventCallback. May be nil.
+	onEvent PluginEventCallback
 }
 
 // NewManager creates a new Manager.
-func NewManager(service *Service, pluginDir string) *Manager {
+func NewManager(service *Service, pluginDir, pluginDataDir string) *Manager {
 	return &Manager{
-		plugins:   make(map[string]*Runtime),
-		service:   service,
-		pluginDir: pluginDir,
-		fetchRepo: FetchRepository,
+		plugins:       make(map[string]*Runtime),
+		service:       service,
+		pluginDir:     pluginDir,
+		pluginDataDir: pluginDataDir,
+		fetchRepo:     FetchRepository,
+	}
+}
+
+// SetEventCallback registers a callback for plugin lifecycle events.
+// Only one callback is supported; subsequent calls replace the previous one.
+func (m *Manager) SetEventCallback(cb PluginEventCallback) {
+	m.onEvent = cb
+}
+
+// emitEvent fires a plugin lifecycle event if a callback is registered.
+func (m *Manager) emitEvent(eventType PluginEventType, scope, id string, hooks []string) {
+	if m.onEvent != nil {
+		m.onEvent(PluginEvent{
+			Type:  eventType,
+			Scope: scope,
+			ID:    id,
+			Hooks: hooks,
+		})
 	}
 }
 
 // pluginKey returns the map key for a plugin.
 func pluginKey(scope, id string) string {
 	return scope + "/" + id
+}
+
+// isVersionIncompatible checks if the error (or any wrapped error) is ErrVersionIncompatible.
+func isVersionIncompatible(err error) bool {
+	var vErr *ErrVersionIncompatible
+	return stderrors.As(err, &vErr)
 }
 
 // LoadAll loads all enabled plugins from the database at startup.
@@ -55,14 +88,21 @@ func (m *Manager) LoadAll(ctx context.Context) error {
 	}
 
 	for _, p := range plugins {
-		if !p.Enabled {
+		if p.Status != models.PluginStatusActive {
 			continue
 		}
 
 		if err := m.loadPlugin(ctx, p.Scope, p.ID); err != nil {
-			// Store error in the plugin record
 			errMsg := err.Error()
 			p.LoadError = &errMsg
+
+			// Distinguish version incompatibility from other load errors
+			if isVersionIncompatible(err) {
+				p.Status = models.PluginStatusNotSupported
+			} else {
+				p.Status = models.PluginStatusMalfunctioned
+			}
+
 			if updateErr := m.service.UpdatePlugin(ctx, p); updateErr != nil {
 				log.Warn("failed to store load error", logger.Data{
 					"plugin": pluginKey(p.Scope, p.ID),
@@ -76,9 +116,10 @@ func (m *Manager) LoadAll(ctx context.Context) error {
 			continue
 		}
 
-		// Clear any previous LoadError on success
-		if p.LoadError != nil {
+		// Clear any previous LoadError and ensure Active status on success
+		if p.LoadError != nil || p.Status != models.PluginStatusActive {
 			p.LoadError = nil
+			p.Status = models.PluginStatusActive
 			if updateErr := m.service.UpdatePlugin(ctx, p); updateErr != nil {
 				log.Warn("failed to clear load error", logger.Data{
 					"plugin": pluginKey(p.Scope, p.ID),
@@ -104,6 +145,9 @@ func (m *Manager) loadPlugin(ctx context.Context, scope, id string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to load plugin %s/%s", scope, id)
 	}
+
+	// Set the persistent data directory for this plugin
+	rt.dataDir = filepath.Join(m.pluginDataDir, scope, id)
 
 	if err := InjectHostAPIs(rt, m.service); err != nil {
 		return errors.Wrapf(err, "failed to inject host APIs for %s/%s", scope, id)
@@ -140,6 +184,20 @@ func (m *Manager) UnloadPlugin(scope, id string) {
 	m.mu.Unlock()
 }
 
+// DeletePluginData removes the persistent data directory for a plugin.
+// Errors are logged but not returned since this is a best-effort cleanup.
+func (m *Manager) DeletePluginData(scope, id string) {
+	dataDir := filepath.Join(m.pluginDataDir, scope, id)
+	if err := os.RemoveAll(dataDir); err != nil {
+		log := logger.New()
+		log.Warn("failed to delete plugin data directory", logger.Data{
+			"plugin": pluginKey(scope, id),
+			"path":   dataDir,
+			"error":  err.Error(),
+		})
+	}
+}
+
 // ReloadPlugin performs a hot-reload (called during update).
 // Acquires write lock on old runtime (waits for in-progress hooks), then swaps.
 func (m *Manager) ReloadPlugin(ctx context.Context, scope, id string) error {
@@ -150,6 +208,9 @@ func (m *Manager) ReloadPlugin(ctx context.Context, scope, id string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to reload plugin %s/%s", scope, id)
 	}
+
+	// Set the persistent data directory
+	newRT.dataDir = filepath.Join(m.pluginDataDir, scope, id)
 
 	// Inject host APIs into new runtime
 	if err := InjectHostAPIs(newRT, m.service); err != nil {
@@ -392,6 +453,11 @@ func (m *Manager) CheckForUpdates(ctx context.Context) error {
 
 	// For each installed plugin, find latest compatible version from matching repos
 	for _, plugin := range installedPlugins {
+		// Skip plugins with auto-update disabled
+		if !plugin.AutoUpdate {
+			continue
+		}
+
 		var latestVersion string
 
 		for _, sm := range manifests {

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -51,13 +51,19 @@ func NewManager(service *Service, pluginDir, pluginDataDir string) *Manager {
 // SetEventCallback registers a callback for plugin lifecycle events.
 // Only one callback is supported; subsequent calls replace the previous one.
 func (m *Manager) SetEventCallback(cb PluginEventCallback) {
+	m.mu.Lock()
 	m.onEvent = cb
+	m.mu.Unlock()
 }
 
 // emitEvent fires a plugin lifecycle event if a callback is registered.
 func (m *Manager) emitEvent(eventType PluginEventType, scope, id string, hooks []string) {
-	if m.onEvent != nil {
-		m.onEvent(PluginEvent{
+	m.mu.RLock()
+	cb := m.onEvent
+	m.mu.RUnlock()
+
+	if cb != nil {
+		cb(PluginEvent{
 			Type:  eventType,
 			Scope: scope,
 			ID:    id,

--- a/pkg/plugins/manager_test.go
+++ b/pkg/plugins/manager_test.go
@@ -8,9 +8,22 @@ import (
 	"time"
 
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// createInlinePlugin creates a plugin directory with the given manifest and main.js in pluginDir/scope/id/.
+func createInlinePlugin(t *testing.T, pluginDir, scope, id, manifestJSON, mainJS string) {
+	t.Helper()
+	destDir := filepath.Join(pluginDir, scope, id)
+	err := os.MkdirAll(destDir, 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(destDir, "manifest.json"), []byte(manifestJSON), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644)
+	require.NoError(t, err)
+}
 
 // setupTestManager creates a Manager with a temp plugin directory containing
 // the specified testdata plugin(s) copied into scope/id subdirectories.
@@ -32,7 +45,7 @@ func setupTestManager(t *testing.T, plugins ...struct{ scope, id, testdata strin
 		copyTestdataFile(t, srcDir, destDir, "main.js")
 	}
 
-	manager := NewManager(service, pluginDir)
+	manager := NewManager(service, pluginDir, "")
 	return manager, service
 }
 
@@ -54,7 +67,7 @@ func TestManager_LoadAll(t *testing.T) {
 		ID:          "simple-enricher",
 		Name:        "Simple Enricher",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -79,7 +92,7 @@ func TestManager_LoadAll_Disabled(t *testing.T) {
 		ID:          "simple-enricher",
 		Name:        "Simple Enricher",
 		Version:     "1.0.0",
-		Enabled:     false,
+		Status:      models.PluginStatusDisabled,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -97,7 +110,7 @@ func TestManager_LoadAll_LoadError(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
 	pluginDir := t.TempDir()
-	mgr := NewManager(service, pluginDir)
+	mgr := NewManager(service, pluginDir, "")
 	ctx := context.Background()
 
 	// Install a plugin record pointing to non-existent directory
@@ -106,7 +119,7 @@ func TestManager_LoadAll_LoadError(t *testing.T) {
 		ID:          "nonexistent-plugin",
 		Name:        "Nonexistent Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := service.InstallPlugin(ctx, plugin)
@@ -137,7 +150,7 @@ func TestManager_LoadPlugin(t *testing.T) {
 		ID:          "simple-enricher",
 		Name:        "Simple Enricher",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -161,7 +174,7 @@ func TestManager_UnloadPlugin(t *testing.T) {
 		ID:          "simple-enricher",
 		Name:        "Simple Enricher",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -186,7 +199,7 @@ func TestManager_ReloadPlugin(t *testing.T) {
 		ID:          "simple-enricher",
 		Name:        "Simple Enricher",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -215,7 +228,7 @@ func TestManager_GetOrderedRuntimes(t *testing.T) {
 		ID:          "simple-enricher",
 		Name:        "Simple Enricher",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -246,7 +259,7 @@ func TestManager_RegisteredFileExtensions(t *testing.T) {
 		ID:          "multi-hook",
 		Name:        "Multi Hook Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -296,7 +309,7 @@ func TestManager_RegisteredFileExtensions_SkipsReserved(t *testing.T) {
 	err = os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644)
 	require.NoError(t, err)
 
-	mgr := NewManager(service, pluginDir)
+	mgr := NewManager(service, pluginDir, "")
 	ctx := context.Background()
 
 	plugin := &models.Plugin{
@@ -304,7 +317,7 @@ func TestManager_RegisteredFileExtensions_SkipsReserved(t *testing.T) {
 		ID:          "reserved-parser",
 		Name:        "Reserved Parser",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = service.InstallPlugin(ctx, plugin)
@@ -331,7 +344,7 @@ func TestManager_RegisteredConverterExtensions(t *testing.T) {
 		ID:          "multi-hook",
 		Name:        "Multi Hook Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -353,7 +366,7 @@ func TestManager_GetParserForType(t *testing.T) {
 		ID:          "multi-hook",
 		Name:        "Multi Hook Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := svc.InstallPlugin(ctx, plugin)
@@ -394,8 +407,8 @@ func TestManager_GetOrderedRuntimes_WithLibrary(t *testing.T) {
 	library := insertTestLibrary(t, db, "Test Library")
 
 	// Install two plugins
-	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Enabled: true}
-	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Enabled: true}
+	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Status: models.PluginStatusActive}
+	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(p1).Exec(ctx)
 	require.NoError(t, err)
 	_, err = db.NewInsert().Model(p2).Exec(ctx)
@@ -456,8 +469,8 @@ func TestManager_GetOrderedRuntimes_GlobalDisabledExcluded(t *testing.T) {
 	library := insertTestLibrary(t, db, "Test Library")
 
 	// Install two plugins
-	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Enabled: true}
-	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Enabled: true}
+	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Status: models.PluginStatusActive}
+	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(p1).Exec(ctx)
 	require.NoError(t, err)
 	_, err = db.NewInsert().Model(p2).Exec(ctx)
@@ -493,4 +506,139 @@ func TestManager_GetOrderedRuntimes_GlobalDisabledExcluded(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, runtimes, 1)
 	assert.Equal(t, "enricher1", runtimes[0].pluginID)
+}
+
+func TestManager_LoadAll_VersionIncompatible_SetsNotSupported(t *testing.T) {
+	// Set a known current version for this test
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	db := setupTestDB(t)
+	service := NewService(db)
+	pluginDir := t.TempDir()
+
+	// Create a plugin that requires version 99.0.0
+	manifestJSON := `{"manifestVersion":1,"id":"future-plugin","name":"Future Plugin","version":"1.0.0","minShishoVersion":"99.0.0","capabilities":{"metadataEnricher":{"fields":["title"]}}}`
+	mainJS := `var plugin=(function(){return{metadataEnricher:{enrich:function(ctx){return{modified:false}}}};})();`
+	createInlinePlugin(t, pluginDir, "test", "future-plugin", manifestJSON, mainJS)
+
+	mgr := NewManager(service, pluginDir, "")
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "test",
+		ID:          "future-plugin",
+		Name:        "Future Plugin",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err := service.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	// LoadAll should not return error but should set NotSupported status
+	err = mgr.LoadAll(ctx)
+	require.NoError(t, err)
+
+	// Runtime should not be loaded
+	rt := mgr.GetRuntime("test", "future-plugin")
+	assert.Nil(t, rt)
+
+	// Status should be NotSupported with descriptive error
+	retrieved, err := service.RetrievePlugin(ctx, "test", "future-plugin")
+	require.NoError(t, err)
+	assert.Equal(t, models.PluginStatusNotSupported, retrieved.Status)
+	require.NotNil(t, retrieved.LoadError)
+	assert.Contains(t, *retrieved.LoadError, "requires Shisho version 99.0.0")
+	assert.Contains(t, *retrieved.LoadError, "current: 1.0.0")
+}
+
+func TestManager_LoadPlugin_VersionIncompatible(t *testing.T) {
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	db := setupTestDB(t)
+	service := NewService(db)
+	pluginDir := t.TempDir()
+
+	manifestJSON := `{"manifestVersion":1,"id":"future-plugin","name":"Future Plugin","version":"1.0.0","minShishoVersion":"99.0.0"}`
+	mainJS := `var plugin=(function(){return{};})();`
+	createInlinePlugin(t, pluginDir, "test", "future-plugin", manifestJSON, mainJS)
+
+	mgr := NewManager(service, pluginDir, "")
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "test",
+		ID:          "future-plugin",
+		Name:        "Future Plugin",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err := service.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	// LoadPlugin should return ErrVersionIncompatible
+	err = mgr.LoadPlugin(ctx, "test", "future-plugin")
+	require.Error(t, err)
+
+	var vErr *ErrVersionIncompatible
+	assert.ErrorAs(t, err, &vErr)
+}
+
+func TestManager_LoadPlugin_CompatibleVersion(t *testing.T) {
+	origVersion := version.Version
+	version.Version = "2.0.0"
+	defer func() { version.Version = origVersion }()
+
+	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "simple-enricher", "simple-enricher"})
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "test",
+		ID:          "simple-enricher",
+		Name:        "Simple Enricher",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err := svc.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	// Should load successfully (simple-enricher has no minShishoVersion or compatible one)
+	err = mgr.LoadPlugin(ctx, "test", "simple-enricher")
+	require.NoError(t, err)
+
+	rt := mgr.GetRuntime("test", "simple-enricher")
+	require.NotNil(t, rt)
+}
+
+func TestManager_LoadPlugin_NoMinVersion(t *testing.T) {
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "simple-enricher", "simple-enricher"})
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "test",
+		ID:          "simple-enricher",
+		Name:        "Simple Enricher",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err := svc.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	// Should load successfully (no minShishoVersion = always compatible)
+	err = mgr.LoadPlugin(ctx, "test", "simple-enricher")
+	require.NoError(t, err)
+
+	rt := mgr.GetRuntime("test", "simple-enricher")
+	require.NotNil(t, rt)
 }

--- a/pkg/plugins/manifest.go
+++ b/pkg/plugins/manifest.go
@@ -14,6 +14,7 @@ type Manifest struct {
 	ID               string       `json:"id"`
 	Name             string       `json:"name"`
 	Version          string       `json:"version"`
+	Overview         string       `json:"overview"`
 	Description      string       `json:"description"`
 	Author           string       `json:"author"`
 	Homepage         string       `json:"homepage"`

--- a/pkg/plugins/repository.go
+++ b/pkg/plugins/repository.go
@@ -27,9 +27,11 @@ type RepositoryManifest struct {
 type AvailablePlugin struct {
 	ID          string          `json:"id"`
 	Name        string          `json:"name"`
+	Overview    string          `json:"overview"`
 	Description string          `json:"description"`
 	Author      string          `json:"author"`
 	Homepage    string          `json:"homepage"`
+	ImageURL    string          `json:"imageUrl"`
 	Versions    []PluginVersion `json:"versions"`
 }
 

--- a/pkg/plugins/routes.go
+++ b/pkg/plugins/routes.go
@@ -4,11 +4,12 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/uptrace/bun"
 )
 
 // RegisterRoutesWithGroup registers plugin management API routes.
-func RegisterRoutesWithGroup(g *echo.Group, service *Service, manager *Manager, installer *Installer) {
-	h := &handler{service: service, manager: manager, installer: installer}
+func RegisterRoutesWithGroup(g *echo.Group, service *Service, manager *Manager, installer *Installer, db *bun.DB) {
+	h := &handler{service: service, manager: manager, installer: installer, db: db}
 
 	g.GET("/identifier-types", h.listIdentifierTypes)
 	g.GET("/installed", h.listInstalled)
@@ -19,6 +20,7 @@ func RegisterRoutesWithGroup(g *echo.Group, service *Service, manager *Manager, 
 	g.GET("/installed/:scope/:id/config", h.getConfig)
 	g.GET("/installed/:scope/:id/fields", h.getFieldSettings)
 	g.PUT("/installed/:scope/:id/fields", h.setFieldSettings)
+	g.GET("/installed/:scope/:id/image", h.getImage)
 	g.POST("/installed/:scope/:id/reload", h.reload)
 	g.POST("/installed/:scope/:id/update", h.updateVersion)
 	g.GET("/order/:hookType", h.getOrder)
@@ -28,6 +30,9 @@ func RegisterRoutesWithGroup(g *echo.Group, service *Service, manager *Manager, 
 	g.POST("/repositories", h.addRepository)
 	g.DELETE("/repositories/:scope", h.removeRepository)
 	g.POST("/repositories/:scope/sync", h.syncRepository)
+
+	g.POST("/search", h.searchMetadata)
+	g.POST("/enrich", h.enrichMetadata)
 
 	g.GET("/available", h.listAvailable)
 	g.GET("/available/:scope/:id", h.retrieveAvailable)

--- a/pkg/plugins/routes.go
+++ b/pkg/plugins/routes.go
@@ -7,9 +7,32 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// EnrichDeps holds optional dependencies for the enrich endpoint.
+// If nil, the enrich endpoint returns metadata without persisting it.
+type EnrichDeps struct {
+	BookStore     bookStore
+	RelStore      relationStore
+	IdentStore    identifierStore
+	PersonFinder  personFinder
+	GenreFinder   genreFinder
+	TagFinder     tagFinder
+	SearchIndexer searchIndexer
+}
+
 // RegisterRoutesWithGroup registers plugin management API routes.
-func RegisterRoutesWithGroup(g *echo.Group, service *Service, manager *Manager, installer *Installer, db *bun.DB) {
+func RegisterRoutesWithGroup(g *echo.Group, service *Service, manager *Manager, installer *Installer, db *bun.DB, ed *EnrichDeps) {
 	h := &handler{service: service, manager: manager, installer: installer, db: db}
+	if ed != nil {
+		h.enrich = &enrichDeps{
+			bookStore:     ed.BookStore,
+			relStore:      ed.RelStore,
+			identStore:    ed.IdentStore,
+			personFinder:  ed.PersonFinder,
+			genreFinder:   ed.GenreFinder,
+			tagFinder:     ed.TagFinder,
+			searchIndexer: ed.SearchIndexer,
+		}
+	}
 
 	g.GET("/identifier-types", h.listIdentifierTypes)
 	g.GET("/installed", h.listInstalled)

--- a/pkg/plugins/runtime.go
+++ b/pkg/plugins/runtime.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -8,7 +9,20 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/version"
 )
+
+// ErrVersionIncompatible is returned when a plugin requires a newer Shisho version.
+// The Manager uses this to distinguish version incompatibility from other load errors
+// and set the appropriate PluginStatusNotSupported status.
+type ErrVersionIncompatible struct {
+	PluginMinVersion string
+	CurrentVersion   string
+}
+
+func (e *ErrVersionIncompatible) Error() string {
+	return fmt.Sprintf("plugin requires Shisho version %s or later (current: %s)", e.PluginMinVersion, e.CurrentVersion)
+}
 
 // Runtime wraps a goja VM for a single plugin. It loads manifest.json,
 // executes main.js (which defines a `plugin` global via IIFE), and extracts
@@ -19,12 +33,14 @@ type Runtime struct {
 	manifest *Manifest
 	scope    string
 	pluginID string
+	dataDir  string // Persistent data directory for this plugin
 
 	// Hook function references (nil if not provided by the plugin)
 	inputConverter   goja.Value
 	fileParser       goja.Value
 	outputGenerator  goja.Value
 	metadataEnricher goja.Value
+	onUninstalling   goja.Callable // Optional lifecycle hook called before uninstall
 
 	// fsCtx is the filesystem context for the current hook invocation.
 	// Set by hook execution code before invoking hooks, cleared after.
@@ -50,7 +66,15 @@ func LoadPlugin(dir, scope, pluginID string) (*Runtime, error) {
 		return nil, errors.Wrap(err, "failed to parse manifest")
 	}
 
-	// 2. Read main.js
+	// 2. Check version compatibility before loading JS
+	if manifest.MinShishoVersion != "" && !version.IsCompatible(manifest.MinShishoVersion) {
+		return nil, &ErrVersionIncompatible{
+			PluginMinVersion: manifest.MinShishoVersion,
+			CurrentVersion:   version.Version,
+		}
+	}
+
+	// 3. Read main.js
 	mainJSPath := filepath.Join(dir, "main.js")
 	mainJS, err := os.ReadFile(mainJSPath)
 	if err != nil {
@@ -91,6 +115,13 @@ func LoadPlugin(dir, scope, pluginID string) (*Runtime, error) {
 	rt.fileParser = extractHook(pluginObj, "fileParser")
 	rt.outputGenerator = extractHook(pluginObj, "outputGenerator")
 	rt.metadataEnricher = extractHook(pluginObj, "metadataEnricher")
+
+	// Extract optional lifecycle hook (no manifest capability needed)
+	if val := pluginObj.Get("onUninstalling"); val != nil && !goja.IsUndefined(val) && !goja.IsNull(val) {
+		if fn, ok := goja.AssertFunction(val); ok {
+			rt.onUninstalling = fn
+		}
+	}
 
 	// 8. Validate: If manifest declares a capability but JS doesn't export it -> warning (don't fail)
 	// (Warnings are silent for now; could be logged in the future)

--- a/pkg/plugins/service_library_test.go
+++ b/pkg/plugins/service_library_test.go
@@ -55,11 +55,11 @@ func TestService_GetLibraryOrder(t *testing.T) {
 	library := insertTestLibrary(t, db, "Test Library")
 
 	// Setup: install plugins first
-	plugin := &models.Plugin{Scope: "test", ID: "enricher", Name: "Test Enricher", Version: "1.0.0", Enabled: true}
+	plugin := &models.Plugin{Scope: "test", ID: "enricher", Name: "Test Enricher", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(plugin).Exec(ctx)
 	require.NoError(t, err)
 
-	plugin2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Test Enricher 2", Version: "1.0.0", Enabled: true}
+	plugin2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Test Enricher 2", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err = db.NewInsert().Model(plugin2).Exec(ctx)
 	require.NoError(t, err)
 
@@ -91,7 +91,7 @@ func TestService_ResetLibraryOrder(t *testing.T) {
 	library := insertTestLibrary(t, db, "Test Library")
 
 	// Setup
-	plugin := &models.Plugin{Scope: "test", ID: "enricher", Name: "Test Enricher", Version: "1.0.0", Enabled: true}
+	plugin := &models.Plugin{Scope: "test", ID: "enricher", Name: "Test Enricher", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(plugin).Exec(ctx)
 	require.NoError(t, err)
 
@@ -121,7 +121,7 @@ func TestService_ResetAllLibraryOrders(t *testing.T) {
 	library := insertTestLibrary(t, db, "Test Library")
 
 	// Setup
-	plugin := &models.Plugin{Scope: "test", ID: "enricher", Name: "Test Enricher", Version: "1.0.0", Enabled: true}
+	plugin := &models.Plugin{Scope: "test", ID: "enricher", Name: "Test Enricher", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(plugin).Exec(ctx)
 	require.NoError(t, err)
 

--- a/pkg/plugins/service_test.go
+++ b/pkg/plugins/service_test.go
@@ -44,7 +44,7 @@ func insertTestPlugin(t *testing.T, db *bun.DB, scope, id string) *models.Plugin
 		ID:          id,
 		Name:        id + " Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	_, err := db.NewInsert().Model(plugin).Exec(context.Background())
@@ -66,7 +66,7 @@ func TestService_InstallAndRetrievePlugin(t *testing.T) {
 		Version:     "1.0.0",
 		Description: &desc,
 		Author:      &author,
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now().UTC().Truncate(time.Second),
 	}
 
@@ -79,7 +79,7 @@ func TestService_InstallAndRetrievePlugin(t *testing.T) {
 	assert.Equal(t, "1.0.0", retrieved.Version)
 	assert.Equal(t, &desc, retrieved.Description)
 	assert.Equal(t, &author, retrieved.Author)
-	assert.True(t, retrieved.Enabled)
+	assert.Equal(t, models.PluginStatusActive, retrieved.Status)
 
 	// Test not found
 	_, err = svc.RetrievePlugin(ctx, "community", "nonexistent")
@@ -116,7 +116,7 @@ func TestService_UpdatePlugin(t *testing.T) {
 	plugin := insertTestPlugin(t, db, "community", "test-plugin")
 
 	plugin.Version = "2.0.0"
-	plugin.Enabled = false
+	plugin.Status = models.PluginStatusDisabled
 	now := time.Now().UTC().Truncate(time.Second)
 	plugin.UpdatedAt = &now
 
@@ -126,7 +126,7 @@ func TestService_UpdatePlugin(t *testing.T) {
 	retrieved, err := svc.RetrievePlugin(ctx, "community", "test-plugin")
 	require.NoError(t, err)
 	assert.Equal(t, "2.0.0", retrieved.Version)
-	assert.False(t, retrieved.Enabled)
+	assert.Equal(t, models.PluginStatusDisabled, retrieved.Status)
 	assert.NotNil(t, retrieved.UpdatedAt)
 }
 

--- a/pkg/plugins/testdata/hooks-enricher/main.js
+++ b/pkg/plugins/testdata/hooks-enricher/main.js
@@ -1,11 +1,33 @@
 var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(context) {
+        return {
+          results: [
+            {
+              title: "Search: " + context.query,
+              authors: ["Search Author"],
+              description: "Found result for " + context.query,
+              publisher: "Search Publisher",
+              identifiers: [
+                { type: "goodreads", value: "12345" }
+              ],
+              providerData: { internalId: 42, query: context.query }
+            }
+          ]
+        };
+      },
       enrich: function(context) {
+        var title = "";
+        if (context.selectedResult && context.selectedResult.query) {
+          title = context.selectedResult.query;
+        } else if (context.book && context.book.title) {
+          title = context.book.title;
+        }
         return {
           modified: true,
           metadata: {
-            description: "Enriched: " + context.book.title,
+            description: "Enriched: " + title,
             genres: ["Enriched Genre"],
             tags: ["enriched-tag"],
             identifiers: [

--- a/pkg/plugins/testdata/simple-enricher/main.js
+++ b/pkg/plugins/testdata/simple-enricher/main.js
@@ -2,6 +2,9 @@ var plugin = (function() {
   var metadataEnricher = {
     name: "Simple Enricher",
     fileTypes: ["epub"],
+    search: function(context) {
+      return { results: [] };
+    },
     enrich: function(context) {
       return { modified: false };
     }

--- a/pkg/plugins/update_check_test.go
+++ b/pkg/plugins/update_check_test.go
@@ -14,7 +14,7 @@ import (
 func TestManager_CheckForUpdates_UpdateAvailable(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
-	mgr := NewManager(service, t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
 	ctx := context.Background()
 
 	// Install a plugin at version 1.0.0
@@ -23,7 +23,7 @@ func TestManager_CheckForUpdates_UpdateAvailable(t *testing.T) {
 		ID:          "my-plugin",
 		Name:        "My Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := service.InstallPlugin(ctx, plugin)
@@ -72,7 +72,7 @@ func TestManager_CheckForUpdates_UpdateAvailable(t *testing.T) {
 func TestManager_CheckForUpdates_AlreadyUpToDate(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
-	mgr := NewManager(service, t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
 	ctx := context.Background()
 
 	// Install a plugin already at the latest version
@@ -81,7 +81,7 @@ func TestManager_CheckForUpdates_AlreadyUpToDate(t *testing.T) {
 		ID:          "my-plugin",
 		Name:        "My Plugin",
 		Version:     "2.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := service.InstallPlugin(ctx, plugin)
@@ -127,7 +127,7 @@ func TestManager_CheckForUpdates_AlreadyUpToDate(t *testing.T) {
 func TestManager_CheckForUpdates_ClearsStaleUpdate(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
-	mgr := NewManager(service, t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
 	ctx := context.Background()
 
 	// Install a plugin that was previously flagged as having an update
@@ -137,7 +137,7 @@ func TestManager_CheckForUpdates_ClearsStaleUpdate(t *testing.T) {
 		ID:                     "my-plugin",
 		Name:                   "My Plugin",
 		Version:                "2.0.0",
-		Enabled:                true,
+		Status:                 models.PluginStatusActive,
 		InstalledAt:            time.Now(),
 		UpdateAvailableVersion: &staleVersion,
 	}
@@ -184,7 +184,7 @@ func TestManager_CheckForUpdates_ClearsStaleUpdate(t *testing.T) {
 func TestManager_CheckForUpdates_DisabledRepoSkipped(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
-	mgr := NewManager(service, t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
 	ctx := context.Background()
 
 	// Remove the seeded official repository so we control what's in the DB
@@ -196,7 +196,7 @@ func TestManager_CheckForUpdates_DisabledRepoSkipped(t *testing.T) {
 		ID:          "my-plugin",
 		Name:        "My Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = service.InstallPlugin(ctx, plugin)
@@ -247,7 +247,7 @@ func TestManager_CheckForUpdates_DisabledRepoSkipped(t *testing.T) {
 func TestManager_CheckForUpdates_FetchErrorSkipped(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
-	mgr := NewManager(service, t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
 	ctx := context.Background()
 
 	plugin := &models.Plugin{
@@ -255,7 +255,7 @@ func TestManager_CheckForUpdates_FetchErrorSkipped(t *testing.T) {
 		ID:          "my-plugin",
 		Name:        "My Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := service.InstallPlugin(ctx, plugin)
@@ -289,7 +289,7 @@ func TestManager_CheckForUpdates_FetchErrorSkipped(t *testing.T) {
 func TestManager_CheckForUpdates_IncompatibleVersionsFiltered(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
-	mgr := NewManager(service, t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
 	ctx := context.Background()
 
 	plugin := &models.Plugin{
@@ -297,7 +297,7 @@ func TestManager_CheckForUpdates_IncompatibleVersionsFiltered(t *testing.T) {
 		ID:          "my-plugin",
 		Name:        "My Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := service.InstallPlugin(ctx, plugin)
@@ -344,7 +344,7 @@ func TestManager_CheckForUpdates_IncompatibleVersionsFiltered(t *testing.T) {
 func TestManager_CheckForUpdates_NoPlugins(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
-	mgr := NewManager(service, t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
 	ctx := context.Background()
 
 	// No plugins installed — should return immediately without error
@@ -355,7 +355,7 @@ func TestManager_CheckForUpdates_NoPlugins(t *testing.T) {
 func TestManager_CheckForUpdates_ScopeMismatch(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)
-	mgr := NewManager(service, t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
 	ctx := context.Background()
 
 	// Plugin from scope "community"
@@ -364,7 +364,7 @@ func TestManager_CheckForUpdates_ScopeMismatch(t *testing.T) {
 		ID:          "my-plugin",
 		Name:        "My Plugin",
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err := service.InstallPlugin(ctx, plugin)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -189,7 +189,7 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 	pluginsGroup.Use(authMiddleware.RequirePermission(models.ResourceConfig, models.OperationWrite))
 	pluginService := plugins.NewService(db)
 	pluginInstaller := plugins.NewInstaller(cfg.PluginDir)
-	plugins.RegisterRoutesWithGroup(pluginsGroup, pluginService, pm, pluginInstaller)
+	plugins.RegisterRoutesWithGroup(pluginsGroup, pluginService, pm, pluginInstaller, db)
 }
 
 func notFoundHandler(c echo.Context) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -189,10 +190,78 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 	pluginsGroup.Use(authMiddleware.RequirePermission(models.ResourceConfig, models.OperationWrite))
 	pluginService := plugins.NewService(db)
 	pluginInstaller := plugins.NewInstaller(cfg.PluginDir)
-	plugins.RegisterRoutesWithGroup(pluginsGroup, pluginService, pm, pluginInstaller, db)
+	bookSvc := books.NewService(db)
+	bookAdapter := &bookUpdaterAdapter{svc: bookSvc}
+	enrichDeps := &plugins.EnrichDeps{
+		BookStore:     bookAdapter,
+		RelStore:      bookAdapter,
+		IdentStore:    bookAdapter,
+		PersonFinder:  people.NewService(db),
+		GenreFinder:   genres.NewService(db),
+		TagFinder:     tags.NewService(db),
+		SearchIndexer: search.NewService(db),
+	}
+	plugins.RegisterRoutesWithGroup(pluginsGroup, pluginService, pm, pluginInstaller, db, enrichDeps)
 }
 
 func notFoundHandler(c echo.Context) error {
 	c.SetPath("/:path")
 	return errcodes.NotFound("Page")
+}
+
+// bookUpdaterAdapter adapts books.Service to plugins.BookUpdater.
+type bookUpdaterAdapter struct {
+	svc *books.Service
+}
+
+func (a *bookUpdaterAdapter) UpdateBook(ctx context.Context, book *models.Book, columns []string) error {
+	return a.svc.UpdateBook(ctx, book, books.UpdateBookOptions{Columns: columns})
+}
+
+func (a *bookUpdaterAdapter) RetrieveBook(ctx context.Context, bookID int) (*models.Book, error) {
+	return a.svc.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
+}
+
+func (a *bookUpdaterAdapter) DeleteAuthors(ctx context.Context, bookID int) error {
+	return a.svc.DeleteAuthors(ctx, bookID)
+}
+
+func (a *bookUpdaterAdapter) CreateAuthor(ctx context.Context, author *models.Author) error {
+	return a.svc.CreateAuthor(ctx, author)
+}
+
+func (a *bookUpdaterAdapter) DeleteBookSeries(ctx context.Context, bookID int) error {
+	return a.svc.DeleteBookSeries(ctx, bookID)
+}
+
+func (a *bookUpdaterAdapter) CreateBookSeries(ctx context.Context, bs *models.BookSeries) error {
+	return a.svc.CreateBookSeries(ctx, bs)
+}
+
+func (a *bookUpdaterAdapter) FindOrCreateSeries(ctx context.Context, name string, libraryID int, nameSource string) (*models.Series, error) {
+	return a.svc.FindOrCreateSeries(ctx, name, libraryID, nameSource)
+}
+
+func (a *bookUpdaterAdapter) DeleteBookGenres(ctx context.Context, bookID int) error {
+	return a.svc.DeleteBookGenres(ctx, bookID)
+}
+
+func (a *bookUpdaterAdapter) CreateBookGenre(ctx context.Context, bg *models.BookGenre) error {
+	return a.svc.CreateBookGenre(ctx, bg)
+}
+
+func (a *bookUpdaterAdapter) DeleteBookTags(ctx context.Context, bookID int) error {
+	return a.svc.DeleteBookTags(ctx, bookID)
+}
+
+func (a *bookUpdaterAdapter) CreateBookTag(ctx context.Context, bt *models.BookTag) error {
+	return a.svc.CreateBookTag(ctx, bt)
+}
+
+func (a *bookUpdaterAdapter) DeleteIdentifiersForFile(ctx context.Context, fileID int) (int, error) {
+	return a.svc.DeleteIdentifiersForFile(ctx, fileID)
+}
+
+func (a *bookUpdaterAdapter) CreateFileIdentifier(ctx context.Context, identifier *models.FileIdentifier) error {
+	return a.svc.CreateFileIdentifier(ctx, identifier)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -13,11 +13,17 @@ var Version = "dev"
 // minimum version requirement. Returns true if either version is empty,
 // "dev", or not parseable as semver (permissive by default).
 func IsCompatible(minVersion string) bool {
-	if minVersion == "" || Version == "" || Version == "dev" {
+	return isVersionCompatible(Version, minVersion)
+}
+
+// isVersionCompatible returns true if currentVersion satisfies the given
+// minimum version requirement. Extracted for testability (avoids mutating global).
+func isVersionCompatible(currentVersion, minVersion string) bool {
+	if minVersion == "" || currentVersion == "" || currentVersion == "dev" {
 		return true
 	}
 
-	currentParts := parseSemver(Version)
+	currentParts := parseSemver(currentVersion)
 	minParts := parseSemver(minVersion)
 	if currentParts == nil || minParts == nil {
 		return true // Can't parse, assume compatible

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,61 @@
 package version
 
+import (
+	"strconv"
+	"strings"
+)
+
 // Version is the application version, set at build time via ldflags.
 // Example: go build -ldflags "-X github.com/shishobooks/shisho/pkg/version.Version=1.0.0".
 var Version = "dev"
+
+// IsCompatible returns true if the current Version satisfies the given
+// minimum version requirement. Returns true if either version is empty,
+// "dev", or not parseable as semver (permissive by default).
+func IsCompatible(minVersion string) bool {
+	if minVersion == "" || Version == "" || Version == "dev" {
+		return true
+	}
+
+	currentParts := parseSemver(Version)
+	minParts := parseSemver(minVersion)
+	if currentParts == nil || minParts == nil {
+		return true // Can't parse, assume compatible
+	}
+
+	for i := 0; i < 3; i++ {
+		if currentParts[i] > minParts[i] {
+			return true
+		}
+		if currentParts[i] < minParts[i] {
+			return false
+		}
+	}
+	return true // Equal
+}
+
+// parseSemver extracts [major, minor, patch] from a semver string.
+// Returns nil if the string cannot be parsed.
+func parseSemver(s string) []int {
+	// Strip leading "v" if present
+	s = strings.TrimPrefix(s, "v")
+	// Strip anything after a hyphen (pre-release)
+	if idx := strings.Index(s, "-"); idx >= 0 {
+		s = s[:idx]
+	}
+
+	parts := strings.Split(s, ".")
+	if len(parts) < 1 || len(parts) > 3 {
+		return nil
+	}
+
+	result := make([]int, 3)
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return nil
+		}
+		result[i] = n
+	}
+	return result
+}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -37,11 +37,7 @@ func TestIsCompatible(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			origVersion := Version
-			Version = tt.version
-			defer func() { Version = origVersion }()
-
-			got := IsCompatible(tt.minVersion)
+			got := isVersionCompatible(tt.version, tt.minVersion)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -1,0 +1,75 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCompatible(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		version    string // current Version
+		minVersion string
+		want       bool
+	}{
+		{"empty minVersion", "1.0.0", "", true},
+		{"empty Version", "", "1.0.0", true},
+		{"dev Version", "dev", "1.0.0", true},
+		{"equal versions", "1.0.0", "1.0.0", true},
+		{"current newer major", "2.0.0", "1.0.0", true},
+		{"current newer minor", "1.2.0", "1.1.0", true},
+		{"current newer patch", "1.0.2", "1.0.1", true},
+		{"current older major", "1.0.0", "2.0.0", false},
+		{"current older minor", "1.0.0", "1.1.0", false},
+		{"current older patch", "1.0.0", "1.0.1", false},
+		{"with v prefix", "v1.2.0", "1.1.0", true},
+		{"both v prefix", "v1.2.0", "v1.3.0", false},
+		{"with prerelease", "1.2.0-beta.1", "1.1.0", true},
+		{"unparseable current", "abc", "1.0.0", true},
+		{"unparseable min", "1.0.0", "abc", true},
+		{"partial version", "1.2", "1.1.0", true},
+		{"partial min version", "1.2.0", "1.1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			origVersion := Version
+			Version = tt.version
+			defer func() { Version = origVersion }()
+
+			got := IsCompatible(tt.minVersion)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseSemver(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		s    string
+		want []int
+	}{
+		{"basic", "1.2.3", []int{1, 2, 3}},
+		{"with v prefix", "v1.2.3", []int{1, 2, 3}},
+		{"with prerelease", "1.2.3-beta.1", []int{1, 2, 3}},
+		{"partial two", "1.2", []int{1, 2, 0}},
+		{"partial one", "1", []int{1, 0, 0}},
+		{"invalid", "abc", nil},
+		{"empty", "", nil},
+		{"too many parts", "1.2.3.4", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseSemver(tt.s)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/worker/scan_plugins_test.go
+++ b/pkg/worker/scan_plugins_test.go
@@ -23,7 +23,7 @@ func newTestContextWithPlugins(t *testing.T, pluginDir string) *testContext {
 	tc := newTestContext(t)
 
 	pluginService := plugins.NewService(tc.db)
-	pm := plugins.NewManager(pluginService, pluginDir)
+	pm := plugins.NewManager(pluginService, pluginDir, "")
 
 	tc.worker.pluginService = pluginService
 	tc.worker.pluginManager = pm
@@ -50,7 +50,7 @@ func installTestPlugin(t *testing.T, tc *testContext, pluginDir, id, manifestJSO
 		ID:          id,
 		Name:        id,
 		Version:     "1.0.0",
-		Enabled:     true,
+		Status:      models.PluginStatusActive,
 		InstalledAt: time.Now(),
 	}
 	err = plugins.NewService(tc.db).InstallPlugin(context.Background(), plugin)
@@ -455,11 +455,20 @@ func TestScanWithPluginMetadataEnricher(t *testing.T) {
 	enricherMainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: { query: ctx.query } }] };
+      },
       enrich: function(ctx) {
+        var title = "";
+        if (ctx.selectedResult && ctx.selectedResult.query) {
+          title = ctx.selectedResult.query;
+        } else if (ctx.book && ctx.book.title) {
+          title = ctx.book.title;
+        }
         return {
           modified: true,
           metadata: {
-            description: "Enriched description for: " + ctx.parsedMetadata.title,
+            description: "Enriched description for: " + title,
             genres: ["Fantasy", "Adventure"]
           }
         };
@@ -561,6 +570,9 @@ func TestScanWithPluginMetadataEnricher_FileTypeFiltering(t *testing.T) {
 	enricherMainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,
@@ -654,6 +666,9 @@ func TestScanWithPluginMetadataEnricher_Ordering(t *testing.T) {
 	enricher1MainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,
@@ -685,6 +700,9 @@ func TestScanWithPluginMetadataEnricher_Ordering(t *testing.T) {
 	enricher2MainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,
@@ -787,6 +805,9 @@ func TestScanWithPluginMetadataEnricher_CascadingFieldSources(t *testing.T) {
 	enricher1MainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,
@@ -819,6 +840,9 @@ func TestScanWithPluginMetadataEnricher_CascadingFieldSources(t *testing.T) {
 	enricher2MainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,
@@ -1121,6 +1145,9 @@ func TestScanWithPluginMetadataEnricher_AllSourcesSet(t *testing.T) {
 	enricherMainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,
@@ -1352,6 +1379,9 @@ func TestScanWithPluginMetadataEnricher_IdentifiersMergedWithParser(t *testing.T
 	enricherMainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,
@@ -1694,6 +1724,9 @@ func TestScanWithPluginMetadataEnricher_FieldFiltering(t *testing.T) {
 	enricherMainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,
@@ -1801,6 +1834,9 @@ func TestScanWithPluginMetadataEnricher_UndeclaredFieldFiltered(t *testing.T) {
 	enricherMainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,
@@ -1903,6 +1939,9 @@ func TestScanWithPluginMetadataEnricher_PerLibraryFieldOverride(t *testing.T) {
 	enricherMainJS := `var plugin = (function() {
   return {
     metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, providerData: {} }] };
+      },
       enrich: function(ctx) {
         return {
           modified: true,

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2528,6 +2528,8 @@ func (w *Worker) parseFileMetadata(ctx context.Context, path, fileType string) (
 }
 
 // runMetadataEnrichers runs metadata enricher plugins on parsed metadata.
+// Uses the search→first→enrich pattern: each enricher's search() is called with the
+// book title as query, then the first result is passed to enrich() for full metadata.
 // Each enricher is called in user-defined order; first non-empty value per field wins.
 func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.ParsedMetadata, file *models.File, book *models.Book, libraryID int, jobLog *joblogs.JobLogger) *mediafile.ParsedMetadata {
 	if w.pluginManager == nil || metadata == nil {
@@ -2548,12 +2550,15 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 		}
 	}
 
-	// Build enrichment context
-	enrichCtx := map[string]interface{}{
-		"parsedMetadata": buildParsedMetadataContext(metadata),
-		"file":           buildFileContext(file),
-		"book":           buildBookContext(book, file),
+	// Determine search query: use book title if available, fall back to parsed title
+	query := book.Title
+	if query == "" && metadata != nil {
+		query = metadata.Title
 	}
+
+	// Build shared context objects
+	fileCtx := buildFileContext(file)
+	bookCtx := buildBookContext(book, file)
 
 	var enrichedMeta mediafile.ParsedMetadata
 	modified := false
@@ -2575,9 +2580,38 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 			continue
 		}
 
-		result, eErr := w.pluginManager.RunMetadataEnricher(ctx, rt, enrichCtx)
+		// Phase 1: Search for candidates
+		searchCtx := map[string]interface{}{
+			"query": query,
+			"book":  bookCtx,
+			"file":  fileCtx,
+		}
+
+		searchResp, sErr := w.pluginManager.RunMetadataSearch(ctx, rt, searchCtx)
+		if sErr != nil {
+			logWarn("enricher search failed", logger.Data{
+				"plugin": rt.Manifest().ID,
+				"error":  sErr.Error(),
+			})
+			continue
+		}
+		if searchResp == nil || len(searchResp.Results) == 0 {
+			continue
+		}
+
+		// Take the first result
+		firstResult := searchResp.Results[0]
+
+		// Phase 2: Enrich with the selected result
+		enrichCtx := map[string]interface{}{
+			"selectedResult": firstResult.ProviderData,
+			"book":           bookCtx,
+			"file":           fileCtx,
+		}
+
+		result, eErr := w.pluginManager.RunMetadataEnrich(ctx, rt, enrichCtx)
 		if eErr != nil {
-			logWarn("enricher plugin failed", logger.Data{
+			logWarn("enricher enrich failed", logger.Data{
 				"plugin": rt.Manifest().ID,
 				"error":  eErr.Error(),
 			})
@@ -2614,7 +2648,7 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 		modified = true
 	}
 
-	// Phase 2: Merge file-parsed metadata as fallback for fields no enricher provided.
+	// Phase 3: Merge file-parsed metadata as fallback for fields no enricher provided.
 	// This gives enrichers priority over file metadata (priority 2 > priority 3).
 	mergeEnrichedMetadata(&enrichedMeta, metadata, metadata.DataSource)
 
@@ -2851,68 +2885,6 @@ func filterMetadataFields(
 	}
 
 	return &result
-}
-
-// buildParsedMetadataContext converts ParsedMetadata to a map for plugin enrichment context.
-func buildParsedMetadataContext(md *mediafile.ParsedMetadata) map[string]interface{} {
-	if md == nil {
-		return nil
-	}
-
-	ctx := map[string]interface{}{
-		"title":       md.Title,
-		"subtitle":    md.Subtitle,
-		"series":      md.Series,
-		"description": md.Description,
-		"publisher":   md.Publisher,
-		"imprint":     md.Imprint,
-		"url":         md.URL,
-		"dataSource":  md.DataSource,
-	}
-
-	if md.SeriesNumber != nil {
-		ctx["seriesNumber"] = *md.SeriesNumber
-	}
-
-	if len(md.Authors) > 0 {
-		authors := make([]map[string]interface{}, len(md.Authors))
-		for i, a := range md.Authors {
-			authors[i] = map[string]interface{}{
-				"name": a.Name,
-				"role": a.Role,
-			}
-		}
-		ctx["authors"] = authors
-	}
-
-	if len(md.Narrators) > 0 {
-		ctx["narrators"] = md.Narrators
-	}
-
-	if len(md.Genres) > 0 {
-		ctx["genres"] = md.Genres
-	}
-
-	if len(md.Tags) > 0 {
-		ctx["tags"] = md.Tags
-	}
-
-	if md.ReleaseDate != nil {
-		ctx["releaseDate"] = md.ReleaseDate.Format("2006-01-02")
-	}
-
-	if len(md.Identifiers) > 0 {
-		identifiers := make([]map[string]interface{}, len(md.Identifiers))
-		for i, id := range md.Identifiers {
-			identifiers[i] = map[string]interface{}{
-				"type":  id.Type,
-				"value": id.Value,
-			}
-		}
-		ctx["identifiers"] = identifiers
-	}
-
-	return ctx
 }
 
 // buildFileContext converts a File model to a map for plugin enrichment context.

--- a/shisho.example.yaml
+++ b/shisho.example.yaml
@@ -100,6 +100,12 @@ download_cache_max_size_gb: 5
 # Default: /config/plugins/installed
 plugin_dir: /config/plugins/installed
 
+# Directory where plugin persistent data is stored (caches, tokens, DB files)
+# Data survives plugin updates; optionally deleted on uninstall with delete_data=true
+# Env: PLUGIN_DATA_DIR
+# Default: /config/plugins/data
+plugin_data_dir: /config/plugins/data
+
 # =============================================================================
 # SUPPLEMENT DISCOVERY SETTINGS
 # =============================================================================

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -56,6 +56,7 @@ Every setting can be set via an environment variable using the uppercase, unders
 | Setting | Env Variable | Default | Description |
 |---------|-------------|---------|-------------|
 | `plugin_dir` | `PLUGIN_DIR` | `/config/plugins/installed` | Directory where installed [plugins](./plugins/overview) are stored |
+| `plugin_data_dir` | `PLUGIN_DATA_DIR` | `/config/plugins/data` | Directory where plugin persistent data is stored (caches, tokens, DB files). Data survives plugin updates; optionally deleted on uninstall with `delete_data=true` |
 
 ### Supplement Discovery
 


### PR DESCRIPTION
## Summary

Major overhaul of the plugin system, implementing 9 key changes:

- **PluginStatus enum** — Replaces boolean `enabled` with `Active`/`Disabled`/`Malfunctioned`/`NotSupported` for clear plugin health status
- **Persistent data directory** — `shisho.dataDir` host API gives plugins storage that survives updates
- **onUninstalling hook** — Plugins can clean up (revoke tokens, delete caches) before removal
- **Version compatibility** — `minShishoVersion` enforced at load time, sets `NotSupported` status when incompatible
- **Repository source tracking** — Installed plugins record where they came from for reliable update lookups
- **Catalog enrichment** — Overview field, plugin icon images, and changelogs from repository manifests
- **Per-plugin auto-update toggle** — Users control which plugins auto-update
- **Unified enricher+search** — New `search()` + `enrich()` two-method pattern replaces single `enrich()`, enabling future manual book identification UI
- **Plugin event system** — Lifecycle events (install/uninstall/update/enable/disable/malfunction) for observability

### Breaking changes
- Enricher plugins must update from single `enrich(ctx)` to `search(ctx)` + `enrich(ctx)` pattern
- `enabled` boolean replaced with `status` integer on plugin model
- DB migration renames `enabled` → `status` column

## Test plan
- [x] All Go tests pass (`make test`)
- [x] golangci-lint passes (`make lint`)
- [x] ESLint, TypeScript, and Prettier pass (`yarn lint`)
- [x] E2E tests pass (31/31 Firefox)
- [x] New tests for: version compatibility, plugin events, search+enrich hooks, onUninstalling, data directory, auto-update filtering
- [x] Updated enricher test fixtures in scan_plugins_test.go to new search+enrich pattern