### PR TITLE
[Feature] Add bulk download for selected books

### DIFF
--- a/app/components/contexts/SSEProvider.tsx
+++ b/app/components/contexts/SSEProvider.tsx
@@ -1,8 +1,18 @@
 import type { ReactNode } from "react";
 
+import { BulkDownloadProvider } from "@/contexts/BulkDownload";
 import { useSSE } from "@/hooks/useSSE";
 
-export function SSEProvider({ children }: { children: ReactNode }) {
+function SSEListener() {
   useSSE();
-  return <>{children}</>;
+  return null;
+}
+
+export function SSEProvider({ children }: { children: ReactNode }) {
+  return (
+    <BulkDownloadProvider>
+      <SSEListener />
+      {children}
+    </BulkDownloadProvider>
+  );
 }

--- a/app/components/library/BulkDownloadToast.tsx
+++ b/app/components/library/BulkDownloadToast.tsx
@@ -55,11 +55,7 @@ export const BulkDownloadToast = () => {
       </div>
 
       {status === "completed" && (
-        <Button
-          asChild
-          className="w-full mt-2"
-          size="sm"
-        >
+        <Button asChild className="w-full mt-2" size="sm">
           <a href={`/api/jobs/${jobId}/download`}>
             <Download className="h-4 w-4" />
             Download Zip

--- a/app/components/library/BulkDownloadToast.tsx
+++ b/app/components/library/BulkDownloadToast.tsx
@@ -1,0 +1,71 @@
+import { Download, Loader2, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { useBulkDownload } from "@/hooks/useBulkDownload";
+import { formatFileSize } from "@/utils/format";
+
+export const BulkDownloadToast = () => {
+  const { activeDownload, dismissDownload } = useBulkDownload();
+
+  if (!activeDownload || activeDownload.dismissed) {
+    return null;
+  }
+
+  const { jobId, status, current, total, estimatedSizeBytes } = activeDownload;
+  const progressPercent = total > 0 ? Math.round((current / total) * 100) : 0;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 bg-background border rounded-lg shadow-lg p-4 w-80">
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          {status === "completed" ? (
+            <Download className="h-4 w-4 text-green-600" />
+          ) : status === "failed" ? (
+            <X className="h-4 w-4 text-destructive" />
+          ) : (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          )}
+          <span>
+            {status === "completed"
+              ? "Download ready"
+              : status === "failed"
+                ? "Download failed"
+                : status === "zipping"
+                  ? "Creating zip file..."
+                  : `Preparing ${current} of ${total} files...`}
+          </span>
+        </div>
+        <Button
+          className="h-6 w-6 shrink-0"
+          onClick={dismissDownload}
+          size="icon"
+          variant="ghost"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      </div>
+
+      {(status === "generating" || status === "zipping") && (
+        <Progress className="h-2 mb-2" value={progressPercent} />
+      )}
+
+      <div className="text-xs text-muted-foreground">
+        {formatFileSize(estimatedSizeBytes)}
+      </div>
+
+      {status === "completed" && (
+        <Button
+          asChild
+          className="w-full mt-2"
+          size="sm"
+        >
+          <a href={`/api/jobs/${jobId}/download`}>
+            <Download className="h-4 w-4" />
+            Download Zip
+          </a>
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -1,5 +1,13 @@
-import { GitMerge, List, Loader2, Plus, Trash2, X } from "lucide-react";
-import { useState } from "react";
+import {
+  Download,
+  GitMerge,
+  List,
+  Loader2,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { CreateListDialog } from "@/components/library/CreateListDialog";
@@ -12,19 +20,23 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { useBooks, useDeleteBooks } from "@/hooks/queries/books";
+import { useCreateJob } from "@/hooks/queries/jobs";
 import {
   useAddBooksToList,
   useCreateList,
   useListLists,
 } from "@/hooks/queries/lists";
+import { useBulkDownload } from "@/hooks/useBulkDownload";
 import { useBulkSelection } from "@/hooks/useBulkSelection";
-import type { CreateListPayload, Library } from "@/types";
+import type { Book, CreateListPayload, Library } from "@/types";
+import { formatFileSize } from "@/utils/format";
 
 interface SelectionToolbarProps {
   library?: Library;
+  books?: Book[];
 }
 
-export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
+export const SelectionToolbar = ({ library, books }: SelectionToolbarProps) => {
   const { selectedBookIds, exitSelectionMode, clearSelection } =
     useBulkSelection();
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -33,10 +45,60 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
+  const { startDownload } = useBulkDownload();
+  const createJobMutation = useCreateJob();
+
   const listsQuery = useListLists();
   const addToListMutation = useAddBooksToList();
   const createListMutation = useCreateList();
   const deleteBooksMutation = useDeleteBooks();
+
+  const downloadInfo = useMemo(() => {
+    if (!books || selectedBookIds.length === 0) return null;
+
+    const fileIds: number[] = [];
+    let totalSize = 0;
+
+    for (const bookId of selectedBookIds) {
+      const book = books.find((b) => b.id === bookId);
+      if (!book?.primary_file_id) continue;
+      const primaryFile = book.files?.find(
+        (f) => f.id === book.primary_file_id,
+      );
+      if (primaryFile) {
+        fileIds.push(primaryFile.id);
+        totalSize += primaryFile.filesize_bytes ?? 0;
+      }
+    }
+
+    return { fileIds, totalSize };
+  }, [books, selectedBookIds]);
+
+  const handleDownload = async () => {
+    if (!downloadInfo || downloadInfo.fileIds.length === 0) return;
+
+    try {
+      const job = await createJobMutation.mutateAsync({
+        payload: {
+          type: "bulk_download",
+          data: {
+            file_ids: downloadInfo.fileIds,
+            estimated_size_bytes: downloadInfo.totalSize,
+          },
+        },
+      });
+      startDownload(
+        job.id,
+        downloadInfo.fileIds.length,
+        downloadInfo.totalSize,
+      );
+      exitSelectionMode();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to start download";
+      toast.error(message);
+    }
+  };
 
   // Fetch book details for selected books (needed for dialog)
   const booksQuery = useBooks(
@@ -183,6 +245,29 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
           )}
         </PopoverContent>
       </Popover>
+
+      <Button
+        disabled={
+          !downloadInfo ||
+          downloadInfo.fileIds.length === 0 ||
+          createJobMutation.isPending
+        }
+        onClick={handleDownload}
+        size="sm"
+        variant="default"
+      >
+        {createJobMutation.isPending ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Download className="h-4 w-4" />
+        )}
+        Download
+        {downloadInfo && downloadInfo.totalSize > 0 && (
+          <span className="text-xs opacity-75">
+            ({formatFileSize(downloadInfo.totalSize)})
+          </span>
+        )}
+      </Button>
 
       {selectedBookIds.length >= 2 && library && (
         <Button

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -28,15 +28,14 @@ import {
 } from "@/hooks/queries/lists";
 import { useBulkDownload } from "@/hooks/useBulkDownload";
 import { useBulkSelection } from "@/hooks/useBulkSelection";
-import type { Book, CreateListPayload, Library } from "@/types";
+import type { CreateListPayload, Library } from "@/types";
 import { formatFileSize } from "@/utils/format";
 
 interface SelectionToolbarProps {
   library?: Library;
-  books?: Book[];
 }
 
-export const SelectionToolbar = ({ library, books }: SelectionToolbarProps) => {
+export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
   const { selectedBookIds, exitSelectionMode, clearSelection } =
     useBulkSelection();
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -53,14 +52,21 @@ export const SelectionToolbar = ({ library, books }: SelectionToolbarProps) => {
   const createListMutation = useCreateList();
   const deleteBooksMutation = useDeleteBooks();
 
+  // Fetch all selected books (not just current page) for download info and delete dialog
+  const allSelectedBooksQuery = useBooks(
+    { ids: selectedBookIds },
+    { enabled: selectedBookIds.length > 0 },
+  );
+
   const downloadInfo = useMemo(() => {
-    if (!books || selectedBookIds.length === 0) return null;
+    const allBooks = allSelectedBooksQuery.data?.books;
+    if (!allBooks || selectedBookIds.length === 0) return null;
 
     const fileIds: number[] = [];
     let totalSize = 0;
 
     for (const bookId of selectedBookIds) {
-      const book = books.find((b) => b.id === bookId);
+      const book = allBooks.find((b) => b.id === bookId);
       if (!book?.primary_file_id) continue;
       const primaryFile = book.files?.find(
         (f) => f.id === book.primary_file_id,
@@ -72,7 +78,7 @@ export const SelectionToolbar = ({ library, books }: SelectionToolbarProps) => {
     }
 
     return { fileIds, totalSize };
-  }, [books, selectedBookIds]);
+  }, [allSelectedBooksQuery.data?.books, selectedBookIds]);
 
   const handleDownload = async () => {
     if (!downloadInfo || downloadInfo.fileIds.length === 0) return;
@@ -99,12 +105,6 @@ export const SelectionToolbar = ({ library, books }: SelectionToolbarProps) => {
       toast.error(message);
     }
   };
-
-  // Fetch book details for selected books (needed for dialog)
-  const booksQuery = useBooks(
-    { ids: selectedBookIds },
-    { enabled: showDeleteDialog && selectedBookIds.length > 0 },
-  );
 
   const lists = listsQuery.data?.lists ?? [];
   const editableLists = lists.filter((list) => list.permission !== "viewer");
@@ -323,7 +323,7 @@ export const SelectionToolbar = ({ library, books }: SelectionToolbarProps) => {
       />
 
       <DeleteConfirmationDialog
-        books={booksQuery.data?.books?.map((b) => ({
+        books={allSelectedBooksQuery.data?.books?.map((b) => ({
           id: b.id,
           title: b.title,
           files: b.files,

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -573,7 +573,10 @@ const HomeContent = () => {
         renderItem={renderBookItem}
         total={booksQuery.data?.total ?? 0}
       />
-      <SelectionToolbar library={libraryQuery.data} />
+      <SelectionToolbar
+        books={booksQuery.data?.books}
+        library={libraryQuery.data}
+      />
     </LibraryLayout>
   );
 };

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -573,10 +573,7 @@ const HomeContent = () => {
         renderItem={renderBookItem}
         total={booksQuery.data?.total ?? 0}
       />
-      <SelectionToolbar
-        books={booksQuery.data?.books}
-        library={libraryQuery.data}
-      />
+      <SelectionToolbar library={libraryQuery.data} />
     </LibraryLayout>
   );
 };

--- a/app/components/pages/Root.tsx
+++ b/app/components/pages/Root.tsx
@@ -1,5 +1,6 @@
 import { Outlet, ScrollRestoration } from "react-router-dom";
 
+import { BulkDownloadToast } from "@/components/library/BulkDownloadToast";
 import MobileDrawer from "@/components/library/MobileDrawer";
 import { Toaster } from "@/components/ui/sonner";
 import { MobileNavProvider } from "@/contexts/MobileNav";
@@ -14,6 +15,7 @@ const Root = () => {
         </div>
         <MobileDrawer />
         <Toaster richColors />
+        <BulkDownloadToast />
       </div>
     </MobileNavProvider>
   );

--- a/app/components/ui/progress.tsx
+++ b/app/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/libraries/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/app/components/ui/progress.tsx
+++ b/app/components/ui/progress.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+import * as React from "react";
 
-import { cn } from "@/libraries/utils"
+import { cn } from "@/libraries/utils";
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
@@ -11,7 +11,7 @@ const Progress = React.forwardRef<
     ref={ref}
     className={cn(
       "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
-      className
+      className,
     )}
     {...props}
   >
@@ -20,7 +20,7 @@ const Progress = React.forwardRef<
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>
-))
-Progress.displayName = ProgressPrimitive.Root.displayName
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
 
-export { Progress }
+export { Progress };

--- a/app/contexts/BulkDownload/BulkDownloadProvider.tsx
+++ b/app/contexts/BulkDownload/BulkDownloadProvider.tsx
@@ -1,0 +1,96 @@
+import {
+  BulkDownloadContext,
+  type BulkDownloadContextValue,
+  type BulkDownloadProgress,
+} from "./context";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+
+export const BulkDownloadProvider = ({ children }: { children: ReactNode }) => {
+  const [activeDownload, setActiveDownload] =
+    useState<BulkDownloadProgress | null>(null);
+
+  const startDownload = useCallback(
+    (jobId: number, total: number, estimatedSizeBytes: number) => {
+      setActiveDownload({
+        jobId,
+        status: "generating",
+        current: 0,
+        total,
+        estimatedSizeBytes,
+        dismissed: false,
+      });
+    },
+    [],
+  );
+
+  const updateProgress = useCallback(
+    (
+      jobId: number,
+      status: string,
+      current: number,
+      total: number,
+      estimatedSizeBytes: number,
+    ) => {
+      setActiveDownload((prev) => {
+        if (!prev || prev.jobId !== jobId) return prev;
+        return {
+          ...prev,
+          status: status as BulkDownloadProgress["status"],
+          current,
+          total,
+          estimatedSizeBytes,
+        };
+      });
+    },
+    [],
+  );
+
+  const completeDownload = useCallback((jobId: number) => {
+    setActiveDownload((prev) => {
+      if (!prev || prev.jobId !== jobId) return prev;
+      return { ...prev, status: "completed", dismissed: false };
+    });
+  }, []);
+
+  const failDownload = useCallback((jobId: number) => {
+    setActiveDownload((prev) => {
+      if (!prev || prev.jobId !== jobId) return prev;
+      return { ...prev, status: "failed", dismissed: false };
+    });
+  }, []);
+
+  const dismissDownload = useCallback(() => {
+    setActiveDownload((prev) => {
+      if (!prev) return prev;
+      if (prev.status === "completed" || prev.status === "failed") {
+        return null;
+      }
+      return { ...prev, dismissed: true };
+    });
+  }, []);
+
+  const value: BulkDownloadContextValue = useMemo(
+    () => ({
+      activeDownload,
+      startDownload,
+      updateProgress,
+      completeDownload,
+      failDownload,
+      dismissDownload,
+    }),
+    [
+      activeDownload,
+      startDownload,
+      updateProgress,
+      completeDownload,
+      failDownload,
+      dismissDownload,
+    ],
+  );
+
+  return (
+    <BulkDownloadContext.Provider value={value}>
+      {children}
+    </BulkDownloadContext.Provider>
+  );
+};

--- a/app/contexts/BulkDownload/context.ts
+++ b/app/contexts/BulkDownload/context.ts
@@ -1,0 +1,32 @@
+import { createContext } from "react";
+
+export interface BulkDownloadProgress {
+  jobId: number;
+  status: "generating" | "zipping" | "completed" | "failed";
+  current: number;
+  total: number;
+  estimatedSizeBytes: number;
+  dismissed: boolean;
+}
+
+export interface BulkDownloadContextValue {
+  activeDownload: BulkDownloadProgress | null;
+  startDownload: (
+    jobId: number,
+    total: number,
+    estimatedSizeBytes: number,
+  ) => void;
+  updateProgress: (
+    jobId: number,
+    status: string,
+    current: number,
+    total: number,
+    estimatedSizeBytes: number,
+  ) => void;
+  completeDownload: (jobId: number) => void;
+  failDownload: (jobId: number) => void;
+  dismissDownload: () => void;
+}
+
+export const BulkDownloadContext =
+  createContext<BulkDownloadContextValue | null>(null);

--- a/app/contexts/BulkDownload/index.ts
+++ b/app/contexts/BulkDownload/index.ts
@@ -1,0 +1,3 @@
+export { BulkDownloadProvider } from "./BulkDownloadProvider";
+export { BulkDownloadContext } from "./context";
+export type { BulkDownloadProgress, BulkDownloadContextValue } from "./context";

--- a/app/hooks/useBulkDownload.ts
+++ b/app/hooks/useBulkDownload.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+
+import { BulkDownloadContext } from "@/contexts/BulkDownload";
+
+export const useBulkDownload = () => {
+  const context = useContext(BulkDownloadContext);
+  if (!context) {
+    throw new Error(
+      "useBulkDownload must be used within a BulkDownloadProvider",
+    );
+  }
+  return context;
+};

--- a/app/hooks/useSSE.ts
+++ b/app/hooks/useSSE.ts
@@ -1,6 +1,10 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useContext, useEffect, useLayoutEffect, useRef } from "react";
 
+import {
+  BulkDownloadContext,
+  type BulkDownloadContextValue,
+} from "@/contexts/BulkDownload";
 import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
 import { QueryKey as JobsQueryKey } from "@/hooks/queries/jobs";
 import { useAuth } from "@/hooks/useAuth";
@@ -8,6 +12,15 @@ import { useAuth } from "@/hooks/useAuth";
 export function useSSE() {
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
+  const bulkDownload = useContext(BulkDownloadContext);
+
+  // Use ref to avoid the EventSource reconnecting on every progress update.
+  // Synced via useLayoutEffect so it's always up-to-date before any async
+  // callbacks fire.
+  const bulkDownloadRef = useRef<BulkDownloadContextValue | null>(null);
+  useLayoutEffect(() => {
+    bulkDownloadRef.current = bulkDownload;
+  });
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -49,6 +62,33 @@ export function useSSE() {
             queryKey: [BooksQueryKey.ListBooks],
           });
         }
+
+        // Handle bulk download completion/failure
+        const bd = bulkDownloadRef.current;
+        if (data.type === "bulk_download" && bd) {
+          if (data.status === "completed") {
+            bd.completeDownload(data.job_id);
+          } else if (data.status === "failed") {
+            bd.failDownload(data.job_id);
+          }
+        }
+      } catch {
+        // Ignore malformed events
+      }
+    };
+
+    const handleBulkDownloadProgress = (event: MessageEvent) => {
+      const bd = bulkDownloadRef.current;
+      if (!bd) return;
+      try {
+        const data = JSON.parse(event.data);
+        bd.updateProgress(
+          data.job_id,
+          data.status,
+          data.current,
+          data.total,
+          data.estimated_size_bytes,
+        );
       } catch {
         // Ignore malformed events
       }
@@ -56,10 +96,15 @@ export function useSSE() {
 
     es.addEventListener("job.created", handleJobCreated);
     es.addEventListener("job.status_changed", handleJobStatusChanged);
+    es.addEventListener("bulk_download.progress", handleBulkDownloadProgress);
 
     return () => {
       es.removeEventListener("job.created", handleJobCreated);
       es.removeEventListener("job.status_changed", handleJobStatusChanged);
+      es.removeEventListener(
+        "bulk_download.progress",
+        handleBulkDownloadProgress,
+      );
       es.close();
     };
   }, [isAuthenticated, queryClient]);

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/robinjoseph08/golib/signals"
 	"github.com/shishobooks/shisho/pkg/config"
 	"github.com/shishobooks/shisho/pkg/database"
+	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/plugins"
@@ -69,9 +70,11 @@ func main() {
 
 	broker := events.NewBroker()
 
-	wrkr := worker.New(cfg, db, pluginManager, broker)
+	dlCache := downloadcache.NewCache(filepath.Join(cfg.CacheDir, "downloads"), cfg.DownloadCacheMaxSizeBytes())
 
-	srv, err := server.New(cfg, db, wrkr, pluginManager, broker)
+	wrkr := worker.New(cfg, db, pluginManager, broker, dlCache)
+
+	srv, err := server.New(cfg, db, wrkr, pluginManager, broker, dlCache)
 	if err != nil {
 		log.Err(err).Fatal("server error")
 	}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -128,11 +128,12 @@ func main() {
 }
 
 // initCacheDir creates the cache directories and verifies write permissions.
-// Creates subdirectories: downloads (generated files), cbz (extracted page images).
+// Creates subdirectories: downloads (generated files), downloads/bulk (bulk zip files), cbz (extracted page images).
 func initCacheDir(dir string) error {
 	// Create subdirectories
 	subdirs := []string{
 		filepath.Join(dir, "downloads"),
+		filepath.Join(dir, "downloads", "bulk"),
 		filepath.Join(dir, "cbz"),
 	}
 

--- a/docs/superpowers/plans/2026-03-15-bulk-download.md
+++ b/docs/superpowers/plans/2026-03-15-bulk-download.md
@@ -1,0 +1,1476 @@
+# Bulk Download Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bulk download to gallery select mode — users select books, download a zip of primary files with metadata injected, backed by the job system with SSE progress.
+
+**Architecture:** New `bulk_download` job type processed by the worker, which generates metadata-injected files via the existing download cache, zips them in store mode, and caches the zip. Frontend adds a Download button to the selection toolbar, tracks progress via SSE in a React context, and shows a persistent toast with a download link on completion.
+
+**Tech Stack:** Go (Echo, Bun, archive/zip), React (Tanstack Query, sonner toasts, React context), SSE
+
+**Spec:** `docs/superpowers/specs/2026-03-15-bulk-download-design.md`
+
+---
+
+## Chunk 1: Backend — Model, Events, Cache, and Worker
+
+### Task 1: Add bulk_download job type and data struct
+
+**Files:**
+- Modify: `pkg/models/job.go`
+
+- [ ] **Step 1: Add `JobTypeBulkDownload` constant and data struct**
+
+In `pkg/models/job.go`, add `JobTypeBulkDownload` to the constants block and create the data struct:
+
+```go
+// Update the tygo:emit comment to include the new type:
+//tygo:emit export type JobType = typeof JobTypeExport | typeof JobTypeScan | typeof JobTypeBulkDownload;
+
+// Add the new constant:
+JobTypeBulkDownload = "bulk_download"
+
+// Add the data struct (after JobScanData):
+type JobBulkDownloadData struct {
+	// Input (set on creation)
+	FileIDs            []int `json:"file_ids"`
+	EstimatedSizeBytes int64 `json:"estimated_size_bytes"`
+
+	// Result (set on completion)
+	ZipFilename     string `json:"zip_filename,omitempty"`
+	SizeBytes       int64  `json:"size_bytes,omitempty"`
+	FileCount       int    `json:"file_count,omitempty"`
+	FingerprintHash string `json:"fingerprint_hash,omitempty"`
+}
+```
+
+- [ ] **Step 2: Update `UnmarshalData()` to handle `bulk_download`**
+
+Add a case in the switch statement:
+
+```go
+case JobTypeBulkDownload:
+	job.DataParsed = &JobBulkDownloadData{}
+```
+
+- [ ] **Step 3: Update `DataParsed` tstype annotation**
+
+Change the `tstype` tag on `DataParsed` from:
+```
+tstype:"JobExportData | JobScanData"
+```
+to:
+```
+tstype:"JobExportData | JobScanData | JobBulkDownloadData"
+```
+
+- [ ] **Step 4: Run `make tygo` and verify**
+
+Run: `make tygo`
+
+Check that `app/types/generated/models.ts` now includes `JobBulkDownloadData` and the updated `JobType` union.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/models/job.go
+git commit -m "[Backend] Add bulk_download job type and data model"
+```
+
+### Task 2: Update job validators
+
+**Files:**
+- Modify: `pkg/jobs/validators.go`
+
+- [ ] **Step 1: Add `bulk_download` to validation rules**
+
+In `CreateJobPayload.Type`, change:
+```
+validate:"required,oneof=export scan"
+```
+to:
+```
+validate:"required,oneof=export scan bulk_download"
+```
+
+Also update the `tstype` on `CreateJobPayload.Data`:
+```
+tstype:"JobExportData | JobScanData | JobBulkDownloadData"
+```
+
+In `ListJobsQuery.Type`, change:
+```
+validate:"omitempty,oneof=export scan"
+```
+to:
+```
+validate:"omitempty,oneof=export scan bulk_download"
+```
+
+- [ ] **Step 2: Run `make tygo` to regenerate types**
+
+Run: `make tygo`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/jobs/validators.go
+git commit -m "[Backend] Add bulk_download to job validation rules"
+```
+
+### Task 3: Add bulk download progress event helper
+
+**Files:**
+- Modify: `pkg/events/broker.go`
+
+- [ ] **Step 1: Add `NewBulkDownloadProgressEvent` function**
+
+```go
+// NewBulkDownloadProgressEvent builds a progress event for bulk download jobs.
+func NewBulkDownloadProgressEvent(jobID int, status string, current, total int, estimatedSizeBytes int64) Event {
+	data := fmt.Sprintf(
+		`{"job_id":%d,"status":"%s","current":%d,"total":%d,"estimated_size_bytes":%d}`,
+		jobID, status, current, total, estimatedSizeBytes,
+	)
+	return Event{Type: "bulk_download.progress", Data: data}
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pkg/events/broker.go
+git commit -m "[Backend] Add SSE event helper for bulk download progress"
+```
+
+### Task 4: Add bulk zip cache methods to download cache
+
+**Files:**
+- Modify: `pkg/downloadcache/cache.go`
+- Modify: `pkg/downloadcache/cleanup.go`
+
+- [ ] **Step 1: Add `BulkZipPath` and `BulkZipExists` methods to `Cache`**
+
+In `cache.go`, add:
+
+```go
+// BulkZipDir returns the path to the bulk zip cache subdirectory.
+func (c *Cache) BulkZipDir() string {
+	return filepath.Join(c.dir, "bulk")
+}
+
+// BulkZipPath returns the expected path for a bulk zip with the given fingerprint hash.
+func (c *Cache) BulkZipPath(fingerprintHash string) string {
+	return filepath.Join(c.dir, "bulk", fingerprintHash+".zip")
+}
+
+// BulkZipExists checks if a bulk zip with the given fingerprint exists.
+func (c *Cache) BulkZipExists(fingerprintHash string) bool {
+	_, err := os.Stat(c.BulkZipPath(fingerprintHash))
+	return err == nil
+}
+```
+
+- [ ] **Step 2: Add `ShouldSkipCleanup` callback field**
+
+In the `Cache` struct, add a callback field:
+
+```go
+type Cache struct {
+	dir              string
+	maxSize          int64
+	ShouldSkipCleanup func() bool // If set and returns true, cleanup is skipped
+}
+```
+
+Update `runCleanup()` to check it:
+
+```go
+func (c *Cache) runCleanup() error {
+	if c.ShouldSkipCleanup != nil && c.ShouldSkipCleanup() {
+		return nil
+	}
+	// ... rest of existing code
+```
+
+- [ ] **Step 3: Add `pdf` to `findCachedFileExtension`**
+
+In `cleanup.go`, update the extensions slice:
+
+```go
+extensions := []string{"epub", "m4b", "cbz", "pdf"}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/downloadcache/cache.go pkg/downloadcache/cleanup.go
+git commit -m "[Backend] Add bulk zip cache methods and cleanup skip callback"
+```
+
+### Task 5: Write the bulk download test
+
+**Files:**
+- Create: `pkg/worker/bulk_download_test.go`
+
+- [ ] **Step 1: Write a test for `ComputeBulkFingerprint`**
+
+```go
+package worker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeBulkFingerprint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deterministic for same inputs", func(t *testing.T) {
+		t.Parallel()
+		hashes := []string{"abc123", "def456", "ghi789"}
+		hash1 := ComputeBulkFingerprint([]int{1, 2, 3}, hashes)
+		hash2 := ComputeBulkFingerprint([]int{1, 2, 3}, hashes)
+		assert.Equal(t, hash1, hash2)
+	})
+
+	t.Run("sorts file IDs for consistency", func(t *testing.T) {
+		t.Parallel()
+		hashes1 := []string{"abc123", "def456"}
+		hashes2 := []string{"def456", "abc123"}
+		hash1 := ComputeBulkFingerprint([]int{1, 2}, hashes1)
+		hash2 := ComputeBulkFingerprint([]int{2, 1}, hashes2)
+		assert.Equal(t, hash1, hash2)
+	})
+
+	t.Run("different hashes produce different fingerprint", func(t *testing.T) {
+		t.Parallel()
+		hash1 := ComputeBulkFingerprint([]int{1, 2}, []string{"abc", "def"})
+		hash2 := ComputeBulkFingerprint([]int{1, 2}, []string{"abc", "xyz"})
+		assert.NotEqual(t, hash1, hash2)
+	})
+}
+
+func TestDeduplicateFilenames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+		names := map[int]string{1: "Book A.epub", 2: "Book B.epub"}
+		result := DeduplicateFilenames(names)
+		assert.Equal(t, "Book A.epub", result[1])
+		assert.Equal(t, "Book B.epub", result[2])
+	})
+
+	t.Run("duplicates get numbered", func(t *testing.T) {
+		t.Parallel()
+		names := map[int]string{1: "Book.epub", 2: "Book.epub", 3: "Book.epub"}
+		result := DeduplicateFilenames(names)
+		// One should keep original, others get (2), (3)
+		values := []string{result[1], result[2], result[3]}
+		require.Contains(t, values, "Book.epub")
+		require.Contains(t, values, "Book (2).epub")
+		require.Contains(t, values, "Book (3).epub")
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/bulk-download && go test ./pkg/worker/ -run "TestComputeBulkFingerprint|TestDeduplicateFilenames" -v`
+Expected: FAIL (functions not defined)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/worker/bulk_download_test.go
+git commit -m "[Test] Add tests for bulk download fingerprint and filename deduplication"
+```
+
+### Task 6: Implement bulk download worker
+
+**Files:**
+- Create: `pkg/worker/bulk_download.go`
+- Modify: `pkg/worker/worker.go`
+
+- [ ] **Step 1: Create `pkg/worker/bulk_download.go` with helper functions**
+
+```go
+package worker
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/robinjoseph08/golib/logger"
+	"github.com/segmentio/encoding/json"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/downloadcache"
+	"github.com/shishobooks/shisho/pkg/events"
+	"github.com/shishobooks/shisho/pkg/joblogs"
+	"github.com/shishobooks/shisho/pkg/jobs"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// ComputeBulkFingerprint computes a composite fingerprint hash from sorted file IDs and their individual hashes.
+func ComputeBulkFingerprint(fileIDs []int, fileHashes []string) string {
+	// Create paired entries for sorting
+	type entry struct {
+		id   int
+		hash string
+	}
+	entries := make([]entry, len(fileIDs))
+	for i := range fileIDs {
+		entries[i] = entry{id: fileIDs[i], hash: fileHashes[i]}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].id < entries[j].id
+	})
+
+	h := sha256.New()
+	for _, e := range entries {
+		fmt.Fprintf(h, "%d:%s\n", e.id, e.hash)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// DeduplicateFilenames takes a map of fileID → filename and appends (2), (3), etc. for duplicates.
+func DeduplicateFilenames(names map[int]string) map[int]string {
+	// Count occurrences of each name
+	counts := make(map[string][]int) // name → list of file IDs
+	for id, name := range names {
+		counts[name] = append(counts[name], id)
+	}
+
+	result := make(map[int]string, len(names))
+	for name, ids := range counts {
+		if len(ids) == 1 {
+			result[ids[0]] = name
+			continue
+		}
+		sort.Ints(ids)
+		for i, id := range ids {
+			if i == 0 {
+				result[id] = name
+			} else {
+				ext := filepath.Ext(name)
+				base := strings.TrimSuffix(name, ext)
+				result[id] = fmt.Sprintf("%s (%d)%s", base, i+1, ext)
+			}
+		}
+	}
+	return result
+}
+
+// ProcessBulkDownloadJob generates metadata-injected files and creates a zip archive.
+func (w *Worker) ProcessBulkDownloadJob(ctx context.Context, job *models.Job, jobLog *joblogs.JobLogger) error {
+	log := logger.FromContext(ctx)
+
+	// Parse job data
+	var data models.JobBulkDownloadData
+	if err := json.Unmarshal([]byte(job.Data), &data); err != nil {
+		return errors.Wrap(err, "failed to parse bulk download job data")
+	}
+
+	if len(data.FileIDs) == 0 {
+		return errors.New("no file IDs provided")
+	}
+
+	jobLog.Info(fmt.Sprintf("starting bulk download for %d files", len(data.FileIDs)), nil)
+
+	// Load all files with their book relations
+	type fileWithBook struct {
+		file *models.File
+		book *models.Book
+	}
+	filesWithBooks := make([]fileWithBook, 0, len(data.FileIDs))
+
+	for _, fileID := range data.FileIDs {
+		file, err := w.bookService.RetrieveFileWithRelations(ctx, fileID)
+		if err != nil {
+			jobLog.Warn(fmt.Sprintf("skipping file %d: %v", fileID, err), nil)
+			continue
+		}
+		book, err := w.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &file.BookID})
+		if err != nil {
+			jobLog.Warn(fmt.Sprintf("skipping file %d: failed to load book: %v", fileID, err), nil)
+			continue
+		}
+		filesWithBooks = append(filesWithBooks, fileWithBook{file: file, book: book})
+	}
+
+	if len(filesWithBooks) == 0 {
+		return errors.New("no valid files found for bulk download")
+	}
+
+	// Compute composite fingerprint
+	fileIDs := make([]int, len(filesWithBooks))
+	fileHashes := make([]string, len(filesWithBooks))
+	for i, fw := range filesWithBooks {
+		fileIDs[i] = fw.file.ID
+		fp, err := downloadcache.ComputeFingerprint(fw.book, fw.file)
+		if err != nil {
+			return errors.Wrapf(err, "failed to compute fingerprint for file %d", fw.file.ID)
+		}
+		hash, err := fp.Hash()
+		if err != nil {
+			return errors.Wrapf(err, "failed to hash fingerprint for file %d", fw.file.ID)
+		}
+		fileHashes[i] = hash
+	}
+	compositeHash := ComputeBulkFingerprint(fileIDs, fileHashes)
+
+	// Check if zip already exists in cache
+	if w.downloadCache.BulkZipExists(compositeHash) {
+		zipPath := w.downloadCache.BulkZipPath(compositeHash)
+		info, err := os.Stat(zipPath)
+		if err == nil {
+			jobLog.Info("bulk zip already cached, skipping generation", nil)
+			data.ZipFilename = filepath.Base(zipPath)
+			data.SizeBytes = info.Size()
+			data.FileCount = len(filesWithBooks)
+			data.FingerprintHash = compositeHash
+			return w.completeBulkDownloadJob(ctx, job, &data)
+		}
+	}
+
+	// Generate each file via download cache
+	total := len(filesWithBooks)
+	cachedPaths := make(map[int]string, total)
+	downloadNames := make(map[int]string, total)
+
+	for i, fw := range filesWithBooks {
+		if err := ctx.Err(); err != nil {
+			return errors.Wrap(err, "job cancelled")
+		}
+
+		cachedPath, downloadFilename, err := w.downloadCache.GetOrGenerate(ctx, fw.book, fw.file)
+		if err != nil {
+			jobLog.Warn(fmt.Sprintf("failed to generate file %d (%s): %v", fw.file.ID, fw.file.Filepath, err), nil)
+			continue
+		}
+		cachedPaths[fw.file.ID] = cachedPath
+		downloadNames[fw.file.ID] = downloadFilename
+
+		// Publish progress event
+		if w.broker != nil {
+			w.broker.Publish(events.NewBulkDownloadProgressEvent(
+				job.ID, "generating", i+1, total, data.EstimatedSizeBytes,
+			))
+		}
+
+		log.Debug("generated file for bulk download", logger.Data{
+			"file_id": fw.file.ID, "progress": fmt.Sprintf("%d/%d", i+1, total),
+		})
+	}
+
+	if len(cachedPaths) == 0 {
+		return errors.New("no files were successfully generated")
+	}
+
+	// Publish zipping status
+	if w.broker != nil {
+		w.broker.Publish(events.NewBulkDownloadProgressEvent(
+			job.ID, "zipping", total, total, data.EstimatedSizeBytes,
+		))
+	}
+
+	// Deduplicate filenames
+	dedupedNames := DeduplicateFilenames(downloadNames)
+
+	// Create the zip file
+	bulkDir := w.downloadCache.BulkZipDir()
+	if err := os.MkdirAll(bulkDir, 0755); err != nil {
+		return errors.Wrap(err, "failed to create bulk zip directory")
+	}
+
+	zipPath := w.downloadCache.BulkZipPath(compositeHash)
+	zipFile, err := os.Create(zipPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to create zip file")
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	for fileID, cachedPath := range cachedPaths {
+		filename := dedupedNames[fileID]
+
+		// Use Store method (no compression) since ebook files are already compressed
+		header := &zip.FileHeader{
+			Name:   filename,
+			Method: zip.Store,
+		}
+
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create zip entry for %s", filename)
+		}
+
+		f, err := os.Open(cachedPath)
+		if err != nil {
+			return errors.Wrapf(err, "failed to open cached file %s", cachedPath)
+		}
+
+		_, err = io.Copy(writer, f)
+		f.Close()
+		if err != nil {
+			return errors.Wrapf(err, "failed to write %s to zip", filename)
+		}
+	}
+
+	// Close the zip writer to flush
+	if err := zipWriter.Close(); err != nil {
+		return errors.Wrap(err, "failed to finalize zip")
+	}
+
+	// Get zip file size
+	zipInfo, err := os.Stat(zipPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to stat zip file")
+	}
+
+	jobLog.Info(fmt.Sprintf("bulk download zip created: %d files, %d bytes", len(cachedPaths), zipInfo.Size()), nil)
+
+	data.ZipFilename = filepath.Base(zipPath)
+	data.SizeBytes = zipInfo.Size()
+	data.FileCount = len(cachedPaths)
+	data.FingerprintHash = compositeHash
+
+	return w.completeBulkDownloadJob(ctx, job, &data)
+}
+
+// completeBulkDownloadJob updates the job data with result fields.
+func (w *Worker) completeBulkDownloadJob(ctx context.Context, job *models.Job, data *models.JobBulkDownloadData) error {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal bulk download result")
+	}
+	job.Data = string(dataBytes)
+	job.DataParsed = data
+
+	return w.jobService.UpdateJob(ctx, job, jobs.UpdateJobOptions{
+		Columns: []string{"data"},
+	})
+}
+```
+
+- [ ] **Step 2: Wire up the worker — add `downloadCache` field and register process function**
+
+In `pkg/worker/worker.go`:
+
+Add import:
+```go
+"github.com/shishobooks/shisho/pkg/downloadcache"
+```
+
+Add field to `Worker` struct:
+```go
+downloadCache *downloadcache.Cache
+```
+
+Update `New()` signature to accept the cache:
+```go
+func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) *Worker {
+```
+
+Set it in the worker initialization:
+```go
+downloadCache: dlCache,
+```
+
+Register the process function:
+```go
+w.processFuncs = map[string]func(ctx context.Context, job *models.Job, jobLog *joblogs.JobLogger) error{
+	models.JobTypeScan:         w.ProcessScanJob,
+	models.JobTypeBulkDownload: w.ProcessBulkDownloadJob,
+}
+```
+
+Set the cleanup skip callback on the cache (after `w` is constructed, use `w.jobService`):
+```go
+if dlCache != nil {
+	dlCache.ShouldSkipCleanup = func() bool {
+		hasActive, err := w.jobService.HasActiveJob(context.Background(), models.JobTypeBulkDownload, nil)
+		if err != nil {
+			return false
+		}
+		return hasActive
+	}
+}
+```
+
+- [ ] **Step 3: Update `cmd/api/main.go` to create the download cache once and pass it everywhere**
+
+In `cmd/api/main.go`, create the download cache before the worker and server, then pass it to both. This ensures a single cache instance is shared (so the `ShouldSkipCleanup` callback protects all cleanup calls).
+
+```go
+// After broker creation, before worker and server creation:
+dlCache := downloadcache.NewCache(filepath.Join(cfg.CacheDir, "downloads"), cfg.DownloadCacheMaxSizeBytes())
+
+wrkr := worker.New(cfg, db, pluginManager, broker, dlCache)
+
+srv, err := server.New(cfg, db, wrkr, pluginManager, broker, dlCache)
+```
+
+Add import:
+```go
+"github.com/shishobooks/shisho/pkg/downloadcache"
+```
+
+Then update `pkg/server/server.go` to accept the download cache instead of creating its own:
+
+Change `New` signature:
+```go
+func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) (*http.Server, error) {
+```
+
+Remove the existing cache creation (line 90):
+```go
+// DELETE: downloadCache := downloadcache.NewCache(filepath.Join(cfg.CacheDir, "downloads"), cfg.DownloadCacheMaxSizeBytes())
+```
+
+Use `dlCache` instead of `downloadCache` where it's referenced (eReader, Kobo routes, and the new jobs route):
+```go
+ereader.RegisterRoutes(e, db, dlCache)
+kobo.RegisterRoutes(e, db, dlCache)
+```
+
+And in `registerProtectedRoutes`, pass `dlCache` through:
+```go
+func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, w *worker.Worker, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) {
+```
+
+Update the call in `New`:
+```go
+registerProtectedRoutes(e, db, cfg, authMiddleware, w, pm, broker, dlCache)
+```
+
+And in `registerProtectedRoutes`, pass `dlCache` to jobs registration:
+```go
+jobs.RegisterRoutesWithGroup(jobsGroup, db, authMiddleware, broker, dlCache)
+```
+
+- [ ] **Step 4: Run tests to verify fingerprint/deduplication tests pass**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/bulk-download && go test ./pkg/worker/ -run "TestComputeBulkFingerprint|TestDeduplicateFilenames" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/bulk-download && make test`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/worker/bulk_download.go pkg/worker/worker.go cmd/api/main.go pkg/server/server.go
+git commit -m "[Feature] Implement bulk download worker with zip generation"
+```
+
+### Task 7: Add job download endpoint
+
+**Files:**
+- Modify: `pkg/jobs/handlers.go`
+- Modify: `pkg/jobs/routes.go`
+
+- [ ] **Step 1: Add download handler to `pkg/jobs/handlers.go`**
+
+Update the handler struct to include the download cache:
+
+```go
+type handler struct {
+	jobService    *Service
+	broker        *events.Broker
+	downloadCache *downloadcache.Cache
+}
+```
+
+Add the download handler:
+
+```go
+func (h *handler) download(c echo.Context) error {
+	ctx := c.Request().Context()
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.NotFound("Job")
+	}
+
+	job, err := h.jobService.RetrieveJob(ctx, RetrieveJobOptions{
+		ID: &id,
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if job.Type != models.JobTypeBulkDownload {
+		return errcodes.BadRequest("Job is not a bulk download")
+	}
+
+	if job.Status != models.JobStatusCompleted {
+		return errcodes.BadRequest("Job is not completed yet")
+	}
+
+	var data models.JobBulkDownloadData
+	if err := json.Unmarshal([]byte(job.Data), &data); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if data.FingerprintHash == "" {
+		return errcodes.BadRequest("Job has no download data")
+	}
+
+	zipPath := h.downloadCache.BulkZipPath(data.FingerprintHash)
+	if _, err := os.Stat(zipPath); os.IsNotExist(err) {
+		return errcodes.NotFound("Download file has expired from cache")
+	}
+
+	filename := fmt.Sprintf("shisho-download-%d-books.zip", data.FileCount)
+	c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+
+	return c.File(zipPath)
+}
+```
+
+Add imports:
+```go
+"fmt"
+"os"
+"github.com/segmentio/encoding/json"
+"github.com/shishobooks/shisho/pkg/downloadcache"
+"github.com/shishobooks/shisho/pkg/models"
+```
+
+- [ ] **Step 2: Update route registration**
+
+In `pkg/jobs/routes.go`, update the function signature and handler construction:
+
+```go
+func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware, broker *events.Broker, dlCache *downloadcache.Cache) {
+	jobService := NewService(db)
+
+	h := &handler{
+		jobService:    jobService,
+		broker:        broker,
+		downloadCache: dlCache,
+	}
+
+	g.GET("", h.list)
+	g.GET("/:id", h.retrieve)
+	g.GET("/:id/download", h.download)
+	g.POST("", h.create, authMiddleware.RequirePermission(models.ResourceJobs, models.OperationWrite))
+}
+```
+
+Add import:
+```go
+"github.com/shishobooks/shisho/pkg/downloadcache"
+```
+
+- [ ] **Step 3: Verify server.go changes from Task 6 Step 3 are in place**
+
+The download cache is now passed through `server.New()` → `registerProtectedRoutes()` → `jobs.RegisterRoutesWithGroup()`. This was done in Task 6 Step 3. Verify the jobs registration call uses `dlCache`:
+
+```go
+jobs.RegisterRoutesWithGroup(jobsGroup, db, authMiddleware, broker, dlCache)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/bulk-download && make test`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/jobs/handlers.go pkg/jobs/routes.go pkg/server/server.go
+git commit -m "[Feature] Add bulk download zip download endpoint"
+```
+
+### Task 8: Add `bulk` subdirectory to cache init
+
+**Files:**
+- Modify: `cmd/api/main.go`
+
+- [ ] **Step 1: Add `downloads/bulk` to the cache subdirectories**
+
+In `initCacheDir`, add the bulk subdirectory:
+
+```go
+subdirs := []string{
+	filepath.Join(dir, "downloads"),
+	filepath.Join(dir, "downloads", "bulk"),
+	filepath.Join(dir, "cbz"),
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add cmd/api/main.go
+git commit -m "[Backend] Add bulk download cache subdirectory to init"
+```
+
+---
+
+## Chunk 2: Frontend — Context, SSE, Toolbar, and Toast
+
+### Task 9: Create BulkDownload context
+
+**Files:**
+- Create: `app/contexts/BulkDownload/context.ts`
+- Create: `app/contexts/BulkDownload/BulkDownloadProvider.tsx`
+- Create: `app/contexts/BulkDownload/index.ts`
+
+- [ ] **Step 1: Create the context definition**
+
+Create `app/contexts/BulkDownload/context.ts`:
+
+```typescript
+import { createContext } from "react";
+
+export interface BulkDownloadProgress {
+  jobId: number;
+  status: "generating" | "zipping" | "completed" | "failed";
+  current: number;
+  total: number;
+  estimatedSizeBytes: number;
+  dismissed: boolean;
+}
+
+export interface BulkDownloadContextValue {
+  activeDownload: BulkDownloadProgress | null;
+  startDownload: (jobId: number, total: number, estimatedSizeBytes: number) => void;
+  updateProgress: (jobId: number, status: string, current: number, total: number, estimatedSizeBytes: number) => void;
+  completeDownload: (jobId: number) => void;
+  failDownload: (jobId: number) => void;
+  dismissDownload: () => void;
+}
+
+export const BulkDownloadContext = createContext<BulkDownloadContextValue | null>(null);
+```
+
+- [ ] **Step 2: Create the provider**
+
+Create `app/contexts/BulkDownload/BulkDownloadProvider.tsx`:
+
+```typescript
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+
+import {
+  BulkDownloadContext,
+  type BulkDownloadContextValue,
+  type BulkDownloadProgress,
+} from "./context";
+
+export const BulkDownloadProvider = ({ children }: { children: ReactNode }) => {
+  const [activeDownload, setActiveDownload] =
+    useState<BulkDownloadProgress | null>(null);
+
+  const startDownload = useCallback(
+    (jobId: number, total: number, estimatedSizeBytes: number) => {
+      setActiveDownload({
+        jobId,
+        status: "generating",
+        current: 0,
+        total,
+        estimatedSizeBytes,
+        dismissed: false,
+      });
+    },
+    [],
+  );
+
+  const updateProgress = useCallback(
+    (
+      jobId: number,
+      status: string,
+      current: number,
+      total: number,
+      estimatedSizeBytes: number,
+    ) => {
+      setActiveDownload((prev) => {
+        if (!prev || prev.jobId !== jobId) return prev;
+        return {
+          ...prev,
+          status: status as BulkDownloadProgress["status"],
+          current,
+          total,
+          estimatedSizeBytes,
+        };
+      });
+    },
+    [],
+  );
+
+  const completeDownload = useCallback((jobId: number) => {
+    setActiveDownload((prev) => {
+      if (!prev || prev.jobId !== jobId) return prev;
+      return { ...prev, status: "completed", dismissed: false };
+    });
+  }, []);
+
+  const failDownload = useCallback((jobId: number) => {
+    setActiveDownload((prev) => {
+      if (!prev || prev.jobId !== jobId) return prev;
+      return { ...prev, status: "failed", dismissed: false };
+    });
+  }, []);
+
+  const dismissDownload = useCallback(() => {
+    setActiveDownload((prev) => {
+      if (!prev) return prev;
+      // If completed or failed, clear it entirely
+      if (prev.status === "completed" || prev.status === "failed") {
+        return null;
+      }
+      // If still in progress, just mark as dismissed
+      return { ...prev, dismissed: true };
+    });
+  }, []);
+
+  const value: BulkDownloadContextValue = useMemo(
+    () => ({
+      activeDownload,
+      startDownload,
+      updateProgress,
+      completeDownload,
+      failDownload,
+      dismissDownload,
+    }),
+    [
+      activeDownload,
+      startDownload,
+      updateProgress,
+      completeDownload,
+      failDownload,
+      dismissDownload,
+    ],
+  );
+
+  return (
+    <BulkDownloadContext.Provider value={value}>
+      {children}
+    </BulkDownloadContext.Provider>
+  );
+};
+```
+
+- [ ] **Step 3: Create the index file**
+
+Create `app/contexts/BulkDownload/index.ts`:
+
+```typescript
+export { BulkDownloadProvider } from "./BulkDownloadProvider";
+export { BulkDownloadContext } from "./context";
+export type { BulkDownloadProgress, BulkDownloadContextValue } from "./context";
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/contexts/BulkDownload/
+git commit -m "[Frontend] Add BulkDownload context for tracking download progress"
+```
+
+### Task 10: Add `useBulkDownload` hook
+
+**Files:**
+- Create: `app/hooks/useBulkDownload.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+import { useContext } from "react";
+
+import { BulkDownloadContext } from "@/contexts/BulkDownload";
+
+export const useBulkDownload = () => {
+  const context = useContext(BulkDownloadContext);
+  if (!context) {
+    throw new Error(
+      "useBulkDownload must be used within a BulkDownloadProvider",
+    );
+  }
+  return context;
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/hooks/useBulkDownload.ts
+git commit -m "[Frontend] Add useBulkDownload hook"
+```
+
+### Task 11: Wire SSE events to BulkDownload context
+
+**Files:**
+- Modify: `app/hooks/useSSE.ts`
+
+- [ ] **Step 1: Update `useSSE` with bulk download event listeners**
+
+**IMPORTANT:** The bulk download context object changes on every progress update (because `activeDownload` state changes). If we put the context in the `useEffect` dependency array, the EventSource would reconnect on every progress tick. Instead, use a `useRef` to hold the latest callbacks so the effect only depends on stable values.
+
+```typescript
+import { useQueryClient } from "@tanstack/react-query";
+import { useContext, useEffect, useRef } from "react";
+
+import { BulkDownloadContext, type BulkDownloadContextValue } from "@/contexts/BulkDownload";
+import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
+import { QueryKey as JobsQueryKey } from "@/hooks/queries/jobs";
+import { useAuth } from "@/hooks/useAuth";
+
+export function useSSE() {
+  const queryClient = useQueryClient();
+  const { isAuthenticated } = useAuth();
+  const bulkDownload = useContext(BulkDownloadContext);
+
+  // Use ref to avoid the EventSource reconnecting on every progress update
+  const bulkDownloadRef = useRef<BulkDownloadContextValue | null>(bulkDownload);
+  bulkDownloadRef.current = bulkDownload;
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
+
+    const es = new EventSource("/api/events");
+
+    es.onerror = () => {
+      console.debug("[SSE] Connection error, will auto-reconnect");
+    };
+
+    const handleJobCreated = () => {
+      queryClient.invalidateQueries({ queryKey: [JobsQueryKey.ListJobs] });
+      queryClient.invalidateQueries({
+        queryKey: [JobsQueryKey.LatestScanJob],
+      });
+    };
+
+    const handleJobStatusChanged = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data);
+        queryClient.invalidateQueries({ queryKey: [JobsQueryKey.ListJobs] });
+        queryClient.invalidateQueries({
+          queryKey: [JobsQueryKey.LatestScanJob],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [JobsQueryKey.RetrieveJob, String(data.job_id)],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [JobsQueryKey.ListJobLogs, String(data.job_id)],
+        });
+
+        // When a scan completes, invalidate book queries so lists refresh
+        if (data.status === "completed" && data.type === "scan") {
+          queryClient.invalidateQueries({
+            queryKey: [BooksQueryKey.ListBooks],
+          });
+        }
+
+        // Handle bulk download completion/failure
+        const bd = bulkDownloadRef.current;
+        if (data.type === "bulk_download" && bd) {
+          if (data.status === "completed") {
+            bd.completeDownload(data.job_id);
+          } else if (data.status === "failed") {
+            bd.failDownload(data.job_id);
+          }
+        }
+      } catch {
+        // Ignore malformed events
+      }
+    };
+
+    const handleBulkDownloadProgress = (event: MessageEvent) => {
+      const bd = bulkDownloadRef.current;
+      if (!bd) return;
+      try {
+        const data = JSON.parse(event.data);
+        bd.updateProgress(
+          data.job_id,
+          data.status,
+          data.current,
+          data.total,
+          data.estimated_size_bytes,
+        );
+      } catch {
+        // Ignore malformed events
+      }
+    };
+
+    es.addEventListener("job.created", handleJobCreated);
+    es.addEventListener("job.status_changed", handleJobStatusChanged);
+    es.addEventListener("bulk_download.progress", handleBulkDownloadProgress);
+
+    return () => {
+      es.removeEventListener("job.created", handleJobCreated);
+      es.removeEventListener("job.status_changed", handleJobStatusChanged);
+      es.removeEventListener(
+        "bulk_download.progress",
+        handleBulkDownloadProgress,
+      );
+      es.close();
+    };
+  }, [isAuthenticated, queryClient]);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/hooks/useSSE.ts
+git commit -m "[Frontend] Wire bulk download SSE events to context"
+```
+
+### Task 12: Wire BulkDownloadProvider into app
+
+**Files:**
+- Modify: `app/components/contexts/SSEProvider.tsx`
+
+- [ ] **Step 1: Wrap SSEProvider children with BulkDownloadProvider**
+
+The `BulkDownloadProvider` needs to be an ancestor of `useSSE`, so wrap it around the SSEProvider's children:
+
+```typescript
+import type { ReactNode } from "react";
+
+import { BulkDownloadProvider } from "@/contexts/BulkDownload";
+import { useSSE } from "@/hooks/useSSE";
+
+function SSEListener() {
+  useSSE();
+  return null;
+}
+
+export function SSEProvider({ children }: { children: ReactNode }) {
+  return (
+    <BulkDownloadProvider>
+      <SSEListener />
+      {children}
+    </BulkDownloadProvider>
+  );
+}
+```
+
+This ensures `useSSE` can access the `BulkDownloadContext` since the provider wraps it.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/components/contexts/SSEProvider.tsx
+git commit -m "[Frontend] Wire BulkDownloadProvider into SSEProvider"
+```
+
+### Task 13: Create BulkDownloadToast component
+
+**Files:**
+- Create: `app/components/library/BulkDownloadToast.tsx`
+
+- [ ] **Step 0: Install the shadcn Progress component**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/bulk-download && npx shadcn@latest add progress`
+
+This creates `app/components/ui/progress.tsx`. Commit it:
+
+```bash
+git add app/components/ui/progress.tsx
+git commit -m "[Frontend] Add shadcn Progress component"
+```
+
+- [ ] **Step 1: Create the toast component**
+
+```typescript
+import { Download, Loader2, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { useBulkDownload } from "@/hooks/useBulkDownload";
+import { formatFileSize } from "@/utils/format";
+
+export const BulkDownloadToast = () => {
+  const { activeDownload, dismissDownload } = useBulkDownload();
+
+  if (!activeDownload || activeDownload.dismissed) {
+    return null;
+  }
+
+  const { jobId, status, current, total, estimatedSizeBytes } = activeDownload;
+  const progressPercent = total > 0 ? Math.round((current / total) * 100) : 0;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 bg-background border rounded-lg shadow-lg p-4 w-80">
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          {status === "completed" ? (
+            <Download className="h-4 w-4 text-green-600" />
+          ) : status === "failed" ? (
+            <X className="h-4 w-4 text-destructive" />
+          ) : (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          )}
+          <span>
+            {status === "completed"
+              ? "Download ready"
+              : status === "failed"
+                ? "Download failed"
+                : status === "zipping"
+                  ? "Creating zip file..."
+                  : `Preparing ${current} of ${total} files...`}
+          </span>
+        </div>
+        <Button
+          className="h-6 w-6 shrink-0"
+          onClick={dismissDownload}
+          size="icon"
+          variant="ghost"
+        >
+          <X className="h-3 w-3" />
+        </Button>
+      </div>
+
+      {(status === "generating" || status === "zipping") && (
+        <Progress className="h-2 mb-2" value={progressPercent} />
+      )}
+
+      <div className="text-xs text-muted-foreground">
+        {formatFileSize(estimatedSizeBytes)}
+      </div>
+
+      {status === "completed" && (
+        <Button
+          asChild
+          className="w-full mt-2"
+          size="sm"
+        >
+          <a href={`/api/jobs/${jobId}/download`}>
+            <Download className="h-4 w-4" />
+            Download Zip
+          </a>
+        </Button>
+      )}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/components/library/BulkDownloadToast.tsx
+git commit -m "[Frontend] Create BulkDownloadToast component"
+```
+
+### Task 14: Render BulkDownloadToast in Root layout
+
+**Files:**
+- Modify: `app/components/pages/Root.tsx`
+
+- [ ] **Step 1: Add BulkDownloadToast to Root**
+
+```typescript
+import { Outlet, ScrollRestoration } from "react-router-dom";
+
+import { BulkDownloadToast } from "@/components/library/BulkDownloadToast";
+import MobileDrawer from "@/components/library/MobileDrawer";
+import { Toaster } from "@/components/ui/sonner";
+import { MobileNavProvider } from "@/contexts/MobileNav";
+
+const Root = () => {
+  return (
+    <MobileNavProvider>
+      <ScrollRestoration />
+      <div className="flex bg-background font-sans min-h-screen">
+        <div className="w-full">
+          <Outlet />
+        </div>
+        <MobileDrawer />
+        <Toaster richColors />
+        <BulkDownloadToast />
+      </div>
+    </MobileNavProvider>
+  );
+};
+
+export default Root;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/components/pages/Root.tsx
+git commit -m "[Frontend] Render BulkDownloadToast in Root layout"
+```
+
+### Task 15: Add Download button to SelectionToolbar
+
+**Files:**
+- Modify: `app/components/library/SelectionToolbar.tsx`
+
+- [ ] **Step 1: Add Download button with size estimate**
+
+Add imports:
+```typescript
+import { Download } from "lucide-react";
+import { useBulkDownload } from "@/hooks/useBulkDownload";
+import { useCreateJob } from "@/hooks/queries/jobs";
+import { formatFileSize } from "@/utils/format";
+import type { Book } from "@/types";
+```
+
+Add a `books` prop for accessing book data:
+```typescript
+interface SelectionToolbarProps {
+  library?: Library;
+  books?: Book[];
+}
+```
+
+Inside the component, add the download logic:
+
+```typescript
+const { startDownload } = useBulkDownload();
+const createJobMutation = useCreateJob();
+
+// Compute file IDs and estimated size from selected books
+const downloadInfo = useMemo(() => {
+  if (!books || selectedBookIds.length === 0) return null;
+
+  const fileIds: number[] = [];
+  let totalSize = 0;
+
+  for (const bookId of selectedBookIds) {
+    const book = books.find((b) => b.id === bookId);
+    if (!book?.primary_file_id) continue;
+    const primaryFile = book.files?.find((f) => f.id === book.primary_file_id);
+    if (primaryFile) {
+      fileIds.push(primaryFile.id);
+      totalSize += primaryFile.filesize_bytes ?? 0;
+    }
+  }
+
+  return { fileIds, totalSize };
+}, [books, selectedBookIds]);
+
+const handleDownload = async () => {
+  if (!downloadInfo || downloadInfo.fileIds.length === 0) return;
+
+  try {
+    const job = await createJobMutation.mutateAsync({
+      payload: {
+        type: "bulk_download",
+        data: {
+          file_ids: downloadInfo.fileIds,
+          estimated_size_bytes: downloadInfo.totalSize,
+        },
+      },
+    });
+    startDownload(
+      job.id,
+      downloadInfo.fileIds.length,
+      downloadInfo.totalSize,
+    );
+    exitSelectionMode();
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to start download";
+    toast.error(message);
+  }
+};
+```
+
+Add the Download button in the JSX, before the Delete button:
+
+```tsx
+<Button
+  disabled={!downloadInfo || downloadInfo.fileIds.length === 0 || createJobMutation.isPending}
+  onClick={handleDownload}
+  size="sm"
+  variant="default"
+>
+  <Download className="h-4 w-4" />
+  {createJobMutation.isPending ? (
+    <Loader2 className="h-4 w-4 animate-spin" />
+  ) : (
+    <>
+      Download
+      {downloadInfo && downloadInfo.totalSize > 0 && (
+        <span className="text-xs opacity-75">
+          ({formatFileSize(downloadInfo.totalSize)})
+        </span>
+      )}
+    </>
+  )}
+</Button>
+```
+
+- [ ] **Step 2: Update Home.tsx to pass books to SelectionToolbar**
+
+In `app/components/pages/Home.tsx`, change:
+```tsx
+<SelectionToolbar library={libraryQuery.data} />
+```
+to:
+```tsx
+<SelectionToolbar
+  books={booksQuery.data?.books}
+  library={libraryQuery.data}
+/>
+```
+
+- [ ] **Step 3: Run lint**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/bulk-download && yarn lint`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/library/SelectionToolbar.tsx app/components/pages/Home.tsx
+git commit -m "[Feature] Add Download button to selection toolbar with size estimate"
+```
+
+---
+
+## Chunk 3: Validation and Cleanup
+
+### Task 16: Run full validation
+
+- [ ] **Step 1: Run `make check:quiet`**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/bulk-download && make check:quiet`
+Expected: All checks pass (tests, Go lint, JS lint)
+
+- [ ] **Step 2: Fix any issues found**
+
+If any checks fail, fix and commit the fixes.
+
+### Task 17: Manual smoke test
+
+- [ ] **Step 1: Start dev server**
+
+Run: `make start` (in a separate terminal)
+
+- [ ] **Step 2: Verify the flow**
+
+1. Open the gallery and enter select mode
+2. Select multiple books
+3. Verify the Download button shows with size estimate
+4. Click Download
+5. Verify the progress toast appears with progress updates
+6. Verify the download completes and the "Download Zip" button works
+7. Navigate away during download and verify toast persists
+8. Verify dismissing and re-receiving the completion notification

--- a/docs/superpowers/specs/2026-03-15-bulk-download-design.md
+++ b/docs/superpowers/specs/2026-03-15-bulk-download-design.md
@@ -23,30 +23,34 @@ Add bulk download functionality to the gallery's select mode. Users select multi
 
 **New constant**: `models.JobTypeBulkDownload = "bulk_download"`
 
-**Job data payload** (stored in `job.Data`):
+**Job data** (single struct stored in `job.Data` throughout lifecycle — input fields populated on creation, result fields populated on completion):
 
 ```go
 type JobBulkDownloadData struct {
+    // Input (set on creation)
     FileIDs            []int `json:"file_ids"`
     EstimatedSizeBytes int64 `json:"estimated_size_bytes"`
+
+    // Result (set on completion)
+    ZipFilename     string `json:"zip_filename,omitempty"`
+    SizeBytes       int64  `json:"size_bytes,omitempty"`
+    FileCount       int    `json:"file_count,omitempty"`
+    FingerprintHash string `json:"fingerprint_hash,omitempty"`
 }
 ```
 
-**Job result** (stored in `job.Data` on completion):
+This single struct avoids the need to distinguish between input and result payloads in `UnmarshalData()`. Input fields are set on creation; result fields are zero-valued until the job completes, then the full struct is re-serialized with both.
 
-```go
-type JobBulkDownloadResult struct {
-    ZipFilename     string `json:"zip_filename"`
-    SizeBytes       int64  `json:"size_bytes"`
-    FileCount       int    `json:"file_count"`
-    FingerprintHash string `json:"fingerprint_hash"`
-}
-```
+### Worker Dependencies
+
+The `Worker` struct needs a `*downloadcache.Cache` field. This requires updating:
+- `worker.New()` to accept the download cache as a parameter
+- `cmd/api/main.go` to pass the download cache when constructing the worker
 
 ### Worker Flow (`ProcessBulkDownloadJob`)
 
 1. Parse `JobBulkDownloadData` from job
-2. Load all files with book relations from DB (need relations for `ComputeFingerprint` and `GetOrGenerate`)
+2. Load all files with book relations from DB using `RetrieveFileWithRelations()` (need Narrators, Identifiers for `ComputeFingerprint`, and full relations for `GetOrGenerate`)
 3. Compute composite fingerprint: sort file IDs, concatenate individual `ComputeFingerprint()` hashes, SHA256 the result
 4. Check if `{cacheDir}/bulk/{fingerprintHash}.zip` already exists — if so, mark job complete immediately
 5. Iterate files:
@@ -56,7 +60,7 @@ type JobBulkDownloadResult struct {
 6. Create zip at `{cacheDir}/bulk/{fingerprintHash}.zip` using store mode (no compression)
    - Filenames from `FormatDownloadFilename(book, file)`
    - Handle duplicate filenames by appending ` (2)`, ` (3)`, etc.
-7. Store `JobBulkDownloadResult` on job, mark complete
+7. Update `JobBulkDownloadData` with result fields (zip filename, size, file count, fingerprint), re-serialize to `job.Data`, mark complete
 
 ### SSE Events
 
@@ -78,11 +82,11 @@ The `generating` → `zipping` → `completed` progression uses the dedicated ev
 
 ### Download Endpoint
 
-**`GET /jobs/:id/download`**
+**`GET /jobs/:id/download`** — lives in `pkg/jobs/routes.go` and `pkg/jobs/handlers.go` since it's a job-scoped operation (not book-scoped).
 
 1. Look up job by ID, verify it's a `bulk_download` type and `completed` status
-2. Parse `JobBulkDownloadResult` from job data
-3. Verify zip file exists on disk
+2. Parse `JobBulkDownloadData` from job data, read result fields
+3. Verify zip file exists on disk at `{cacheDir}/bulk/{fingerprintHash}.zip`
 4. Serve zip with `Content-Disposition: attachment; filename="shisho-download-{N}-books.zip"`
 5. Requires authentication (same as other download endpoints)
 
@@ -96,7 +100,7 @@ The `generating` → `zipping` → `completed` progression uses the dedicated ev
 
 **Individual file caching**: Each `GetOrGenerate()` call populates the standard per-file cache. Future single-file downloads benefit from this warm cache.
 
-**Cache cleanup protection**: `TriggerCleanup()` checks for active `bulk_download` jobs (status `in_progress`) before running. If one is active, skip cleanup. Cleanup resumes after the job completes.
+**Cache cleanup protection**: The cleanup skip check happens at the caller level — the worker checks for active `bulk_download` jobs before calling `TriggerCleanup()`. This avoids adding a database dependency to the cache package, which is currently pure filesystem. Alternatively, `TriggerCleanup()` can accept an optional callback `func() bool` that the worker provides to check for active jobs.
 
 **Cache reuse**: Before generating anything, compute composite fingerprint and check for existing zip. If metadata hasn't changed for any of the selected books, the cached zip is served immediately.
 
@@ -114,8 +118,10 @@ Add "Download" button to `SelectionToolbar.tsx` alongside existing Add to List /
 
 - Icon: `Download` from lucide-react
 - Label shows estimated size: `Download (4.2 GB)` computed from `filesize_bytes` of each selected book's primary file
+- **Book ID → File ID mapping**: For each selected book ID, find the book in the loaded query data, use `book.primary_file_id` to identify the primary file, look up `filesize_bytes` from the matching entry in `book.files`. Skip books with no primary file (shouldn't happen normally, but handle gracefully).
 - On click: `POST /jobs` with `{ type: "bulk_download", data: { file_ids: [...], estimated_size_bytes: N } }`
 - After job creation: exit selection mode, show progress toast
+- **No duplicate prevention**: Users can re-trigger bulk downloads freely. If the zip is already cached, the job completes instantly.
 
 ### Progress Toast
 
@@ -136,8 +142,9 @@ Persistent toast component rendered at the app layout level (survives navigation
 **Behavior:**
 - Toast appears when job is created
 - Persists across page navigation (app-level component)
+- **State management**: A React context (`BulkDownloadContext`) at the app level tracks active bulk download jobs (job ID, progress, status). SSE events update this context. The toast component reads from this context. This survives navigation and allows the toast to reappear after dismissal.
 - Dismissible (doesn't cancel the job — job runs to completion regardless)
-- If dismissed and job completes, a new completion toast appears
+- If dismissed and job completes, a new completion toast appears (driven by context state change)
 
 ### Mutation & Query Hooks
 
@@ -150,14 +157,17 @@ Persistent toast component rendered at the app layout level (survives navigation
 ### New files
 - `pkg/worker/bulk_download.go` — `ProcessBulkDownloadJob` worker method
 - `app/components/library/BulkDownloadToast.tsx` — progress toast component
+- `app/contexts/BulkDownload/` — React context for tracking bulk download state across navigation
 
 ### Modified files
-- `pkg/models/job.go` — add `JobTypeBulkDownload` constant and data structs
-- `pkg/worker/worker.go` — register `bulk_download` process function
-- `pkg/jobs/handlers.go` — handle `bulk_download` job creation (duplicate prevention optional)
-- `pkg/books/routes.go` — add `GET /jobs/:id/download` route (or in `pkg/jobs/routes.go`)
-- `pkg/downloadcache/cache.go` — add bulk zip methods, cleanup protection
+- `pkg/models/job.go` — add `JobTypeBulkDownload` constant and `JobBulkDownloadData` struct, update `UnmarshalData()`
+- `pkg/jobs/validators.go` — add `bulk_download` to `type` validation `oneof` for `CreateJobPayload` and `ListJobsQuery`
+- `pkg/jobs/handlers.go` — add download handler
+- `pkg/jobs/routes.go` — add `GET /jobs/:id/download` route
+- `pkg/worker/worker.go` — add `*downloadcache.Cache` field, accept it in `New()`, register `bulk_download` process function
+- `cmd/api/main.go` — pass download cache to `worker.New()`
+- `pkg/downloadcache/cache.go` — add bulk zip methods, add cleanup skip callback
 - `pkg/events/broker.go` — add `NewBulkDownloadProgressEvent` helper
 - `app/components/library/SelectionToolbar.tsx` — add Download button
 - `app/hooks/useSSE.ts` — add `bulk_download.progress` event listener
-- `app/components/App.tsx` (or layout) — render `BulkDownloadToast`
+- `app/components/App.tsx` (or layout) — render `BulkDownloadToast`, wrap with `BulkDownloadProvider`

--- a/docs/superpowers/specs/2026-03-15-bulk-download-design.md
+++ b/docs/superpowers/specs/2026-03-15-bulk-download-design.md
@@ -1,0 +1,163 @@
+# Bulk Download Design
+
+## Overview
+
+Add bulk download functionality to the gallery's select mode. Users select multiple books, click "Download", and receive a zip file containing the primary file (with metadata injected) for each selected book. The operation is backed by the existing job system with SSE progress events, allowing users to navigate away and return to download the completed zip.
+
+## Decisions
+
+- **Files per book**: Primary file only
+- **File version**: Metadata-injected (same as single-file download)
+- **Zip compression**: Store mode (`zip -0`) — source files are already compressed internally, so re-compression wastes CPU for negligible savings. This also makes the size estimate accurate.
+- **Long-running UX**: Job-based with SSE progress events (reuses existing infrastructure)
+- **Navigate away**: Supported — job runs in background, toast notification appears on completion
+- **Size limits**: None — self-hosted app, user manages their own storage
+- **Size estimate**: Computed client-side from already-loaded `file.filesize_bytes` data. Accurate because store mode means zip size ≈ sum of file sizes.
+- **Cache strategy**: Zip stored in download cache directory (`bulk/` subdirectory). Individual files cached via existing `GetOrGenerate()`. Both persist for future reuse.
+- **Cache cleanup protection**: Skip cache cleanup while a `bulk_download` job is in progress.
+- **Notification**: Toast only (no persistent badge). Job history available as fallback.
+
+## Backend
+
+### Job Type & Data Model
+
+**New constant**: `models.JobTypeBulkDownload = "bulk_download"`
+
+**Job data payload** (stored in `job.Data`):
+
+```go
+type JobBulkDownloadData struct {
+    FileIDs            []int `json:"file_ids"`
+    EstimatedSizeBytes int64 `json:"estimated_size_bytes"`
+}
+```
+
+**Job result** (stored in `job.Data` on completion):
+
+```go
+type JobBulkDownloadResult struct {
+    ZipFilename     string `json:"zip_filename"`
+    SizeBytes       int64  `json:"size_bytes"`
+    FileCount       int    `json:"file_count"`
+    FingerprintHash string `json:"fingerprint_hash"`
+}
+```
+
+### Worker Flow (`ProcessBulkDownloadJob`)
+
+1. Parse `JobBulkDownloadData` from job
+2. Load all files with book relations from DB (need relations for `ComputeFingerprint` and `GetOrGenerate`)
+3. Compute composite fingerprint: sort file IDs, concatenate individual `ComputeFingerprint()` hashes, SHA256 the result
+4. Check if `{cacheDir}/bulk/{fingerprintHash}.zip` already exists — if so, mark job complete immediately
+5. Iterate files:
+   - Call `downloadCache.GetOrGenerate(ctx, book, file)` for each
+   - Publish `bulk_download.progress` event after each file (current/total)
+   - Check `ctx.Err()` for cancellation between files
+6. Create zip at `{cacheDir}/bulk/{fingerprintHash}.zip` using store mode (no compression)
+   - Filenames from `FormatDownloadFilename(book, file)`
+   - Handle duplicate filenames by appending ` (2)`, ` (3)`, etc.
+7. Store `JobBulkDownloadResult` on job, mark complete
+
+### SSE Events
+
+**New event type**: `bulk_download.progress`
+
+```json
+{
+    "job_id": 1,
+    "status": "generating",
+    "current": 3,
+    "total": 25,
+    "estimated_size_bytes": 4500000000
+}
+```
+
+**Statuses**: `generating` (file-by-file progress) → `zipping` (building zip) → then standard `job.status_changed` with `completed`/`failed`
+
+The `generating` → `zipping` → `completed` progression uses the dedicated event type for granular progress, then falls back to the existing `job.status_changed` event for terminal states. This means existing `useSSE` cache invalidation logic works without modification for job completion.
+
+### Download Endpoint
+
+**`GET /jobs/:id/download`**
+
+1. Look up job by ID, verify it's a `bulk_download` type and `completed` status
+2. Parse `JobBulkDownloadResult` from job data
+3. Verify zip file exists on disk
+4. Serve zip with `Content-Disposition: attachment; filename="shisho-download-{N}-books.zip"`
+5. Requires authentication (same as other download endpoints)
+
+### Cache Integration
+
+**Zip storage**: `{cacheDir}/bulk/{fingerprintHash}.zip`
+
+- New `bulk/` subdirectory within the existing download cache directory
+- Follows existing flat-file naming pattern (no dot prefix — consistent with codebase)
+- Included in cache size calculations for TTL/size-based eviction
+
+**Individual file caching**: Each `GetOrGenerate()` call populates the standard per-file cache. Future single-file downloads benefit from this warm cache.
+
+**Cache cleanup protection**: `TriggerCleanup()` checks for active `bulk_download` jobs (status `in_progress`) before running. If one is active, skip cleanup. Cleanup resumes after the job completes.
+
+**Cache reuse**: Before generating anything, compute composite fingerprint and check for existing zip. If metadata hasn't changed for any of the selected books, the cached zip is served immediately.
+
+### Permissions
+
+- Requires authentication
+- Requires `books:read` permission (same as single-file download)
+- Library access checked per-file during generation
+
+## Frontend
+
+### Selection Toolbar
+
+Add "Download" button to `SelectionToolbar.tsx` alongside existing Add to List / Merge / Delete actions.
+
+- Icon: `Download` from lucide-react
+- Label shows estimated size: `Download (4.2 GB)` computed from `filesize_bytes` of each selected book's primary file
+- On click: `POST /jobs` with `{ type: "bulk_download", data: { file_ids: [...], estimated_size_bytes: N } }`
+- After job creation: exit selection mode, show progress toast
+
+### Progress Toast
+
+Persistent toast component rendered at the app layout level (survives navigation).
+
+**States:**
+1. **Generating**: Progress bar + "Preparing 3 of 25 files..." + estimated size
+2. **Zipping**: "Creating zip file..."
+3. **Completed**: "Download ready (4.2 GB)" + download button → `GET /jobs/:id/download`
+4. **Failed**: Error message
+
+**SSE integration:**
+- Listen for `bulk_download.progress` events in `useSSE` hook
+- Update toast state on each progress event
+- On `job.status_changed` → `completed`: show download button
+- On `job.status_changed` → `failed`: show error
+
+**Behavior:**
+- Toast appears when job is created
+- Persists across page navigation (app-level component)
+- Dismissible (doesn't cancel the job — job runs to completion regardless)
+- If dismissed and job completes, a new completion toast appears
+
+### Mutation & Query Hooks
+
+- `useCreateBulkDownload()` — wraps `POST /jobs` for the bulk download job type
+- Reuses existing `useSSE` hook with new event listener
+- No new query hooks needed — job status comes via SSE, not polling
+
+## File Structure
+
+### New files
+- `pkg/worker/bulk_download.go` — `ProcessBulkDownloadJob` worker method
+- `app/components/library/BulkDownloadToast.tsx` — progress toast component
+
+### Modified files
+- `pkg/models/job.go` — add `JobTypeBulkDownload` constant and data structs
+- `pkg/worker/worker.go` — register `bulk_download` process function
+- `pkg/jobs/handlers.go` — handle `bulk_download` job creation (duplicate prevention optional)
+- `pkg/books/routes.go` — add `GET /jobs/:id/download` route (or in `pkg/jobs/routes.go`)
+- `pkg/downloadcache/cache.go` — add bulk zip methods, cleanup protection
+- `pkg/events/broker.go` — add `NewBulkDownloadProgressEvent` helper
+- `app/components/library/SelectionToolbar.tsx` — add Download button
+- `app/hooks/useSSE.ts` — add `bulk_download.progress` event listener
+- `app/components/App.tsx` (or layout) — render `BulkDownloadToast`

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -231,7 +231,7 @@ func setupTestServer(t *testing.T, db *bun.DB) *echo.Echo {
 
 	// Register routes (pass nil for plugin manager in tests)
 	g := e.Group("/books")
-	RegisterRoutesWithGroup(g, db, cfg, authMiddleware, &mockScanner{}, nil)
+	RegisterRoutesWithGroup(g, db, cfg, authMiddleware, &mockScanner{}, nil, nil)
 
 	return e
 }

--- a/pkg/books/routes.go
+++ b/pkg/books/routes.go
@@ -1,8 +1,6 @@
 package books
 
 import (
-	"path/filepath"
-
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/cbzpages"
@@ -22,7 +20,7 @@ import (
 )
 
 // RegisterRoutesWithGroup registers book routes on a pre-configured group.
-func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, scanner Scanner, pm *plugins.Manager) {
+func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, scanner Scanner, pm *plugins.Manager, dlCache *downloadcache.Cache) {
 	bookService := NewService(db)
 	libraryService := libraries.NewService(db)
 	personService := people.NewService(db)
@@ -32,7 +30,6 @@ func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, auth
 	publisherService := publishers.NewService(db)
 	imprintService := imprints.NewService(db)
 	listsService := lists.NewService(db)
-	cache := downloadcache.NewCache(filepath.Join(cfg.CacheDir, "downloads"), cfg.DownloadCacheMaxSizeBytes())
 	pageCache := cbzpages.NewCache(cfg.CacheDir)
 
 	h := &handler{
@@ -46,7 +43,7 @@ func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, auth
 		publisherService: publisherService,
 		imprintService:   imprintService,
 		listsService:     listsService,
-		downloadCache:    cache,
+		downloadCache:    dlCache,
 		pageCache:        pageCache,
 		scanner:          scanner,
 	}

--- a/pkg/downloadcache/cache.go
+++ b/pkg/downloadcache/cache.go
@@ -14,8 +14,9 @@ import (
 
 // Cache manages the download cache for generated files.
 type Cache struct {
-	dir     string
-	maxSize int64
+	dir               string
+	maxSize           int64
+	ShouldSkipCleanup func() bool
 }
 
 // NewCache creates a new Cache with the given directory and max size.
@@ -277,6 +278,22 @@ func (c *Cache) GetCachedPath(fileID int, fileType string, book *models.Book, fi
 	return GetCachedFilePath(c.dir, fileID, fileType, hash)
 }
 
+// BulkZipDir returns the directory path for bulk zip files.
+func (c *Cache) BulkZipDir() string {
+	return filepath.Join(c.dir, "bulk")
+}
+
+// BulkZipPath returns the full path for a bulk zip file identified by its fingerprint hash.
+func (c *Cache) BulkZipPath(fingerprintHash string) string {
+	return filepath.Join(c.dir, "bulk", fingerprintHash+".zip")
+}
+
+// BulkZipExists returns true if a bulk zip file with the given fingerprint hash exists.
+func (c *Cache) BulkZipExists(fingerprintHash string) bool {
+	_, err := os.Stat(c.BulkZipPath(fingerprintHash))
+	return err == nil
+}
+
 // TriggerCleanup runs cache cleanup if the cache exceeds the max size.
 // This runs in the current goroutine - call with `go` to run in background.
 func (c *Cache) TriggerCleanup() {
@@ -286,6 +303,10 @@ func (c *Cache) TriggerCleanup() {
 
 // runCleanup performs the actual cleanup operation.
 func (c *Cache) runCleanup() error {
+	if c.ShouldSkipCleanup != nil && c.ShouldSkipCleanup() {
+		return nil
+	}
+
 	// Get lock file to prevent concurrent cleanups
 	lockPath := filepath.Join(c.dir, ".cleanup.lock")
 	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)

--- a/pkg/downloadcache/cleanup.go
+++ b/pkg/downloadcache/cleanup.go
@@ -70,7 +70,7 @@ func RunCleanup(cacheDir string, maxSizeBytes int64) error {
 // findCachedFileExtension finds the extension of a cached file by file ID.
 func findCachedFileExtension(cacheDir string, fileID int) string {
 	// Try common extensions
-	extensions := []string{"epub", "m4b", "cbz"}
+	extensions := []string{"epub", "m4b", "cbz", "pdf"}
 	for _, ext := range extensions {
 		path := cachedFilename(cacheDir, fileID, ext)
 		if _, err := os.Stat(path); err == nil {

--- a/pkg/downloadcache/cleanup.go
+++ b/pkg/downloadcache/cleanup.go
@@ -2,10 +2,50 @@ package downloadcache
 
 import (
 	"os"
+	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 )
+
+// bulkZipEntry holds information about a bulk zip file for cleanup.
+type bulkZipEntry struct {
+	path    string
+	size    int64
+	modTime time.Time
+}
+
+// listBulkZipEntries returns information about bulk zip files and their total size.
+func listBulkZipEntries(cacheDir string) ([]bulkZipEntry, int64, error) {
+	bulkDir := filepath.Join(cacheDir, "bulk")
+	dirEntries, err := os.ReadDir(bulkDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+
+	var entries []bulkZipEntry
+	var totalSize int64
+	for _, e := range dirEntries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".zip" {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		entries = append(entries, bulkZipEntry{
+			path:    filepath.Join(bulkDir, e.Name()),
+			size:    info.Size(),
+			modTime: info.ModTime(),
+		})
+		totalSize += info.Size()
+	}
+	return entries, totalSize, nil
+}
 
 // CleanupThreshold is the percentage of maxSize to reduce the cache to during cleanup.
 // For example, 0.8 means cleanup will reduce the cache to 80% of maxSize.
@@ -14,11 +54,18 @@ const CleanupThreshold = 0.8
 // RunCleanup removes cached files until the total size is below the threshold.
 // Files are removed in LRU (least recently used) order.
 func RunCleanup(cacheDir string, maxSizeBytes int64) error {
-	// Get current total size
+	// Get current total size (individual cached files)
 	totalSize, err := GetTotalCacheSize(cacheDir)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cache size")
 	}
+
+	// Include bulk zip files in total size
+	bulkEntries, bulkSize, err := listBulkZipEntries(cacheDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to list bulk zip entries")
+	}
+	totalSize += bulkSize
 
 	// Check if cleanup is needed
 	if totalSize <= maxSizeBytes {
@@ -31,10 +78,6 @@ func RunCleanup(cacheDir string, maxSizeBytes int64) error {
 		return errors.Wrap(err, "failed to list cache entries")
 	}
 
-	if len(entries) == 0 {
-		return nil
-	}
-
 	// Sort by last accessed time (oldest first)
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].LastAccessedAt.Before(entries[j].LastAccessedAt)
@@ -43,7 +86,7 @@ func RunCleanup(cacheDir string, maxSizeBytes int64) error {
 	// Calculate target size (80% of max)
 	targetSize := int64(float64(maxSizeBytes) * CleanupThreshold)
 
-	// Remove files until we're under the target
+	// Remove individual cached files until we're under the target
 	for _, entry := range entries {
 		if totalSize <= targetSize {
 			break
@@ -62,6 +105,22 @@ func RunCleanup(cacheDir string, maxSizeBytes int64) error {
 		}
 
 		totalSize -= entry.SizeBytes
+	}
+
+	// If still over target, evict bulk zip files by oldest modification time
+	if totalSize > targetSize && len(bulkEntries) > 0 {
+		sort.Slice(bulkEntries, func(i, j int) bool {
+			return bulkEntries[i].modTime.Before(bulkEntries[j].modTime)
+		})
+		for _, b := range bulkEntries {
+			if totalSize <= targetSize {
+				break
+			}
+			if err := os.Remove(b.path); err != nil {
+				continue
+			}
+			totalSize -= b.size
+		}
 	}
 
 	return nil

--- a/pkg/downloadcache/cleanup.go
+++ b/pkg/downloadcache/cleanup.go
@@ -148,35 +148,40 @@ type CleanupStats struct {
 }
 
 // RunCleanupWithStats performs cleanup and returns statistics.
+// Includes both individual cached files and bulk zip files in accounting.
 func RunCleanupWithStats(cacheDir string, maxSizeBytes int64) (*CleanupStats, error) {
 	stats := &CleanupStats{}
 
-	// Get initial state
+	// Get initial state (individual files + bulk zips)
 	entriesBefore, err := ListCacheEntries(cacheDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list cache entries")
 	}
+	_, bulkSizeBefore, _ := listBulkZipEntries(cacheDir)
 
 	var totalBefore int64
 	for _, e := range entriesBefore {
 		totalBefore += e.SizeBytes
 	}
+	totalBefore += bulkSizeBefore
 
 	// Run cleanup
 	if err := RunCleanup(cacheDir, maxSizeBytes); err != nil {
 		return nil, err
 	}
 
-	// Get final state
+	// Get final state (individual files + bulk zips)
 	entriesAfter, err := ListCacheEntries(cacheDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list cache entries after cleanup")
 	}
+	_, bulkSizeAfter, _ := listBulkZipEntries(cacheDir)
 
 	var totalAfter int64
 	for _, e := range entriesAfter {
 		totalAfter += e.SizeBytes
 	}
+	totalAfter += bulkSizeAfter
 
 	stats.FilesRemoved = len(entriesBefore) - len(entriesAfter)
 	stats.BytesRemoved = totalBefore - totalAfter

--- a/pkg/errcodes/errors.go
+++ b/pkg/errcodes/errors.go
@@ -95,6 +95,15 @@ func MalformedPayload() error {
 	}
 }
 
+// BadRequest returns a 400 error with the given message.
+func BadRequest(msg string) error {
+	return &Error{
+		http.StatusBadRequest,
+		msg,
+		"bad_request",
+	}
+}
+
 func EmptyRequestBody() error {
 	return &Error{
 		http.StatusBadRequest,

--- a/pkg/events/CLAUDE.md
+++ b/pkg/events/CLAUDE.md
@@ -20,7 +20,7 @@ event: job.status_changed
 data: {"job_id":1,"status":"in_progress","type":"scan","library_id":2}
 ```
 
-Use `NewJobEvent()` to build job events consistently across callers (worker, HTTP handler).
+Use `NewJobEvent()` to build job events consistently across callers (worker, HTTP handler). Use `NewBulkDownloadProgressEvent()` for bulk download progress events.
 
 ## Event Types
 
@@ -28,6 +28,7 @@ Use `NewJobEvent()` to build job events consistently across callers (worker, HTT
 |-------|---------------|------------|
 | `job.created` | Job created via API or scheduler | `pkg/jobs/handlers.go`, `pkg/worker/worker.go` (scheduler) |
 | `job.status_changed` | Job transitions status (pending→in_progress, →completed, →failed) | `pkg/worker/worker.go` |
+| `bulk_download.progress` | Bulk download file generation progress (per-file updates, zipping status) | `pkg/worker/bulk_download.go` |
 
 ## Adding New Event Types
 

--- a/pkg/events/broker.go
+++ b/pkg/events/broker.go
@@ -55,6 +55,15 @@ func (b *Broker) Publish(evt Event) {
 	}
 }
 
+// NewBulkDownloadProgressEvent builds a progress event for bulk download jobs.
+func NewBulkDownloadProgressEvent(jobID int, status string, current, total int, estimatedSizeBytes int64) Event {
+	data := fmt.Sprintf(
+		`{"job_id":%d,"status":"%s","current":%d,"total":%d,"estimated_size_bytes":%d}`,
+		jobID, status, current, total, estimatedSizeBytes,
+	)
+	return Event{Type: "bulk_download.progress", Data: data}
+}
+
 // NewJobEvent builds an Event with the standard job payload format.
 func NewJobEvent(eventType string, jobID int, status, jobType string, libraryID *int) Event {
 	data := fmt.Sprintf(`{"job_id":%d,"status":"%s","type":"%s"}`, jobID, status, jobType)

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -50,7 +50,7 @@ func (h *handler) create(c echo.Context) error {
 			return errcodes.Unauthorized("User not found in context")
 		}
 		if !user.HasPermission(models.ResourceBooks, models.OperationRead) {
-			return errcodes.Forbidden("Bulk download requires books:read permission")
+			return errcodes.Forbidden("Bulk download without books:read permission")
 		}
 
 		// Validate file_ids by marshaling the data and checking the field.
@@ -147,7 +147,7 @@ func (h *handler) download(c echo.Context) error {
 		return errcodes.Unauthorized("User not found in context")
 	}
 	if !user.HasPermission(models.ResourceBooks, models.OperationRead) {
-		return errcodes.Forbidden("You need books:read permission to download")
+		return errcodes.Forbidden("Downloading without books:read permission")
 	}
 
 	id, err := strconv.Atoi(c.Param("id"))
@@ -188,7 +188,7 @@ func (h *handler) download(c echo.Context) error {
 			continue // File may have been deleted since job was created
 		}
 		if !user.HasLibraryAccess(file.LibraryID) {
-			return errcodes.Forbidden("You don't have access to one or more libraries in this download")
+			return errcodes.Forbidden("Accessing libraries in this download without permission")
 		}
 	}
 

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -6,14 +6,16 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
 type handler struct {
-	jobService *Service
-	broker     *events.Broker
+	jobService    *Service
+	broker        *events.Broker
+	downloadCache *downloadcache.Cache
 }
 
 func (h *handler) create(c echo.Context) error {

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -43,6 +43,30 @@ func (h *handler) create(c echo.Context) error {
 		}
 	}
 
+	// Validate bulk download jobs: require books:read permission and non-empty file_ids.
+	if params.Type == models.JobTypeBulkDownload {
+		user, ok := c.Get("user").(*models.User)
+		if !ok {
+			return errcodes.Unauthorized("User not found in context")
+		}
+		if !user.HasPermission(models.ResourceBooks, models.OperationRead) {
+			return errcodes.Forbidden("Bulk download requires books:read permission")
+		}
+
+		// Validate file_ids by marshaling the data and checking the field.
+		dataBytes, err := json.Marshal(params.Data)
+		if err != nil {
+			return errcodes.BadRequest("Invalid bulk download data")
+		}
+		var bulkData models.JobBulkDownloadData
+		if err := json.Unmarshal(dataBytes, &bulkData); err != nil {
+			return errcodes.BadRequest("Invalid bulk download data")
+		}
+		if len(bulkData.FileIDs) == 0 {
+			return errcodes.BadRequest("No file IDs provided for bulk download")
+		}
+	}
+
 	job := &models.Job{
 		Type:       params.Type,
 		Status:     models.JobStatusPending,

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -1,11 +1,14 @@
 package jobs
 
 import (
+	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/events"
@@ -107,4 +110,46 @@ func (h *handler) list(c echo.Context) error {
 	}{jobs, total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, resp))
+}
+
+func (h *handler) download(c echo.Context) error {
+	ctx := c.Request().Context()
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.NotFound("Job")
+	}
+
+	job, err := h.jobService.RetrieveJob(ctx, RetrieveJobOptions{
+		ID: &id,
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if job.Type != models.JobTypeBulkDownload {
+		return errcodes.BadRequest("Job is not a bulk download")
+	}
+
+	if job.Status != models.JobStatusCompleted {
+		return errcodes.BadRequest("Job is not completed yet")
+	}
+
+	var data models.JobBulkDownloadData
+	if err := json.Unmarshal([]byte(job.Data), &data); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if data.FingerprintHash == "" {
+		return errcodes.BadRequest("Job has no download data")
+	}
+
+	zipPath := h.downloadCache.BulkZipPath(data.FingerprintHash)
+	if _, err := os.Stat(zipPath); os.IsNotExist(err) {
+		return errcodes.NotFound("Download file has expired from cache")
+	}
+
+	filename := fmt.Sprintf("shisho-download-%d-books.zip", data.FileCount)
+	c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+
+	return c.File(zipPath)
 }

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -13,10 +13,12 @@ import (
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/uptrace/bun"
 )
 
 type handler struct {
 	jobService    *Service
+	db            *bun.DB
 	broker        *events.Broker
 	downloadCache *downloadcache.Cache
 }
@@ -114,6 +116,16 @@ func (h *handler) list(c echo.Context) error {
 
 func (h *handler) download(c echo.Context) error {
 	ctx := c.Request().Context()
+
+	// Verify the user has books:read permission
+	user, ok := c.Get("user").(*models.User)
+	if !ok {
+		return errcodes.Unauthorized("User not found in context")
+	}
+	if !user.HasPermission(models.ResourceBooks, models.OperationRead) {
+		return errcodes.Forbidden("You need books:read permission to download")
+	}
+
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		return errcodes.NotFound("Job")
@@ -141,6 +153,19 @@ func (h *handler) download(c echo.Context) error {
 
 	if data.FingerprintHash == "" {
 		return errcodes.BadRequest("Job has no download data")
+	}
+
+	// Verify the user has library access for the files in this download.
+	// Query the DB directly to avoid an import cycle (jobs cannot import books).
+	for _, fileID := range data.FileIDs {
+		var file models.File
+		err := h.db.NewSelect().Model(&file).Column("library_id").Where("id = ?", fileID).Scan(ctx)
+		if err != nil {
+			continue // File may have been deleted since job was created
+		}
+		if !user.HasLibraryAccess(file.LibraryID) {
+			return errcodes.Forbidden("You don't have access to one or more libraries in this download")
+		}
 	}
 
 	zipPath := h.downloadCache.BulkZipPath(data.FingerprintHash)

--- a/pkg/jobs/routes.go
+++ b/pkg/jobs/routes.go
@@ -21,5 +21,6 @@ func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Mid
 
 	g.GET("", h.list)
 	g.GET("/:id", h.retrieve)
+	g.GET("/:id/download", h.download)
 	g.POST("", h.create, authMiddleware.RequirePermission(models.ResourceJobs, models.OperationWrite))
 }

--- a/pkg/jobs/routes.go
+++ b/pkg/jobs/routes.go
@@ -15,6 +15,7 @@ func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Mid
 
 	h := &handler{
 		jobService:    jobService,
+		db:            db,
 		broker:        broker,
 		downloadCache: dlCache,
 	}

--- a/pkg/jobs/routes.go
+++ b/pkg/jobs/routes.go
@@ -3,18 +3,20 @@ package jobs
 import (
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
 )
 
 // RegisterRoutesWithGroup registers job routes on a pre-configured group.
-func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware, broker *events.Broker) {
+func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware, broker *events.Broker, dlCache *downloadcache.Cache) {
 	jobService := NewService(db)
 
 	h := &handler{
-		jobService: jobService,
-		broker:     broker,
+		jobService:    jobService,
+		broker:        broker,
+		downloadCache: dlCache,
 	}
 
 	g.GET("", h.list)

--- a/pkg/jobs/validators.go
+++ b/pkg/jobs/validators.go
@@ -1,8 +1,8 @@
 package jobs
 
 type CreateJobPayload struct {
-	Type      string      `json:"type" validate:"required,oneof=export scan"`
-	Data      interface{} `json:"data" validate:"required" tstype:"JobExportData | JobScanData"`
+	Type      string      `json:"type" validate:"required,oneof=export scan bulk_download"`
+	Data      interface{} `json:"data" validate:"required" tstype:"JobExportData | JobScanData | JobBulkDownloadData"`
 	LibraryID *int        `json:"library_id,omitempty"`
 }
 
@@ -10,6 +10,6 @@ type ListJobsQuery struct {
 	Limit             int      `query:"limit" json:"limit,omitempty" default:"10" validate:"min=1,max=100"`
 	Offset            int      `query:"offset" json:"offset,omitempty" validate:"min=0"`
 	Status            []string `query:"status" json:"status,omitempty" validate:"dive,oneof=pending in_progress completed failed"`
-	Type              *string  `query:"type" json:"type,omitempty" validate:"omitempty,oneof=export scan"`
+	Type              *string  `query:"type" json:"type,omitempty" validate:"omitempty,oneof=export scan bulk_download"`
 	LibraryIDOrGlobal *int     `query:"library_id_or_global" json:"library_id_or_global,omitempty"`
 }

--- a/pkg/models/job.go
+++ b/pkg/models/job.go
@@ -17,9 +17,10 @@ const (
 )
 
 const (
-	//tygo:emit export type JobType = typeof JobTypeExport | typeof JobTypeScan;
-	JobTypeExport = "export"
-	JobTypeScan   = "scan"
+	//tygo:emit export type JobType = typeof JobTypeExport | typeof JobTypeScan | typeof JobTypeBulkDownload;
+	JobTypeExport       = "export"
+	JobTypeScan         = "scan"
+	JobTypeBulkDownload = "bulk_download"
 )
 
 type Job struct {
@@ -31,7 +32,7 @@ type Job struct {
 	Type       string      `bun:",nullzero" json:"type" tstype:"JobType"`
 	Status     string      `bun:",nullzero" json:"status" tstype:"JobStatus"`
 	Data       string      `bun:",nullzero" json:"-"`
-	DataParsed interface{} `bun:"-" json:"data" tstype:"JobExportData | JobScanData"`
+	DataParsed interface{} `bun:"-" json:"data" tstype:"JobExportData | JobScanData | JobBulkDownloadData"`
 	Progress   int         `json:"progress"`
 	ProcessID  *string     `json:"process_id,omitempty"`
 	LibraryID  *int        `json:"library_id,omitempty"`
@@ -43,6 +44,8 @@ func (job *Job) UnmarshalData() error {
 		job.DataParsed = &JobExportData{}
 	case JobTypeScan:
 		job.DataParsed = &JobScanData{}
+	case JobTypeBulkDownload:
+		job.DataParsed = &JobBulkDownloadData{}
 	}
 
 	err := json.Unmarshal([]byte(job.Data), job.DataParsed)
@@ -56,3 +59,15 @@ func (job *Job) UnmarshalData() error {
 type JobExportData struct{}
 
 type JobScanData struct{}
+
+type JobBulkDownloadData struct {
+	// Input (set on creation)
+	FileIDs            []int `json:"file_ids"`
+	EstimatedSizeBytes int64 `json:"estimated_size_bytes"`
+
+	// Result (set on completion)
+	ZipFilename     string `json:"zip_filename,omitempty"`
+	SizeBytes       int64  `json:"size_bytes,omitempty"`
+	FileCount       int    `json:"file_count,omitempty"`
+	FingerprintHash string `json:"fingerprint_hash,omitempty"`
+}

--- a/pkg/server/file_organizer_test.go
+++ b/pkg/server/file_organizer_test.go
@@ -64,7 +64,7 @@ func newTestContext(t *testing.T) *testContext {
 		WorkerProcesses:           1,
 		SupplementExcludePatterns: []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
 	}
-	w := worker.New(cfg, db, nil, nil)
+	w := worker.New(cfg, db, nil, nil, nil)
 
 	// Create file organizer
 	fo := &fileOrganizer{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -121,7 +121,7 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 	booksGroup := e.Group("/books")
 	booksGroup.Use(authMiddleware.Authenticate)
 	booksGroup.Use(authMiddleware.RequirePermission(models.ResourceBooks, models.OperationRead))
-	books.RegisterRoutesWithGroup(booksGroup, db, cfg, authMiddleware, w, pm)
+	books.RegisterRoutesWithGroup(booksGroup, db, cfg, authMiddleware, w, pm, dlCache)
 	chapters.RegisterRoutes(booksGroup, db, authMiddleware)
 
 	// Libraries routes

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"path/filepath"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -47,7 +46,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, broker *events.Broker) (*http.Server, error) {
+func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) (*http.Server, error) {
 	e := echo.New()
 
 	b, err := binder.New()
@@ -81,17 +80,16 @@ func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, 
 
 	// Register protected API routes
 	// These routes require authentication and appropriate permissions
-	registerProtectedRoutes(e, db, cfg, authMiddleware, w, pm, broker)
+	registerProtectedRoutes(e, db, cfg, authMiddleware, w, pm, broker, dlCache)
 
 	// Register OPDS routes with Basic Auth
 	opds.RegisterRoutes(e, db, cfg, authMiddleware)
 
 	// Register eReader routes (API key auth for stock browser support)
-	downloadCache := downloadcache.NewCache(filepath.Join(cfg.CacheDir, "downloads"), cfg.DownloadCacheMaxSizeBytes())
-	ereader.RegisterRoutes(e, db, downloadCache)
+	ereader.RegisterRoutes(e, db, dlCache)
 
 	// Register Kobo sync routes (API key auth for Kobo device sync)
-	kobo.RegisterRoutes(e, db, downloadCache)
+	kobo.RegisterRoutes(e, db, dlCache)
 
 	// Config routes (require authentication)
 	config.RegisterRoutesWithAuth(e, cfg, authMiddleware)
@@ -118,7 +116,7 @@ func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, 
 }
 
 // registerProtectedRoutes registers all protected API routes with proper authentication and authorization.
-func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, w *worker.Worker, pm *plugins.Manager, broker *events.Broker) {
+func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, w *worker.Worker, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) {
 	// Books routes
 	booksGroup := e.Group("/books")
 	booksGroup.Use(authMiddleware.Authenticate)
@@ -139,7 +137,7 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 	jobsGroup := e.Group("/jobs")
 	jobsGroup.Use(authMiddleware.Authenticate)
 	jobsGroup.Use(authMiddleware.RequirePermission(models.ResourceJobs, models.OperationRead))
-	jobs.RegisterRoutesWithGroup(jobsGroup, db, authMiddleware, broker)
+	jobs.RegisterRoutesWithGroup(jobsGroup, db, authMiddleware, broker, dlCache)
 	joblogs.RegisterRoutes(jobsGroup, db)
 
 	// People routes

--- a/pkg/worker/bulk_download.go
+++ b/pkg/worker/bulk_download.go
@@ -137,7 +137,7 @@ func (w *Worker) ProcessBulkDownloadJob(ctx context.Context, job *models.Job, jo
 			data.SizeBytes = info.Size()
 			data.FileCount = len(filesWithBooks)
 			data.FingerprintHash = compositeHash
-			return w.completeBulkDownloadJob(ctx, job, &data)
+			return w.saveBulkDownloadResult(ctx, job, &data)
 		}
 	}
 
@@ -197,6 +197,14 @@ func (w *Worker) ProcessBulkDownloadJob(ctx context.Context, job *models.Job, jo
 	}
 
 	zipWriter := zip.NewWriter(zipFile)
+	zipSuccess := false
+	defer func() {
+		if !zipSuccess {
+			zipWriter.Close()
+			zipFile.Close()
+			os.Remove(zipPath)
+		}
+	}()
 
 	// Sort file IDs for deterministic zip ordering
 	sortedFileIDs := make([]int, 0, len(cachedPaths))
@@ -216,36 +224,26 @@ func (w *Worker) ProcessBulkDownloadJob(ctx context.Context, job *models.Job, jo
 
 		writer, err := zipWriter.CreateHeader(header)
 		if err != nil {
-			zipWriter.Close()
-			zipFile.Close()
-			os.Remove(zipPath)
 			return errors.Wrapf(err, "failed to create zip entry for %s", filename)
 		}
 
 		f, err := os.Open(cachedPath)
 		if err != nil {
-			zipWriter.Close()
-			zipFile.Close()
-			os.Remove(zipPath)
 			return errors.Wrapf(err, "failed to open cached file %s", cachedPath)
 		}
 
 		_, err = io.Copy(writer, f)
 		f.Close()
 		if err != nil {
-			zipWriter.Close()
-			zipFile.Close()
-			os.Remove(zipPath)
 			return errors.Wrapf(err, "failed to write %s to zip", filename)
 		}
 	}
 
 	if err := zipWriter.Close(); err != nil {
-		zipFile.Close()
-		os.Remove(zipPath)
 		return errors.Wrap(err, "failed to finalize zip")
 	}
 	zipFile.Close()
+	zipSuccess = true
 
 	// Get zip file size
 	zipInfo, err := os.Stat(zipPath)
@@ -260,10 +258,10 @@ func (w *Worker) ProcessBulkDownloadJob(ctx context.Context, job *models.Job, jo
 	data.FileCount = len(cachedPaths)
 	data.FingerprintHash = compositeHash
 
-	return w.completeBulkDownloadJob(ctx, job, &data)
+	return w.saveBulkDownloadResult(ctx, job, &data)
 }
 
-func (w *Worker) completeBulkDownloadJob(ctx context.Context, job *models.Job, data *models.JobBulkDownloadData) error {
+func (w *Worker) saveBulkDownloadResult(ctx context.Context, job *models.Job, data *models.JobBulkDownloadData) error {
 	dataBytes, err := json.Marshal(data)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal bulk download result")

--- a/pkg/worker/bulk_download.go
+++ b/pkg/worker/bulk_download.go
@@ -1,0 +1,269 @@
+package worker
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/robinjoseph08/golib/logger"
+	"github.com/segmentio/encoding/json"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/downloadcache"
+	"github.com/shishobooks/shisho/pkg/events"
+	"github.com/shishobooks/shisho/pkg/joblogs"
+	"github.com/shishobooks/shisho/pkg/jobs"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// ComputeBulkFingerprint computes a composite fingerprint hash from sorted file IDs and their individual hashes.
+func ComputeBulkFingerprint(fileIDs []int, fileHashes []string) string {
+	type entry struct {
+		id   int
+		hash string
+	}
+	entries := make([]entry, len(fileIDs))
+	for i := range fileIDs {
+		entries[i] = entry{id: fileIDs[i], hash: fileHashes[i]}
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].id < entries[j].id
+	})
+
+	h := sha256.New()
+	for _, e := range entries {
+		fmt.Fprintf(h, "%d:%s\n", e.id, e.hash)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// DeduplicateFilenames takes a map of fileID -> filename and appends (2), (3), etc. for duplicates.
+func DeduplicateFilenames(names map[int]string) map[int]string {
+	counts := make(map[string][]int)
+	for id, name := range names {
+		counts[name] = append(counts[name], id)
+	}
+
+	result := make(map[int]string, len(names))
+	for name, ids := range counts {
+		if len(ids) == 1 {
+			result[ids[0]] = name
+			continue
+		}
+		sort.Ints(ids)
+		for i, id := range ids {
+			if i == 0 {
+				result[id] = name
+			} else {
+				ext := filepath.Ext(name)
+				base := strings.TrimSuffix(name, ext)
+				result[id] = fmt.Sprintf("%s (%d)%s", base, i+1, ext)
+			}
+		}
+	}
+	return result
+}
+
+// ProcessBulkDownloadJob generates metadata-injected files and creates a zip archive.
+func (w *Worker) ProcessBulkDownloadJob(ctx context.Context, job *models.Job, jobLog *joblogs.JobLogger) error {
+	log := logger.FromContext(ctx)
+
+	var data models.JobBulkDownloadData
+	if err := json.Unmarshal([]byte(job.Data), &data); err != nil {
+		return errors.Wrap(err, "failed to parse bulk download job data")
+	}
+
+	if len(data.FileIDs) == 0 {
+		return errors.New("no file IDs provided")
+	}
+
+	jobLog.Info(fmt.Sprintf("starting bulk download for %d files", len(data.FileIDs)), nil)
+
+	type fileWithBook struct {
+		file *models.File
+		book *models.Book
+	}
+	filesWithBooks := make([]fileWithBook, 0, len(data.FileIDs))
+
+	for _, fileID := range data.FileIDs {
+		file, err := w.bookService.RetrieveFileWithRelations(ctx, fileID)
+		if err != nil {
+			jobLog.Warn(fmt.Sprintf("skipping file %d: %v", fileID, err), nil)
+			continue
+		}
+		book, err := w.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &file.BookID})
+		if err != nil {
+			jobLog.Warn(fmt.Sprintf("skipping file %d: failed to load book: %v", fileID, err), nil)
+			continue
+		}
+		filesWithBooks = append(filesWithBooks, fileWithBook{file: file, book: book})
+	}
+
+	if len(filesWithBooks) == 0 {
+		return errors.New("no valid files found for bulk download")
+	}
+
+	// Compute composite fingerprint
+	fileIDs := make([]int, len(filesWithBooks))
+	fileHashes := make([]string, len(filesWithBooks))
+	for i, fw := range filesWithBooks {
+		fileIDs[i] = fw.file.ID
+		fp, err := downloadcache.ComputeFingerprint(fw.book, fw.file)
+		if err != nil {
+			return errors.Wrapf(err, "failed to compute fingerprint for file %d", fw.file.ID)
+		}
+		hash, err := fp.Hash()
+		if err != nil {
+			return errors.Wrapf(err, "failed to hash fingerprint for file %d", fw.file.ID)
+		}
+		fileHashes[i] = hash
+	}
+	compositeHash := ComputeBulkFingerprint(fileIDs, fileHashes)
+
+	// Check if zip already exists in cache
+	if w.downloadCache.BulkZipExists(compositeHash) {
+		zipPath := w.downloadCache.BulkZipPath(compositeHash)
+		info, err := os.Stat(zipPath)
+		if err == nil {
+			jobLog.Info("bulk zip already cached, skipping generation", nil)
+			data.ZipFilename = filepath.Base(zipPath)
+			data.SizeBytes = info.Size()
+			data.FileCount = len(filesWithBooks)
+			data.FingerprintHash = compositeHash
+			return w.completeBulkDownloadJob(ctx, job, &data)
+		}
+	}
+
+	// Generate each file via download cache
+	total := len(filesWithBooks)
+	cachedPaths := make(map[int]string, total)
+	downloadNames := make(map[int]string, total)
+
+	for i, fw := range filesWithBooks {
+		if err := ctx.Err(); err != nil {
+			return errors.Wrap(err, "job cancelled")
+		}
+
+		cachedPath, downloadFilename, err := w.downloadCache.GetOrGenerate(ctx, fw.book, fw.file)
+		if err != nil {
+			jobLog.Warn(fmt.Sprintf("failed to generate file %d (%s): %v", fw.file.ID, fw.file.Filepath, err), nil)
+			continue
+		}
+		cachedPaths[fw.file.ID] = cachedPath
+		downloadNames[fw.file.ID] = downloadFilename
+
+		if w.broker != nil {
+			w.broker.Publish(events.NewBulkDownloadProgressEvent(
+				job.ID, "generating", i+1, total, data.EstimatedSizeBytes,
+			))
+		}
+
+		log.Debug("generated file for bulk download", logger.Data{
+			"file_id": fw.file.ID, "progress": fmt.Sprintf("%d/%d", i+1, total),
+		})
+	}
+
+	if len(cachedPaths) == 0 {
+		return errors.New("no files were successfully generated")
+	}
+
+	// Publish zipping status
+	if w.broker != nil {
+		w.broker.Publish(events.NewBulkDownloadProgressEvent(
+			job.ID, "zipping", total, total, data.EstimatedSizeBytes,
+		))
+	}
+
+	// Deduplicate filenames
+	dedupedNames := DeduplicateFilenames(downloadNames)
+
+	// Create the zip file
+	bulkDir := w.downloadCache.BulkZipDir()
+	if err := os.MkdirAll(bulkDir, 0755); err != nil {
+		return errors.Wrap(err, "failed to create bulk zip directory")
+	}
+
+	zipPath := w.downloadCache.BulkZipPath(compositeHash)
+	zipFile, err := os.Create(zipPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to create zip file")
+	}
+
+	zipWriter := zip.NewWriter(zipFile)
+
+	for fileID, cachedPath := range cachedPaths {
+		filename := dedupedNames[fileID]
+
+		header := &zip.FileHeader{
+			Name:   filename,
+			Method: zip.Store,
+		}
+
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			zipWriter.Close()
+			zipFile.Close()
+			os.Remove(zipPath)
+			return errors.Wrapf(err, "failed to create zip entry for %s", filename)
+		}
+
+		f, err := os.Open(cachedPath)
+		if err != nil {
+			zipWriter.Close()
+			zipFile.Close()
+			os.Remove(zipPath)
+			return errors.Wrapf(err, "failed to open cached file %s", cachedPath)
+		}
+
+		_, err = io.Copy(writer, f)
+		f.Close()
+		if err != nil {
+			zipWriter.Close()
+			zipFile.Close()
+			os.Remove(zipPath)
+			return errors.Wrapf(err, "failed to write %s to zip", filename)
+		}
+	}
+
+	if err := zipWriter.Close(); err != nil {
+		zipFile.Close()
+		os.Remove(zipPath)
+		return errors.Wrap(err, "failed to finalize zip")
+	}
+	zipFile.Close()
+
+	// Get zip file size
+	zipInfo, err := os.Stat(zipPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to stat zip file")
+	}
+
+	jobLog.Info(fmt.Sprintf("bulk download zip created: %d files, %d bytes", len(cachedPaths), zipInfo.Size()), nil)
+
+	data.ZipFilename = filepath.Base(zipPath)
+	data.SizeBytes = zipInfo.Size()
+	data.FileCount = len(cachedPaths)
+	data.FingerprintHash = compositeHash
+
+	return w.completeBulkDownloadJob(ctx, job, &data)
+}
+
+func (w *Worker) completeBulkDownloadJob(ctx context.Context, job *models.Job, data *models.JobBulkDownloadData) error {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal bulk download result")
+	}
+	job.Data = string(dataBytes)
+	job.DataParsed = data
+
+	return w.jobService.UpdateJob(ctx, job, jobs.UpdateJobOptions{
+		Columns: []string{"data"},
+	})
+}

--- a/pkg/worker/bulk_download.go
+++ b/pkg/worker/bulk_download.go
@@ -198,7 +198,15 @@ func (w *Worker) ProcessBulkDownloadJob(ctx context.Context, job *models.Job, jo
 
 	zipWriter := zip.NewWriter(zipFile)
 
-	for fileID, cachedPath := range cachedPaths {
+	// Sort file IDs for deterministic zip ordering
+	sortedFileIDs := make([]int, 0, len(cachedPaths))
+	for fileID := range cachedPaths {
+		sortedFileIDs = append(sortedFileIDs, fileID)
+	}
+	sort.Ints(sortedFileIDs)
+
+	for _, fileID := range sortedFileIDs {
+		cachedPath := cachedPaths[fileID]
 		filename := dedupedNames[fileID]
 
 		header := &zip.FileHeader{

--- a/pkg/worker/bulk_download_test.go
+++ b/pkg/worker/bulk_download_test.go
@@ -1,8 +1,11 @@
 package worker
 
 import (
+	"context"
 	"testing"
 
+	"github.com/segmentio/encoding/json"
+	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,4 +58,123 @@ func TestDeduplicateFilenames(t *testing.T) {
 		require.Contains(t, values, "Book (2).epub")
 		require.Contains(t, values, "Book (3).epub")
 	})
+}
+
+func TestProcessBulkDownloadJob_EmptyFileIDs(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	data := models.JobBulkDownloadData{FileIDs: []int{}}
+	dataBytes, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	job := &models.Job{
+		Type:   models.JobTypeBulkDownload,
+		Status: models.JobStatusInProgress,
+		Data:   string(dataBytes),
+	}
+	jobLog := tc.worker.jobLogService.NewJobLogger(tc.ctx, 0, tc.worker.log)
+
+	err = tc.worker.ProcessBulkDownloadJob(tc.ctx, job, jobLog)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no file IDs provided")
+}
+
+func TestProcessBulkDownloadJob_InvalidFileIDs(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	data := models.JobBulkDownloadData{FileIDs: []int{99999, 99998}}
+	dataBytes, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	job := &models.Job{
+		Type:   models.JobTypeBulkDownload,
+		Status: models.JobStatusInProgress,
+		Data:   string(dataBytes),
+	}
+	jobLog := tc.worker.jobLogService.NewJobLogger(tc.ctx, 0, tc.worker.log)
+
+	err = tc.worker.ProcessBulkDownloadJob(tc.ctx, job, jobLog)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no valid files found")
+}
+
+func TestProcessBulkDownloadJob_CancelledContext(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(tc.ctx)
+	cancel()
+
+	data := models.JobBulkDownloadData{FileIDs: []int{1}}
+	dataBytes, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	job := &models.Job{
+		Type:   models.JobTypeBulkDownload,
+		Status: models.JobStatusInProgress,
+		Data:   string(dataBytes),
+	}
+	jobLog := tc.worker.jobLogService.NewJobLogger(ctx, 0, tc.worker.log)
+
+	// With no downloadCache set, this will fail at file retrieval, but that's fine —
+	// the point is it processes without panicking on a cancelled context
+	err = tc.worker.ProcessBulkDownloadJob(ctx, job, jobLog)
+	require.Error(t, err)
+}
+
+func TestProcessBulkDownloadJob_InvalidJobData(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	job := &models.Job{
+		Type:   models.JobTypeBulkDownload,
+		Status: models.JobStatusInProgress,
+		Data:   "not valid json",
+	}
+	jobLog := tc.worker.jobLogService.NewJobLogger(tc.ctx, 0, tc.worker.log)
+
+	err := tc.worker.ProcessBulkDownloadJob(tc.ctx, job, jobLog)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse bulk download job data")
+}
+
+func TestSaveBulkDownloadResult(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	// Create a job in the database
+	job := &models.Job{
+		Type:       models.JobTypeBulkDownload,
+		Status:     models.JobStatusInProgress,
+		DataParsed: &models.JobBulkDownloadData{FileIDs: []int{1, 2}},
+	}
+	err := tc.worker.jobService.CreateJob(tc.ctx, job)
+	require.NoError(t, err)
+
+	// Save result
+	data := &models.JobBulkDownloadData{
+		FileIDs:            []int{1, 2},
+		EstimatedSizeBytes: 1000,
+		ZipFilename:        "test.zip",
+		SizeBytes:          950,
+		FileCount:          2,
+		FingerprintHash:    "abc123",
+	}
+	err = tc.worker.saveBulkDownloadResult(tc.ctx, job, data)
+	require.NoError(t, err)
+
+	// Verify the job data was updated
+	var savedData models.JobBulkDownloadData
+	err = json.Unmarshal([]byte(job.Data), &savedData)
+	require.NoError(t, err)
+	assert.Equal(t, "test.zip", savedData.ZipFilename)
+	assert.Equal(t, int64(950), savedData.SizeBytes)
+	assert.Equal(t, 2, savedData.FileCount)
+	assert.Equal(t, "abc123", savedData.FingerprintHash)
+	// Input fields are preserved
+	assert.Equal(t, []int{1, 2}, savedData.FileIDs)
+	assert.Equal(t, int64(1000), savedData.EstimatedSizeBytes)
 }

--- a/pkg/worker/bulk_download_test.go
+++ b/pkg/worker/bulk_download_test.go
@@ -1,0 +1,58 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeBulkFingerprint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deterministic for same inputs", func(t *testing.T) {
+		t.Parallel()
+		hashes := []string{"abc123", "def456", "ghi789"}
+		hash1 := ComputeBulkFingerprint([]int{1, 2, 3}, hashes)
+		hash2 := ComputeBulkFingerprint([]int{1, 2, 3}, hashes)
+		assert.Equal(t, hash1, hash2)
+	})
+
+	t.Run("sorts file IDs for consistency", func(t *testing.T) {
+		t.Parallel()
+		hashes1 := []string{"abc123", "def456"}
+		hashes2 := []string{"def456", "abc123"}
+		hash1 := ComputeBulkFingerprint([]int{1, 2}, hashes1)
+		hash2 := ComputeBulkFingerprint([]int{2, 1}, hashes2)
+		assert.Equal(t, hash1, hash2)
+	})
+
+	t.Run("different hashes produce different fingerprint", func(t *testing.T) {
+		t.Parallel()
+		hash1 := ComputeBulkFingerprint([]int{1, 2}, []string{"abc", "def"})
+		hash2 := ComputeBulkFingerprint([]int{1, 2}, []string{"abc", "xyz"})
+		assert.NotEqual(t, hash1, hash2)
+	})
+}
+
+func TestDeduplicateFilenames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no duplicates", func(t *testing.T) {
+		t.Parallel()
+		names := map[int]string{1: "Book A.epub", 2: "Book B.epub"}
+		result := DeduplicateFilenames(names)
+		assert.Equal(t, "Book A.epub", result[1])
+		assert.Equal(t, "Book B.epub", result[2])
+	})
+
+	t.Run("duplicates get numbered", func(t *testing.T) {
+		t.Parallel()
+		names := map[int]string{1: "Book.epub", 2: "Book.epub", 3: "Book.epub"}
+		result := DeduplicateFilenames(names)
+		values := []string{result[1], result[2], result[3]}
+		require.Contains(t, values, "Book.epub")
+		require.Contains(t, values, "Book (2).epub")
+		require.Contains(t, values, "Book (3).epub")
+	})
+}

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/chapters"
+	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/events"
 	"github.com/shishobooks/shisho/pkg/genres"
 	"github.com/shishobooks/shisho/pkg/imprints"
@@ -57,7 +58,8 @@ type Worker struct {
 	pluginService    *plugins.Service
 	pluginManager    *plugins.Manager
 
-	broker *events.Broker
+	broker        *events.Broker
+	downloadCache *downloadcache.Cache
 
 	monitor *Monitor
 
@@ -70,7 +72,7 @@ type Worker struct {
 	doneUpdateCheck chan struct{}
 }
 
-func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Broker) *Worker {
+func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) *Worker {
 	bookService := books.NewService(db)
 	chapterService := chapters.NewService(db)
 	genreService := genres.NewService(db)
@@ -105,6 +107,7 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 		pluginService:    pluginService,
 		pluginManager:    pm,
 		broker:           broker,
+		downloadCache:    dlCache,
 
 		queue:           make(chan *models.Job, cfg.WorkerProcesses),
 		shutdown:        make(chan struct{}),
@@ -116,7 +119,18 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 	}
 
 	w.processFuncs = map[string]func(ctx context.Context, job *models.Job, jobLog *joblogs.JobLogger) error{
-		models.JobTypeScan: w.ProcessScanJob,
+		models.JobTypeScan:         w.ProcessScanJob,
+		models.JobTypeBulkDownload: w.ProcessBulkDownloadJob,
+	}
+
+	if dlCache != nil {
+		dlCache.ShouldSkipCleanup = func() bool {
+			hasActive, err := w.jobService.HasActiveJob(context.Background(), models.JobTypeBulkDownload, nil)
+			if err != nil {
+				return false
+			}
+			return hasActive
+		}
 	}
 
 	return w

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -15,7 +15,7 @@ packages:
   - path: "github.com/shishobooks/shisho/pkg/jobs"
     output_path: "app/types/generated/jobs.ts"
     frontmatter: |
-      import { JobExportData, JobScanData } from "@/types";
+      import { JobBulkDownloadData, JobExportData, JobScanData } from "@/types";
     include_files:
       - validators.go
   - path: "github.com/shishobooks/shisho/pkg/joblogs"

--- a/website/docs/advanced/bulk-download.md
+++ b/website/docs/advanced/bulk-download.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 2
+---
+
+# Bulk Download
+
+Shisho supports downloading multiple books at once as a zip file. This is useful when you want to transfer a batch of books to another device or backup a selection of your library.
+
+## How It Works
+
+1. **Enter select mode** in the library gallery by long-pressing a book or using the selection toggle.
+2. **Select the books** you want to download — you can select across pages and use Shift+click for range selection.
+3. **Click the Download button** in the selection toolbar at the bottom of the screen. The button shows the estimated total file size.
+4. Shisho creates a background job to prepare your download. You'll see a progress toast showing how many files have been processed.
+5. **Navigate freely** while the download is being prepared — the progress toast persists across pages and will notify you when the download is ready.
+6. Once complete, click **Download Zip** to save the file.
+
+## What's Included
+
+- Each selected book contributes its **primary file** (the file designated for downloads and device sync).
+- Files include **embedded metadata** — the same enriched version you get from individual downloads, with title, authors, cover art, and other metadata written into the file.
+- The zip uses **store mode** (no compression) since ebook formats like EPUB and CBZ are already compressed internally. This makes the download faster and the file size estimate accurate.
+
+## Caching
+
+Bulk downloads are cached to speed up repeated requests:
+
+- **Individual files** generated during a bulk download are cached in the download cache. Future single-file downloads of the same books will be served instantly from this cache.
+- **The zip file itself** is cached based on a fingerprint of the selected files and their metadata. If you request the same set of books again with no metadata changes, the cached zip is served immediately.
+
+Cache is managed automatically and respects the configured download cache size limit.
+
+## Permissions
+
+Bulk download requires:
+- **Authentication** — you must be logged in.
+- **books:read** permission — granted to all default roles (Admin, Editor, Viewer).
+- **Library access** — you must have access to the libraries containing the selected books.

--- a/yarn.lock
+++ b/yarn.lock
@@ -651,6 +651,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"
   integrity sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==
 
+"@radix-ui/react-context@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.3.tgz#81286f643b310d040eaac13b18e223130861d839"
+  integrity sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==
+
 "@radix-ui/react-dialog@^1.1.15", "@radix-ui/react-dialog@^1.1.6":
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz#1de3d7a7e9a17a9874d29c07f5940a18a119b632"
@@ -833,6 +838,14 @@
   integrity sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==
   dependencies:
     "@radix-ui/react-slot" "1.2.4"
+
+"@radix-ui/react-progress@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-progress/-/react-progress-1.1.8.tgz#9f9a68d75bf763f9c64808724a83d2de804bd061"
+  integrity sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==
+  dependencies:
+    "@radix-ui/react-context" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.4"
 
 "@radix-ui/react-radio-group@^1.3.8":
   version "1.3.8"


### PR DESCRIPTION
## Summary
- Add bulk download to gallery select mode — users select books, click Download, and receive a zip of primary files with metadata injected
- Uses the existing job system with SSE progress events, so users can navigate away and return to download the completed zip
- Zip uses store mode (no compression) since ebook files are already compressed, making size estimates accurate
- Individual files are cached via the download cache, warming it for future single-file downloads

## Test plan
- Enter select mode in the gallery and select multiple books across pages
- Verify the Download button shows with an accurate size estimate
- Click Download and verify the progress toast appears with real-time updates
- Navigate to another page while download is in progress — toast should persist
- When complete, click "Download Zip" and verify the zip contains the expected files
- Dismiss the toast mid-progress, verify it reappears on completion
- Re-trigger the same download — should complete instantly (cached zip)
- Verify single-file downloads benefit from the warmed cache