### PR TITLE
[Fix] Clean up cover and sidecar files when deleting last file in a book

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,12 @@ When updating the Node.js version, update **all** of these locations:
 - Frontend uses the same linting rules as backend for consistency
 - Database migrations tested via `make db:rollback && make db:migrate`
 - Tests should be added for any major pieces of functionality like workers or file parsers. If handler logic is also complex, it should be extracted out and tested separately.
-- Whenever fixing a bug, test-driven development should be employed: write a test for the bug, confirm that it fails, fix the bug, and confirm that it passes.
+- **Follow Red-Green-Refactor TDD for bug fixes and new features.** Do NOT write the implementation and test at the same time. The steps must be sequential:
+  1. **Red:** Write the test first. Run it and confirm it **fails** (proving the test actually catches the bug or asserts the new behavior).
+  2. **Green:** Write the minimal implementation to make the test pass. Run the test and confirm it **passes**.
+  3. **Refactor:** Clean up the implementation if needed, re-running tests to ensure they still pass.
+
+  Skipping the Red step means you can't be sure the test is valid — it might pass regardless of the fix.
 
 ## Git Conventions
 

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
-	"github.com/shishobooks/shisho/pkg/sidecar"
 	"github.com/shishobooks/shisho/pkg/sortname"
 	"github.com/uptrace/bun"
 )
@@ -1672,12 +1671,14 @@ func (svc *Service) DeleteFileAndCleanup(ctx context.Context, fileID int, librar
 
 	// Clean up book directory if organized structure
 	if library.OrganizeFileStructure && file.Book != nil && file.Book.Filepath != "" {
-		// Delete book-level sidecar
-		bookSidecarPath := sidecar.BookSidecarPath(file.Book.Filepath)
-		_ = os.Remove(bookSidecarPath)
+		// Combine caller's ignored patterns with shisho special file patterns
+		// so covers (*.cover.*) and sidecars (*.metadata.json) are cleaned up too
+		allIgnoredPatterns := make([]string, 0, len(ignoredPatterns)+len(fileutils.ShishoSpecialFilePatterns))
+		allIgnoredPatterns = append(allIgnoredPatterns, ignoredPatterns...)
+		allIgnoredPatterns = append(allIgnoredPatterns, fileutils.ShishoSpecialFilePatterns...)
 
-		// Clean up empty book directory (ignoredPatterns handles .DS_Store, etc.)
-		_, _ = fileutils.CleanupEmptyDirectory(file.Book.Filepath, ignoredPatterns...)
+		// Clean up book directory (removes covers, sidecars, and OS junk files)
+		_, _ = fileutils.CleanupEmptyDirectory(file.Book.Filepath, allIgnoredPatterns...)
 	}
 
 	return result, nil

--- a/pkg/books/service_test.go
+++ b/pkg/books/service_test.go
@@ -688,6 +688,87 @@ func TestDeleteFileAndCleanup_CleansUpDirectoryWithIgnoredFiles(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "book directory should be completely removed, including ignored files")
 }
 
