### PR TITLE
Fix flakey E2E tests by isolating Vite cache per browser

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -140,6 +140,9 @@ function createWebServers(config: BrowserConfig): WebServerConfig[] {
       timeout: 30000,
       env: {
         API_PORT: String(config.apiPort),
+        // Each browser gets its own Vite cache to prevent dependency pre-bundling
+        // corruption when multiple Vite instances run from the same project directory.
+        VITE_CACHE_DIR: path.join(config.tmpDir, "vite-cache"),
       },
     },
   ];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,6 +46,11 @@ function getApiPort(): number {
 
 // https://vite.dev/config/
 export default defineConfig({
+  // Allow E2E tests to isolate Vite's dependency pre-bundling cache per browser,
+  // preventing corruption when multiple Vite instances run from the same project.
+  ...(process.env.VITE_CACHE_DIR
+    ? { cacheDir: process.env.VITE_CACHE_DIR }
+    : {}),
   server: {
     host: "0.0.0.0",
     strictPort: false, // Allow Vite to auto-increment port if busy


### PR DESCRIPTION
## Summary

- Isolate each browser's Vite dependency pre-bundling cache during parallel E2E test runs
- When `yarn test:e2e` runs chromium and firefox in parallel, both Vite dev servers shared `node_modules/.vite/deps`, causing the second browser's React SPA to silently fail to render
- Each browser now gets its own `VITE_CACHE_DIR` inside its existing isolated temp directory

## Evidence

Across two CI runs, the failing browser swapped:
- [Run 22831066021](https://github.com/shishobooks/shisho/actions/runs/22831066021): Firefox fails 13 login/setup tests, Chromium passes all
- [Run 22831418357](https://github.com/shishobooks/shisho/actions/runs/22831418357): Chromium fails 13 login/setup tests, Firefox passes all

In both cases, ereader tests (server-rendered HTML, no Vite pre-bundling) passed in both browsers.

## Test plan

- [ ] CI E2E tests pass on this PR
- [ ] Re-run CI a couple times to confirm flakiness is resolved