### PR TITLE
[Feature] Add plugin search and identify dialog with full metadata enrichment

### DIFF
--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -1,5 +1,5 @@
-import { Loader2, Search } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { ExternalLink, Info, Loader2, Search } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
@@ -15,11 +15,14 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   usePluginEnrich,
+  usePluginIdentifierTypes,
   usePluginSearch,
   type PluginSearchResult,
 } from "@/hooks/queries/plugins";
 import { cn } from "@/libraries/utils";
 import type { Book } from "@/types";
+import { formatIdentifierType, formatMetadataFieldLabel } from "@/utils/format";
+import { getIdentifierUrl } from "@/utils/identifiers";
 
 interface IdentifyBookDialogProps {
   open: boolean;
@@ -37,6 +40,7 @@ export function IdentifyBookDialog({
     useState<PluginSearchResult | null>(null);
   const searchMutation = usePluginSearch();
   const enrichMutation = usePluginEnrich();
+  const { data: pluginIdentifierTypes } = usePluginIdentifierTypes();
   const inputRef = useRef<HTMLInputElement>(null);
   const hasSearchedRef = useRef(false);
 
@@ -92,6 +96,27 @@ export function IdentifyBookDialog({
   };
 
   const results = searchMutation.data?.results ?? [];
+
+  // Detect plugin IDs that appear under multiple scopes
+  const ambiguousIds = useMemo(() => {
+    const items = searchMutation.data?.results ?? [];
+    const scopesByPluginId = new Map<string, Set<string>>();
+    for (const r of items) {
+      const scopes = scopesByPluginId.get(r.plugin_id) ?? new Set();
+      scopes.add(r.plugin_scope);
+      scopesByPluginId.set(r.plugin_id, scopes);
+    }
+    const ids = new Set<string>();
+    for (const [id, scopes] of scopesByPluginId) {
+      if (scopes.size > 1) ids.add(id);
+    }
+    return ids;
+  }, [searchMutation.data?.results]);
+
+  const pluginLabel = (result: PluginSearchResult) =>
+    ambiguousIds.has(result.plugin_id)
+      ? `${result.plugin_scope}/${result.plugin_id}`
+      : result.plugin_id;
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
@@ -150,10 +175,10 @@ export function IdentifyBookDialog({
               {results.map((result, index) => (
                 <button
                   className={cn(
-                    "w-full text-left rounded-lg border p-3 cursor-pointer transition-colors",
+                    "w-full text-left rounded-lg border-2 p-3 cursor-pointer transition-colors",
                     "hover:bg-muted/50",
                     selectedResult === result
-                      ? "ring-2 ring-primary border-primary"
+                      ? "border-primary bg-primary/5"
                       : "border-border",
                   )}
                   key={`${result.plugin_scope}-${result.plugin_id}-${index}`}
@@ -181,7 +206,7 @@ export function IdentifyBookDialog({
                           {result.title}
                         </p>
                         <Badge className="shrink-0 text-xs" variant="outline">
-                          {result.plugin_id}
+                          {pluginLabel(result)}
                         </Badge>
                       </div>
 
@@ -207,19 +232,55 @@ export function IdentifyBookDialog({
                         )}
                       </div>
 
-                      {result.identifiers && result.identifiers.length > 0 && (
-                        <div className="flex flex-wrap gap-1 mt-1">
-                          {result.identifiers.map((id) => (
-                            <Badge
-                              className="text-xs"
-                              key={`${id.type}-${id.value}`}
-                              variant="secondary"
-                            >
-                              {id.type}: {id.value}
-                            </Badge>
-                          ))}
-                        </div>
-                      )}
+                      {result.identifiers &&
+                        result.identifiers.filter((id) => id.type && id.value)
+                          .length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-1">
+                            {result.identifiers
+                              .filter((id) => id.type && id.value)
+                              .map((id) => {
+                                const url = getIdentifierUrl(
+                                  id.type,
+                                  id.value,
+                                  pluginIdentifierTypes,
+                                );
+                                return url ? (
+                                  <a
+                                    className="inline-flex"
+                                    href={url}
+                                    key={`${id.type}-${id.value}`}
+                                    onClick={(e) => e.stopPropagation()}
+                                    rel="noopener noreferrer"
+                                    target="_blank"
+                                  >
+                                    <Badge
+                                      className="text-xs hover:bg-primary/20 transition-colors"
+                                      variant="secondary"
+                                    >
+                                      {formatIdentifierType(
+                                        id.type,
+                                        pluginIdentifierTypes,
+                                      )}
+                                      : {id.value}
+                                      <ExternalLink className="h-3 w-3 ml-1 shrink-0" />
+                                    </Badge>
+                                  </a>
+                                ) : (
+                                  <Badge
+                                    className="text-xs"
+                                    key={`${id.type}-${id.value}`}
+                                    variant="secondary"
+                                  >
+                                    {formatIdentifierType(
+                                      id.type,
+                                      pluginIdentifierTypes,
+                                    )}
+                                    : {id.value}
+                                  </Badge>
+                                );
+                              })}
+                          </div>
+                        )}
 
                       {result.description && (
                         <p className="text-xs text-muted-foreground line-clamp-2 mt-1">
@@ -239,6 +300,22 @@ export function IdentifyBookDialog({
             </div>
           )}
         </div>
+
+        {selectedResult?.disabled_fields &&
+          selectedResult.disabled_fields.length > 0 && (
+            <div className="flex items-start gap-2 rounded-md border border-border bg-muted/50 p-3 text-sm text-muted-foreground">
+              <Info className="h-4 w-4 mt-0.5 shrink-0" />
+              <span>
+                The following fields are disabled for this plugin and won&apos;t
+                be updated:{" "}
+                {selectedResult.disabled_fields
+                  .map((f) => formatMetadataFieldLabel(f))
+                  .sort()
+                  .join(", ")}
+                . You can change this in the plugin settings.
+              </span>
+            </div>
+          )}
 
         <DialogFooter>
           <Button onClick={() => onOpenChange(false)} variant="outline">

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -65,10 +65,10 @@ export function IdentifyBookDialog({
     if (open) {
       setQuery(book.title);
       setSelectedResult(null);
-      setSelectedFileId(undefined);
+      setSelectedFileId(mainFiles.length > 1 ? mainFiles[0].id : undefined);
       hasSearchedRef.current = false;
     }
-  }, [open, book.title]);
+  }, [open, book.title, mainFiles]);
 
   // Auto-search after query is set from dialog open
   useEffect(() => {
@@ -340,8 +340,8 @@ export function IdentifyBookDialog({
             <div>
               <Label>Apply to file</Label>
               <p className="mt-1 text-xs text-muted-foreground">
-                Identifiers and cover image will be applied to the selected
-                file.
+                File-specific metadata (identifiers, cover, narrators,
+                publisher, etc.) will be applied to the selected file.
               </p>
             </div>
             <div className="space-y-1.5">
@@ -350,9 +350,7 @@ export function IdentifyBookDialog({
                   className={cn(
                     "w-full text-left rounded-md border p-2.5 cursor-pointer transition-colors",
                     "hover:bg-muted/50",
-                    selectedFileId === file.id ||
-                      (selectedFileId === undefined &&
-                        file.id === mainFiles[0].id)
+                    selectedFileId === file.id
                       ? "border-primary bg-primary/5"
                       : "border-border",
                   )}

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   usePluginEnrich,
   usePluginIdentifierTypes,
@@ -21,7 +22,13 @@ import {
 } from "@/hooks/queries/plugins";
 import { cn } from "@/libraries/utils";
 import type { Book } from "@/types";
-import { formatIdentifierType, formatMetadataFieldLabel } from "@/utils/format";
+import {
+  formatDuration,
+  formatFileSize,
+  formatIdentifierType,
+  formatMetadataFieldLabel,
+  getFilename,
+} from "@/utils/format";
 import { getIdentifierUrl } from "@/utils/identifiers";
 
 interface IdentifyBookDialogProps {
@@ -38,17 +45,27 @@ export function IdentifyBookDialog({
   const [query, setQuery] = useState("");
   const [selectedResult, setSelectedResult] =
     useState<PluginSearchResult | null>(null);
+  const [selectedFileId, setSelectedFileId] = useState<number | undefined>(
+    undefined,
+  );
   const searchMutation = usePluginSearch();
   const enrichMutation = usePluginEnrich();
   const { data: pluginIdentifierTypes } = usePluginIdentifierTypes();
   const inputRef = useRef<HTMLInputElement>(null);
   const hasSearchedRef = useRef(false);
 
+  const mainFiles = useMemo(
+    () => book.files?.filter((f) => f.file_role === "main") ?? [],
+    [book.files],
+  );
+  const hasMultipleFiles = mainFiles.length > 1;
+
   // Pre-fill query and auto-search when dialog opens
   useEffect(() => {
     if (open) {
       setQuery(book.title);
       setSelectedResult(null);
+      setSelectedFileId(undefined);
       hasSearchedRef.current = false;
     }
   }, [open, book.title]);
@@ -81,6 +98,7 @@ export function IdentifyBookDialog({
         pluginScope: selectedResult.plugin_scope,
         pluginId: selectedResult.plugin_id,
         bookId: book.id,
+        fileId: selectedFileId,
         providerData: selectedResult.provider_data,
       },
       {
@@ -316,6 +334,65 @@ export function IdentifyBookDialog({
               </span>
             </div>
           )}
+
+        {hasMultipleFiles && (
+          <div className="space-y-2">
+            <div>
+              <Label>Apply to file</Label>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Identifiers and cover image will be applied to the selected
+                file.
+              </p>
+            </div>
+            <div className="space-y-1.5">
+              {mainFiles.map((file) => (
+                <button
+                  className={cn(
+                    "w-full text-left rounded-md border p-2.5 cursor-pointer transition-colors",
+                    "hover:bg-muted/50",
+                    selectedFileId === file.id ||
+                      (selectedFileId === undefined &&
+                        file.id === mainFiles[0].id)
+                      ? "border-primary bg-primary/5"
+                      : "border-border",
+                  )}
+                  key={file.id}
+                  onClick={() => setSelectedFileId(file.id)}
+                  type="button"
+                >
+                  <div className="flex items-center gap-2">
+                    <Badge className="shrink-0 text-xs" variant="outline">
+                      {file.file_type.toUpperCase()}
+                    </Badge>
+                    <span className="text-sm truncate min-w-0">
+                      {file.name || getFilename(file.filepath)}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-x-2 mt-1 text-xs text-muted-foreground">
+                    <span>{formatFileSize(file.filesize_bytes)}</span>
+                    {file.audiobook_duration_seconds != null && (
+                      <>
+                        <span className="text-muted-foreground/50">·</span>
+                        <span>
+                          {formatDuration(file.audiobook_duration_seconds)}
+                        </span>
+                      </>
+                    )}
+                    {file.page_count != null && (
+                      <>
+                        <span className="text-muted-foreground/50">·</span>
+                        <span>
+                          {file.page_count} page
+                          {file.page_count !== 1 ? "s" : ""}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         <DialogFooter>
           <Button onClick={() => onOpenChange(false)} variant="outline">

--- a/app/components/plugins/PluginConfigDialog.tsx
+++ b/app/components/plugins/PluginConfigDialog.tsx
@@ -23,6 +23,7 @@ import {
   type ConfigField,
 } from "@/hooks/queries/plugins";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
+import { formatMetadataFieldLabel } from "@/utils/format";
 
 interface PluginConfigDialogProps {
   onOpenChange: (open: boolean) => void;
@@ -33,28 +34,6 @@ interface PluginConfigDialogProps {
 }
 
 const SECRET_MASK = "***";
-
-const FIELD_LABELS: Record<string, string> = {
-  title: "Title",
-  subtitle: "Subtitle",
-  authors: "Authors",
-  narrators: "Narrators",
-  series: "Series",
-  seriesNumber: "Series Number",
-  genres: "Genres",
-  tags: "Tags",
-  description: "Description",
-  publisher: "Publisher",
-  imprint: "Imprint",
-  url: "URL",
-  releaseDate: "Release Date",
-  cover: "Cover Image",
-  identifiers: "Identifiers",
-};
-
-const formatFieldLabel = (field: string): string => {
-  return FIELD_LABELS[field] ?? field;
-};
 
 export const PluginConfigDialog = ({
   onOpenChange,
@@ -310,7 +289,9 @@ export const PluginConfigDialog = ({
             <div className="space-y-3">
               {data.declaredFields.map((field) => (
                 <div className="flex items-center justify-between" key={field}>
-                  <span className="text-sm">{formatFieldLabel(field)}</span>
+                  <span className="text-sm">
+                    {formatMetadataFieldLabel(field)}
+                  </span>
                   <Switch
                     checked={fieldSettings[field] ?? true}
                     onCheckedChange={(checked) =>

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -543,14 +543,16 @@ export const usePluginEnrich = () => {
       pluginScope: string;
       pluginId: string;
       bookId: number;
+      fileId?: number;
       providerData: unknown;
     }
   >({
-    mutationFn: ({ pluginScope, pluginId, bookId, providerData }) => {
+    mutationFn: ({ pluginScope, pluginId, bookId, fileId, providerData }) => {
       return API.request("POST", "/plugins/enrich", {
         plugin_scope: pluginScope,
         plugin_id: pluginId,
         book_id: bookId,
+        file_id: fileId,
         provider_data: providerData,
       });
     },

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
 import { API, type ShishoAPIError } from "@/libraries/api";
 import type {
   Plugin,
@@ -510,6 +511,7 @@ export interface PluginSearchResult {
   provider_data?: unknown;
   plugin_scope: string;
   plugin_id: string;
+  disabled_fields?: string[];
 }
 
 export interface PluginSearchResponse {
@@ -553,7 +555,12 @@ export const usePluginEnrich = () => {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["books"] });
+      queryClient.invalidateQueries({
+        queryKey: [BooksQueryKey.ListBooks],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [BooksQueryKey.RetrieveBook],
+      });
     },
   });
 };

--- a/app/utils/format.ts
+++ b/app/utils/format.ts
@@ -59,6 +59,35 @@ export const formatTimestamp = (ms: number): string => {
 };
 
 /**
+ * Human-readable labels for plugin metadata field names.
+ */
+export const METADATA_FIELD_LABELS: Record<string, string> = {
+  title: "Title",
+  subtitle: "Subtitle",
+  authors: "Authors",
+  narrators: "Narrators",
+  series: "Series",
+  seriesNumber: "Series Number",
+  genres: "Genres",
+  tags: "Tags",
+  description: "Description",
+  publisher: "Publisher",
+  imprint: "Imprint",
+  url: "URL",
+  releaseDate: "Release Date",
+  cover: "Cover Image",
+  identifiers: "Identifiers",
+};
+
+/**
+ * Formats a metadata field name into a human-readable label.
+ * @example formatMetadataFieldLabel("releaseDate") // "Release Date"
+ */
+export const formatMetadataFieldLabel = (field: string): string => {
+  return METADATA_FIELD_LABELS[field] ?? field;
+};
+
+/**
  * Formats identifier type codes into human-readable labels.
  * @example formatIdentifierType("isbn_13") // "ISBN-13"
  */

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -260,6 +260,18 @@ var payload setOrderPayload
 if err := c.Bind(&payload); err != nil { ... }
 ```
 
+- **Bun table aliases in WHERE/ORDER clauses**: Bun auto-aliases tables using the first letter of the table name (e.g., `books` → `b`, `files` → `f`, `persons` → `p`). Always use these aliases in `Where()`, `Order()`, and other SQL clauses — never use the full table name:
+
+```go
+// ❌ WRONG - "book" is not a valid alias, causes "no such column" error
+q.Where("book.id = ?", id)
+
+// ✅ CORRECT - Bun aliases "books" table as "b"
+q.Where("b.id = ?", id)
+```
+
+Check existing queries in `pkg/books/service.go` for reference. Common aliases: `b` (books), `f` (files), `a` (authors), `p` (persons), `s` (series), `bs` (book_series), `ch` (chapters), `n` (narrators).
+
 ### Config
 
 - Self-hosted app with config file-based configuration

--- a/pkg/mediafile/mediafile.go
+++ b/pkg/mediafile/mediafile.go
@@ -16,8 +16,8 @@ type ParsedAuthor struct {
 
 // ParsedIdentifier represents an identifier parsed from file metadata.
 type ParsedIdentifier struct {
-	Type  string // One of the IdentifierType constants (isbn_10, isbn_13, asin, uuid, goodreads, google, other)
-	Value string // The identifier value
+	Type  string `json:"type"`  // One of the IdentifierType constants (isbn_10, isbn_13, asin, uuid, goodreads, google, other)
+	Value string `json:"value"` // The identifier value
 }
 
 // ParsedChapter represents a chapter parsed from file metadata.

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1617,6 +1617,9 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 		}
 	}
 
+	// File-level metadata: accumulate column updates and flush once at the end
+	var fileColumns []string
+
 	// Narrators (file-level, applied to target file)
 	if len(md.Narrators) > 0 && isAllowed("narrators") && targetFile != nil && h.enrich.personFinder != nil {
 		if _, err := h.enrich.bookStore.DeleteNarratorsForFile(ctx, targetFile.ID); err != nil {
@@ -1640,9 +1643,7 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 			}
 		}
 		targetFile.NarratorSource = &pluginSource
-		if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"narrator_source"}); err != nil {
-			return errors.Wrap(err, "failed to update narrator source")
-		}
+		fileColumns = append(fileColumns, "narrator_source")
 	}
 
 	// Publisher (file-level, applied to target file)
@@ -1653,9 +1654,7 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 		} else {
 			targetFile.PublisherID = &publisher.ID
 			targetFile.PublisherSource = &pluginSource
-			if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"publisher_id", "publisher_source"}); err != nil {
-				return errors.Wrap(err, "failed to update file publisher")
-			}
+			fileColumns = append(fileColumns, "publisher_id", "publisher_source")
 		}
 	}
 
@@ -1667,9 +1666,7 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 		} else {
 			targetFile.ImprintID = &imprint.ID
 			targetFile.ImprintSource = &pluginSource
-			if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"imprint_id", "imprint_source"}); err != nil {
-				return errors.Wrap(err, "failed to update file imprint")
-			}
+			fileColumns = append(fileColumns, "imprint_id", "imprint_source")
 		}
 	}
 
@@ -1677,18 +1674,14 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 	if md.URL != "" && isAllowed("url") && targetFile != nil {
 		targetFile.URL = &md.URL
 		targetFile.URLSource = &pluginSource
-		if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"url", "url_source"}); err != nil {
-			return errors.Wrap(err, "failed to update file URL")
-		}
+		fileColumns = append(fileColumns, "url", "url_source")
 	}
 
 	// Release date (file-level, applied to target file)
 	if md.ReleaseDate != nil && isAllowed("releaseDate") && targetFile != nil {
 		targetFile.ReleaseDate = md.ReleaseDate
 		targetFile.ReleaseDateSource = &pluginSource
-		if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"release_date", "release_date_source"}); err != nil {
-			return errors.Wrap(err, "failed to update file release date")
-		}
+		fileColumns = append(fileColumns, "release_date", "release_date_source")
 	}
 
 	// Identifiers (file-level, applied to target file)
@@ -1730,9 +1723,14 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 			log.Warn("failed to write cover file", logger.Data{"error": err.Error()})
 		} else {
 			targetFile.CoverImageFilename = &coverFilename
-			if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"cover_image_filename"}); err != nil {
-				log.Warn("failed to update file cover path", logger.Data{"error": err.Error()})
-			}
+			fileColumns = append(fileColumns, "cover_image_filename")
+		}
+	}
+
+	// Flush all file-level column updates in a single DB call
+	if len(fileColumns) > 0 && targetFile != nil {
+		if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, fileColumns); err != nil {
+			return errors.Wrap(err, "failed to update file metadata")
 		}
 	}
 

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -28,19 +28,24 @@ const validRepoURLPrefix = "https://raw.githubusercontent.com/"
 // enrichDeps holds dependencies for the enrich endpoint.
 // Uses interfaces to avoid circular imports with the books package.
 type enrichDeps struct {
-	bookStore     bookStore
-	relStore      relationStore
-	identStore    identifierStore
-	personFinder  personFinder
-	genreFinder   genreFinder
-	tagFinder     tagFinder
-	searchIndexer searchIndexer
+	bookStore       bookStore
+	relStore        relationStore
+	identStore      identifierStore
+	personFinder    personFinder
+	genreFinder     genreFinder
+	tagFinder       tagFinder
+	publisherFinder publisherFinder
+	imprintFinder   imprintFinder
+	searchIndexer   searchIndexer
 }
 
-// bookStore provides core book CRUD operations.
+// bookStore provides core book and file CRUD operations.
 type bookStore interface {
 	UpdateBook(ctx context.Context, book *models.Book, columns []string) error
 	RetrieveBook(ctx context.Context, bookID int) (*models.Book, error)
+	UpdateFile(ctx context.Context, file *models.File, columns []string) error
+	DeleteNarratorsForFile(ctx context.Context, fileID int) (int, error)
+	CreateNarrator(ctx context.Context, narrator *models.Narrator) error
 }
 
 // relationStore provides book relationship CRUD operations.
@@ -62,7 +67,7 @@ type identifierStore interface {
 	CreateFileIdentifier(ctx context.Context, identifier *models.FileIdentifier) error
 }
 
-// personFinder finds or creates persons for author associations.
+// personFinder finds or creates persons for author and narrator associations.
 type personFinder interface {
 	FindOrCreatePerson(ctx context.Context, name string, libraryID int) (*models.Person, error)
 }
@@ -75,6 +80,16 @@ type genreFinder interface {
 // tagFinder finds or creates tags.
 type tagFinder interface {
 	FindOrCreateTag(ctx context.Context, name string, libraryID int) (*models.Tag, error)
+}
+
+// publisherFinder finds or creates publishers.
+type publisherFinder interface {
+	FindOrCreatePublisher(ctx context.Context, name string, libraryID int) (*models.Publisher, error)
+}
+
+// imprintFinder finds or creates imprints.
+type imprintFinder interface {
+	FindOrCreateImprint(ctx context.Context, name string, libraryID int) (*models.Imprint, error)
 }
 
 // searchIndexer updates the search index after metadata changes.
@@ -123,6 +138,7 @@ type enrichPayload struct {
 	PluginScope  string `json:"plugin_scope" validate:"required"`
 	PluginID     string `json:"plugin_id" validate:"required"`
 	BookID       int    `json:"book_id" validate:"required"`
+	FileID       *int   `json:"file_id"`
 	ProviderData any    `json:"provider_data"`
 }
 
@@ -1366,12 +1382,27 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 		return errcodes.Forbidden("You don't have access to this library")
 	}
 
+	// Resolve the target file for enrichment
+	var targetFile *models.File
+	if payload.FileID != nil {
+		for _, f := range book.Files {
+			if f.ID == *payload.FileID {
+				targetFile = f
+				break
+			}
+		}
+		if targetFile == nil {
+			return errcodes.NotFound("File")
+		}
+	} else if len(book.Files) > 0 {
+		targetFile = book.Files[0]
+	}
+
 	bookCtx := buildSearchBookContext(&book)
 	fileCtx := map[string]interface{}{}
-	if len(book.Files) > 0 {
-		f := book.Files[0]
-		fileCtx["fileType"] = f.FileType
-		fileCtx["filePath"] = f.Filepath
+	if targetFile != nil {
+		fileCtx["fileType"] = targetFile.FileType
+		fileCtx["filePath"] = targetFile.Filepath
 	}
 
 	enrichCtx := map[string]interface{}{
@@ -1391,7 +1422,7 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 	}
 
 	// Apply enriched metadata to the book
-	if err := h.applyEnrichment(ctx, &book, result.Metadata, rt, log); err != nil {
+	if err := h.applyEnrichment(ctx, &book, targetFile, result.Metadata, rt, log); err != nil {
 		return errors.WithStack(err)
 	}
 
@@ -1405,7 +1436,8 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 }
 
 // applyEnrichment applies enriched metadata to a book, respecting field filtering.
-func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, md *mediafile.ParsedMetadata, rt *Runtime, log logger.Logger) error {
+// targetFile is the specific file to apply file-level metadata (identifiers, cover) to; may be nil.
+func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, targetFile *models.File, md *mediafile.ParsedMetadata, rt *Runtime, log logger.Logger) error {
 	manifest := rt.Manifest()
 	if manifest.Capabilities.MetadataEnricher == nil {
 		return nil
@@ -1585,10 +1617,83 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, md *me
 		}
 	}
 
-	// Identifiers (file-level, applied to first file)
-	if len(md.Identifiers) > 0 && isAllowed("identifiers") && len(book.Files) > 0 {
-		fileID := book.Files[0].ID
-		if _, err := h.enrich.identStore.DeleteIdentifiersForFile(ctx, fileID); err != nil {
+	// Narrators (file-level, applied to target file)
+	if len(md.Narrators) > 0 && isAllowed("narrators") && targetFile != nil && h.enrich.personFinder != nil {
+		if _, err := h.enrich.bookStore.DeleteNarratorsForFile(ctx, targetFile.ID); err != nil {
+			return errors.Wrap(err, "failed to delete narrators")
+		}
+		for i, narratorName := range md.Narrators {
+			if narratorName == "" {
+				continue
+			}
+			person, pErr := h.enrich.personFinder.FindOrCreatePerson(ctx, narratorName, book.LibraryID)
+			if pErr != nil {
+				log.Warn("failed to find/create person for narrator", logger.Data{"name": narratorName, "error": pErr.Error()})
+				continue
+			}
+			if err := h.enrich.bookStore.CreateNarrator(ctx, &models.Narrator{
+				FileID:    targetFile.ID,
+				PersonID:  person.ID,
+				SortOrder: i + 1,
+			}); err != nil {
+				log.Warn("failed to create narrator", logger.Data{"error": err.Error()})
+			}
+		}
+		targetFile.NarratorSource = &pluginSource
+		if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"narrator_source"}); err != nil {
+			return errors.Wrap(err, "failed to update narrator source")
+		}
+	}
+
+	// Publisher (file-level, applied to target file)
+	if md.Publisher != "" && isAllowed("publisher") && targetFile != nil && h.enrich.publisherFinder != nil {
+		publisher, pErr := h.enrich.publisherFinder.FindOrCreatePublisher(ctx, md.Publisher, book.LibraryID)
+		if pErr != nil {
+			log.Warn("failed to find/create publisher", logger.Data{"name": md.Publisher, "error": pErr.Error()})
+		} else {
+			targetFile.PublisherID = &publisher.ID
+			targetFile.PublisherSource = &pluginSource
+			if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"publisher_id", "publisher_source"}); err != nil {
+				return errors.Wrap(err, "failed to update file publisher")
+			}
+		}
+	}
+
+	// Imprint (file-level, applied to target file)
+	if md.Imprint != "" && isAllowed("imprint") && targetFile != nil && h.enrich.imprintFinder != nil {
+		imprint, iErr := h.enrich.imprintFinder.FindOrCreateImprint(ctx, md.Imprint, book.LibraryID)
+		if iErr != nil {
+			log.Warn("failed to find/create imprint", logger.Data{"name": md.Imprint, "error": iErr.Error()})
+		} else {
+			targetFile.ImprintID = &imprint.ID
+			targetFile.ImprintSource = &pluginSource
+			if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"imprint_id", "imprint_source"}); err != nil {
+				return errors.Wrap(err, "failed to update file imprint")
+			}
+		}
+	}
+
+	// URL (file-level, applied to target file)
+	if md.URL != "" && isAllowed("url") && targetFile != nil {
+		targetFile.URL = &md.URL
+		targetFile.URLSource = &pluginSource
+		if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"url", "url_source"}); err != nil {
+			return errors.Wrap(err, "failed to update file URL")
+		}
+	}
+
+	// Release date (file-level, applied to target file)
+	if md.ReleaseDate != nil && isAllowed("releaseDate") && targetFile != nil {
+		targetFile.ReleaseDate = md.ReleaseDate
+		targetFile.ReleaseDateSource = &pluginSource
+		if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"release_date", "release_date_source"}); err != nil {
+			return errors.Wrap(err, "failed to update file release date")
+		}
+	}
+
+	// Identifiers (file-level, applied to target file)
+	if len(md.Identifiers) > 0 && isAllowed("identifiers") && targetFile != nil {
+		if _, err := h.enrich.identStore.DeleteIdentifiersForFile(ctx, targetFile.ID); err != nil {
 			return errors.Wrap(err, "failed to delete identifiers")
 		}
 		for _, ident := range md.Identifiers {
@@ -1596,20 +1701,20 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, md *me
 				continue
 			}
 			if err := h.enrich.identStore.CreateFileIdentifier(ctx, &models.FileIdentifier{
-				FileID: fileID,
+				FileID: targetFile.ID,
 				Type:   ident.Type,
 				Value:  ident.Value,
+				Source: pluginSource,
 			}); err != nil {
 				log.Warn("failed to create identifier", logger.Data{"error": err.Error()})
 			}
 		}
 	}
 
-	// Cover image (applied to first file)
-	if len(md.CoverData) > 0 && isAllowed("cover") && len(book.Files) > 0 {
-		file := book.Files[0]
+	// Cover image (applied to target file)
+	if len(md.CoverData) > 0 && isAllowed("cover") && targetFile != nil {
 		coverDir := book.Filepath
-		coverBaseName := filepath.Base(file.Filepath) + ".cover"
+		coverBaseName := filepath.Base(targetFile.Filepath) + ".cover"
 
 		// Normalize the cover image
 		normalizedData, normalizedMime, _ := fileutils.NormalizeImage(md.CoverData, md.CoverMimeType)
@@ -1624,8 +1729,8 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, md *me
 		if err := os.WriteFile(coverFilepath, normalizedData, 0600); err != nil {
 			log.Warn("failed to write cover file", logger.Data{"error": err.Error()})
 		} else {
-			file.CoverImageFilename = &coverFilename
-			if _, err := h.db.NewUpdate().Model(&file).Column("cover_image_filename").WherePK().Exec(ctx); err != nil {
+			targetFile.CoverImageFilename = &coverFilename
+			if err := h.enrich.bookStore.UpdateFile(ctx, targetFile, []string{"cover_image_filename"}); err != nil {
 				log.Warn("failed to update file cover path", logger.Data{"error": err.Error()})
 			}
 		}

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/htmlutil"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -1250,7 +1251,7 @@ func (h *handler) searchMetadata(c echo.Context) error {
 	// Look up the book
 	var book models.Book
 	if err := h.db.NewSelect().Model(&book).
-		Where("book.id = ?", payload.BookID).
+		Where("b.id = ?", payload.BookID).
 		Relation("Authors").
 		Relation("Authors.Person").
 		Relation("BookSeries").
@@ -1291,9 +1292,29 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		if sErr != nil {
 			continue // Skip failed plugins
 		}
-		if resp != nil {
-			allResults = append(allResults, resp.Results...)
+		if resp == nil {
+			continue
 		}
+
+		// Compute disabled fields for this plugin
+		var disabledFields []string
+		manifest := rt.Manifest()
+		if manifest.Capabilities.MetadataEnricher != nil {
+			declaredFields := manifest.Capabilities.MetadataEnricher.Fields
+			effectiveSettings, fErr := h.service.GetEffectiveFieldSettings(ctx, book.LibraryID, rt.Scope(), rt.PluginID(), declaredFields)
+			if fErr == nil {
+				for field, enabled := range effectiveSettings {
+					if !enabled {
+						disabledFields = append(disabledFields, field)
+					}
+				}
+			}
+		}
+
+		for i := range resp.Results {
+			resp.Results[i].DisabledFields = disabledFields
+		}
+		allResults = append(allResults, resp.Results...)
 	}
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
@@ -1321,7 +1342,7 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 	// Look up the book with all relations needed for enrichment
 	var book models.Book
 	if err := h.db.NewSelect().Model(&book).
-		Where("book.id = ?", payload.BookID).
+		Where("b.id = ?", payload.BookID).
 		Relation("Authors").
 		Relation("Authors.Person").
 		Relation("BookSeries").
@@ -1580,6 +1601,32 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, md *me
 				Value:  ident.Value,
 			}); err != nil {
 				log.Warn("failed to create identifier", logger.Data{"error": err.Error()})
+			}
+		}
+	}
+
+	// Cover image (applied to first file)
+	if len(md.CoverData) > 0 && isAllowed("cover") && len(book.Files) > 0 {
+		file := book.Files[0]
+		coverDir := book.Filepath
+		coverBaseName := filepath.Base(file.Filepath) + ".cover"
+
+		// Normalize the cover image
+		normalizedData, normalizedMime, _ := fileutils.NormalizeImage(md.CoverData, md.CoverMimeType)
+		coverExt := ".png"
+		if normalizedMime == md.CoverMimeType {
+			coverExt = md.CoverExtension()
+		}
+
+		coverFilename := coverBaseName + coverExt
+		coverFilepath := filepath.Join(coverDir, coverFilename)
+
+		if err := os.WriteFile(coverFilepath, normalizedData, 0600); err != nil {
+			log.Warn("failed to write cover file", logger.Data{"error": err.Error()})
+		} else {
+			file.CoverImageFilename = &coverFilename
+			if _, err := h.db.NewUpdate().Model(&file).Column("cover_image_filename").WherePK().Exec(ctx); err != nil {
+				log.Warn("failed to update file cover path", logger.Data{"error": err.Error()})
 			}
 		}
 	}

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -144,8 +144,9 @@ type SearchResult struct {
 	Identifiers  []mediafile.ParsedIdentifier `json:"identifiers"`
 	ProviderData interface{}                  `json:"provider_data"` // Opaque data passed back to enrich()
 	// Added by the caller, not the plugin:
-	PluginScope string `json:"plugin_scope"`
-	PluginID    string `json:"plugin_id"`
+	PluginScope    string   `json:"plugin_scope"`
+	PluginID       string   `json:"plugin_id"`
+	DisabledFields []string `json:"disabled_fields,omitempty"`
 }
 
 // SearchResponse is the result of a metadata enricher's search() hook.

--- a/pkg/plugins/routes.go
+++ b/pkg/plugins/routes.go
@@ -10,13 +10,15 @@ import (
 // EnrichDeps holds optional dependencies for the enrich endpoint.
 // If nil, the enrich endpoint returns metadata without persisting it.
 type EnrichDeps struct {
-	BookStore     bookStore
-	RelStore      relationStore
-	IdentStore    identifierStore
-	PersonFinder  personFinder
-	GenreFinder   genreFinder
-	TagFinder     tagFinder
-	SearchIndexer searchIndexer
+	BookStore       bookStore
+	RelStore        relationStore
+	IdentStore      identifierStore
+	PersonFinder    personFinder
+	GenreFinder     genreFinder
+	TagFinder       tagFinder
+	PublisherFinder publisherFinder
+	ImprintFinder   imprintFinder
+	SearchIndexer   searchIndexer
 }
 
 // RegisterRoutesWithGroup registers plugin management API routes.
@@ -24,13 +26,15 @@ func RegisterRoutesWithGroup(g *echo.Group, service *Service, manager *Manager, 
 	h := &handler{service: service, manager: manager, installer: installer, db: db}
 	if ed != nil {
 		h.enrich = &enrichDeps{
-			bookStore:     ed.BookStore,
-			relStore:      ed.RelStore,
-			identStore:    ed.IdentStore,
-			personFinder:  ed.PersonFinder,
-			genreFinder:   ed.GenreFinder,
-			tagFinder:     ed.TagFinder,
-			searchIndexer: ed.SearchIndexer,
+			bookStore:       ed.BookStore,
+			relStore:        ed.RelStore,
+			identStore:      ed.IdentStore,
+			personFinder:    ed.PersonFinder,
+			genreFinder:     ed.GenreFinder,
+			tagFinder:       ed.TagFinder,
+			publisherFinder: ed.PublisherFinder,
+			imprintFinder:   ed.ImprintFinder,
+			searchIndexer:   ed.SearchIndexer,
 		}
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -193,13 +193,15 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 	bookSvc := books.NewService(db)
 	bookAdapter := &bookUpdaterAdapter{svc: bookSvc}
 	enrichDeps := &plugins.EnrichDeps{
-		BookStore:     bookAdapter,
-		RelStore:      bookAdapter,
-		IdentStore:    bookAdapter,
-		PersonFinder:  people.NewService(db),
-		GenreFinder:   genres.NewService(db),
-		TagFinder:     tags.NewService(db),
-		SearchIndexer: search.NewService(db),
+		BookStore:       bookAdapter,
+		RelStore:        bookAdapter,
+		IdentStore:      bookAdapter,
+		PersonFinder:    people.NewService(db),
+		GenreFinder:     genres.NewService(db),
+		TagFinder:       tags.NewService(db),
+		PublisherFinder: publishers.NewService(db),
+		ImprintFinder:   imprints.NewService(db),
+		SearchIndexer:   search.NewService(db),
 	}
 	plugins.RegisterRoutesWithGroup(pluginsGroup, pluginService, pm, pluginInstaller, db, enrichDeps)
 }
@@ -264,4 +266,16 @@ func (a *bookUpdaterAdapter) DeleteIdentifiersForFile(ctx context.Context, fileI
 
 func (a *bookUpdaterAdapter) CreateFileIdentifier(ctx context.Context, identifier *models.FileIdentifier) error {
 	return a.svc.CreateFileIdentifier(ctx, identifier)
+}
+
+func (a *bookUpdaterAdapter) UpdateFile(ctx context.Context, file *models.File, columns []string) error {
+	return a.svc.UpdateFile(ctx, file, books.UpdateFileOptions{Columns: columns})
+}
+
+func (a *bookUpdaterAdapter) DeleteNarratorsForFile(ctx context.Context, fileID int) (int, error) {
+	return a.svc.DeleteNarratorsForFile(ctx, fileID)
+}
+
+func (a *bookUpdaterAdapter) CreateNarrator(ctx context.Context, narrator *models.Narrator) error {
+	return a.svc.CreateNarrator(ctx, narrator)
 }


### PR DESCRIPTION
## Summary
- Add "Identify Book" dialog that searches metadata providers via plugins and lets users select the correct match to apply
- Rich file selector for multi-file books (shows file type, size, duration, page count) so identifiers/cover are applied to the right file
- Apply all metadata fields from enrichment: title, subtitle, description, authors, series, genres, tags, narrators, publisher, imprint, URL, release date, identifiers, and cover image
- Disambiguate plugins that appear under multiple scopes with scope/id labels, and show disabled field warnings

## Test plan
- [ ] Open Identify dialog on a book — verify it auto-searches with the book title
- [ ] Search returns results with cover thumbnails, authors, identifiers, and publisher info
- [ ] Select a result and click Apply — verify all metadata fields are updated on the book
- [ ] For multi-file books, verify the file selector appears and identifiers/cover go to the selected file
- [ ] Verify enricher field settings are respected (disabled fields not applied)
- [ ] Verify sidecars are written and search index updated after enrichment