### PR TITLE
[Frontend] Redesign docs homepage, darken app theme, use Tailwind font-logo class

### DIFF
--- a/app/components/library/Logo.tsx
+++ b/app/components/library/Logo.tsx
@@ -76,20 +76,15 @@ const Logo = ({ asLink = false, className, size = "md" }: LogoProps) => {
   );
 
   const baseClasses = cn(
-    "inline-flex items-center font-bold uppercase tracking-wider text-foreground",
+    "inline-flex items-center font-logo font-bold uppercase tracking-wider text-foreground",
     sizeClasses[size],
     className,
   );
-
-  const logoFont = {
-    fontFamily: '"Noto Sans", "Noto Sans Japanese", sans-serif',
-  };
 
   if (asLink) {
     return (
       <Link
         className={cn(baseClasses, "hover:opacity-80 transition-opacity")}
-        style={logoFont}
         to="/"
       >
         {content}
@@ -97,11 +92,7 @@ const Logo = ({ asLink = false, className, size = "md" }: LogoProps) => {
     );
   }
 
-  return (
-    <span className={baseClasses} style={logoFont}>
-      {content}
-    </span>
-  );
+  return <span className={baseClasses}>{content}</span>;
 };
 
 export default Logo;

--- a/app/components/library/Logo.tsx
+++ b/app/components/library/Logo.tsx
@@ -81,10 +81,15 @@ const Logo = ({ asLink = false, className, size = "md" }: LogoProps) => {
     className,
   );
 
+  const logoFont = {
+    fontFamily: '"Noto Sans", "Noto Sans Japanese", sans-serif',
+  };
+
   if (asLink) {
     return (
       <Link
         className={cn(baseClasses, "hover:opacity-80 transition-opacity")}
+        style={logoFont}
         to="/"
       >
         {content}
@@ -92,7 +97,11 @@ const Logo = ({ asLink = false, className, size = "md" }: LogoProps) => {
     );
   }
 
-  return <span className={baseClasses}>{content}</span>;
+  return (
+    <span className={baseClasses} style={logoFont}>
+      {content}
+    </span>
+  );
 };
 
 export default Logo;

--- a/app/index.css
+++ b/app/index.css
@@ -6,7 +6,7 @@
 
 @theme {
   --font-sans:
-    Geist Variable, Noto Sans, Noto Sans Japanese, ui-sans-serif, system-ui,
+    Geist, Noto Sans, Noto Sans Japanese, ui-sans-serif, system-ui,
     sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji";
 }

--- a/app/index.css
+++ b/app/index.css
@@ -55,11 +55,11 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.18 0 0);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.2 0 0);
+  --card: oklch(0.22 0 0);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.2 0 0);
+  --popover: oklch(0.22 0 0);
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.8 0.15 280);
   --primary-foreground: oklch(0.145 0 0);
@@ -78,7 +78,7 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.12 0 0);
+  --sidebar: oklch(0.13 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.8 0.15 280);
   --sidebar-primary-foreground: oklch(0.985 0 0);

--- a/app/index.css
+++ b/app/index.css
@@ -8,6 +8,7 @@
   --font-sans:
     Geist, Noto Sans, Noto Sans Japanese, ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-logo: "Noto Sans", "Noto Sans Japanese", sans-serif;
 }
 
 @utility container {
@@ -54,36 +55,36 @@
 }
 
 .dark {
-  --background: oklch(0.23 0 0);
+  --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.27 0 0);
+  --card: oklch(0.2 0 0);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.27 0 0);
+  --popover: oklch(0.2 0 0);
   --popover-foreground: oklch(0.985 0 0);
   --primary: oklch(0.8 0.15 280);
   --primary-foreground: oklch(0.145 0 0);
-  --secondary: oklch(0.32 0 0);
+  --secondary: oklch(0.25 0 0);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.32 0 0);
+  --muted: oklch(0.25 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.32 0 0);
+  --accent: oklch(0.25 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 15%);
-  --input: oklch(1 0 0 / 20%);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 14%);
   --ring: oklch(0.8 0.15 280);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
+  --sidebar: oklch(0.12 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.8 0.15 280);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.32 0 0);
+  --sidebar-accent: oklch(0.25 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 15%);
+  --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.8 0.15 280);
 }
 

