### PR TITLE
[CI] Update task-start script to use mise instead of make

### DIFF
--- a/scripts/task-start
+++ b/scripts/task-start
@@ -61,10 +61,10 @@ tmux split-window -d -v -l "$HALF_SIZE" -t "${TASK_NAME}.1" -c "$WORKTREE_DIR"
 
 # Pane layout:
 #   Pane 0 (top): claude
-#   Pane 1 (middle): make start (pre-typed, not executed)
-#   Pane 2 (bottom): other commands / make setup
-tmux send-keys -t "${TASK_NAME}.2" "make setup" Enter
-tmux send-keys -t "${TASK_NAME}.1" "make start"
+#   Pane 1 (middle): mise start (pre-typed, not executed)
+#   Pane 2 (bottom): other commands / mise setup
+tmux send-keys -t "${TASK_NAME}.2" "mise setup" Enter
+tmux send-keys -t "${TASK_NAME}.1" "mise start"
 tmux send-keys -t "${TASK_NAME}.0" "claude --dangerously-skip-permissions" Enter
 tmux select-window -t "$TASK_NAME"
 tmux select-pane -t "${TASK_NAME}.0"


### PR DESCRIPTION
## Summary
- Updates `scripts/task-start` tmux setup to use `mise setup` and `mise start` instead of the removed `make` equivalents
- Follows up on the Make-to-mise migration (#26)

## Test plan
- Run `scripts/task-start` with a task name and verify the tmux session uses `mise setup` and `mise start` commands