+func TestDeleteFileAndCleanup_CleansUpCoverAndSidecarFiles(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Create temp directory for the book
+	bookDir := t.TempDir()
+
+	// Create library with OrganizeFileStructure enabled
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		OrganizeFileStructure:    true,
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create book
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create single main file
+	filePath := filepath.Join(bookDir, "test.epub")
+	err = os.WriteFile(filePath, []byte("content"), 0644)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filePath,
+		FilesizeBytes: 7,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create shisho-generated cover and sidecar files
+	coverPath := filepath.Join(bookDir, "test.epub.cover.jpg")
+	err = os.WriteFile(coverPath, []byte("fake cover"), 0644)
+	require.NoError(t, err)
+
+	sidecarPath := filepath.Join(bookDir, "test.epub.metadata.json")
+	err = os.WriteFile(sidecarPath, []byte("{}"), 0644)
+	require.NoError(t, err)
+
+	bookSidecarPath := filepath.Join(bookDir, "Test Book.metadata.json")
+	err = os.WriteFile(bookSidecarPath, []byte("{}"), 0644)
+	require.NoError(t, err)
+
+	// Verify files exist before deletion
+	_, err = os.Stat(coverPath)
+	require.NoError(t, err, "cover file should exist before deletion")
+	_, err = os.Stat(sidecarPath)
+	require.NoError(t, err, "sidecar file should exist before deletion")
+	_, err = os.Stat(bookSidecarPath)
+	require.NoError(t, err, "book sidecar file should exist before deletion")
+
+	// Delete the only file
+	bookSvc := NewService(db)
+	ignoredPatterns := []string{".*", ".DS_Store", "Thumbs.db"}
+	result, err := bookSvc.DeleteFileAndCleanup(ctx, file.ID, library, nil, ignoredPatterns)
+	require.NoError(t, err)
+
+	assert.True(t, result.BookDeleted, "book should be deleted when last file removed")
+
+	// Verify book directory is completely removed (including cover and sidecar files)
+	_, err = os.Stat(bookDir)
+	assert.True(t, os.IsNotExist(err), "book directory should be completely removed, including cover and sidecar files")
+}
+
 func TestDeleteFileAndCleanup_FileNotFound(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/fileutils/operations.go
+++ b/pkg/fileutils/operations.go
@@ -21,6 +21,7 @@ import (
 // ShishoSpecialFilePatterns are glob patterns for shisho-generated files (covers, sidecars).
 // These are used to skip special files during scanning and to treat them as ignorable
 // during directory cleanup after book deletion.
+// This slice must not be mutated at runtime.
 var ShishoSpecialFilePatterns = []string{
 	"*.cover.*",       // individual cover files: book.epub.cover.jpg
 	"*.metadata.json", // sidecar files: book.epub.metadata.json, Book Title.metadata.json

--- a/pkg/fileutils/operations.go
+++ b/pkg/fileutils/operations.go
@@ -18,6 +18,14 @@ import (
 	_ "golang.org/x/image/webp" // Register WebP decoder for image normalization.
 )
 
+// ShishoSpecialFilePatterns are glob patterns for shisho-generated files (covers, sidecars).
+// These are used to skip special files during scanning and to treat them as ignorable
+// during directory cleanup after book deletion.
+var ShishoSpecialFilePatterns = []string{
+	"*.cover.*",       // individual cover files: book.epub.cover.jpg
+	"*.metadata.json", // sidecar files: book.epub.metadata.json, Book Title.metadata.json
+}
+
 // OrganizeFileResult contains the results of organizing a file.
 type OrganizeFileResult struct {
 	OriginalPath  string

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -116,13 +116,10 @@ func isMainFileExtension(ext string) bool {
 	return ok
 }
 
-// shishoSpecialFilePatterns aliases the shared patterns from fileutils.
-var shishoSpecialFilePatterns = fileutils.ShishoSpecialFilePatterns
-
 // isShishoSpecialFile returns true if the filename is a shisho-specific file.
 func isShishoSpecialFile(filename string) bool {
 	lower := strings.ToLower(filename)
-	for _, pattern := range shishoSpecialFilePatterns {
+	for _, pattern := range fileutils.ShishoSpecialFilePatterns {
 		if matched, _ := filepath.Match(pattern, lower); matched {
 			return true
 		}

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -116,13 +116,8 @@ func isMainFileExtension(ext string) bool {
 	return ok
 }
 
-// shishoSpecialFilePatterns are glob patterns for shisho-generated files (covers, sidecars).
-// These are used both to skip special files during scanning and to treat them as ignorable
-// during directory cleanup after book deletion.
-var shishoSpecialFilePatterns = []string{
-	"*.cover.*",       // individual cover files: book.epub.cover.jpg
-	"*.metadata.json", // sidecar files: book.epub.metadata.json, Book Title.metadata.json
-}
+// shishoSpecialFilePatterns aliases the shared patterns from fileutils.
+var shishoSpecialFilePatterns = fileutils.ShishoSpecialFilePatterns
 
 // isShishoSpecialFile returns true if the filename is a shisho-specific file.
 func isShishoSpecialFile(filename string) bool {

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -282,8 +282,8 @@ func (w *Worker) scanFileByID(ctx context.Context, opts ScanOptions, cache *Scan
 
 	// Patterns for files that should be treated as ignorable during directory cleanup
 	// (shisho covers/sidecars + OS junk like .DS_Store).
-	cleanupIgnoredPatterns := make([]string, 0, len(shishoSpecialFilePatterns)+len(w.config.SupplementExcludePatterns))
-	cleanupIgnoredPatterns = append(cleanupIgnoredPatterns, shishoSpecialFilePatterns...)
+	cleanupIgnoredPatterns := make([]string, 0, len(fileutils.ShishoSpecialFilePatterns)+len(w.config.SupplementExcludePatterns))
+	cleanupIgnoredPatterns = append(cleanupIgnoredPatterns, fileutils.ShishoSpecialFilePatterns...)
 	cleanupIgnoredPatterns = append(cleanupIgnoredPatterns, w.config.SupplementExcludePatterns...)
 
 	// Retrieve file with relations from DB
@@ -520,8 +520,8 @@ func (w *Worker) scanBook(ctx context.Context, opts ScanOptions, cache *ScanCach
 		}
 
 		// Clean up empty directories up to library path
-		cleanupIgnoredPatterns := make([]string, 0, len(shishoSpecialFilePatterns)+len(w.config.SupplementExcludePatterns))
-		cleanupIgnoredPatterns = append(cleanupIgnoredPatterns, shishoSpecialFilePatterns...)
+		cleanupIgnoredPatterns := make([]string, 0, len(fileutils.ShishoSpecialFilePatterns)+len(w.config.SupplementExcludePatterns))
+		cleanupIgnoredPatterns = append(cleanupIgnoredPatterns, fileutils.ShishoSpecialFilePatterns...)
 		cleanupIgnoredPatterns = append(cleanupIgnoredPatterns, w.config.SupplementExcludePatterns...)
 		library, libErr := w.libraryService.RetrieveLibrary(ctx, libraries.RetrieveLibraryOptions{
 			ID: &book.LibraryID,


### PR DESCRIPTION
## Summary
- `DeleteFileAndCleanup` left orphan book directories on disk because it only treated OS junk files (`.DS_Store`, `Thumbs.db`) as ignorable during cleanup, not shisho-generated covers (`*.cover.*`) and sidecars (`*.metadata.json`)
- Moved `shishoSpecialFilePatterns` from `pkg/worker/scan.go` to `pkg/fileutils/operations.go` as an exported `ShishoSpecialFilePatterns` so both the scanner and book service can share them
- Expanded CLAUDE.md TDD guidance to explicitly require Red-Green-Refactor steps

## Test plan
- [x] New test `TestDeleteFileAndCleanup_CleansUpCoverAndSidecarFiles` creates cover and sidecar files alongside a book file, deletes the last file, and asserts the directory is fully removed
- [x] Verified test fails against the old code (Red) and passes with the fix (Green)
- [x] All existing tests pass (`make check:quiet`)