--- a/app/index.css
+++ b/app/index.css
@@ -6,9 +6,8 @@
 
 @theme {
   --font-sans:
-    Geist, Noto Sans, Noto Sans Japanese, ui-sans-serif, system-ui,
-    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    "Noto Color Emoji";
+    Geist, Noto Sans, Noto Sans Japanese, ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 @utility container {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       rel="stylesheet"
     />
   </head>
-  <body>
+  <body class="antialiased">
     <div id="root"></div>
     <script type="module" src="/app/index.tsx"></script>
   </body>

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -16,7 +16,7 @@ Shisho's docs site is a Docusaurus 3 app in `website/` deployed to GitHub Pages.
 | Deploy trigger | Push to `master` touching `website/**` |
 | Workflow | `.github/workflows/docs.yml` |
 | Icons | `lucide-react` (swizzled theme icons) |
-| Fonts | Geist Variable, Noto Sans, Noto Sans JP |
+| Fonts | Geist, Noto Sans, Noto Sans JP |
 
 ## Directory Structure
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -391,7 +391,7 @@ body {
 .docs-home__why-grid {
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  overflow: hidden;
+  overflow-x: auto;
 }
 
 .docs-home__why-grid-header {
@@ -725,10 +725,6 @@ body {
 }
 
 @media (max-width: 996px) {
-  .docs-home__highlights {
-    grid-template-columns: 1fr;
-  }
-
   .navbar__inner {
     padding-left: 16px;
     padding-right: 16px;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -55,10 +55,10 @@
   --primary-foreground: oklch(0.145 0 0);
   --secondary: oklch(0.25 0 0);
   --muted: oklch(0.25 0 0);
-  --muted-foreground: oklch(0.65 0 0);
+  --muted-foreground: oklch(0.708 0 0);
   --accent: oklch(0.25 0 0);
   --accent-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 8%);
+  --border: oklch(1 0 0 / 10%);
   --ring: oklch(0.8 0.15 280);
   --ifm-color-primary: var(--shisho-violet-300);
   --ifm-color-primary-dark: oklch(0.75 0.111 293.571);
@@ -221,16 +221,6 @@ body {
   font-size: 1.25rem;
 }
 
-.shisho-logo--lg {
-  font-size: 2rem;
-}
-
-.shisho-logo--lg .shisho-logo__icon {
-  height: 1.5rem;
-  margin-right: 0.375rem;
-  width: 1.5rem;
-}
-
 .shisho-logo--link:hover {
   opacity: 0.8;
   text-decoration: none;
@@ -380,6 +370,10 @@ body {
   margin-bottom: 3rem;
 }
 
+.docs-home__section-desc--tight {
+  margin-bottom: 2rem;
+}
+
 /* ---- HOMEPAGE: WORKFLOW ---- */
 .docs-home__workflow {
   display: grid;
@@ -434,12 +428,6 @@ body {
   line-height: 1.55;
 }
 
-@media (max-width: 900px) {
-  .docs-home__workflow {
-    grid-template-columns: 1fr;
-  }
-}
-
 /* ---- HOMEPAGE: FORMATS ---- */
 .docs-home__formats {
   border: 1px solid var(--border);
@@ -487,11 +475,6 @@ body {
   font-weight: 600;
   letter-spacing: 0.01em;
   padding: 0.35rem 0.75rem;
-  transition: border-color 0.15s;
-}
-
-.docs-home__format-tag:hover {
-  border-color: color-mix(in oklch, var(--foreground), transparent 78%);
 }
 
 .docs-home__format-tag--planned {
@@ -652,6 +635,10 @@ body {
 
 /* ---- HOMEPAGE: RESPONSIVE ---- */
 @media (max-width: 900px) {
+  .docs-home__workflow {
+    grid-template-columns: 1fr;
+  }
+
   .docs-home__quickstart {
     grid-template-columns: 1fr;
   }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -15,9 +15,9 @@
   --ring: oklch(0.55 0.2 280);
   --shisho-violet-300: oklch(0.811 0.111 293.571);
   --ifm-font-family-base:
-    "Geist Variable", "Noto Sans", "Noto Sans Japanese", ui-sans-serif,
-    system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-    "Segoe UI Symbol", "Noto Color Emoji";
+    "Geist", "Noto Sans", "Noto Sans Japanese", ui-sans-serif, system-ui,
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
   --ifm-heading-font-family: var(--ifm-font-family-base);
   --ifm-font-weight-bold: 700;
   --ifm-line-height-base: 1.6;
@@ -47,18 +47,18 @@
 }
 
 [data-theme="dark"] {
-  --background: oklch(0.23 0 0);
+  --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.27 0 0);
+  --card: oklch(0.2 0 0);
   --card-foreground: oklch(0.985 0 0);
   --primary: oklch(0.8 0.15 280);
   --primary-foreground: oklch(0.145 0 0);
-  --secondary: oklch(0.32 0 0);
-  --muted: oklch(0.32 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.32 0 0);
+  --secondary: oklch(0.25 0 0);
+  --muted: oklch(0.25 0 0);
+  --muted-foreground: oklch(0.65 0 0);
+  --accent: oklch(0.25 0 0);
   --accent-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 15%);
+  --border: oklch(1 0 0 / 8%);
   --ring: oklch(0.8 0.15 280);
   --ifm-color-primary: var(--shisho-violet-300);
   --ifm-color-primary-dark: oklch(0.75 0.111 293.571);
@@ -69,7 +69,7 @@
   --ifm-color-primary-lightest: oklch(0.91 0.111 293.571);
   --ifm-background-color: var(--background);
   --ifm-font-color-base: var(--foreground);
-  --ifm-navbar-background-color: oklch(0.23 0 0);
+  --ifm-navbar-background-color: oklch(0.145 0 0);
   --ifm-navbar-link-color: var(--foreground);
   --ifm-card-background-color: var(--card);
   --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.08);
@@ -185,6 +185,8 @@ body {
   align-items: center;
   color: var(--foreground);
   display: inline-flex;
+  font-family:
+    "Noto Sans", "Noto Sans Japanese", ui-sans-serif, system-ui, sans-serif;
   font-weight: 700;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -234,15 +236,17 @@ body {
   text-decoration: none;
 }
 
+/* ---- HOMEPAGE: HERO ---- */
 .docs-home__hero {
   border-bottom: 1px solid var(--border);
+  overflow: hidden;
   position: relative;
 }
 
 .docs-home__hero::before {
   background: radial-gradient(
-    70% 70% at 50% 20%,
-    color-mix(in oklch, var(--primary), transparent 82%),
+    ellipse 70% 55% at 50% 0%,
+    color-mix(in oklch, var(--shisho-violet-300), transparent 80%),
     transparent
   );
   content: "";
@@ -253,49 +257,47 @@ body {
 
 .docs-home__hero-inner {
   margin: 0 auto;
-  max-width: 48rem;
-  padding: 4rem 1.5rem;
+  max-width: 720px;
+  padding: 6rem 1.5rem 5rem;
   position: relative;
   text-align: center;
 }
 
 .docs-home__eyebrow {
-  color: var(--muted-foreground);
-  font-size: 0.875rem;
-  letter-spacing: 0.12em;
-  margin-bottom: 1rem;
+  color: var(--shisho-violet-300);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  margin-bottom: 1.5rem;
   text-transform: uppercase;
 }
 
-.docs-home__logo {
-  font-size: clamp(2.9rem, 9vw, 5.9rem);
-  line-height: 1;
-  margin-bottom: 1.25rem;
+.docs-home__title {
+  font-size: clamp(2.5rem, 6vw, 3.75rem);
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  margin-bottom: 1.5rem;
 }
 
-.docs-home__logo .shisho-logo__wordmark {
-  letter-spacing: 0.01em;
-}
-
-.docs-home__logo .shisho-logo__icon {
-  height: clamp(2.3rem, 7vw, 5rem);
-  margin-right: clamp(0.45rem, 1.4vw, 0.85rem);
-  transform: translateY(0.05em);
-  width: clamp(2.3rem, 7vw, 5rem);
-}
-
-.docs-home__logo .shisho-logo__sup {
-  font-size: 0.45em;
-  margin-left: 0.18em;
-  position: relative;
-  top: -0.18em;
+.docs-home__title em {
+  background: linear-gradient(
+    135deg,
+    var(--ifm-color-primary-lighter),
+    var(--ifm-color-primary-dark)
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  font-style: normal;
 }
 
 .docs-home__subtitle {
   color: var(--muted-foreground);
-  font-size: 1.125rem;
-  margin: 0 auto 2rem;
-  max-width: 38rem;
+  font-size: 1.15rem;
+  line-height: 1.65;
+  margin: 0 auto 2.5rem;
+  max-width: 540px;
 }
 
 .docs-home__actions {
@@ -305,36 +307,383 @@ body {
   justify-content: center;
 }
 
-.docs-home__button {
+.docs-home__btn {
+  align-items: center;
   border-radius: var(--radius);
+  display: inline-flex;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  text-decoration: none;
+  transition: all 0.2s;
 }
 
-.docs-home__highlights {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  max-width: 80rem;
-  padding: 2rem 1.5rem 3rem;
+.docs-home__btn--primary {
+  background: var(--shisho-violet-300);
+  color: oklch(0.15 0 0);
 }
 
-.docs-home__card {
-  border-radius: var(--radius);
-  padding: 1.25rem;
-  text-align: center;
+.docs-home__btn--primary:hover {
+  background: var(--ifm-color-primary-light);
+  transform: translateY(-1px);
+  text-decoration: none;
+  color: oklch(0.15 0 0);
 }
 
-.docs-home__card h2 {
-  font-size: 1.1rem;
-  margin-bottom: 0.5rem;
+.docs-home__btn--ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--foreground);
 }
 
-.docs-home__card p {
-  color: var(--muted-foreground);
+.docs-home__btn--ghost:hover {
+  background: color-mix(in oklch, var(--foreground), transparent 95%);
+  border-color: color-mix(in oklch, var(--foreground), transparent 78%);
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+/* ---- HOMEPAGE: SECTIONS ---- */
+.docs-home__section {
+  border-bottom: 1px solid var(--border);
+  margin: 0 auto;
+  max-width: 1280px;
+  padding: 5rem 1.5rem;
+}
+
+.docs-home__section--no-border {
+  border-bottom: none;
+}
+
+.docs-home__section-label {
+  color: var(--shisho-violet-300);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+.docs-home__section-heading {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
   margin-bottom: 1rem;
 }
 
-.docs-home__card-link {
+.docs-home__section-desc {
+  color: var(--muted-foreground);
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  margin-bottom: 3rem;
+}
+
+/* ---- HOMEPAGE: WHY SECTION ---- */
+.docs-home__why-intro {
+  color: var(--muted-foreground);
+  font-size: 1.0625rem;
+  line-height: 1.75;
+  margin-bottom: 2.5rem;
+}
+
+.docs-home__why-grid {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.docs-home__why-grid-header {
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+  color: var(--muted-foreground);
+  display: grid;
+  font-size: 0.6875rem;
   font-weight: 600;
+  grid-template-columns: 1.6fr repeat(3, 1fr);
+  letter-spacing: 0.08em;
+  padding: 0.75rem 1.25rem;
+  text-transform: uppercase;
+}
+
+.docs-home__why-grid-header span:not(:first-child) {
+  text-align: center;
+}
+
+.docs-home__why-grid-row {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  font-size: 0.9375rem;
+  grid-template-columns: 1.6fr repeat(3, 1fr);
+  padding: 0.875rem 1.25rem;
+}
+
+.docs-home__why-grid-row:last-child {
+  border-bottom: none;
+}
+
+.docs-home__why-grid-row--highlight {
+  background: color-mix(in oklch, var(--shisho-violet-300), transparent 96%);
+}
+
+.docs-home__why-name {
+  font-weight: 600;
+}
+
+.docs-home__why-name--highlight {
+  color: var(--shisho-violet-300);
+}
+
+.docs-home__why-cell {
+  font-size: 0.875rem;
+  text-align: center;
+}
+
+.docs-home__why-check {
+  color: var(--shisho-violet-300);
+  font-weight: 600;
+}
+
+.docs-home__why-dash {
+  color: color-mix(in oklch, var(--foreground), transparent 88%);
+}
+
+/* ---- HOMEPAGE: FORMATS ---- */
+.docs-home__formats {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.docs-home__format-row {
+  align-items: baseline;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  gap: 1.25rem;
+  padding: 1.25rem 1.5rem;
+}
+
+.docs-home__format-row:last-child {
+  border-bottom: none;
+}
+
+.docs-home__format-category {
+  color: var(--muted-foreground);
+  flex: none;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  width: 110px;
+}
+
+.docs-home__format-items {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.docs-home__format-tag {
+  align-items: center;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--foreground);
+  display: inline-flex;
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  padding: 0.35rem 0.75rem;
+  transition: border-color 0.15s;
+}
+
+.docs-home__format-tag:hover {
+  border-color: color-mix(in oklch, var(--foreground), transparent 78%);
+}
+
+.docs-home__format-tag--planned {
+  border-style: dashed;
+  color: var(--muted-foreground);
+  font-weight: 500;
+}
+
+.docs-home__format-soon {
+  color: var(--shisho-violet-300);
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  margin-left: 0.4rem;
+  text-transform: uppercase;
+}
+
+/* ---- HOMEPAGE: FEATURES ---- */
+.docs-home__features {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.docs-home__feature {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.75rem;
+  transition: border-color 0.2s;
+}
+
+.docs-home__feature:hover {
+  border-color: color-mix(in oklch, var(--foreground), transparent 78%);
+}
+
+.docs-home__feature-icon {
+  align-items: center;
+  background: color-mix(in oklch, var(--shisho-violet-300), transparent 88%);
+  border-radius: 8px;
+  color: var(--shisho-violet-300);
+  display: flex;
+  height: 2.5rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+  width: 2.5rem;
+}
+
+.docs-home__feature-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.docs-home__feature-desc {
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  line-height: 1.55;
+}
+
+/* ---- HOMEPAGE: QUICKSTART ---- */
+.docs-home__quickstart {
+  align-items: start;
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: 1fr 1.2fr;
+}
+
+.docs-home__quickstart-steps {
+  counter-reset: step;
+}
+
+.docs-home__quickstart-step {
+  counter-increment: step;
+  margin-bottom: 1.5rem;
+  padding-left: 2.5rem;
+  position: relative;
+}
+
+.docs-home__quickstart-step::before {
+  align-items: center;
+  background: color-mix(in oklch, var(--shisho-violet-300), transparent 88%);
+  border-radius: 50%;
+  color: var(--shisho-violet-300);
+  content: counter(step);
+  display: flex;
+  font-size: 0.75rem;
+  font-weight: 700;
+  height: 1.75rem;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0.1rem;
+  width: 1.75rem;
+}
+
+.docs-home__quickstart-step h4 {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.docs-home__quickstart-step p {
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.docs-home__quickstart-step code {
+  background: var(--card);
+  border-radius: 4px;
+  font-size: 0.85em;
+  padding: 0.15em 0.4em;
+}
+
+.docs-home__quickstart-code {
+  background: color-mix(in oklch, var(--background), black 30%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.7;
+  overflow-x: auto;
+  padding: 1.5rem;
+}
+
+.docs-home__quickstart-code .qs-comment {
+  color: var(--muted-foreground);
+}
+
+.docs-home__quickstart-code .qs-key {
+  color: var(--ifm-color-primary-lighter);
+}
+
+.docs-home__quickstart-code .qs-string {
+  color: oklch(0.78 0.12 150);
+}
+
+/* ---- HOMEPAGE: CTA ---- */
+.docs-home__cta {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 3.5rem;
+  text-align: center;
+}
+
+.docs-home__cta-heading {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.docs-home__cta-text {
+  color: var(--muted-foreground);
+  font-size: 1rem;
+  margin-bottom: 2rem;
+}
+
+/* ---- HOMEPAGE: RESPONSIVE ---- */
+@media (max-width: 900px) {
+  .docs-home__quickstart {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-home__features {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .docs-home__format-row {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .docs-home__format-category {
+    width: auto;
+  }
+}
+
+@media (max-width: 600px) {
+  .docs-home__features {
+    grid-template-columns: 1fr;
+  }
 }
 
 .footer {
@@ -342,7 +691,7 @@ body {
 }
 
 .footer.footer--dark {
-  background-color: oklch(0.23 0 0) !important;
+  background-color: oklch(0.145 0 0) !important;
   background-image: none !important;
 }
 
@@ -383,5 +732,15 @@ body {
   .navbar__inner {
     padding-left: 16px;
     padding-right: 16px;
+  }
+
+  /* Hide Docs link on mobile — accessible via hamburger sidebar */
+  .navbar__items:not(.navbar__items--right) > .navbar__item.navbar__link {
+    display: none;
+  }
+
+  /* Hide version dropdown on mobile */
+  .navbar__items--right .dropdown {
+    display: none;
   }
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -380,74 +380,64 @@ body {
   margin-bottom: 3rem;
 }
 
-/* ---- HOMEPAGE: WHY SECTION ---- */
-.docs-home__why-intro {
-  color: var(--muted-foreground);
-  font-size: 1.0625rem;
-  line-height: 1.75;
-  margin-bottom: 2.5rem;
+/* ---- HOMEPAGE: WORKFLOW ---- */
+.docs-home__workflow {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(3, 1fr);
 }
 
-.docs-home__why-grid {
+.docs-home__workflow-step {
+  background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  overflow-x: auto;
+  padding: 2rem 1.75rem 1.75rem;
+  position: relative;
 }
 
-.docs-home__why-grid-header {
-  background: var(--card);
-  border-bottom: 1px solid var(--border);
-  color: var(--muted-foreground);
-  display: grid;
+.docs-home__workflow-number {
+  color: var(--shisho-violet-300);
   font-size: 0.6875rem;
-  font-weight: 600;
-  grid-template-columns: 1.6fr repeat(3, 1fr);
-  letter-spacing: 0.08em;
-  padding: 0.75rem 1.25rem;
-  text-transform: uppercase;
+  font-weight: 700;
+  left: 1.75rem;
+  letter-spacing: 0.06em;
+  position: absolute;
+  top: 1.25rem;
 }
 
-.docs-home__why-grid-header span:not(:first-child) {
-  text-align: center;
+.docs-home__workflow-number::before {
+  content: "Step ";
 }
 
-.docs-home__why-grid-row {
+.docs-home__workflow-icon {
   align-items: center;
-  border-bottom: 1px solid var(--border);
-  display: grid;
-  font-size: 0.9375rem;
-  grid-template-columns: 1.6fr repeat(3, 1fr);
-  padding: 0.875rem 1.25rem;
-}
-
-.docs-home__why-grid-row:last-child {
-  border-bottom: none;
-}
-
-.docs-home__why-grid-row--highlight {
-  background: color-mix(in oklch, var(--shisho-violet-300), transparent 96%);
-}
-
-.docs-home__why-name {
-  font-weight: 600;
-}
-
-.docs-home__why-name--highlight {
+  background: color-mix(in oklch, var(--shisho-violet-300), transparent 88%);
+  border-radius: 8px;
   color: var(--shisho-violet-300);
+  display: flex;
+  height: 2.5rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+  margin-top: 0.75rem;
+  width: 2.5rem;
 }
 
-.docs-home__why-cell {
+.docs-home__workflow-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.docs-home__workflow-desc {
+  color: var(--muted-foreground);
   font-size: 0.875rem;
-  text-align: center;
+  line-height: 1.55;
 }
 
-.docs-home__why-check {
-  color: var(--shisho-violet-300);
-  font-weight: 600;
-}
-
-.docs-home__why-dash {
-  color: color-mix(in oklch, var(--foreground), transparent 88%);
+@media (max-width: 900px) {
+  .docs-home__workflow {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ---- HOMEPAGE: FORMATS ---- */

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,26 +1,134 @@
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import ShishoLogo from "@site/src/components/ShishoLogo";
 import Layout from "@theme/Layout";
+import {
+  Blocks,
+  BookOpen,
+  Github,
+  Grid2x2,
+  Layers,
+  Shield,
+  Users,
+} from "lucide-react";
 import type { ReactNode } from "react";
 
-const highlights = [
+const comparisonRows = [
+  { name: "Calibre", ebooks: true, audiobooks: false, comics: false },
+  { name: "Audiobookshelf", ebooks: false, audiobooks: true, comics: false },
+  { name: "Komga", ebooks: false, audiobooks: false, comics: true },
+];
+
+const formatCategories = [
   {
-    title: "All Your Books, One Place",
-    description:
-      "Manage ebooks (EPUB), audiobooks (M4B), and comics (CBZ) in a single unified library. No more juggling separate apps for different formats.",
+    category: "Ebooks",
+    formats: [
+      { name: "EPUB", planned: false },
+      { name: "PDF", planned: false },
+      { name: "MOBI", planned: true },
+    ],
   },
   {
-    title: "Self-Hosted",
-    description:
-      "Your books, your server. Run Shisho on your own hardware with Docker. No cloud dependencies, no subscriptions, no data leaving your network.",
+    category: "Audiobooks",
+    formats: [
+      { name: "M4B", planned: false },
+      { name: "M4A", planned: true },
+      { name: "MP3", planned: true },
+    ],
   },
   {
-    title: "Extensible with Plugins",
-    description:
-      "Extend Shisho with JavaScript plugins to customize metadata processing, add integrations, and tailor the system to your workflow.",
+    category: "Comics",
+    formats: [
+      { name: "CBZ", planned: false },
+      { name: "CBR", planned: true },
+    ],
   },
 ];
+
+const features = [
+  {
+    icon: Grid2x2,
+    title: "Unified Library",
+    desc: "Ebooks, audiobooks, and comics all live together. Browse by series, author, genre, or format from one interface.",
+  },
+  {
+    icon: Shield,
+    title: "Self-Hosted & Private",
+    desc: "Your books stay on your hardware. No cloud, no subscriptions, no data leaving your network. Docker makes setup trivial.",
+  },
+  {
+    icon: Layers,
+    title: "Rich Metadata",
+    desc: "Automatically extracts titles, authors, narrators, series, covers, genres, and identifiers from every supported format.",
+  },
+  {
+    icon: BookOpen,
+    title: "Kobo Sync & OPDS",
+    desc: "Sync books directly to your Kobo e-reader with automatic KePub conversion. OPDS catalog for any compatible reader app.",
+  },
+  {
+    icon: Users,
+    title: "Multi-User & Permissions",
+    desc: "Create users with Admin, Editor, or Viewer roles. Control access per library with fine-grained permissions.",
+  },
+  {
+    icon: Blocks,
+    title: "Plugin System",
+    desc: "Extend functionality with JavaScript plugins for format conversion, metadata enrichment, and custom integrations.",
+  },
+];
+
+const dockerCompose = `services:
+  shisho:
+    image: ghcr.io/shishobooks/shisho:latest
+    container_name: shisho
+    restart: unless-stopped
+    ports:
+      - "5173:8080"
+    volumes:
+      - ./data:/data
+      - ./config:/config
+      - /path/to/books:/media
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - DATABASE_FILE_PATH=/data/shisho.db
+      - JWT_SECRET=your-secret-key`;
+
+function DockerComposeHighlighted(): ReactNode {
+  const lines = dockerCompose.split("\n");
+  return (
+    <>
+      <span className="qs-comment"># docker-compose.yml</span>
+      {"\n"}
+      {lines.map((line, i) => {
+        const highlighted = line
+          .replace(
+            /^(\s*)([\w_]+)(:)/gm,
+            (_, indent, key, colon) => `${indent}<k>${key}</k>${colon}`,
+          )
+          .replace(/(".*?")/g, "<s>$1</s>")
+          .replace(
+            /(ghcr\.io\/shishobooks\/shisho:latest|unless-stopped)/g,
+            "<s>$1</s>",
+          );
+        return (
+          <span key={i}>
+            <span
+              dangerouslySetInnerHTML={{
+                __html: highlighted
+                  .replace(/<k>/g, '<span class="qs-key">')
+                  .replace(/<\/k>/g, "</span>")
+                  .replace(/<s>/g, '<span class="qs-string">')
+                  .replace(/<\/s>/g, "</span>"),
+              }}
+            />
+            {"\n"}
+          </span>
+        );
+      })}
+    </>
+  );
+}
 
 export default function Home(): ReactNode {
   const { siteConfig } = useDocusaurusContext();
@@ -31,27 +139,227 @@ export default function Home(): ReactNode {
       title={siteConfig.title}
     >
       <main className="docs-home">
+        {/* HERO */}
         <section className="docs-home__hero">
           <div className="docs-home__hero-inner">
-            <ShishoLogo className="docs-home__logo" size="lg" />
-            <p className="docs-home__subtitle">{siteConfig.tagline}</p>
+            <p className="docs-home__eyebrow">Self-Hosted Book Management</p>
+            <h1 className="docs-home__title">
+              One library for <em>every</em> book you own
+            </h1>
+            <p className="docs-home__subtitle">
+              Shisho is an open-source, self-hosted system that brings ebooks,
+              audiobooks, and comics together in a single unified library. No
+              more juggling separate apps.
+            </p>
             <div className="docs-home__actions">
               <Link
-                className="button button--primary button--lg docs-home__button"
+                className="docs-home__btn docs-home__btn--primary"
                 to="/docs/getting-started"
               >
-                Getting Started
+                Get Started
               </Link>
+              <a
+                className="docs-home__btn docs-home__btn--ghost"
+                href="https://github.com/shishobooks/shisho"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <Github size={16} strokeWidth={2} />
+                View on GitHub
+              </a>
             </div>
           </div>
         </section>
-        <section className="docs-home__highlights container">
-          {highlights.map((highlight) => (
-            <article className="docs-home__card" key={highlight.title}>
-              <h2>{highlight.title}</h2>
-              <p>{highlight.description}</p>
-            </article>
-          ))}
+
+        {/* WHY SHISHO */}
+        <section className="docs-home__section">
+          <p className="docs-home__section-label">Why Shisho</p>
+          <h2 className="docs-home__section-heading">
+            Jellyfin, but for books
+          </h2>
+          <p className="docs-home__why-intro">
+            There are excellent self-hosted tools for specific book types, but
+            nothing that handles them all well together. If you collect across
+            formats, you end up running multiple apps, each with its own
+            database, its own interface, and its own limitations.
+          </p>
+          <div className="docs-home__why-grid">
+            <div className="docs-home__why-grid-header">
+              <span />
+              <span>Ebooks</span>
+              <span>Audiobooks</span>
+              <span>Comics</span>
+            </div>
+            {comparisonRows.map((row) => (
+              <div className="docs-home__why-grid-row" key={row.name}>
+                <span className="docs-home__why-name">{row.name}</span>
+                <span className="docs-home__why-cell">
+                  {row.ebooks ? (
+                    <span className="docs-home__why-check">&#10003;</span>
+                  ) : (
+                    <span className="docs-home__why-dash">-</span>
+                  )}
+                </span>
+                <span className="docs-home__why-cell">
+                  {row.audiobooks ? (
+                    <span className="docs-home__why-check">&#10003;</span>
+                  ) : (
+                    <span className="docs-home__why-dash">-</span>
+                  )}
+                </span>
+                <span className="docs-home__why-cell">
+                  {row.comics ? (
+                    <span className="docs-home__why-check">&#10003;</span>
+                  ) : (
+                    <span className="docs-home__why-dash">-</span>
+                  )}
+                </span>
+              </div>
+            ))}
+            <div className="docs-home__why-grid-row docs-home__why-grid-row--highlight">
+              <span className="docs-home__why-name docs-home__why-name--highlight">
+                Shisho
+              </span>
+              <span className="docs-home__why-cell docs-home__why-check">
+                &#10003;
+              </span>
+              <span className="docs-home__why-cell docs-home__why-check">
+                &#10003;
+              </span>
+              <span className="docs-home__why-cell docs-home__why-check">
+                &#10003;
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {/* FORMATS */}
+        <section className="docs-home__section">
+          <p className="docs-home__section-label">Format Support</p>
+          <h2 className="docs-home__section-heading">
+            Native support for every book format
+          </h2>
+          <p className="docs-home__section-desc">
+            Full metadata extraction, cover art, and chapter detection. All
+            built in, no plugins required.
+          </p>
+          <div className="docs-home__formats">
+            {formatCategories.map((cat) => (
+              <div className="docs-home__format-row" key={cat.category}>
+                <span className="docs-home__format-category">
+                  {cat.category}
+                </span>
+                <div className="docs-home__format-items">
+                  {cat.formats.map((fmt) => (
+                    <span
+                      className={`docs-home__format-tag${fmt.planned ? " docs-home__format-tag--planned" : ""}`}
+                      key={fmt.name}
+                    >
+                      {fmt.name}
+                      {fmt.planned && (
+                        <span className="docs-home__format-soon">Soon</span>
+                      )}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* FEATURES */}
+        <section className="docs-home__section">
+          <p className="docs-home__section-label">Features</p>
+          <h2 className="docs-home__section-heading">
+            Everything you need to manage your library
+          </h2>
+          <p className="docs-home__section-desc">
+            From metadata to device syncing, Shisho gives you full control over
+            your books.
+          </p>
+          <div className="docs-home__features">
+            {features.map((feat) => (
+              <article className="docs-home__feature" key={feat.title}>
+                <div className="docs-home__feature-icon">
+                  <feat.icon size={18} strokeWidth={2} />
+                </div>
+                <h3 className="docs-home__feature-title">{feat.title}</h3>
+                <p className="docs-home__feature-desc">{feat.desc}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        {/* QUICKSTART */}
+        <section className="docs-home__section">
+          <div className="docs-home__quickstart">
+            <div>
+              <p className="docs-home__section-label">Quick Start</p>
+              <h2 className="docs-home__section-heading">
+                Up and running in minutes
+              </h2>
+              <p
+                className="docs-home__section-desc"
+                style={{ marginBottom: "2rem" }}
+              >
+                Shisho runs as a Docker container. Point it at your book
+                collection and you're done.
+              </p>
+              <div className="docs-home__quickstart-steps">
+                <div className="docs-home__quickstart-step">
+                  <h4>Create a docker-compose.yml</h4>
+                  <p>
+                    Copy the configuration and adjust the paths to your book
+                    library.
+                  </p>
+                </div>
+                <div className="docs-home__quickstart-step">
+                  <h4>Start the container</h4>
+                  <p>
+                    Run <code>docker compose up -d</code> and visit port 5173.
+                  </p>
+                </div>
+                <div className="docs-home__quickstart-step">
+                  <h4>Create a library</h4>
+                  <p>
+                    Point Shisho at your mounted media directory. It scans
+                    automatically.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <pre className="docs-home__quickstart-code">
+              <DockerComposeHighlighted />
+            </pre>
+          </div>
+        </section>
+
+        {/* BOTTOM CTA */}
+        <section className="docs-home__section docs-home__section--no-border">
+          <div className="docs-home__cta">
+            <h2 className="docs-home__cta-heading">
+              Ready to organize your library?
+            </h2>
+            <p className="docs-home__cta-text">
+              Shisho is free, open-source, and always will be.
+            </p>
+            <div className="docs-home__actions">
+              <Link
+                className="docs-home__btn docs-home__btn--primary"
+                to="/docs/getting-started"
+              >
+                Read the Docs
+              </Link>
+              <a
+                className="docs-home__btn docs-home__btn--ghost"
+                href="https://www.patreon.com/shishobooks"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Support on Patreon
+              </a>
+            </div>
+          </div>
         </section>
       </main>
     </Layout>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -19,12 +19,12 @@ const workflowSteps = [
   {
     icon: FolderOpen,
     title: "Point it at your books",
-    desc: "Mount a directory of ebooks, audiobooks, or comics. Shisho scans the folder and imports everything it finds automatically.",
+    desc: "Mount a directory of ebooks, audiobooks, or comics. Shisho scans the folder, imports everything it finds automatically, and organizes everything on the file system.",
   },
   {
     icon: ScanSearch,
     title: "Metadata is extracted and enriched",
-    desc: "Titles, authors, narrators, series info, covers, and identifiers are pulled from each file. Auto-identify matches books against online sources to fill in any gaps.",
+    desc: "Titles, authors, narrators, series info, covers, and identifiers are pulled from each file. Metadata enricher plugins matches books against online sources to fill in any gaps.",
   },
   {
     icon: MonitorSmartphone,

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -275,10 +275,7 @@ export default function Home(): ReactNode {
               <h2 className="docs-home__section-heading">
                 Up and running in minutes
               </h2>
-              <p
-                className="docs-home__section-desc"
-                style={{ marginBottom: "2rem" }}
-              >
+              <p className="docs-home__section-desc docs-home__section-desc--tight">
                 Shisho runs as a Docker container. Point it at your book
                 collection and you're done.
               </p>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -4,18 +4,33 @@ import Layout from "@theme/Layout";
 import {
   Blocks,
   BookOpen,
+  FolderOpen,
   Github,
   Grid2x2,
   Layers,
+  MonitorSmartphone,
+  ScanSearch,
   Shield,
   Users,
 } from "lucide-react";
 import type { ReactNode } from "react";
 
-const comparisonRows = [
-  { name: "Calibre", ebooks: true, audiobooks: false, comics: false },
-  { name: "Audiobookshelf", ebooks: false, audiobooks: true, comics: false },
-  { name: "Komga", ebooks: false, audiobooks: false, comics: true },
+const workflowSteps = [
+  {
+    icon: FolderOpen,
+    title: "Point it at your books",
+    desc: "Mount a directory of ebooks, audiobooks, or comics. Shisho scans the folder and imports everything it finds automatically.",
+  },
+  {
+    icon: ScanSearch,
+    title: "Metadata is extracted and enriched",
+    desc: "Titles, authors, narrators, series info, covers, and identifiers are pulled from each file. Auto-identify matches books against online sources to fill in any gaps.",
+  },
+  {
+    icon: MonitorSmartphone,
+    title: "Read, listen, or download from anywhere",
+    desc: "Browse your library from any device. Read in the browser, sync to your Kobo, connect via OPDS, or download files directly.",
+  },
 ];
 
 const formatCategories = [
@@ -171,65 +186,27 @@ export default function Home(): ReactNode {
           </div>
         </section>
 
-        {/* WHY SHISHO */}
+        {/* HOW IT WORKS */}
         <section className="docs-home__section">
-          <p className="docs-home__section-label">Why Shisho</p>
+          <p className="docs-home__section-label">How It Works</p>
           <h2 className="docs-home__section-heading">
-            Jellyfin, but for books
+            From folder to library in minutes
           </h2>
-          <p className="docs-home__why-intro">
-            There are excellent self-hosted tools for specific book types, but
-            nothing that handles them all well together. If you collect across
-            formats, you end up running multiple apps, each with its own
-            database, its own interface, and its own limitations.
+          <p className="docs-home__section-desc">
+            Shisho turns a directory of files into an organized, searchable
+            library with rich metadata. No manual cataloging required.
           </p>
-          <div className="docs-home__why-grid">
-            <div className="docs-home__why-grid-header">
-              <span />
-              <span>Ebooks</span>
-              <span>Audiobooks</span>
-              <span>Comics</span>
-            </div>
-            {comparisonRows.map((row) => (
-              <div className="docs-home__why-grid-row" key={row.name}>
-                <span className="docs-home__why-name">{row.name}</span>
-                <span className="docs-home__why-cell">
-                  {row.ebooks ? (
-                    <span className="docs-home__why-check">&#10003;</span>
-                  ) : (
-                    <span className="docs-home__why-dash">-</span>
-                  )}
-                </span>
-                <span className="docs-home__why-cell">
-                  {row.audiobooks ? (
-                    <span className="docs-home__why-check">&#10003;</span>
-                  ) : (
-                    <span className="docs-home__why-dash">-</span>
-                  )}
-                </span>
-                <span className="docs-home__why-cell">
-                  {row.comics ? (
-                    <span className="docs-home__why-check">&#10003;</span>
-                  ) : (
-                    <span className="docs-home__why-dash">-</span>
-                  )}
-                </span>
+          <div className="docs-home__workflow">
+            {workflowSteps.map((step, i) => (
+              <div className="docs-home__workflow-step" key={step.title}>
+                <div className="docs-home__workflow-number">{i + 1}</div>
+                <div className="docs-home__workflow-icon">
+                  <step.icon size={22} />
+                </div>
+                <h3 className="docs-home__workflow-title">{step.title}</h3>
+                <p className="docs-home__workflow-desc">{step.desc}</p>
               </div>
             ))}
-            <div className="docs-home__why-grid-row docs-home__why-grid-row--highlight">
-              <span className="docs-home__why-name docs-home__why-name--highlight">
-                Shisho
-              </span>
-              <span className="docs-home__why-cell docs-home__why-check">
-                &#10003;
-              </span>
-              <span className="docs-home__why-cell docs-home__why-check">
-                &#10003;
-              </span>
-              <span className="docs-home__why-cell docs-home__why-check">
-                &#10003;
-              </span>
-            </div>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Complete rewrite of the docs site homepage with a refined editorial design: hero with gradient emphasis, "Why Shisho" comparison table, format support section with "coming soon" labels for planned formats, feature cards with lucide icons, quick start with syntax-highlighted docker-compose, and bottom CTA
- Fixed long-standing font-family naming bug where CSS declared `"Geist Variable"` but Google Fonts registers the font as `"Geist"`, causing silent fallback to system fonts in both the docs site (`website/src/css/custom.css`) and main app (`app/index.css`)
- Ensured logo renders in Noto Sans across all contexts (docs site via CSS class, main app via inline style in `Logo.tsx`)
- Improved mobile navbar by hiding Docs link and version dropdown (accessible via hamburger sidebar)

## Test plan
- Visit the docs homepage at localhost:3333 and verify the full page layout renders correctly at desktop (1920px), tablet (768px), and mobile (375px) viewports
- Verify the "Soon" badge appears on planned format tags (MOBI, M4A, MP3, CBR) and is vertically centered
- Verify the docker-compose code block no longer highlights `shisho` in green everywhere
- Verify the mobile navbar shows only hamburger + logo + GitHub (no Docs link or version dropdown)
- Verify the logo font is Noto Sans in both the docs site navbar and the main app
- Verify body text renders in Geist font (not system fallback) on both docs site and main app
- Run `make check:quiet` to confirm all linting and tests pass