### PR TITLE
[CI] Add concurrency limits to cancel redundant CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [master]
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Go Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- Adds a `concurrency` group to the CI workflow keyed on workflow name + branch ref
- When a new commit is pushed to the same branch, any in-progress CI run is automatically cancelled
- Saves runner minutes and avoids stale results on fast-moving branches

## Test plan
- Push two commits in quick succession to a PR branch and verify the first CI run is cancelled
- Verify pushes to different branches don't cancel each other
- Verify `workflow_call` triggers still work correctly