### PR TITLE
[Feature] Add richer search results with new fields, coverUrl, and passthrough pattern

### DIFF
--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -136,6 +136,36 @@ export function IdentifyBookDialog({
       ? `${result.plugin_scope}/${result.plugin_id}`
       : result.plugin_id;
 
+  const resolveField = (
+    result: PluginSearchResult,
+    field: keyof PluginSearchResult,
+    metadataField?: string,
+  ) => {
+    const topLevel = result[field];
+    if (topLevel !== undefined && topLevel !== null && topLevel !== "") return topLevel;
+    if (result.metadata) {
+      const mdField = metadataField || field;
+      return (result.metadata as Record<string, unknown>)[mdField as string];
+    }
+    return undefined;
+  };
+
+  const resolveAuthors = (result: PluginSearchResult): string[] | undefined => {
+    if (result.authors && result.authors.length > 0) return result.authors;
+    if (result.metadata?.authors && result.metadata.authors.length > 0) {
+      return result.metadata.authors.map((a) => a.name);
+    }
+    return undefined;
+  };
+
+  const resolveNarrators = (result: PluginSearchResult): string[] | undefined => {
+    if (result.narrators && result.narrators.length > 0) return result.narrators;
+    if (result.metadata?.narrators && result.metadata.narrators.length > 0) {
+      return result.metadata.narrators;
+    }
+    return undefined;
+  };
+
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto overflow-x-hidden">
@@ -228,11 +258,43 @@ export function IdentifyBookDialog({
                         </Badge>
                       </div>
 
-                      {result.authors && result.authors.length > 0 && (
-                        <p className="text-sm text-muted-foreground">
-                          {result.authors.join(", ")}
-                        </p>
-                      )}
+                      {(() => {
+                        const subtitle = resolveField(result, "subtitle") as string;
+                        return subtitle ? (
+                          <p className="text-sm text-muted-foreground/80 leading-tight">
+                            {subtitle}
+                          </p>
+                        ) : null;
+                      })()}
+
+                      {(() => {
+                        const series = resolveField(result, "series") as string;
+                        const seriesNum = resolveField(result, "series_number") as number;
+                        return series ? (
+                          <p className="text-xs text-muted-foreground font-medium">
+                            {series}
+                            {seriesNum != null && ` #${seriesNum}`}
+                          </p>
+                        ) : null;
+                      })()}
+
+                      {(() => {
+                        const authors = resolveAuthors(result);
+                        return authors && authors.length > 0 ? (
+                          <p className="text-sm text-muted-foreground">
+                            {authors.join(", ")}
+                          </p>
+                        ) : null;
+                      })()}
+
+                      {(() => {
+                        const narrators = resolveNarrators(result);
+                        return narrators && narrators.length > 0 ? (
+                          <p className="text-xs text-muted-foreground">
+                            Narrated by {narrators.join(", ")}
+                          </p>
+                        ) : null;
+                      })()}
 
                       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
                         {result.release_date && (
@@ -299,6 +361,33 @@ export function IdentifyBookDialog({
                               })}
                           </div>
                         )}
+
+                      {(() => {
+                        const genres = (resolveField(result, "genres") as string[]) ?? [];
+                        const tags = (resolveField(result, "tags") as string[]) ?? [];
+                        return (genres.length > 0 || tags.length > 0) ? (
+                          <div className="flex flex-wrap gap-1 mt-1">
+                            {genres.map((g) => (
+                              <Badge
+                                className="text-xs"
+                                key={`genre-${g}`}
+                                variant="secondary"
+                              >
+                                {g}
+                              </Badge>
+                            ))}
+                            {tags.map((tag) => (
+                              <Badge
+                                className="text-xs bg-muted text-muted-foreground"
+                                key={`tag-${tag}`}
+                                variant="outline"
+                              >
+                                {tag}
+                              </Badge>
+                            ))}
+                          </div>
+                        ) : null;
+                      })()}
 
                       {result.description && (
                         <p className="text-xs text-muted-foreground line-clamp-2 mt-1">

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -142,7 +142,8 @@ export function IdentifyBookDialog({
     metadataField?: string,
   ) => {
     const topLevel = result[field];
-    if (topLevel !== undefined && topLevel !== null && topLevel !== "") return topLevel;
+    if (topLevel !== undefined && topLevel !== null && topLevel !== "")
+      return topLevel;
     if (result.metadata) {
       const mdField = metadataField || field;
       return (result.metadata as Record<string, unknown>)[mdField as string];
@@ -158,8 +159,11 @@ export function IdentifyBookDialog({
     return undefined;
   };
 
-  const resolveNarrators = (result: PluginSearchResult): string[] | undefined => {
-    if (result.narrators && result.narrators.length > 0) return result.narrators;
+  const resolveNarrators = (
+    result: PluginSearchResult,
+  ): string[] | undefined => {
+    if (result.narrators && result.narrators.length > 0)
+      return result.narrators;
     if (result.metadata?.narrators && result.metadata.narrators.length > 0) {
       return result.metadata.narrators;
     }
@@ -259,7 +263,10 @@ export function IdentifyBookDialog({
                       </div>
 
                       {(() => {
-                        const subtitle = resolveField(result, "subtitle") as string;
+                        const subtitle = resolveField(
+                          result,
+                          "subtitle",
+                        ) as string;
                         return subtitle ? (
                           <p className="text-sm text-muted-foreground/80 leading-tight">
                             {subtitle}
@@ -269,7 +276,10 @@ export function IdentifyBookDialog({
 
                       {(() => {
                         const series = resolveField(result, "series") as string;
-                        const seriesNum = resolveField(result, "series_number") as number;
+                        const seriesNum = resolveField(
+                          result,
+                          "series_number",
+                        ) as number;
                         return series ? (
                           <p className="text-xs text-muted-foreground font-medium">
                             {series}
@@ -363,9 +373,11 @@ export function IdentifyBookDialog({
                         )}
 
                       {(() => {
-                        const genres = (resolveField(result, "genres") as string[]) ?? [];
-                        const tags = (resolveField(result, "tags") as string[]) ?? [];
-                        return (genres.length > 0 || tags.length > 0) ? (
+                        const genres =
+                          (resolveField(result, "genres") as string[]) ?? [];
+                        const tags =
+                          (resolveField(result, "tags") as string[]) ?? [];
+                        return genres.length > 0 || tags.length > 0 ? (
                           <div className="flex flex-wrap gap-1 mt-1">
                             {genres.map((g) => (
                               <Badge

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -507,11 +507,33 @@ export interface PluginSearchResult {
   image_url?: string;
   release_date?: string;
   publisher?: string;
+  subtitle?: string;
+  series?: string;
+  series_number?: number;
+  genres?: string[];
+  tags?: string[];
+  narrators?: string[];
   identifiers?: { type: string; value: string }[];
   provider_data?: unknown;
   plugin_scope: string;
   plugin_id: string;
   disabled_fields?: string[];
+  /** Display-oriented subset of ParsedMetadata. Only includes fields relevant to search result display. */
+  metadata?: {
+    title?: string;
+    subtitle?: string;
+    authors?: { name: string; role?: string }[];
+    narrators?: string[];
+    series?: string;
+    series_number?: number;
+    genres?: string[];
+    tags?: string[];
+    description?: string;
+    publisher?: string;
+    release_date?: string;
+    cover_url?: string;
+    identifiers?: { type: string; value: string }[];
+  };
 }
 
 export interface PluginSearchResponse {

--- a/packages/plugin-types/hooks.d.ts
+++ b/packages/plugin-types/hooks.d.ts
@@ -56,9 +56,17 @@ export interface SearchResult {
   imageUrl?: string;
   releaseDate?: string;
   publisher?: string;
+  subtitle?: string;
+  series?: string;
+  seriesNumber?: number;
+  genres?: string[];
+  tags?: string[];
+  narrators?: string[];
   identifiers?: Array<{ type: string; value: string }>;
   /** Opaque data passed back to enrich(). Use this to store internal IDs. */
   providerData?: unknown;
+  /** Full metadata for passthrough pattern. If provided, enrich() can return it as-is. */
+  metadata?: ParsedMetadata;
 }
 
 /** Result returned from metadataEnricher.search(). */

--- a/packages/plugin-types/metadata.d.ts
+++ b/packages/plugin-types/metadata.d.ts
@@ -46,6 +46,8 @@ export interface ParsedMetadata {
   releaseDate?: string;
   /** MIME type of cover image (e.g., "image/jpeg"). */
   coverMimeType?: string;
+  /** Public URL for cover image. Server downloads at apply time. Lower precedence than coverData. */
+  coverUrl?: string;
   /** Cover image data as ArrayBuffer. */
   coverData?: ArrayBuffer;
   /** 0-indexed page number for CBZ cover. */

--- a/pkg/mediafile/mediafile.go
+++ b/pkg/mediafile/mediafile.go
@@ -10,8 +10,8 @@ import (
 // Role is used for CBZ ComicInfo.xml creator types (writer, penciller, etc.).
 // For EPUB/M4B files, Role will be empty (generic author).
 type ParsedAuthor struct {
-	Name string
-	Role string // empty for generic author, or one of: writer, penciller, inker, colorist, letterer, cover_artist, editor, translator
+	Name string `json:"name"`
+	Role string `json:"role"` // empty for generic author, or one of: writer, penciller, inker, colorist, letterer, cover_artist, editor, translator
 }
 
 // ParsedIdentifier represents an identifier parsed from file metadata.
@@ -23,50 +23,51 @@ type ParsedIdentifier struct {
 // ParsedChapter represents a chapter parsed from file metadata.
 // Position fields are mutually exclusive based on file type.
 type ParsedChapter struct {
-	Title            string
-	StartPage        *int            // CBZ: 0-indexed page number
-	StartTimestampMs *int64          // M4B: milliseconds from start
-	Href             *string         // EPUB: content document href
-	Children         []ParsedChapter // EPUB nesting only; CBZ/M4B always empty
+	Title            string          `json:"title"`
+	StartPage        *int            `json:"start_page,omitempty"`         // CBZ: 0-indexed page number
+	StartTimestampMs *int64          `json:"start_timestamp_ms,omitempty"` // M4B: milliseconds from start
+	Href             *string         `json:"href,omitempty"`               // EPUB: content document href
+	Children         []ParsedChapter `json:"children,omitempty"`           // EPUB nesting only; CBZ/M4B always empty
 }
 
 type ParsedMetadata struct {
-	Title         string
-	Subtitle      string // from M4B freeform SUBTITLE atom
-	Authors       []ParsedAuthor
-	Narrators     []string
-	Series        string
-	SeriesNumber  *float64
-	Genres        []string // Genre names from file metadata
-	Tags          []string // Tag names from file metadata
-	Description   string
-	Publisher     string
-	Imprint       string
-	URL           string
-	ReleaseDate   *time.Time
-	CoverMimeType string
-	CoverData     []byte
-	CoverPage     *int // 0-indexed page number for CBZ cover, nil for other file types
+	Title         string         `json:"title"`
+	Subtitle      string         `json:"subtitle"` // from M4B freeform SUBTITLE atom
+	Authors       []ParsedAuthor `json:"authors"`
+	Narrators     []string       `json:"narrators"`
+	Series        string         `json:"series"`
+	SeriesNumber  *float64       `json:"series_number,omitempty"`
+	Genres        []string       `json:"genres"` // Genre names from file metadata
+	Tags          []string       `json:"tags"`   // Tag names from file metadata
+	Description   string         `json:"description"`
+	Publisher     string         `json:"publisher"`
+	Imprint       string         `json:"imprint"`
+	URL           string         `json:"url"`
+	ReleaseDate   *time.Time     `json:"release_date,omitempty"`
+	CoverMimeType string         `json:"cover_mime_type"`
+	CoverURL      string         `json:"cover_url"`
+	CoverData     []byte         `json:"-"`
+	CoverPage     *int           `json:"cover_page,omitempty"` // 0-indexed page number for CBZ cover, nil for other file types
 	// DataSource should be a value of books.DataSource
-	DataSource string
+	DataSource string `json:"-"`
 	// FieldDataSources maps individual field names to the data source that provided them.
 	// Used when multiple enrichers contribute different fields (per-field first-wins tracking).
 	// Keys are field names: "title", "subtitle", "authors", "narrators", "series",
 	// "genres", "tags", "description", "publisher", "imprint", "url", "releaseDate",
 	// "cover", "identifiers".
-	FieldDataSources map[string]string
+	FieldDataSources map[string]string `json:"-"`
 	// Duration is the length of the audiobook (M4B files only)
-	Duration time.Duration
+	Duration time.Duration `json:"duration"`
 	// BitrateBps is the audio bitrate in bits per second (M4B files only)
-	BitrateBps int
+	BitrateBps int `json:"bitrate_bps"`
 	// Codec is the audio codec with profile (M4B files only), e.g. "AAC-LC", "xHE-AAC"
-	Codec string
+	Codec string `json:"-"`
 	// PageCount is the number of pages (CBZ and PDF files)
-	PageCount *int
+	PageCount *int `json:"page_count,omitempty"`
 	// Identifiers contains file identifiers (ISBN, ASIN, etc.) parsed from metadata
-	Identifiers []ParsedIdentifier
+	Identifiers []ParsedIdentifier `json:"identifiers"`
 	// Chapters contains chapter information parsed from file metadata
-	Chapters []ParsedChapter
+	Chapters []ParsedChapter `json:"chapters"`
 }
 
 func (m *ParsedMetadata) String() string {

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -100,7 +100,7 @@ shisho/goodreads-metadata/
 `title`, `subtitle`, `authors`, `narrators`, `series`, `seriesNumber`, `genres`, `tags`, `description`, `publisher`, `imprint`, `url`, `releaseDate`, `cover`, `identifiers`
 
 **Logical field groupings:**
-- `cover` → controls `coverData`, `coverMimeType`, and `coverPage`
+- `cover` → controls `coverData`, `coverMimeType`, `coverPage`, and `coverUrl`
 - `series` → controls both `series` (name) and `seriesNumber`
 
 ## main.js Pattern

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1473,7 +1473,7 @@ func downloadCoverFromURL(ctx context.Context, md *mediafile.ParsedMetadata, log
 		return false
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10 MB max
 	if err != nil {
 		log.Warn("failed to read cover response body", logger.Data{"url": md.CoverURL, "error": err.Error()})
 		return false

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1445,13 +1445,13 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 
 // downloadCoverFromURL fetches a cover image from a URL and populates md.CoverData and md.CoverMimeType.
 // Returns true if the download succeeded, false otherwise. Skips if CoverData is already set (precedence rule).
-func downloadCoverFromURL(md *mediafile.ParsedMetadata, log logger.Logger) bool {
+func downloadCoverFromURL(ctx context.Context, md *mediafile.ParsedMetadata, log logger.Logger) bool {
 	if len(md.CoverData) > 0 || md.CoverURL == "" {
 		return false
 	}
 
 	client := &http.Client{Timeout: 30 * time.Second}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, md.CoverURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, md.CoverURL, nil)
 	if err != nil {
 		log.Warn("failed to create cover download request", logger.Data{"url": md.CoverURL, "error": err.Error()})
 		return false
@@ -1755,7 +1755,7 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 
 	// Cover image: download from URL if coverData is empty and coverUrl is set
 	if md.CoverURL != "" && isAllowed("cover") && targetFile != nil {
-		downloadCoverFromURL(md, log)
+		downloadCoverFromURL(ctx, md, log)
 	}
 
 	// Apply cover data (from coverData or downloaded from coverUrl)

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1451,7 +1451,12 @@ func downloadCoverFromURL(md *mediafile.ParsedMetadata, log logger.Logger) bool 
 	}
 
 	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(md.CoverURL)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, md.CoverURL, nil)
+	if err != nil {
+		log.Warn("failed to create cover download request", logger.Data{"url": md.CoverURL, "error": err.Error()})
+		return false
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		log.Warn("failed to download cover from URL", logger.Data{"url": md.CoverURL, "error": err.Error()})
 		return false

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"context"
 	"database/sql"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -1333,6 +1334,13 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		allResults = append(allResults, resp.Results...)
 	}
 
+	// Strip binary cover data from search results — covers are displayed via imageUrl
+	for i := range allResults {
+		if allResults[i].Metadata != nil {
+			allResults[i].Metadata.CoverData = nil
+		}
+	}
+
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"results": allResults,
 	})
@@ -1433,6 +1441,42 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, updatedBook)
+}
+
+// downloadCoverFromURL fetches a cover image from a URL and populates md.CoverData and md.CoverMimeType.
+// Returns true if the download succeeded, false otherwise. Skips if CoverData is already set (precedence rule).
+func downloadCoverFromURL(md *mediafile.ParsedMetadata, log logger.Logger) bool {
+	if len(md.CoverData) > 0 || md.CoverURL == "" {
+		return false
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(md.CoverURL)
+	if err != nil {
+		log.Warn("failed to download cover from URL", logger.Data{"url": md.CoverURL, "error": err.Error()})
+		return false
+	}
+	defer resp.Body.Close()
+
+	contentType := resp.Header.Get("Content-Type")
+	if resp.StatusCode != http.StatusOK || !strings.HasPrefix(contentType, "image/") {
+		log.Warn("cover URL returned non-image response", logger.Data{
+			"url":          md.CoverURL,
+			"status":       resp.StatusCode,
+			"content_type": contentType,
+		})
+		return false
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Warn("failed to read cover response body", logger.Data{"url": md.CoverURL, "error": err.Error()})
+		return false
+	}
+
+	md.CoverData = body
+	md.CoverMimeType = contentType
+	return true
 }
 
 // applyEnrichment applies enriched metadata to a book, respecting field filtering.
@@ -1704,7 +1748,12 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 		}
 	}
 
-	// Cover image (applied to target file)
+	// Cover image: download from URL if coverData is empty and coverUrl is set
+	if md.CoverURL != "" && isAllowed("cover") && targetFile != nil {
+		downloadCoverFromURL(md, log)
+	}
+
+	// Apply cover data (from coverData or downloaded from coverUrl)
 	if len(md.CoverData) > 0 && isAllowed("cover") && targetFile != nil {
 		coverDir := book.Filepath
 		coverBaseName := filepath.Base(targetFile.Filepath) + ".cover"

--- a/pkg/plugins/handler_enrich_test.go
+++ b/pkg/plugins/handler_enrich_test.go
@@ -1,0 +1,89 @@
+package plugins
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/mediafile"
+	"github.com/stretchr/testify/assert"
+)
+
+func testLogger() logger.Logger {
+	return logger.New()
+}
+
+func TestDownloadCoverFromURL_Success(t *testing.T) {
+	t.Parallel()
+
+	fakeJPEG := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write(fakeJPEG)
+	}))
+	defer srv.Close()
+
+	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/cover.jpg"}
+	ok := downloadCoverFromURL(md, testLogger())
+
+	assert.True(t, ok)
+	assert.Equal(t, fakeJPEG, md.CoverData)
+	assert.Equal(t, "image/jpeg", md.CoverMimeType)
+}
+
+func TestDownloadCoverFromURL_CoverDataTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	existing := []byte{0xFF, 0xD8, 0xFF, 0xE0}
+	md := &mediafile.ParsedMetadata{
+		CoverData:     existing,
+		CoverMimeType: "image/jpeg",
+		CoverURL:      "https://should-not-be-called.example.com/cover.jpg",
+	}
+
+	ok := downloadCoverFromURL(md, testLogger())
+
+	assert.False(t, ok, "should skip when CoverData already set")
+	assert.Equal(t, existing, md.CoverData, "CoverData should be unchanged")
+}
+
+func TestDownloadCoverFromURL_NonImageRejected(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte("<html>Not an image</html>"))
+	}))
+	defer srv.Close()
+
+	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/not-image"}
+	ok := downloadCoverFromURL(md, testLogger())
+
+	assert.False(t, ok, "should reject non-image content type")
+	assert.Nil(t, md.CoverData, "CoverData should remain nil")
+}
+
+func TestDownloadCoverFromURL_EmptyURL(t *testing.T) {
+	t.Parallel()
+
+	md := &mediafile.ParsedMetadata{}
+	ok := downloadCoverFromURL(md, testLogger())
+
+	assert.False(t, ok, "should return false for empty URL")
+}
+
+func TestDownloadCoverFromURL_ServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/error"}
+	ok := downloadCoverFromURL(md, testLogger())
+
+	assert.False(t, ok, "should return false on server error")
+	assert.Nil(t, md.CoverData, "CoverData should remain nil")
+}

--- a/pkg/plugins/handler_enrich_test.go
+++ b/pkg/plugins/handler_enrich_test.go
@@ -18,7 +18,7 @@ func TestDownloadCoverFromURL_Success(t *testing.T) {
 	t.Parallel()
 
 	fakeJPEG := []byte{0xFF, 0xD8, 0xFF, 0xE0}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
 		w.Write(fakeJPEG)
 	}))
@@ -51,7 +51,7 @@ func TestDownloadCoverFromURL_CoverDataTakesPrecedence(t *testing.T) {
 func TestDownloadCoverFromURL_NonImageRejected(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.Write([]byte("<html>Not an image</html>"))
 	}))
@@ -76,7 +76,7 @@ func TestDownloadCoverFromURL_EmptyURL(t *testing.T) {
 func TestDownloadCoverFromURL_ServerError(t *testing.T) {
 	t.Parallel()
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv.Close()

--- a/pkg/plugins/handler_enrich_test.go
+++ b/pkg/plugins/handler_enrich_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -25,7 +26,7 @@ func TestDownloadCoverFromURL_Success(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/cover.jpg"}
-	ok := downloadCoverFromURL(md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, testLogger())
 
 	assert.True(t, ok)
 	assert.Equal(t, fakeJPEG, md.CoverData)
@@ -42,7 +43,7 @@ func TestDownloadCoverFromURL_CoverDataTakesPrecedence(t *testing.T) {
 		CoverURL:      "https://should-not-be-called.example.com/cover.jpg",
 	}
 
-	ok := downloadCoverFromURL(md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, testLogger())
 
 	assert.False(t, ok, "should skip when CoverData already set")
 	assert.Equal(t, existing, md.CoverData, "CoverData should be unchanged")
@@ -58,7 +59,7 @@ func TestDownloadCoverFromURL_NonImageRejected(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/not-image"}
-	ok := downloadCoverFromURL(md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, testLogger())
 
 	assert.False(t, ok, "should reject non-image content type")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")
@@ -68,7 +69,7 @@ func TestDownloadCoverFromURL_EmptyURL(t *testing.T) {
 	t.Parallel()
 
 	md := &mediafile.ParsedMetadata{}
-	ok := downloadCoverFromURL(md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, testLogger())
 
 	assert.False(t, ok, "should return false for empty URL")
 }
@@ -82,7 +83,7 @@ func TestDownloadCoverFromURL_ServerError(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/error"}
-	ok := downloadCoverFromURL(md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, testLogger())
 
 	assert.False(t, ok, "should return false on server error")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -141,8 +141,15 @@ type SearchResult struct {
 	ImageURL     string                       `json:"image_url"`
 	ReleaseDate  string                       `json:"release_date"`
 	Publisher    string                       `json:"publisher"`
+	Subtitle     string                       `json:"subtitle"`
+	Series       string                       `json:"series"`
+	SeriesNumber *float64                     `json:"series_number,omitempty"`
+	Genres       []string                     `json:"genres"`
+	Tags         []string                     `json:"tags"`
+	Narrators    []string                     `json:"narrators"`
 	Identifiers  []mediafile.ParsedIdentifier `json:"identifiers"`
 	ProviderData interface{}                  `json:"provider_data"` // Opaque data passed back to enrich()
+	Metadata     *mediafile.ParsedMetadata    `json:"metadata,omitempty"`
 	// Added by the caller, not the plugin:
 	PluginScope    string   `json:"plugin_scope"`
 	PluginID       string   `json:"plugin_id"`
@@ -414,8 +421,35 @@ func parseSearchResponse(vm *goja.Runtime, val goja.Value, pluginScope, pluginID
 			ImageURL:    getStringField(itemObj, "imageUrl"),
 			ReleaseDate: getStringField(itemObj, "releaseDate"),
 			Publisher:   getStringField(itemObj, "publisher"),
+			Subtitle:    getStringField(itemObj, "subtitle"),
+			Series:      getStringField(itemObj, "series"),
 			PluginScope: pluginScope,
 			PluginID:    pluginID,
+		}
+
+		// seriesNumber -> *float64
+		seriesNumVal := itemObj.Get("seriesNumber")
+		if seriesNumVal != nil && !goja.IsUndefined(seriesNumVal) && !goja.IsNull(seriesNumVal) {
+			f := seriesNumVal.ToFloat()
+			sr.SeriesNumber = &f
+		}
+
+		// genres -> []string
+		genresVal := itemObj.Get("genres")
+		if genresVal != nil && !goja.IsUndefined(genresVal) && !goja.IsNull(genresVal) {
+			sr.Genres = parseStringArray(vm, genresVal)
+		}
+
+		// tags -> []string
+		tagsVal := itemObj.Get("tags")
+		if tagsVal != nil && !goja.IsUndefined(tagsVal) && !goja.IsNull(tagsVal) {
+			sr.Tags = parseStringArray(vm, tagsVal)
+		}
+
+		// narrators -> []string
+		narratorsVal := itemObj.Get("narrators")
+		if narratorsVal != nil && !goja.IsUndefined(narratorsVal) && !goja.IsNull(narratorsVal) {
+			sr.Narrators = parseStringArray(vm, narratorsVal)
 		}
 
 		// authors -> []string
@@ -434,6 +468,15 @@ func parseSearchResponse(vm *goja.Runtime, val goja.Value, pluginScope, pluginID
 		providerDataVal := itemObj.Get("providerData")
 		if providerDataVal != nil && !goja.IsUndefined(providerDataVal) && !goja.IsNull(providerDataVal) {
 			sr.ProviderData = providerDataVal.Export()
+		}
+
+		// metadata -> *ParsedMetadata (optional, for passthrough pattern)
+		metadataVal := itemObj.Get("metadata")
+		if metadataVal != nil && !goja.IsUndefined(metadataVal) && !goja.IsNull(metadataVal) {
+			md, mErr := parseParsedMetadata(vm, metadataVal)
+			if mErr == nil {
+				sr.Metadata = md
+			}
 		}
 
 		results = append(results, sr)
@@ -460,6 +503,7 @@ func parseParsedMetadata(vm *goja.Runtime, val goja.Value) (*mediafile.ParsedMet
 	md.Imprint = getStringField(obj, "imprint")
 	md.URL = getStringField(obj, "url")
 	md.CoverMimeType = getStringField(obj, "coverMimeType")
+	md.CoverURL = getStringField(obj, "coverUrl")
 	md.DataSource = getStringField(obj, "dataSource")
 
 	// seriesNumber -> *float64

--- a/pkg/plugins/hooks_test.go
+++ b/pkg/plugins/hooks_test.go
@@ -537,6 +537,173 @@ func TestRunMetadataEnrich_NoHook(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not have a metadataEnricher hook")
 }
 
+func TestRunMetadataSearch_NewFields(t *testing.T) {
+	t.Parallel()
+	mgr, rt := setupHooksTestManager(t, "hooks-enricher", "hooks-enricher")
+	ctx := context.Background()
+
+	searchCtx := map[string]interface{}{
+		"query": "My Book",
+		"book": map[string]interface{}{
+			"title":   "My Book",
+			"authors": []string{"Author A"},
+		},
+		"file": map[string]interface{}{
+			"fileType": "epub",
+			"filePath": "/library/book.epub",
+		},
+	}
+
+	resp, err := mgr.RunMetadataSearch(ctx, rt, searchCtx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+
+	result := resp.Results[0]
+
+	// Existing fields still work
+	assert.Equal(t, "Search: My Book", result.Title)
+	assert.Equal(t, []string{"Search Author"}, result.Authors)
+	assert.Equal(t, "Search Publisher", result.Publisher)
+
+	// New scalar fields
+	assert.Equal(t, "A Search Subtitle", result.Subtitle)
+	assert.Equal(t, "Search Series", result.Series)
+	require.NotNil(t, result.SeriesNumber)
+	assert.InDelta(t, 2.5, *result.SeriesNumber, 0.001)
+
+	// New array fields
+	assert.Equal(t, []string{"Fiction", "Fantasy"}, result.Genres)
+	assert.Equal(t, []string{"epic", "adventure"}, result.Tags)
+	assert.Equal(t, []string{"Narrator One", "Narrator Two"}, result.Narrators)
+
+	// Embedded metadata
+	require.NotNil(t, result.Metadata)
+	assert.Equal(t, "Search: My Book", result.Metadata.Title)
+	assert.Equal(t, "A Search Subtitle", result.Metadata.Subtitle)
+	assert.Equal(t, "Search Series", result.Metadata.Series)
+	require.NotNil(t, result.Metadata.SeriesNumber)
+	assert.InDelta(t, 2.5, *result.Metadata.SeriesNumber, 0.001)
+	assert.Equal(t, []string{"Fiction", "Fantasy"}, result.Metadata.Genres)
+	assert.Equal(t, []string{"epic", "adventure"}, result.Metadata.Tags)
+	assert.Equal(t, []string{"Narrator One", "Narrator Two"}, result.Metadata.Narrators)
+	assert.Equal(t, "https://example.com/cover.jpg", result.Metadata.CoverURL)
+	require.Len(t, result.Metadata.Authors, 1)
+	assert.Equal(t, "Search Author", result.Metadata.Authors[0].Name)
+	assert.Equal(t, "writer", result.Metadata.Authors[0].Role)
+}
+
+func TestRunMetadataEnrich_CoverUrl(t *testing.T) {
+	t.Parallel()
+	mgr, rt := setupHooksTestManager(t, "hooks-enricher", "hooks-enricher")
+	ctx := context.Background()
+
+	enrichCtx := map[string]interface{}{
+		"selectedResult": map[string]interface{}{
+			"internalId": 42,
+			"query":      "My Book",
+		},
+		"book": map[string]interface{}{
+			"title":   "My Book",
+			"authors": []string{"Author A"},
+		},
+		"file": map[string]interface{}{
+			"fileType": "epub",
+			"filePath": "/library/book.epub",
+		},
+	}
+
+	result, err := mgr.RunMetadataEnrich(ctx, rt, enrichCtx)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.Modified)
+	require.NotNil(t, result.Metadata)
+	assert.Equal(t, "https://example.com/enriched-cover.jpg", result.Metadata.CoverURL)
+}
+
+func TestRunMetadataSearch_NoNewFields(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	service := NewService(db)
+	pluginDir := t.TempDir()
+
+	destDir := filepath.Join(pluginDir, "test", "minimal-enricher")
+	err := os.MkdirAll(destDir, 0755)
+	require.NoError(t, err)
+
+	manifest := `{
+  "manifestVersion": 1,
+  "id": "minimal-enricher",
+  "name": "Minimal Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "description": "Minimal",
+      "fileTypes": ["epub"],
+      "fields": ["title"]
+    }
+  }
+}`
+	mainJS := `var plugin = (function() {
+  return {
+    metadataEnricher: {
+      search: function(context) {
+        return { results: [{ title: "Just Title" }] };
+      },
+      enrich: function(context) {
+        return { modified: false };
+      }
+    }
+  };
+})();`
+
+	err = os.WriteFile(filepath.Join(destDir, "manifest.json"), []byte(manifest), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644)
+	require.NoError(t, err)
+
+	manager := NewManager(service, pluginDir, "")
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "test",
+		ID:          "minimal-enricher",
+		Name:        "Minimal Enricher",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err = service.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	err = manager.LoadPlugin(ctx, "test", "minimal-enricher")
+	require.NoError(t, err)
+
+	rt := manager.GetRuntime("test", "minimal-enricher")
+	require.NotNil(t, rt)
+
+	searchCtx := map[string]interface{}{
+		"query": "Test",
+		"book":  map[string]interface{}{"title": "Test"},
+		"file":  map[string]interface{}{"fileType": "epub"},
+	}
+
+	resp, err := manager.RunMetadataSearch(ctx, rt, searchCtx)
+	require.NoError(t, err)
+	require.Len(t, resp.Results, 1)
+
+	result := resp.Results[0]
+	assert.Equal(t, "Just Title", result.Title)
+	assert.Empty(t, result.Subtitle)
+	assert.Empty(t, result.Series)
+	assert.Nil(t, result.SeriesNumber)
+	assert.Nil(t, result.Genres)
+	assert.Nil(t, result.Tags)
+	assert.Nil(t, result.Narrators)
+	assert.Nil(t, result.Metadata)
+}
+
 func TestRunOutputGenerator_NoHook(t *testing.T) {
 	// Use the converter plugin which has no generator hook
 	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")

--- a/pkg/plugins/hooks_test.go
+++ b/pkg/plugins/hooks_test.go
@@ -704,6 +704,122 @@ func TestRunMetadataSearch_NoNewFields(t *testing.T) {
 	assert.Nil(t, result.Metadata)
 }
 
+func TestPassthroughPattern(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	service := NewService(db)
+	pluginDir := t.TempDir()
+
+	// Create a plugin that uses the passthrough pattern:
+	// search() returns metadata in providerData, enrich() returns it unchanged
+	destDir := filepath.Join(pluginDir, "test", "passthrough-enricher")
+	err := os.MkdirAll(destDir, 0755)
+	require.NoError(t, err)
+
+	manifest := `{
+  "manifestVersion": 1,
+  "id": "passthrough-enricher",
+  "name": "Passthrough Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "description": "Passthrough enricher",
+      "fileTypes": ["epub"],
+      "fields": ["title", "description", "genres", "cover"]
+    }
+  }
+}`
+	mainJS := `var plugin = (function() {
+  return {
+    metadataEnricher: {
+      search: function(context) {
+        var md = {
+          title: "Passthrough Title",
+          description: "Passthrough description",
+          genres: ["SciFi"],
+          coverUrl: "https://example.com/cover.jpg"
+        };
+        return {
+          results: [{
+            title: "Passthrough Title",
+            description: "Passthrough description",
+            genres: ["SciFi"],
+            providerData: md,
+            metadata: md
+          }]
+        };
+      },
+      enrich: function(context) {
+        return { modified: true, metadata: context.selectedResult };
+      }
+    }
+  };
+})();`
+
+	err = os.WriteFile(filepath.Join(destDir, "manifest.json"), []byte(manifest), 0644)
+	require.NoError(t, err)
+	err = os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644)
+	require.NoError(t, err)
+
+	manager := NewManager(service, pluginDir, "")
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "test",
+		ID:          "passthrough-enricher",
+		Name:        "Passthrough Enricher",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err = service.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	err = manager.LoadPlugin(ctx, "test", "passthrough-enricher")
+	require.NoError(t, err)
+
+	rt := manager.GetRuntime("test", "passthrough-enricher")
+	require.NotNil(t, rt)
+
+	// Step 1: Search returns metadata in both display fields and metadata object
+	searchCtx := map[string]interface{}{
+		"query": "Test",
+		"book":  map[string]interface{}{"title": "Test"},
+		"file":  map[string]interface{}{"fileType": "epub"},
+	}
+
+	searchResp, err := manager.RunMetadataSearch(ctx, rt, searchCtx)
+	require.NoError(t, err)
+	require.Len(t, searchResp.Results, 1)
+
+	sr := searchResp.Results[0]
+	assert.Equal(t, "Passthrough Title", sr.Title)
+	assert.Equal(t, []string{"SciFi"}, sr.Genres)
+	require.NotNil(t, sr.Metadata)
+	assert.Equal(t, "Passthrough Title", sr.Metadata.Title)
+	assert.Equal(t, "https://example.com/cover.jpg", sr.Metadata.CoverURL)
+
+	// Step 2: Enrich receives providerData (the metadata) and returns it unchanged
+	enrichCtx := map[string]interface{}{
+		"selectedResult": sr.ProviderData,
+		"book":           map[string]interface{}{"title": "Test"},
+		"file":           map[string]interface{}{"fileType": "epub"},
+	}
+
+	enrichResp, err := manager.RunMetadataEnrich(ctx, rt, enrichCtx)
+	require.NoError(t, err)
+	require.NotNil(t, enrichResp)
+	assert.True(t, enrichResp.Modified)
+	require.NotNil(t, enrichResp.Metadata)
+
+	// The enriched metadata should match what was originally returned at search time
+	assert.Equal(t, "Passthrough Title", enrichResp.Metadata.Title)
+	assert.Equal(t, "Passthrough description", enrichResp.Metadata.Description)
+	assert.Equal(t, []string{"SciFi"}, enrichResp.Metadata.Genres)
+	assert.Equal(t, "https://example.com/cover.jpg", enrichResp.Metadata.CoverURL)
+}
+
 func TestRunOutputGenerator_NoHook(t *testing.T) {
 	// Use the converter plugin which has no generator hook
 	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")

--- a/pkg/plugins/testdata/hooks-enricher/main.js
+++ b/pkg/plugins/testdata/hooks-enricher/main.js
@@ -9,10 +9,32 @@ var plugin = (function() {
               authors: ["Search Author"],
               description: "Found result for " + context.query,
               publisher: "Search Publisher",
+              subtitle: "A Search Subtitle",
+              series: "Search Series",
+              seriesNumber: 2.5,
+              genres: ["Fiction", "Fantasy"],
+              tags: ["epic", "adventure"],
+              narrators: ["Narrator One", "Narrator Two"],
               identifiers: [
                 { type: "goodreads", value: "12345" }
               ],
-              providerData: { internalId: 42, query: context.query }
+              providerData: { internalId: 42, query: context.query },
+              metadata: {
+                title: "Search: " + context.query,
+                subtitle: "A Search Subtitle",
+                series: "Search Series",
+                seriesNumber: 2.5,
+                genres: ["Fiction", "Fantasy"],
+                tags: ["epic", "adventure"],
+                narrators: ["Narrator One", "Narrator Two"],
+                authors: [{ name: "Search Author", role: "writer" }],
+                description: "Found result for " + context.query,
+                publisher: "Search Publisher",
+                coverUrl: "https://example.com/cover.jpg",
+                identifiers: [
+                  { type: "goodreads", value: "12345" }
+                ]
+              }
             }
           ]
         };
@@ -36,7 +58,8 @@ var plugin = (function() {
             series: "Enriched Series",
             seriesNumber: 3,
             publisher: "Enriched Publisher",
-            url: "https://enriched.example.com"
+            url: "https://enriched.example.com",
+            coverUrl: "https://example.com/enriched-cover.jpg"
           }
         };
       }

--- a/pkg/plugins/testdata/hooks-enricher/manifest.json
+++ b/pkg/plugins/testdata/hooks-enricher/manifest.json
@@ -7,7 +7,7 @@
     "metadataEnricher": {
       "description": "Test enricher",
       "fileTypes": ["epub"],
-      "fields": ["title", "authors", "description", "genres", "tags", "cover"]
+      "fields": ["title", "subtitle", "authors", "narrators", "description", "genres", "tags", "series", "seriesNumber", "cover", "publisher", "identifiers", "url", "releaseDate"]
     }
   }
 }

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -279,6 +279,7 @@ The full set of fields you can return:
 | `coverData` | `ArrayBuffer` | Cover image data |
 | `coverMimeType` | `string` | Cover MIME type (e.g., `image/jpeg`) |
 | `coverPage` | `number` | Cover page index (0-indexed, for page-based formats) |
+| `coverUrl` | `string` | Public URL for cover image. Server downloads at apply time. |
 | `duration` | `number` | Audiobook duration in seconds |
 | `bitrateBps` | `number` | Audio bitrate in bits per second |
 | `pageCount` | `number` | Page count |
@@ -287,7 +288,7 @@ The full set of fields you can return:
 
 :::note[Field groupings for enrichers]
 When declaring `fields` in an enricher manifest, some return fields are grouped under a single logical name:
-- **`cover`** controls `coverData`, `coverMimeType`, and `coverPage`
+- **`cover`** controls `coverData`, `coverMimeType`, `coverPage`, and `coverUrl`
 - **`series`** controls both `series` and `seriesNumber`
 :::
 
@@ -304,33 +305,66 @@ When declaring `fields` in an enricher manifest, some return fields are grouped 
 
 ### Metadata Enricher
 
-Enhances existing book metadata from external APIs. Runs after file parsing during library scans.
+Enhances existing book metadata from external APIs. The enricher has two hooks:
+
+1. **`search(context)`** — Returns candidate results for the user to choose from
+2. **`enrich(context)`** — Fetches full metadata for the selected result
 
 **Timeout:** 1 minute
+
+#### Search Results
+
+The `search()` hook returns results with display fields for comparing candidates:
 
 ```javascript
 var plugin = (function() {
   return {
     metadataEnricher: {
-      enrich: function(context) {
-        // context.book  - book metadata (title, authors, etc.)
-        // context.file  - file metadata (identifiers, etc.)
-
+      search: function(context) {
         var apiKey = shisho.config.get("apiKey");
-        var query = shisho.url.encodeURIComponent(context.book.title);
+        var query = shisho.url.encodeURIComponent(context.query);
         var resp = shisho.http.fetch(
           "https://api.example.com/search?q=" + query,
           { headers: { "Authorization": "Bearer " + apiKey } }
         );
 
-        if (!resp.ok) {
-          return { modified: false };
-        }
+        if (!resp.ok) return { results: [] };
+
+        var data = resp.json();
+        return {
+          results: data.items.map(function(item) {
+            return {
+              title: item.title,
+              subtitle: item.subtitle,
+              authors: item.authors,
+              narrators: item.narrators,
+              series: item.seriesName,
+              seriesNumber: item.seriesNumber,
+              genres: item.genres,
+              tags: item.tags,
+              description: item.description,
+              imageUrl: item.coverUrl,
+              releaseDate: item.publishDate,
+              publisher: item.publisher,
+              identifiers: [{ type: "isbn_13", value: item.isbn }],
+              providerData: { id: item.id }
+            };
+          })
+        };
+      },
+
+      enrich: function(context) {
+        var resp = shisho.http.fetch(
+          "https://api.example.com/books/" + context.selectedResult.id,
+          {}
+        );
+        if (!resp.ok) return { modified: false };
 
         var data = resp.json();
         return {
           modified: true,
           metadata: {
+            title: data.title,
             description: data.description,
             genres: data.genres
           }
@@ -340,6 +374,100 @@ var plugin = (function() {
   };
 })();
 ```
+
+**Search result fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | `string` | **Required.** Book title |
+| `subtitle` | `string` | Subtitle or edition info |
+| `authors` | `string[]` | Author names |
+| `narrators` | `string[]` | Narrator names (audiobooks) |
+| `series` | `string` | Series name |
+| `seriesNumber` | `number` | Position in series |
+| `genres` | `string[]` | Genre classification |
+| `tags` | `string[]` | Freeform labels |
+| `description` | `string` | Book description |
+| `imageUrl` | `string` | Cover thumbnail URL for display |
+| `releaseDate` | `string` | Publication date |
+| `publisher` | `string` | Publisher name |
+| `identifiers` | `Array<{type, value}>` | ISBNs, ASINs, etc. |
+| `providerData` | `unknown` | Opaque data passed back to `enrich()` |
+| `metadata` | `ParsedMetadata` | Full metadata for passthrough (see below) |
+
+All fields except `title` are optional. The more fields you provide, the easier it is for users to pick the correct match.
+
+#### Cover Images: `coverUrl` vs `coverData`
+
+`ParsedMetadata` supports two ways to provide cover images:
+
+| Field | Use when | Works with passthrough? |
+|-------|----------|------------------------|
+| `coverUrl` | URL is publicly accessible (no auth required) | Yes |
+| `coverData` | URL requires authentication; download via `shisho.http.fetch()` | No (binary data doesn't survive JSON) |
+
+**Precedence:** `coverData` > `coverUrl`. If both are set, `coverData` wins.
+
+For authenticated covers, use `coverData` in the `enrich()` step:
+
+```javascript
+enrich: function(context) {
+  var resp = shisho.http.fetch("https://api.example.com/cover/" + context.selectedResult.id, {
+    headers: { "Authorization": "Bearer " + shisho.config.get("apiKey") }
+  });
+  return {
+    modified: true,
+    metadata: {
+      coverData: resp.arrayBuffer(),
+      coverMimeType: "image/jpeg"
+    }
+  };
+}
+```
+
+#### Passthrough Pattern
+
+If your API returns all metadata at search time, you can avoid a second API call in `enrich()` by including a `metadata` field in search results:
+
+```javascript
+search: function(context) {
+  var resp = shisho.http.fetch("https://api.example.com/search?q=" + context.query, {});
+  var data = resp.json();
+
+  return {
+    results: data.items.map(function(item) {
+      var md = {
+        title: item.title,
+        authors: [{ name: item.author, role: "" }],
+        description: item.description,
+        genres: item.genres,
+        coverUrl: item.coverImageUrl,
+        identifiers: [{ type: "isbn_13", value: item.isbn }]
+      };
+
+      return {
+        title: item.title,
+        authors: [item.author],
+        description: item.description,
+        imageUrl: item.coverImageUrl,
+        providerData: md,
+        metadata: md
+      };
+    })
+  };
+},
+
+enrich: function(context) {
+  // Passthrough — metadata was already provided at search time
+  return { modified: true, metadata: context.selectedResult };
+}
+```
+
+The `metadata` field on search results is used for display only — the actual enrichment still goes through `enrich()`. Store whatever `enrich()` needs in `providerData`.
+
+For authenticated covers with passthrough, use a partial passthrough: return text metadata at search time, then download just the cover in `enrich()`.
+
+#### Enrichment Behavior
 
 Return `{ modified: false }` to skip updating metadata for a book.
 


### PR DESCRIPTION
## Summary
- Expand metadata enricher search results with 6 new display fields (subtitle, series, seriesNumber, genres, tags, narrators) and an optional `metadata` field for the passthrough pattern
- Add `coverUrl` to `ParsedMetadata` for URL-based cover downloads — server fetches at enrich time with `coverData` > `coverUrl` precedence
- Update IdentifyBookDialog to display new fields with top-level/metadata fallback resolution
- Update plugin TypeScript SDK and development docs with search result fields, `coverUrl` vs `coverData`, and passthrough pattern

## Test plan
- [ ] Run `make check:quiet` — all Go tests, lint, TS types, and JS lint pass
- [ ] Verify new Go tests pass: `go test ./pkg/plugins/... -run "TestRunMetadataSearch_NewFields|TestRunMetadataEnrich_CoverUrl|TestRunMetadataSearch_NoNewFields|TestPassthroughPattern|TestDownloadCoverFromURL" -v`
- [ ] Install a metadata enricher plugin that returns the new fields and verify they display in the Identify Book dialog
- [ ] Test coverUrl: enricher returns `coverUrl` in metadata, verify cover is downloaded and applied after enrichment
- [ ] Test passthrough: enricher returns `metadata` at search time and passes it through in `enrich()`, verify metadata is applied
- [ ] Verify existing enricher plugins still work unchanged (backward compatible)