### PR TITLE
[CI] Move race detection to CI-only, speed up local test runs 8x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           go-version: "1.25"
 
       - name: Run tests
-        run: make test
+        run: make test:race
 
   lint-js:
     name: JS Lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ const coverUrl = `/api/books/${id}/cover?t=${query.dataUpdatedAt}`;
 - `make start:air` - Start API with hot reload via Air
 - `make check` - Run all validation checks in parallel (tests, Go lint, JS lint)
 - `make lint` - Run Go linting with golangci-lint
-- `make test` - Run all Go tests with race detection and coverage
+- `make test` - Run all Go tests with coverage
+- `make test:race` - Run all Go tests with race detection and coverage (used in CI)
 
 ### Frontend (React/TypeScript)
 - `pnpm start` - Start Vite dev server

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ start\:api:
 
 .PHONY: test
 test:
+	TZ=America/Chicago CI=true go test $(TEST_FILES) -coverprofile $(COVERAGE_PROFILE) $(TEST_FLAGS)
+
+.PHONY: test\:race
+test\:race:
 	TZ=America/Chicago CI=true go test -race $(TEST_FILES) -coverprofile $(COVERAGE_PROFILE) $(TEST_FLAGS)
 
 .PHONY: test\:cover


### PR DESCRIPTION
## Summary
- Remove `-race` flag from `make test` so local runs complete in ~21s instead of ~172s (8x speedup)
- Add new `make test:race` target that preserves the old behavior with `-race`
- Update CI workflow to use `make test:race` so race detection still runs on every push/PR

## Test plan
- Run `make test` locally and verify it completes in ~20s without `-race`
- Run `make test:race` locally and verify it includes `-race` flag
- Run `make check:quiet` and verify it uses the fast `test` target
- Verify CI workflow uses `test:race` by checking `.github/workflows/ci.yml`