### PR TITLE
[Feature] Replace job status polling with Server-Sent Events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Project-specific conventions are documented in `CLAUDE.md` files within each sub
 | `pkg/kepub/CLAUDE.md` | KePub format: koboSpan wrapping, CBZ-to-KePub conversion |
 | `pkg/mp4/CLAUDE.md` | M4B format: iTunes atoms, chapters, narrator fallback |
 | `pkg/pdf/CLAUDE.md` | PDF format: info dict metadata, pdfcpu thread safety |
+| `pkg/events/CLAUDE.md` | SSE: event broker, streaming handler, event types |
 | `website/CLAUDE.md` | Docs site: Docusaurus, versioning, deployment |
 | `e2e/CLAUDE.md` | E2E testing: Playwright, per-browser isolation, fixtures |
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -9,10 +9,12 @@
     }
 
     # API routes - proxy to Go backend (strip /api prefix)
+    # flush_interval -1 disables response buffering so SSE events stream immediately
     handle /api/* {
         uri strip_prefix /api
         reverse_proxy localhost:3689 {
             header_up X-Forwarded-Prefix /api
+            flush_interval -1
         }
     }
 

--- a/app/components/contexts/SSEProvider.tsx
+++ b/app/components/contexts/SSEProvider.tsx
@@ -1,0 +1,8 @@
+import type { ReactNode } from "react";
+
+import { useSSE } from "@/hooks/useSSE";
+
+export function SSEProvider({ children }: { children: ReactNode }) {
+  useSSE();
+  return <>{children}</>;
+}

--- a/app/components/library/ResyncButton.tsx
+++ b/app/components/library/ResyncButton.tsx
@@ -1,8 +1,6 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { formatDistanceToNow } from "date-fns";
 import { AlertTriangle, RefreshCw } from "lucide-react";
-import { useEffect, useRef } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -11,7 +9,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
 import { useCreateJob, useLatestScanJob } from "@/hooks/queries/jobs";
 
 interface ResyncButtonProps {
@@ -20,8 +17,6 @@ interface ResyncButtonProps {
 
 export function ResyncButton({ libraryId }: ResyncButtonProps) {
   const navigate = useNavigate();
-  const location = useLocation();
-  const queryClient = useQueryClient();
   const { data, isLoading } = useLatestScanJob(libraryId);
   const createJob = useCreateJob();
 
@@ -32,21 +27,6 @@ export function ResyncButton({ libraryId }: ResyncButtonProps) {
   const isCompleted = latestJob?.status === "completed";
   // Show spinning when mutation is pending or job is active
   const showSpinning = createJob.isPending || isActive;
-
-  // Track previous active state to detect when scan completes
-  const wasActiveRef = useRef(false);
-
-  useEffect(() => {
-    // Detect transition from active to completed
-    if (wasActiveRef.current && !isActive && isCompleted) {
-      // Check if we're on the home page (library books list)
-      const isHomePage = /^\/libraries\/\d+\/?$/.test(location.pathname);
-      if (isHomePage) {
-        queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
-      }
-    }
-    wasActiveRef.current = isActive;
-  }, [isActive, isCompleted, location.pathname, queryClient]);
 
   const handleClick = () => {
     if (isActive || isFailed) {

--- a/app/components/pages/JobDetail.tsx
+++ b/app/components/pages/JobDetail.tsx
@@ -23,7 +23,6 @@ import {
   JobLogLevelInfo,
   JobLogLevelWarn,
   JobStatusInProgress,
-  JobStatusPending,
   type JobLog,
 } from "@/types";
 
@@ -182,7 +181,7 @@ const JobDetail = () => {
   const logContainerRef = useRef<HTMLDivElement>(null);
   const lastLogIdRef = useRef<number | undefined>(undefined);
 
-  const { data, isLoading, error, refetch } = useJobLogs(id, {
+  const { data, isLoading, error } = useJobLogs(id, {
     level: levelFilter.length > 0 ? levelFilter : undefined,
     plugin: pluginFilter || undefined,
   });
@@ -221,17 +220,6 @@ const JobDetail = () => {
     }
     return true;
   });
-
-  // Polling for live updates
-  useEffect(() => {
-    if (
-      job?.status === JobStatusPending ||
-      job?.status === JobStatusInProgress
-    ) {
-      const interval = setInterval(refetch, 2000);
-      return () => clearInterval(interval);
-    }
-  }, [job?.status, refetch]);
 
   // Auto-scroll to bottom when new logs arrive
   useEffect(() => {

--- a/app/hooks/queries/jobs.ts
+++ b/app/hooks/queries/jobs.ts
@@ -70,12 +70,6 @@ export const useLatestScanJob = (libraryId: number | undefined) => {
       );
     },
     enabled: libraryId !== undefined,
-    refetchInterval: (query) => {
-      const job = query.state.data?.jobs[0];
-      const isActive =
-        job?.status === "pending" || job?.status === "in_progress";
-      return isActive ? 2000 : 30000;
-    },
   });
 };
 

--- a/app/hooks/useSSE.test.ts
+++ b/app/hooks/useSSE.test.ts
@@ -1,9 +1,21 @@
+import { useSSE } from "./useSSE";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AuthContext,
+  type AuthContextValue,
+} from "@/components/contexts/Auth/context";
+import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
+import { QueryKey as JobsQueryKey } from "@/hooks/queries/jobs";
 
 // Mock EventSource
 class MockEventSource {
   static instances: MockEventSource[] = [];
   url: string;
+  onerror: (() => void) | null = null;
   listeners: Record<string, ((event: MessageEvent) => void)[]> = {};
   close = vi.fn();
 
@@ -25,25 +37,177 @@ class MockEventSource {
     }
   }
 
-  // Test helper: simulate an event
   simulateEvent(type: string, data: string) {
     const event = new MessageEvent(type, { data });
     this.listeners[type]?.forEach((l) => l(event));
   }
 }
 
-describe("useSSE EventSource URL", () => {
+function createWrapper(isAuthenticated: boolean, queryClient: QueryClient) {
+  const authValue: AuthContextValue = {
+    user: isAuthenticated
+      ? {
+          id: 1,
+          username: "test",
+          role_id: 1,
+          role_name: "admin",
+          permissions: [],
+          must_change_password: false,
+        }
+      : null,
+    isLoading: false,
+    isAuthenticated,
+    needsSetup: false,
+    login: vi.fn(),
+    logout: vi.fn(),
+    hasPermission: () => true,
+    hasLibraryAccess: () => true,
+    refetch: vi.fn(),
+    setAuthUser: vi.fn(),
+  };
+
+  return ({ children }: { children: ReactNode }) =>
+    createElement(
+      AuthContext.Provider,
+      { value: authValue },
+      createElement(QueryClientProvider, { client: queryClient }, children),
+    );
+}
+
+describe("useSSE", () => {
+  let queryClient: QueryClient;
+
   beforeEach(() => {
     MockEventSource.instances = [];
     vi.stubGlobal("EventSource", MockEventSource);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    queryClient.clear();
   });
 
-  it("connects to /api/events", async () => {
-    const es = new MockEventSource("/api/events");
-    expect(es.url).toBe("/api/events");
+  it("opens EventSource when authenticated", () => {
+    renderHook(() => useSSE(), {
+      wrapper: createWrapper(true, queryClient),
+    });
+
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe("/api/events");
+  });
+
+  it("does not open EventSource when not authenticated", () => {
+    renderHook(() => useSSE(), {
+      wrapper: createWrapper(false, queryClient),
+    });
+
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it("closes EventSource on unmount", () => {
+    const { unmount } = renderHook(() => useSSE(), {
+      wrapper: createWrapper(true, queryClient),
+    });
+
+    const es = MockEventSource.instances[0];
+    unmount();
+
+    expect(es.close).toHaveBeenCalled();
+  });
+
+  it("invalidates job queries on job.created event", () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useSSE(), {
+      wrapper: createWrapper(true, queryClient),
+    });
+
+    act(() => {
+      MockEventSource.instances[0].simulateEvent("job.created", '{"job_id":1}');
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: [JobsQueryKey.ListJobs] }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: [JobsQueryKey.LatestScanJob] }),
+    );
+  });
+
+  it("invalidates job and log queries on job.status_changed event", () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useSSE(), {
+      wrapper: createWrapper(true, queryClient),
+    });
+
+    act(() => {
+      MockEventSource.instances[0].simulateEvent(
+        "job.status_changed",
+        '{"job_id":5,"status":"in_progress","type":"scan"}',
+      );
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [JobsQueryKey.RetrieveJob, "5"],
+      }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [JobsQueryKey.ListJobLogs, "5"],
+      }),
+    );
+  });
+
+  it("invalidates book queries when scan completes", () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useSSE(), {
+      wrapper: createWrapper(true, queryClient),
+    });
+
+    act(() => {
+      MockEventSource.instances[0].simulateEvent(
+        "job.status_changed",
+        '{"job_id":1,"status":"completed","type":"scan"}',
+      );
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: [BooksQueryKey.ListBooks] }),
+    );
+  });
+
+  it("does not invalidate book queries for non-scan job completion", () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useSSE(), {
+      wrapper: createWrapper(true, queryClient),
+    });
+
+    act(() => {
+      MockEventSource.instances[0].simulateEvent(
+        "job.status_changed",
+        '{"job_id":1,"status":"completed","type":"export"}',
+      );
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: [BooksQueryKey.ListBooks] }),
+    );
+  });
+
+  it("registers event listeners for both event types", () => {
+    renderHook(() => useSSE(), {
+      wrapper: createWrapper(true, queryClient),
+    });
+
+    const es = MockEventSource.instances[0];
+    expect(es.listeners["job.created"]).toHaveLength(1);
+    expect(es.listeners["job.status_changed"]).toHaveLength(1);
   });
 });

--- a/app/hooks/useSSE.test.ts
+++ b/app/hooks/useSSE.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock EventSource
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  listeners: Record<string, ((event: MessageEvent) => void)[]> = {};
+  close = vi.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    if (!this.listeners[type]) {
+      this.listeners[type] = [];
+    }
+    this.listeners[type].push(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: MessageEvent) => void) {
+    if (this.listeners[type]) {
+      this.listeners[type] = this.listeners[type].filter((l) => l !== listener);
+    }
+  }
+
+  // Test helper: simulate an event
+  simulateEvent(type: string, data: string) {
+    const event = new MessageEvent(type, { data });
+    this.listeners[type]?.forEach((l) => l(event));
+  }
+}
+
+describe("useSSE EventSource URL", () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal("EventSource", MockEventSource);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("connects to /api/events", async () => {
+    const es = new MockEventSource("/api/events");
+    expect(es.url).toBe("/api/events");
+  });
+});

--- a/app/hooks/useSSE.ts
+++ b/app/hooks/useSSE.ts
@@ -1,0 +1,63 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
+import { QueryKey as JobsQueryKey } from "@/hooks/queries/jobs";
+import { useAuth } from "@/hooks/useAuth";
+
+export function useSSE() {
+  const queryClient = useQueryClient();
+  const { isAuthenticated } = useAuth();
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    const es = new EventSource("/api/events");
+    eventSourceRef.current = es;
+
+    const handleJobCreated = () => {
+      queryClient.invalidateQueries({ queryKey: [JobsQueryKey.ListJobs] });
+      queryClient.invalidateQueries({
+        queryKey: [JobsQueryKey.LatestScanJob],
+      });
+    };
+
+    const handleJobStatusChanged = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data);
+        queryClient.invalidateQueries({ queryKey: [JobsQueryKey.ListJobs] });
+        queryClient.invalidateQueries({
+          queryKey: [JobsQueryKey.LatestScanJob],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [JobsQueryKey.RetrieveJob, String(data.job_id)],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [JobsQueryKey.ListJobLogs, String(data.job_id)],
+        });
+
+        // When a scan completes, invalidate book queries so lists refresh
+        if (data.status === "completed" && data.type === "scan") {
+          queryClient.invalidateQueries({
+            queryKey: [BooksQueryKey.ListBooks],
+          });
+        }
+      } catch {
+        // Ignore malformed events
+      }
+    };
+
+    es.addEventListener("job.created", handleJobCreated);
+    es.addEventListener("job.status_changed", handleJobStatusChanged);
+
+    return () => {
+      es.removeEventListener("job.created", handleJobCreated);
+      es.removeEventListener("job.status_changed", handleJobStatusChanged);
+      es.close();
+      eventSourceRef.current = null;
+    };
+  }, [isAuthenticated, queryClient]);
+}

--- a/app/hooks/useSSE.ts
+++ b/app/hooks/useSSE.ts
@@ -16,6 +16,12 @@ export function useSSE() {
 
     const es = new EventSource("/api/events");
 
+    es.onerror = () => {
+      // EventSource auto-reconnects on error. Log for debugging visibility
+      // but don't take action — reconnection is handled by the browser.
+      console.debug("[SSE] Connection error, will auto-reconnect");
+    };
+
     const handleJobCreated = () => {
       queryClient.invalidateQueries({ queryKey: [JobsQueryKey.ListJobs] });
       queryClient.invalidateQueries({

--- a/app/hooks/useSSE.ts
+++ b/app/hooks/useSSE.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
 import { QueryKey as JobsQueryKey } from "@/hooks/queries/jobs";
@@ -8,7 +8,6 @@ import { useAuth } from "@/hooks/useAuth";
 export function useSSE() {
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
-  const eventSourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -16,7 +15,6 @@ export function useSSE() {
     }
 
     const es = new EventSource("/api/events");
-    eventSourceRef.current = es;
 
     const handleJobCreated = () => {
       queryClient.invalidateQueries({ queryKey: [JobsQueryKey.ListJobs] });
@@ -57,7 +55,6 @@ export function useSSE() {
       es.removeEventListener("job.created", handleJobCreated);
       es.removeEventListener("job.status_changed", handleJobStatusChanged);
       es.close();
-      eventSourceRef.current = null;
     };
   }, [isAuthenticated, queryClient]);
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 
 import { AuthProvider } from "@/components/contexts/Auth";
+import { SSEProvider } from "@/components/contexts/SSEProvider";
 import ThemeProvider from "@/components/contexts/Theme/ThemeProvider";
 import { queryClient } from "@/libraries/query-client";
 import { router } from "@/router";
@@ -16,7 +17,9 @@ root.render(
     <ThemeProvider>
       <AuthProvider>
         <QueryClientProvider client={queryClient}>
-          <RouterProvider router={router} />
+          <SSEProvider>
+            <RouterProvider router={router} />
+          </SSEProvider>
         </QueryClientProvider>
       </AuthProvider>
     </ThemeProvider>

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/robinjoseph08/golib/signals"
 	"github.com/shishobooks/shisho/pkg/config"
 	"github.com/shishobooks/shisho/pkg/database"
+	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/plugins"
 	"github.com/shishobooks/shisho/pkg/server"
@@ -66,9 +67,11 @@ func main() {
 		log.Warn("plugin load errors occurred", logger.Data{"error": err.Error()})
 	}
 
-	wrkr := worker.New(cfg, db, pluginManager)
+	broker := events.NewBroker()
 
-	srv, err := server.New(cfg, db, wrkr, pluginManager)
+	wrkr := worker.New(cfg, db, pluginManager, broker)
+
+	srv, err := server.New(cfg, db, wrkr, pluginManager, broker)
 	if err != nil {
 		log.Err(err).Fatal("server error")
 	}

--- a/pkg/events/CLAUDE.md
+++ b/pkg/events/CLAUDE.md
@@ -1,0 +1,49 @@
+# Server-Sent Events (SSE)
+
+In-memory event broker and SSE streaming endpoint for pushing real-time updates to the frontend.
+
+## Architecture
+
+- **Broker** (`broker.go`): Goroutine-safe pub/sub fan-out using `sync.RWMutex` and buffered channels. Subscribers get a channel; publishers send to all channels. Slow subscribers (full buffer) have events dropped to avoid blocking.
+- **Handler** (`handler.go`): Echo handler that opens a streaming HTTP response with `text/event-stream` content type, subscribes to the broker, and writes SSE-formatted lines until the client disconnects. Sends keepalive comments every 30 seconds to prevent proxy idle timeouts.
+- **Routes** (`routes.go`): Registers `GET /events` with authentication middleware. No permission check beyond authentication — all authenticated users receive all events.
+
+## Event Format
+
+Events follow the SSE spec with named event types:
+
+```
+event: job.created
+data: {"job_id":1,"status":"pending","type":"scan"}
+
+event: job.status_changed
+data: {"job_id":1,"status":"in_progress","type":"scan","library_id":2}
+```
+
+Use `NewJobEvent()` to build job events consistently across callers (worker, HTTP handler).
+
+## Event Types
+
+| Event | Published When | Publishers |
+|-------|---------------|------------|
+| `job.created` | Job created via API or scheduler | `pkg/jobs/handlers.go`, `pkg/worker/worker.go` (scheduler) |
+| `job.status_changed` | Job transitions status (pending→in_progress, →completed, →failed) | `pkg/worker/worker.go` |
+
+## Adding New Event Types
+
+1. Define the event type name (e.g., `library.updated`)
+2. Use `NewJobEvent()` if it's a job event, or construct `Event{Type: "...", Data: "..."}` directly
+3. Call `broker.Publish(event)` from the appropriate place
+4. Add a listener in `app/hooks/useSSE.ts` via `es.addEventListener("event.type", handler)`
+
+## Frontend Integration
+
+The `useSSE` hook (`app/hooks/useSSE.ts`) opens an `EventSource` to `/api/events` when authenticated. It listens for job events and invalidates relevant Tanstack Query caches so the UI updates instantly without polling.
+
+## Authentication
+
+`EventSource` doesn't support custom headers, but the backend uses cookie-based auth (`shisho_session`). Since `EventSource` sends cookies automatically on same-origin requests, authentication works out of the box.
+
+## Proxy Configuration
+
+The Caddy reverse proxy must have `flush_interval -1` to disable response buffering for SSE. Without this, events are buffered until the buffer fills, breaking real-time delivery.

--- a/pkg/events/broker.go
+++ b/pkg/events/broker.go
@@ -1,6 +1,9 @@
 package events
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // Event represents a server-sent event with a named type and JSON data.
 type Event struct {
@@ -50,4 +53,13 @@ func (b *Broker) Publish(evt Event) {
 			// Subscriber buffer full — drop event to avoid blocking.
 		}
 	}
+}
+
+// NewJobEvent builds an Event with the standard job payload format.
+func NewJobEvent(eventType string, jobID int, status, jobType string, libraryID *int) Event {
+	data := fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s"}`, jobID, status, jobType)
+	if libraryID != nil {
+		data = fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s","library_id":%d}`, jobID, status, jobType, *libraryID)
+	}
+	return Event{Type: eventType, Data: data}
 }

--- a/pkg/events/broker.go
+++ b/pkg/events/broker.go
@@ -1,0 +1,53 @@
+package events
+
+import "sync"
+
+// Event represents a server-sent event with a named type and JSON data.
+type Event struct {
+	Type string
+	Data string
+}
+
+// Broker fans out events to all subscribed SSE connections.
+type Broker struct {
+	mu          sync.RWMutex
+	subscribers map[chan Event]struct{}
+}
+
+func NewBroker() *Broker {
+	return &Broker{
+		subscribers: make(map[chan Event]struct{}),
+	}
+}
+
+// Subscribe returns a channel that receives all future published events.
+// The caller must call Unsubscribe when done.
+func (b *Broker) Subscribe() chan Event {
+	ch := make(chan Event, 64)
+	b.mu.Lock()
+	b.subscribers[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch
+}
+
+// Unsubscribe removes a subscriber channel and closes it.
+func (b *Broker) Unsubscribe(ch chan Event) {
+	b.mu.Lock()
+	delete(b.subscribers, ch)
+	close(ch)
+	b.mu.Unlock()
+}
+
+// Publish sends an event to all subscribers. Slow subscribers that have
+// a full buffer will have this event dropped (non-blocking send).
+func (b *Broker) Publish(evt Event) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for ch := range b.subscribers {
+		select {
+		case ch <- evt:
+		default:
+			// Subscriber buffer full — drop event to avoid blocking.
+		}
+	}
+}

--- a/pkg/events/broker_test.go
+++ b/pkg/events/broker_test.go
@@ -1,0 +1,93 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBroker_SubscribeAndPublish(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker()
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	evt := Event{Type: "job.status_changed", Data: `{"job_id":1,"status":"in_progress"}`}
+	b.Publish(evt)
+
+	select {
+	case received := <-ch:
+		assert.Equal(t, evt.Type, received.Type)
+		assert.Equal(t, evt.Data, received.Data)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestBroker_MultipleSubscribers(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker()
+	ch1 := b.Subscribe()
+	ch2 := b.Subscribe()
+	defer b.Unsubscribe(ch1)
+	defer b.Unsubscribe(ch2)
+
+	evt := Event{Type: "job.created", Data: `{"job_id":2}`}
+	b.Publish(evt)
+
+	for _, ch := range []<-chan Event{ch1, ch2} {
+		select {
+		case received := <-ch:
+			assert.Equal(t, evt.Type, received.Type)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for event")
+		}
+	}
+}
+
+func TestBroker_Unsubscribe(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker()
+	ch := b.Subscribe()
+	b.Unsubscribe(ch)
+
+	// Publishing after unsubscribe should not block
+	evt := Event{Type: "job.created", Data: `{}`}
+	b.Publish(evt)
+
+	// Channel should be closed
+	_, ok := <-ch
+	assert.False(t, ok)
+}
+
+func TestBroker_SlowSubscriberDropsEvents(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker()
+	ch := b.Subscribe()
+	defer b.Unsubscribe(ch)
+
+	// Fill the channel buffer and then some — should not block
+	for i := 0; i < 200; i++ {
+		b.Publish(Event{Type: "job.created", Data: `{}`})
+	}
+
+	// Drain what we can — we just care that Publish didn't block
+	drained := 0
+	for {
+		select {
+		case <-ch:
+			drained++
+		default:
+			goto done
+		}
+	}
+done:
+	// Should have received up to buffer size (64), not all 200
+	require.LessOrEqual(t, drained, 64)
+}

--- a/pkg/events/broker_test.go
+++ b/pkg/events/broker_test.go
@@ -91,3 +91,20 @@ done:
 	// Should have received up to buffer size (64), not all 200
 	require.LessOrEqual(t, drained, 64)
 }
+
+func TestNewJobEvent_WithoutLibraryID(t *testing.T) {
+	t.Parallel()
+
+	evt := NewJobEvent("job.created", 1, "pending", "scan", nil)
+	assert.Equal(t, "job.created", evt.Type)
+	assert.JSONEq(t, `{"job_id":1,"status":"pending","type":"scan"}`, evt.Data)
+}
+
+func TestNewJobEvent_WithLibraryID(t *testing.T) {
+	t.Parallel()
+
+	libraryID := 5
+	evt := NewJobEvent("job.status_changed", 3, "in_progress", "scan", &libraryID)
+	assert.Equal(t, "job.status_changed", evt.Type)
+	assert.JSONEq(t, `{"job_id":3,"status":"in_progress","type":"scan","library_id":5}`, evt.Data)
+}

--- a/pkg/events/handler.go
+++ b/pkg/events/handler.go
@@ -1,0 +1,45 @@
+package events
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type handler struct {
+	broker *Broker
+}
+
+func (h *handler) stream(c echo.Context) error {
+	w := c.Response()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.Writer.(http.Flusher)
+	if !ok {
+		return echo.NewHTTPError(http.StatusInternalServerError, "streaming not supported")
+	}
+
+	ch := h.broker.Subscribe()
+	defer h.broker.Unsubscribe(ch)
+
+	// Flush headers so client receives them immediately.
+	flusher.Flush()
+
+	ctx := c.Request().Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case evt, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", evt.Type, evt.Data)
+			flusher.Flush()
+		}
+	}
+}

--- a/pkg/events/handler.go
+++ b/pkg/events/handler.go
@@ -3,9 +3,12 @@ package events
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/labstack/echo/v4"
 )
+
+const heartbeatInterval = 30 * time.Second
 
 type handler struct {
 	broker *Broker
@@ -30,10 +33,17 @@ func (h *handler) stream(c echo.Context) error {
 	flusher.Flush()
 
 	ctx := c.Request().Context()
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-heartbeat.C:
+			// SSE comment line keeps the connection alive through proxies.
+			fmt.Fprint(w, ": keepalive\n\n")
+			flusher.Flush()
 		case evt, ok := <-ch:
 			if !ok {
 				return nil

--- a/pkg/events/handler_test.go
+++ b/pkg/events/handler_test.go
@@ -1,0 +1,71 @@
+package events
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSEHandler_StreamsEvents(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker()
+	h := &handler{broker: b}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+
+	// Use a context we can cancel to simulate client disconnect
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// Run handler in goroutine (it blocks until client disconnects)
+	done := make(chan error, 1)
+	go func() {
+		done <- h.stream(c)
+	}()
+
+	// Give handler time to subscribe and start streaming
+	time.Sleep(50 * time.Millisecond)
+
+	// Publish an event
+	b.Publish(Event{Type: "job.created", Data: `{"job_id":1}`})
+
+	// Give time for event to be written
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel context to stop handler
+	cancel()
+
+	err := <-done
+	require.NoError(t, err)
+
+	// Check response headers
+	assert.Equal(t, "text/event-stream", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "keep-alive", rec.Header().Get("Connection"))
+
+	// Parse SSE output
+	body := rec.Body.String()
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	// Should contain the event
+	assert.Contains(t, lines, "event: job.created")
+	assert.Contains(t, lines, `data: {"job_id":1}`)
+}

--- a/pkg/events/routes.go
+++ b/pkg/events/routes.go
@@ -1,0 +1,11 @@
+package events
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/auth"
+)
+
+func RegisterRoutes(e *echo.Echo, broker *Broker, authMiddleware *auth.Middleware) {
+	h := &handler{broker: broker}
+	e.GET("/events", h.stream, authMiddleware.Authenticate)
+}

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -57,11 +56,7 @@ func (h *handler) create(c echo.Context) error {
 	}
 
 	if h.broker != nil {
-		data := fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s"}`, job.ID, job.Status, job.Type)
-		if job.LibraryID != nil {
-			data = fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s","library_id":%d}`, job.ID, job.Status, job.Type, *job.LibraryID)
-		}
-		h.broker.Publish(events.Event{Type: "job.created", Data: data})
+		h.broker.Publish(events.NewJobEvent("job.created", job.ID, job.Status, job.Type, job.LibraryID))
 	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, job))

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -1,17 +1,20 @@
 package jobs
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
 type handler struct {
 	jobService *Service
+	broker     *events.Broker
 }
 
 func (h *handler) create(c echo.Context) error {
@@ -51,6 +54,14 @@ func (h *handler) create(c echo.Context) error {
 	})
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	if h.broker != nil {
+		data := fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s"}`, job.ID, job.Status, job.Type)
+		if job.LibraryID != nil {
+			data = fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s","library_id":%d}`, job.ID, job.Status, job.Type, *job.LibraryID)
+		}
+		h.broker.Publish(events.Event{Type: "job.created", Data: data})
 	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, job))

--- a/pkg/jobs/routes.go
+++ b/pkg/jobs/routes.go
@@ -3,16 +3,18 @@ package jobs
 import (
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
 )
 
 // RegisterRoutesWithGroup registers job routes on a pre-configured group.
-func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware) {
+func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware, broker *events.Broker) {
 	jobService := NewService(db)
 
 	h := &handler{
 		jobService: jobService,
+		broker:     broker,
 	}
 
 	g.GET("", h.list)

--- a/pkg/server/file_organizer_test.go
+++ b/pkg/server/file_organizer_test.go
@@ -64,7 +64,7 @@ func newTestContext(t *testing.T) *testContext {
 		WorkerProcesses:           1,
 		SupplementExcludePatterns: []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
 	}
-	w := worker.New(cfg, db, nil)
+	w := worker.New(cfg, db, nil, nil)
 
 	// Create file organizer
 	fo := &fileOrganizer{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/ereader"
 	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/filesystem"
 	"github.com/shishobooks/shisho/pkg/genres"
 	"github.com/shishobooks/shisho/pkg/imprints"
@@ -46,7 +47,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager) (*http.Server, error) {
+func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, broker *events.Broker) (*http.Server, error) {
 	e := echo.New()
 
 	b, err := binder.New()
@@ -80,7 +81,7 @@ func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager) 
 
 	// Register protected API routes
 	// These routes require authentication and appropriate permissions
-	registerProtectedRoutes(e, db, cfg, authMiddleware, w, pm)
+	registerProtectedRoutes(e, db, cfg, authMiddleware, w, pm, broker)
 
 	// Register OPDS routes with Basic Auth
 	opds.RegisterRoutes(e, db, cfg, authMiddleware)
@@ -101,6 +102,9 @@ func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager) 
 	// Settings routes (require authentication)
 	settings.RegisterRoutes(e, db, authMiddleware)
 
+	// SSE event stream
+	events.RegisterRoutes(e, broker, authMiddleware)
+
 	echo.NotFoundHandler = notFoundHandler
 	e.HTTPErrorHandler = errcodes.NewHandler().Handle
 
@@ -114,7 +118,7 @@ func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager) 
 }
 
 // registerProtectedRoutes registers all protected API routes with proper authentication and authorization.
-func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, w *worker.Worker, pm *plugins.Manager) {
+func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, w *worker.Worker, pm *plugins.Manager, broker *events.Broker) {
 	// Books routes
 	booksGroup := e.Group("/books")
 	booksGroup.Use(authMiddleware.Authenticate)
@@ -135,7 +139,7 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 	jobsGroup := e.Group("/jobs")
 	jobsGroup.Use(authMiddleware.Authenticate)
 	jobsGroup.Use(authMiddleware.RequirePermission(models.ResourceJobs, models.OperationRead))
-	jobs.RegisterRoutesWithGroup(jobsGroup, db, authMiddleware)
+	jobs.RegisterRoutesWithGroup(jobsGroup, db, authMiddleware, broker)
 	joblogs.RegisterRoutes(jobsGroup, db)
 
 	// People routes

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
 	"time"
 
@@ -434,11 +433,7 @@ func (w *Worker) publishJobEvent(eventType string, job *models.Job) {
 	if w.broker == nil {
 		return
 	}
-	data := fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s"}`, job.ID, job.Status, job.Type)
-	if job.LibraryID != nil {
-		data = fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s","library_id":%d}`, job.ID, job.Status, job.Type, *job.LibraryID)
-	}
-	w.broker.Publish(events.Event{Type: eventType, Data: data})
+	w.broker.Publish(events.NewJobEvent(eventType, job.ID, job.Status, job.Type, job.LibraryID))
 }
 
 const letterBytes = "abcdef0123456789"

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -2,11 +2,13 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"time"
 
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/chapters"
+	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/genres"
 	"github.com/shishobooks/shisho/pkg/imprints"
 	"github.com/shishobooks/shisho/pkg/joblogs"
@@ -56,6 +58,8 @@ type Worker struct {
 	pluginService    *plugins.Service
 	pluginManager    *plugins.Manager
 
+	broker *events.Broker
+
 	monitor *Monitor
 
 	queue           chan *models.Job
@@ -67,7 +71,7 @@ type Worker struct {
 	doneUpdateCheck chan struct{}
 }
 
-func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager) *Worker {
+func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Broker) *Worker {
 	bookService := books.NewService(db)
 	chapterService := chapters.NewService(db)
 	genreService := genres.NewService(db)
@@ -101,6 +105,7 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager) *Worker {
 		tagService:       tagService,
 		pluginService:    pluginService,
 		pluginManager:    pm,
+		broker:           broker,
 
 		queue:           make(chan *models.Job, cfg.WorkerProcesses),
 		shutdown:        make(chan struct{}),
@@ -202,6 +207,7 @@ func (w *Worker) processJobs() {
 				log.Err(err).Error("update job error")
 				continue
 			}
+			w.publishJobEvent("job.status_changed", job)
 
 			// Process with panic recovery
 			func() {
@@ -212,6 +218,7 @@ func (w *Worker) processJobs() {
 						_ = w.jobService.UpdateJob(ctx, job, jobs.UpdateJobOptions{
 							Columns: []string{"status"},
 						})
+						w.publishJobEvent("job.status_changed", job)
 					}
 				}()
 
@@ -223,6 +230,7 @@ func (w *Worker) processJobs() {
 					_ = w.jobService.UpdateJob(ctx, job, jobs.UpdateJobOptions{
 						Columns: []string{"status"},
 					})
+					w.publishJobEvent("job.status_changed", job)
 					return
 				}
 
@@ -233,6 +241,7 @@ func (w *Worker) processJobs() {
 					_ = w.jobService.UpdateJob(ctx, job, jobs.UpdateJobOptions{
 						Columns: []string{"status"},
 					})
+					w.publishJobEvent("job.status_changed", job)
 					return
 				}
 
@@ -244,6 +253,7 @@ func (w *Worker) processJobs() {
 				if err != nil {
 					log.Err(err).Error("update job error")
 				}
+				w.publishJobEvent("job.status_changed", job)
 			}()
 		}
 	}
@@ -302,6 +312,7 @@ func (w *Worker) scheduleScanJobs() {
 				timer.Reset(duration)
 				continue
 			}
+			w.publishJobEvent("job.created", scanJob)
 
 			log.Info("created scheduled scan job")
 			timer.Reset(duration)
@@ -417,6 +428,17 @@ func (w *Worker) Shutdown() {
 		<-w.doneCleanup
 	}
 	<-w.doneUpdateCheck
+}
+
+func (w *Worker) publishJobEvent(eventType string, job *models.Job) {
+	if w.broker == nil {
+		return
+	}
+	data := fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s"}`, job.ID, job.Status, job.Type)
+	if job.LibraryID != nil {
+		data = fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s","library_id":%d}`, job.ID, job.Status, job.Type, *job.LibraryID)
+	}
+	w.broker.Publish(events.Event{Type: eventType, Data: data})
 }
 
 const letterBytes = "abcdef0123456789"


### PR DESCRIPTION
## Summary
- Adds an in-memory event broker (`pkg/events/`) that fans out typed events to connected SSE clients via `GET /events`
- Worker publishes `job.status_changed` events on all 5 job status transitions; HTTP handler and scheduler publish `job.created` events
- Frontend `useSSE` hook opens an `EventSource` connection, listens for job events, and triggers Tanstack Query cache invalidations — replacing the 2s/30s polling intervals in `useLatestScanJob`, `JobDetail`, and `ResyncButton`

## Test plan
- [ ] Start dev server (`make start`), open browser DevTools Network tab
- [ ] Log in and verify `EventSource` connection to `/api/events` is established
- [ ] Trigger a library scan — verify `job.created` and `job.status_changed` events appear in the stream
- [ ] Verify ResyncButton updates immediately when scan starts/completes (no 2-30s delay)
- [ ] Verify book list refreshes when scan completes
- [ ] Stop/restart the API server — verify EventSource auto-reconnects
- [ ] Log out — verify EventSource connection closes; log back in — verify it reopens
- [ ] View job detail page — verify logs update via SSE without manual polling