### PR TITLE
[Feature] Add configurable session duration

### DIFF
--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -167,6 +167,11 @@ const AdminSettings = () => {
               value={`${config.library_monitor_delay_seconds}s`}
             />
             <ConfigRow
+              description="How long login sessions remain valid"
+              label="Session Duration"
+              value={`${config.session_duration_days} days`}
+            />
+            <ConfigRow
               description="Application environment mode"
               label="Environment"
               value={config.environment || "production"}

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -167,11 +167,6 @@ const AdminSettings = () => {
               value={`${config.library_monitor_delay_seconds}s`}
             />
             <ConfigRow
-              description="How long login sessions remain valid"
-              label="Session Duration"
-              value={`${config.session_duration_days} days`}
-            />
-            <ConfigRow
               description="Application environment mode"
               label="Environment"
               value={config.environment || "production"}
@@ -209,6 +204,20 @@ const AdminSettings = () => {
               description="File patterns excluded from supplement discovery"
               label="Supplement Exclude Patterns"
               value={config.supplement_exclude_patterns.join(", ")}
+            />
+          </div>
+        </div>
+
+        {/* Authentication Settings */}
+        <div className="border border-border rounded-md p-4 md:p-6">
+          <h2 className="text-base md:text-lg font-semibold mb-3 md:mb-4">
+            Authentication
+          </h2>
+          <div className="space-y-0">
+            <ConfigRow
+              description="How long login sessions remain valid"
+              label="Session Duration"
+              value={`${config.session_duration_days} days`}
             />
           </div>
         </div>

--- a/pkg/auth/handlers.go
+++ b/pkg/auth/handlers.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
@@ -13,8 +12,6 @@ import (
 const (
 	// CookieName is the name of the session cookie.
 	CookieName = "shisho_session"
-	// CookieMaxAge is how long the cookie is valid.
-	CookieMaxAge = 7 * 24 * time.Hour // 7 days
 )
 
 type handler struct {
@@ -71,7 +68,7 @@ func (h *handler) login(c echo.Context) error {
 		Name:     CookieName,
 		Value:    token,
 		Path:     "/",
-		MaxAge:   int(CookieMaxAge.Seconds()),
+		MaxAge:   int(h.authService.sessionDuration.Seconds()),
 		HttpOnly: true,
 		Secure:   c.Request().TLS != nil || c.Request().Header.Get("X-Forwarded-Proto") == "https",
 		SameSite: http.SameSiteLaxMode,
@@ -169,7 +166,7 @@ func (h *handler) setup(c echo.Context) error {
 		Name:     CookieName,
 		Value:    token,
 		Path:     "/",
-		MaxAge:   int(CookieMaxAge.Seconds()),
+		MaxAge:   int(h.authService.sessionDuration.Seconds()),
 		HttpOnly: true,
 		Secure:   c.Request().TLS != nil || c.Request().Header.Get("X-Forwarded-Proto") == "https",
 		SameSite: http.SameSiteLaxMode,

--- a/pkg/auth/handlers_test.go
+++ b/pkg/auth/handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/binder"
@@ -106,7 +107,7 @@ func newTestContext(t *testing.T, payload, method, path string) (echo.Context, *
 func TestHandler_Setup_RejectsWhenUsersExist(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
-	svc := NewService(db, "test-jwt-secret")
+	svc := NewService(db, "test-jwt-secret", 30*24*time.Hour)
 	h := &handler{authService: svc}
 
 	// First create a user using raw SQL to simulate existing user
@@ -132,7 +133,7 @@ func TestHandler_Login_ReturnsMustChangePassword(t *testing.T) {
 	t.Parallel()
 
 	db := setupTestDB(t)
-	svc := NewService(db, "test-jwt-secret")
+	svc := NewService(db, "test-jwt-secret", 30*24*time.Hour)
 	h := &handler{authService: svc}
 
 	hashedPassword, err := HashPassword("securepassword123")

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/errcodes"
@@ -70,7 +71,7 @@ func TestMiddlewareAuthenticate_BlocksWhenPasswordResetIsRequired(t *testing.T) 
 	t.Parallel()
 
 	db := setupMiddlewareDB(t)
-	authService := NewService(db, "test-secret")
+	authService := NewService(db, "test-secret", 30*24*time.Hour)
 	middleware := NewMiddleware(authService)
 	ctx := context.Background()
 
@@ -102,7 +103,7 @@ func TestMiddlewareAuthenticate_AllowsSelfPasswordResetWhenRequired(t *testing.T
 	t.Parallel()
 
 	db := setupMiddlewareDB(t)
-	authService := NewService(db, "test-secret")
+	authService := NewService(db, "test-secret", 30*24*time.Hour)
 	middleware := NewMiddleware(authService)
 	ctx := context.Background()
 
@@ -132,7 +133,7 @@ func TestMiddlewareAuthenticate_BlocksCrossUserPasswordReset(t *testing.T) {
 	t.Parallel()
 
 	db := setupMiddlewareDB(t)
-	authService := NewService(db, "test-secret")
+	authService := NewService(db, "test-secret", 30*24*time.Hour)
 	middleware := NewMiddleware(authService)
 	ctx := context.Background()
 
@@ -167,7 +168,7 @@ func TestMiddlewareBasicAuth_RejectsWhenMustChangePassword(t *testing.T) {
 	t.Parallel()
 
 	db := setupMiddlewareDB(t)
-	authService := NewService(db, "test-secret")
+	authService := NewService(db, "test-secret", 30*24*time.Hour)
 	middleware := NewMiddleware(authService)
 	ctx := context.Background()
 

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -1,13 +1,15 @@
 package auth
 
 import (
+	"time"
+
 	"github.com/labstack/echo/v4"
 	"github.com/uptrace/bun"
 )
 
 // RegisterRoutes registers all auth routes.
-func RegisterRoutes(e *echo.Echo, db *bun.DB, jwtSecret string) *Service {
-	authService := NewService(db, jwtSecret)
+func RegisterRoutes(e *echo.Echo, db *bun.DB, jwtSecret string, sessionDuration time.Duration) *Service {
+	authService := NewService(db, jwtSecret, sessionDuration)
 
 	h := &handler{
 		authService: authService,

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -15,8 +15,6 @@ import (
 const (
 	// BcryptCost is the cost factor for bcrypt hashing.
 	BcryptCost = 12
-	// TokenExpiry is how long JWT tokens are valid.
-	TokenExpiry = 7 * 24 * time.Hour // 7 days
 )
 
 // JWTClaims represents the claims in a JWT token.
@@ -28,15 +26,17 @@ type JWTClaims struct {
 
 // Service handles authentication operations.
 type Service struct {
-	db        *bun.DB
-	jwtSecret []byte
+	db              *bun.DB
+	jwtSecret       []byte
+	sessionDuration time.Duration
 }
 
 // NewService creates a new auth service.
-func NewService(db *bun.DB, jwtSecret string) *Service {
+func NewService(db *bun.DB, jwtSecret string, sessionDuration time.Duration) *Service {
 	return &Service{
-		db:        db,
-		jwtSecret: []byte(jwtSecret),
+		db:              db,
+		jwtSecret:       []byte(jwtSecret),
+		sessionDuration: sessionDuration,
 	}
 }
 
@@ -79,7 +79,7 @@ func (s *Service) GenerateToken(user *models.User) (string, error) {
 		UserID:   user.ID,
 		Username: user.Username,
 		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(now.Add(TokenExpiry)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(s.sessionDuration)),
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),
 		},

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -226,7 +226,7 @@ func setupTestServer(t *testing.T, db *bun.DB) *echo.Echo {
 	cfg.CacheDir = t.TempDir()
 
 	// Create auth service and middleware
-	authService := auth.NewService(db, cfg.JWTSecret)
+	authService := auth.NewService(db, cfg.JWTSecret, cfg.SessionDuration())
 	authMiddleware := auth.NewMiddleware(authService)
 
 	// Register routes (pass nil for plugin manager in tests)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,7 +57,7 @@ type Config struct {
 
 	// Authentication settings
 	JWTSecret           string `koanf:"jwt_secret" json:"-" validate:"required"` // Never expose in JSON
-	SessionDurationDays int    `koanf:"session_duration_days" json:"session_duration_days"`
+	SessionDurationDays int    `koanf:"session_duration_days" json:"session_duration_days" validate:"min=1"`
 
 	// Environment settings
 	// Set to "test" to enable test-only API endpoints (e.g., /test/users)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,8 @@ type Config struct {
 	SupplementExcludePatterns []string `koanf:"supplement_exclude_patterns" json:"supplement_exclude_patterns"`
 
 	// Authentication settings
-	JWTSecret string `koanf:"jwt_secret" json:"-" validate:"required"` // Never expose in JSON
+	JWTSecret           string `koanf:"jwt_secret" json:"-" validate:"required"` // Never expose in JSON
+	SessionDurationDays int    `koanf:"session_duration_days" json:"session_duration_days"`
 
 	// Environment settings
 	// Set to "test" to enable test-only API endpoints (e.g., /test/users)
@@ -97,6 +98,7 @@ func defaults() *Config {
 		LibraryMonitorEnabled:      true,
 		LibraryMonitorDelaySeconds: 60,
 		SupplementExcludePatterns:  []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
+		SessionDurationDays:        30,
 		JWTSecret:                  "", // Must be set via config or env var
 	}
 }
@@ -172,6 +174,11 @@ func NewForTest() *Config {
 	cfg.SupplementExcludePatterns = []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"}
 	cfg.JWTSecret = "test-secret-key-for-testing-only"
 	return cfg
+}
+
+// SessionDuration returns the session duration as a time.Duration.
+func (c *Config) SessionDuration() time.Duration {
+	return time.Duration(c.SessionDurationDays) * 24 * time.Hour
 }
 
 // DownloadCacheMaxSizeBytes returns the maximum cache size in bytes.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -68,7 +68,7 @@ func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager) 
 	}
 
 	// Register auth routes and get the auth service
-	authService := auth.RegisterRoutes(e, db, cfg.JWTSecret)
+	authService := auth.RegisterRoutes(e, db, cfg.JWTSecret, cfg.SessionDuration())
 	authMiddleware := auth.NewMiddleware(authService)
 
 	// Register user and role management routes

--- a/shisho.example.yaml
+++ b/shisho.example.yaml
@@ -152,3 +152,8 @@ supplement_exclude_patterns:
 # Generate one with: openssl rand -base64 32
 # Env: JWT_SECRET
 jwt_secret: your-secret-key-here-change-me
+
+# How many days a login session remains valid before requiring re-authentication
+# Env: SESSION_DURATION_DAYS
+# Default: 30
+session_duration_days: 30

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -91,3 +91,4 @@ macOS (FSEvents) and Docker containers typically don't need this adjustment.
 | Setting | Env Variable | Default | Description |
 |---------|-------------|---------|-------------|
 | `jwt_secret` | `JWT_SECRET` | - | **Required.** Secret key for signing JWT authentication tokens. Use a long, random string (at least 32 characters). Generate one with: `openssl rand -base64 32` |
+| `session_duration_days` | `SESSION_DURATION_DAYS` | `30` | How many days a login session remains valid before requiring re-authentication |


### PR DESCRIPTION
## Summary
- Replaces hardcoded 7-day session expiry with a configurable `session_duration_days` setting (default: 30 days)
- Configurable via config file or `SESSION_DURATION_DAYS` environment variable
- Displayed in the Server Settings admin page

## Test plan
- [ ] Verify `make test` passes (Go tests updated for new `NewService` signature)
- [ ] Verify `yarn lint:types` passes (TypeScript types generated correctly)
- [ ] Set `session_duration_days: 1` in dev config and confirm cookie MaxAge is ~86400s
- [ ] Confirm Server Settings page shows the session duration value