### PR TITLE
[Fix] Validate and download cover URLs using plugin httpAccess domains

### DIFF
--- a/packages/plugin-types/metadata.d.ts
+++ b/packages/plugin-types/metadata.d.ts
@@ -46,7 +46,7 @@ export interface ParsedMetadata {
   releaseDate?: string;
   /** MIME type of cover image (e.g., "image/jpeg"). */
   coverMimeType?: string;
-  /** Public URL for cover image. Server downloads at apply time. Lower precedence than coverData. */
+  /** Public URL for cover image. Server downloads at apply time. Lower precedence than coverData. Domain must be in httpAccess.domains. */
   coverUrl?: string;
   /** Cover image data as ArrayBuffer. */
   coverData?: ArrayBuffer;

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1445,10 +1445,10 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 	return c.JSON(http.StatusOK, updatedBook)
 }
 
-// downloadCoverFromURL fetches a cover image from a URL and populates md.CoverData and md.CoverMimeType.
+// DownloadCoverFromURL fetches a cover image from a URL and populates md.CoverData and md.CoverMimeType.
 // Returns true if the download succeeded, false otherwise. Skips if CoverData is already set (precedence rule).
 // The URL's domain (and any redirect domains) must be in the plugin's httpAccess.domains allowlist.
-func downloadCoverFromURL(ctx context.Context, md *mediafile.ParsedMetadata, allowedDomains []string, log logger.Logger) bool {
+func DownloadCoverFromURL(ctx context.Context, md *mediafile.ParsedMetadata, allowedDomains []string, log logger.Logger) bool {
 	if len(md.CoverData) > 0 || md.CoverURL == "" {
 		return false
 	}
@@ -1785,7 +1785,7 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 		if manifest.Capabilities.HTTPAccess != nil {
 			allowedDomains = manifest.Capabilities.HTTPAccess.Domains
 		}
-		downloadCoverFromURL(ctx, md, allowedDomains, log)
+		DownloadCoverFromURL(ctx, md, allowedDomains, log)
 	}
 
 	// Apply cover data (from coverData or downloaded from coverUrl)

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -3,8 +3,10 @@ package plugins
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1445,12 +1447,36 @@ func (h *handler) enrichMetadata(c echo.Context) error {
 
 // downloadCoverFromURL fetches a cover image from a URL and populates md.CoverData and md.CoverMimeType.
 // Returns true if the download succeeded, false otherwise. Skips if CoverData is already set (precedence rule).
-func downloadCoverFromURL(ctx context.Context, md *mediafile.ParsedMetadata, log logger.Logger) bool {
+// The URL's domain (and any redirect domains) must be in the plugin's httpAccess.domains allowlist.
+func downloadCoverFromURL(ctx context.Context, md *mediafile.ParsedMetadata, allowedDomains []string, log logger.Logger) bool {
 	if len(md.CoverData) > 0 || md.CoverURL == "" {
 		return false
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	// Validate the cover URL domain against the plugin's allowed domains
+	parsedURL, err := url.Parse(md.CoverURL)
+	if err != nil {
+		log.Warn("failed to parse cover URL", logger.Data{"url": md.CoverURL, "error": err.Error()})
+		return false
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		log.Warn("cover URL uses unsupported scheme", logger.Data{"url": md.CoverURL, "scheme": parsedURL.Scheme})
+		return false
+	}
+	if err := validateDomain(parsedURL.Host, allowedDomains); err != nil {
+		log.Warn("cover URL domain not in plugin's httpAccess.domains", logger.Data{"url": md.CoverURL, "error": err.Error()})
+		return false
+	}
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			if err := validateDomain(req.URL.Host, allowedDomains); err != nil {
+				return fmt.Errorf("redirect blocked: %w", err)
+			}
+			return nil
+		},
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, md.CoverURL, nil)
 	if err != nil {
 		log.Warn("failed to create cover download request", logger.Data{"url": md.CoverURL, "error": err.Error()})
@@ -1755,7 +1781,11 @@ func (h *handler) applyEnrichment(ctx context.Context, book *models.Book, target
 
 	// Cover image: download from URL if coverData is empty and coverUrl is set
 	if md.CoverURL != "" && isAllowed("cover") && targetFile != nil {
-		downloadCoverFromURL(ctx, md, log)
+		var allowedDomains []string
+		if manifest.Capabilities.HTTPAccess != nil {
+			allowedDomains = manifest.Capabilities.HTTPAccess.Domains
+		}
+		downloadCoverFromURL(ctx, md, allowedDomains, log)
 	}
 
 	// Apply cover data (from coverData or downloaded from coverUrl)

--- a/pkg/plugins/handler_enrich_test.go
+++ b/pkg/plugins/handler_enrich_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/robinjoseph08/golib/logger"
@@ -13,6 +14,13 @@ import (
 
 func testLogger() logger.Logger {
 	return logger.New()
+}
+
+// testServerHost returns the host:port from an httptest server URL,
+// suitable for use in the allowedDomains list.
+func testServerHost(srv *httptest.Server) string {
+	u, _ := url.Parse(srv.URL)
+	return u.Host
 }
 
 func TestDownloadCoverFromURL_Success(t *testing.T) {
@@ -26,7 +34,7 @@ func TestDownloadCoverFromURL_Success(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/cover.jpg"}
-	ok := downloadCoverFromURL(context.Background(), md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, []string{testServerHost(srv)}, testLogger())
 
 	assert.True(t, ok)
 	assert.Equal(t, fakeJPEG, md.CoverData)
@@ -43,7 +51,7 @@ func TestDownloadCoverFromURL_CoverDataTakesPrecedence(t *testing.T) {
 		CoverURL:      "https://should-not-be-called.example.com/cover.jpg",
 	}
 
-	ok := downloadCoverFromURL(context.Background(), md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, []string{"example.com"}, testLogger())
 
 	assert.False(t, ok, "should skip when CoverData already set")
 	assert.Equal(t, existing, md.CoverData, "CoverData should be unchanged")
@@ -59,7 +67,7 @@ func TestDownloadCoverFromURL_NonImageRejected(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/not-image"}
-	ok := downloadCoverFromURL(context.Background(), md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, []string{testServerHost(srv)}, testLogger())
 
 	assert.False(t, ok, "should reject non-image content type")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")
@@ -69,7 +77,7 @@ func TestDownloadCoverFromURL_EmptyURL(t *testing.T) {
 	t.Parallel()
 
 	md := &mediafile.ParsedMetadata{}
-	ok := downloadCoverFromURL(context.Background(), md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, nil, testLogger())
 
 	assert.False(t, ok, "should return false for empty URL")
 }
@@ -83,8 +91,68 @@ func TestDownloadCoverFromURL_ServerError(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/error"}
-	ok := downloadCoverFromURL(context.Background(), md, testLogger())
+	ok := downloadCoverFromURL(context.Background(), md, []string{testServerHost(srv)}, testLogger())
 
 	assert.False(t, ok, "should return false on server error")
+	assert.Nil(t, md.CoverData, "CoverData should remain nil")
+}
+
+func TestDownloadCoverFromURL_DomainNotAllowed(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0})
+	}))
+	defer srv.Close()
+
+	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/cover.jpg"}
+	ok := downloadCoverFromURL(context.Background(), md, []string{"example.com"}, testLogger())
+
+	assert.False(t, ok, "should reject URL with domain not in allowed list")
+	assert.Nil(t, md.CoverData, "CoverData should remain nil")
+}
+
+func TestDownloadCoverFromURL_NoHTTPAccess(t *testing.T) {
+	t.Parallel()
+
+	md := &mediafile.ParsedMetadata{CoverURL: "https://example.com/cover.jpg"}
+	ok := downloadCoverFromURL(context.Background(), md, nil, testLogger())
+
+	assert.False(t, ok, "should reject when no domains are allowed")
+	assert.Nil(t, md.CoverData, "CoverData should remain nil")
+}
+
+func TestDownloadCoverFromURL_RedirectToDisallowedDomain(t *testing.T) {
+	t.Parallel()
+
+	// Target server (will be on a different port, not in allowed list)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0})
+	}))
+	defer target.Close()
+
+	// Redirect server that redirects to target
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/cover.jpg", http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	md := &mediafile.ParsedMetadata{CoverURL: redirector.URL + "/cover.jpg"}
+	// Only allow the redirector's host:port, not the target's
+	ok := downloadCoverFromURL(context.Background(), md, []string{testServerHost(redirector)}, testLogger())
+
+	assert.False(t, ok, "should reject redirect to disallowed domain")
+	assert.Nil(t, md.CoverData, "CoverData should remain nil")
+}
+
+func TestDownloadCoverFromURL_UnsupportedScheme(t *testing.T) {
+	t.Parallel()
+
+	md := &mediafile.ParsedMetadata{CoverURL: "ftp://example.com/cover.jpg"}
+	ok := downloadCoverFromURL(context.Background(), md, []string{"example.com"}, testLogger())
+
+	assert.False(t, ok, "should reject non-http/https scheme")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")
 }

--- a/pkg/plugins/handler_enrich_test.go
+++ b/pkg/plugins/handler_enrich_test.go
@@ -34,7 +34,7 @@ func TestDownloadCoverFromURL_Success(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/cover.jpg"}
-	ok := downloadCoverFromURL(context.Background(), md, []string{testServerHost(srv)}, testLogger())
+	ok := DownloadCoverFromURL(context.Background(), md, []string{testServerHost(srv)}, testLogger())
 
 	assert.True(t, ok)
 	assert.Equal(t, fakeJPEG, md.CoverData)
@@ -51,7 +51,7 @@ func TestDownloadCoverFromURL_CoverDataTakesPrecedence(t *testing.T) {
 		CoverURL:      "https://should-not-be-called.example.com/cover.jpg",
 	}
 
-	ok := downloadCoverFromURL(context.Background(), md, []string{"example.com"}, testLogger())
+	ok := DownloadCoverFromURL(context.Background(), md, []string{"example.com"}, testLogger())
 
 	assert.False(t, ok, "should skip when CoverData already set")
 	assert.Equal(t, existing, md.CoverData, "CoverData should be unchanged")
@@ -67,7 +67,7 @@ func TestDownloadCoverFromURL_NonImageRejected(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/not-image"}
-	ok := downloadCoverFromURL(context.Background(), md, []string{testServerHost(srv)}, testLogger())
+	ok := DownloadCoverFromURL(context.Background(), md, []string{testServerHost(srv)}, testLogger())
 
 	assert.False(t, ok, "should reject non-image content type")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")
@@ -77,7 +77,7 @@ func TestDownloadCoverFromURL_EmptyURL(t *testing.T) {
 	t.Parallel()
 
 	md := &mediafile.ParsedMetadata{}
-	ok := downloadCoverFromURL(context.Background(), md, nil, testLogger())
+	ok := DownloadCoverFromURL(context.Background(), md, nil, testLogger())
 
 	assert.False(t, ok, "should return false for empty URL")
 }
@@ -91,7 +91,7 @@ func TestDownloadCoverFromURL_ServerError(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/error"}
-	ok := downloadCoverFromURL(context.Background(), md, []string{testServerHost(srv)}, testLogger())
+	ok := DownloadCoverFromURL(context.Background(), md, []string{testServerHost(srv)}, testLogger())
 
 	assert.False(t, ok, "should return false on server error")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")
@@ -107,7 +107,7 @@ func TestDownloadCoverFromURL_DomainNotAllowed(t *testing.T) {
 	defer srv.Close()
 
 	md := &mediafile.ParsedMetadata{CoverURL: srv.URL + "/cover.jpg"}
-	ok := downloadCoverFromURL(context.Background(), md, []string{"example.com"}, testLogger())
+	ok := DownloadCoverFromURL(context.Background(), md, []string{"example.com"}, testLogger())
 
 	assert.False(t, ok, "should reject URL with domain not in allowed list")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")
@@ -117,7 +117,7 @@ func TestDownloadCoverFromURL_NoHTTPAccess(t *testing.T) {
 	t.Parallel()
 
 	md := &mediafile.ParsedMetadata{CoverURL: "https://example.com/cover.jpg"}
-	ok := downloadCoverFromURL(context.Background(), md, nil, testLogger())
+	ok := DownloadCoverFromURL(context.Background(), md, nil, testLogger())
 
 	assert.False(t, ok, "should reject when no domains are allowed")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")
@@ -141,7 +141,7 @@ func TestDownloadCoverFromURL_RedirectToDisallowedDomain(t *testing.T) {
 
 	md := &mediafile.ParsedMetadata{CoverURL: redirector.URL + "/cover.jpg"}
 	// Only allow the redirector's host:port, not the target's
-	ok := downloadCoverFromURL(context.Background(), md, []string{testServerHost(redirector)}, testLogger())
+	ok := DownloadCoverFromURL(context.Background(), md, []string{testServerHost(redirector)}, testLogger())
 
 	assert.False(t, ok, "should reject redirect to disallowed domain")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")
@@ -151,7 +151,7 @@ func TestDownloadCoverFromURL_UnsupportedScheme(t *testing.T) {
 	t.Parallel()
 
 	md := &mediafile.ParsedMetadata{CoverURL: "ftp://example.com/cover.jpg"}
-	ok := downloadCoverFromURL(context.Background(), md, []string{"example.com"}, testLogger())
+	ok := DownloadCoverFromURL(context.Background(), md, []string{"example.com"}, testLogger())
 
 	assert.False(t, ok, "should reject non-http/https scheme")
 	assert.Nil(t, md.CoverData, "CoverData should remain nil")

--- a/pkg/worker/scan_plugins_test.go
+++ b/pkg/worker/scan_plugins_test.go
@@ -1558,7 +1558,7 @@ func TestFilterMetadataFields_SeriesNumberAliasForSeries(t *testing.T) {
 }
 
 // TestFilterMetadataFields_CoverGrouping verifies that the "cover" field declaration
-// controls coverData, coverMimeType, and coverPage.
+// controls coverData, coverMimeType, coverPage, and coverUrl.
 func TestFilterMetadataFields_CoverGrouping(t *testing.T) {
 	t.Parallel()
 
@@ -1568,6 +1568,7 @@ func TestFilterMetadataFields_CoverGrouping(t *testing.T) {
 		CoverData:     []byte("fake cover data"),
 		CoverMimeType: "image/jpeg",
 		CoverPage:     &coverPage,
+		CoverURL:      "https://example.com/cover.jpg",
 	}
 
 	// Cover field is declared but disabled
@@ -1584,6 +1585,7 @@ func TestFilterMetadataFields_CoverGrouping(t *testing.T) {
 	assert.Empty(t, filtered.CoverData, "coverData should be zeroed when 'cover' is disabled")
 	assert.Empty(t, filtered.CoverMimeType, "coverMimeType should be zeroed when 'cover' is disabled")
 	assert.Nil(t, filtered.CoverPage, "coverPage should be zeroed when 'cover' is disabled")
+	assert.Empty(t, filtered.CoverURL, "coverURL should be zeroed when 'cover' is disabled")
 }
 
 // TestFilterMetadataFields_AllFieldsEnabled verifies that when all fields are

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -27,6 +27,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/mp4"
 	"github.com/shishobooks/shisho/pkg/pdf"
+	"github.com/shishobooks/shisho/pkg/plugins"
 	"github.com/shishobooks/shisho/pkg/sidecar"
 	"github.com/shishobooks/shisho/pkg/sortname"
 )
@@ -2691,6 +2692,15 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 		// Filter to only declared and enabled fields, log warnings for undeclared
 		filteredMetadata := filterMetadataFields(result.Metadata, declaredFields, enabledFields, rt.PluginID(), logWarn)
 
+		// Download cover from URL if coverData is empty and coverUrl is set
+		if filteredMetadata.CoverURL != "" && len(filteredMetadata.CoverData) == 0 {
+			var allowedDomains []string
+			if rt.Manifest().Capabilities.HTTPAccess != nil {
+				allowedDomains = rt.Manifest().Capabilities.HTTPAccess.Domains
+			}
+			plugins.DownloadCoverFromURL(ctx, filteredMetadata, allowedDomains, log)
+		}
+
 		// Merge: first non-empty wins per field, tracking source per field
 		enricherSource := models.PluginDataSource(rt.Scope(), rt.PluginID())
 		mergeEnrichedMetadata(&enrichedMeta, filteredMetadata, enricherSource)
@@ -2880,10 +2890,11 @@ func filterMetadataFields(
 
 	// Handle "cover" grouping
 	if !isFieldAllowed("cover") {
-		warnIfUndeclared("cover", len(result.CoverData) > 0 || result.CoverMimeType != "" || result.CoverPage != nil)
+		warnIfUndeclared("cover", len(result.CoverData) > 0 || result.CoverMimeType != "" || result.CoverPage != nil || result.CoverURL != "")
 		result.CoverData = nil
 		result.CoverMimeType = ""
 		result.CoverPage = nil
+		result.CoverURL = ""
 	}
 
 	// Handle individual fields

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -279,7 +279,7 @@ The full set of fields you can return:
 | `coverData` | `ArrayBuffer` | Cover image data |
 | `coverMimeType` | `string` | Cover MIME type (e.g., `image/jpeg`) |
 | `coverPage` | `number` | Cover page index (0-indexed, for page-based formats) |
-| `coverUrl` | `string` | Public URL for cover image. Server downloads at apply time. |
+| `coverUrl` | `string` | Public URL for cover image. Server downloads at apply time. Domain must be in `httpAccess.domains`. |
 | `duration` | `number` | Audiobook duration in seconds |
 | `bitrateBps` | `number` | Audio bitrate in bits per second |
 | `pageCount` | `number` | Page count |
@@ -407,6 +407,8 @@ All fields except `title` are optional. The more fields you provide, the easier 
 | `coverData` | URL requires authentication; download via `shisho.http.fetch()` | No (binary data doesn't survive JSON) |
 
 **Precedence:** `coverData` > `coverUrl`. If both are set, `coverData` wins.
+
+**Domain requirement:** When the server downloads a `coverUrl`, it validates the URL's domain against the plugin's `httpAccess.domains` allowlist — the same restriction that applies to `shisho.http.fetch()`. If the domain isn't allowed, or the plugin doesn't declare `httpAccess`, the download is rejected. Redirects are also validated against the allowlist.
 
 For authenticated covers, use `coverData` in the `enrich()` step:
 

--- a/website/docs/plugins/overview.md
+++ b/website/docs/plugins/overview.md
@@ -71,7 +71,7 @@ When a new version of a plugin is available, you'll see an update indicator in *
 
 Plugins run in a sandboxed JavaScript environment. Each plugin must declare its required permissions in its manifest:
 
-- **HTTP access**: Which domains the plugin can make requests to
+- **HTTP access**: Which domains the plugin can make requests to (this also applies to `coverUrl` downloads — the server validates the URL domain against the plugin's allowed list)
 - **File access**: Whether the plugin can read or write files beyond its own directory
 - **FFmpeg access**: Whether the plugin can use FFmpeg for media processing
 - **Shell access**: Which specific shell commands the plugin can execute


### PR DESCRIPTION
## Summary
- Plugin `coverUrl` downloads were not validated against the plugin's `httpAccess.domains` allowlist, creating an SSRF vector where plugins could cause the server to make requests to arbitrary domains
- `DownloadCoverFromURL` now validates the URL domain (and redirect domains) against the same allowlist used by `shisho.http.fetch()`
- Plugins without `httpAccess` declared cannot use `coverUrl` at all
- Scan-time enrichers that return `coverUrl` now actually download covers — previously `coverUrl` was silently ignored during scans, so plugins relying on it would produce no covers
- `filterMetadataFields` now also zeroes `CoverURL` when the cover field is not allowed

## Test plan
- [ ] Verify cover URL download tests pass (`go test ./pkg/plugins/ -run TestDownloadCoverFromURL`)
- [ ] Verify new tests: `DomainNotAllowed`, `NoHTTPAccess`, `RedirectToDisallowedDomain`, `UnsupportedScheme`
- [ ] Install a plugin with `httpAccess.domains: ["example.com"]` and confirm `coverUrl` pointing to `example.com` works during both interactive enrichment and scan-time enrichment
- [ ] Confirm `coverUrl` pointing to an unlisted domain is rejected with a warning log
- [ ] Run a scan with an enricher that returns `coverUrl` and verify covers are downloaded