### PR TITLE
[CI] Cache Playwright browsers in CI to speed up JS tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,24 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium firefox
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium firefox
 
       - name: Download Go modules
         run: make install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(npx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+        run: echo "version=$(npx playwright --version | awk '{print $NF}')" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
         id: playwright-cache


### PR DESCRIPTION
## Summary
- Cache Playwright browser binaries (~300-400MB) using `actions/cache@v4`, keyed by Playwright version
- On cache hit, only install system dependencies (fast apt packages) instead of re-downloading browsers
- On cache miss (e.g. Playwright version bump), does the full browser download as before

## Test plan
- [ ] Verify first CI run downloads and caches browsers (cache miss)
- [ ] Verify subsequent CI runs skip browser download and only install system deps (cache hit)
- [ ] Verify E2E tests still pass with cached browsers