### PR TITLE
[Fix] Fix chapter leaks in DeleteFile/DeleteBook and misleading orphan cleanup logs

### DIFF
--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1269,7 +1269,7 @@ func (svc *Service) DeleteIdentifiersForFile(ctx context.Context, fileID int) (i
 	return int(n), nil
 }
 
-// DeleteFile deletes a file and its associated records (narrators, identifiers).
+// DeleteFile deletes a file and its associated records (narrators, identifiers, chapters).
 // If the deleted file was the book's primary file, promotes another file to primary.
 func (svc *Service) DeleteFile(ctx context.Context, fileID int) error {
 	return svc.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
@@ -1295,6 +1295,15 @@ func (svc *Service) DeleteFile(ctx context.Context, fileID int) error {
 		// Delete identifiers for this file
 		_, err = tx.NewDelete().
 			Model((*models.FileIdentifier)(nil)).
+			Where("file_id = ?", fileID).
+			Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Delete chapters for this file
+		_, err = tx.NewDelete().
+			Model((*models.Chapter)(nil)).
 			Where("file_id = ?", fileID).
 			Exec(ctx)
 		if err != nil {
@@ -1447,6 +1456,15 @@ func (svc *Service) DeleteBook(ctx context.Context, bookID int) error {
 			// Delete identifiers for all files
 			_, err = tx.NewDelete().
 				Model((*models.FileIdentifier)(nil)).
+				Where("file_id IN (?)", bun.In(fileIDs)).
+				Exec(ctx)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+
+			// Delete chapters for all files
+			_, err = tx.NewDelete().
+				Model((*models.Chapter)(nil)).
 				Where("file_id IN (?)", bun.In(fileIDs)).
 				Exec(ctx)
 			if err != nil {

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1429,7 +1429,7 @@ func (svc *Service) ListFilesForLibrary(ctx context.Context, libraryID int) ([]*
 	return files, errors.WithStack(err)
 }
 
-// DeleteBook deletes a book and all its associated records (files, authors, series, genres, tags).
+// DeleteBook deletes a book and all its associated records (files, narrators, identifiers, chapters, authors, series, genres, tags).
 func (svc *Service) DeleteBook(ctx context.Context, bookID int) error {
 	return svc.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		// Get all file IDs for this book

--- a/pkg/books/service_delete_files_test.go
+++ b/pkg/books/service_delete_files_test.go
@@ -428,6 +428,129 @@ func TestDeleteBooksByIDs_EmptySlice(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDeleteFile_DeletesChapters(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	_, book := setupTestLibraryAndBook(t, db)
+	now := time.Now()
+
+	// Create a file
+	file := &models.File{
+		LibraryID:     book.LibraryID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeM4B,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/test/audiobook.m4b",
+		FilesizeBytes: 1000,
+	}
+	err := svc.CreateFile(ctx, file)
+	require.NoError(t, err)
+
+	// Create a second file so the book isn't empty after deletion
+	file2 := &models.File{
+		LibraryID:     book.LibraryID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeM4B,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/test/audiobook2.m4b",
+		FilesizeBytes: 2000,
+	}
+	err = svc.CreateFile(ctx, file2)
+	require.NoError(t, err)
+
+	// Add chapters to the file being deleted
+	chapter1 := &models.Chapter{FileID: file.ID, Title: "Chapter 1", SortOrder: 0, CreatedAt: now, UpdatedAt: now}
+	chapter2 := &models.Chapter{FileID: file.ID, Title: "Chapter 2", SortOrder: 1, CreatedAt: now, UpdatedAt: now}
+	_, err = db.NewInsert().Model(chapter1).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(chapter2).Exec(ctx)
+	require.NoError(t, err)
+
+	// Add a chapter to file2 (should NOT be deleted)
+	chapter3 := &models.Chapter{FileID: file2.ID, Title: "Other Chapter", SortOrder: 0, CreatedAt: now, UpdatedAt: now}
+	_, err = db.NewInsert().Model(chapter3).Exec(ctx)
+	require.NoError(t, err)
+
+	// Delete file1
+	err = svc.DeleteFile(ctx, file.ID)
+	require.NoError(t, err)
+
+	// Verify chapters for deleted file are gone
+	var chapterCount int
+	err = db.NewSelect().TableExpr("chapters").
+		Where("file_id = ?", file.ID).
+		ColumnExpr("count(*)").
+		Scan(ctx, &chapterCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, chapterCount, "chapters for deleted file should be removed")
+
+	// Verify chapter for other file still exists
+	var otherChapterCount int
+	err = db.NewSelect().TableExpr("chapters").
+		Where("file_id = ?", file2.ID).
+		ColumnExpr("count(*)").
+		Scan(ctx, &otherChapterCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, otherChapterCount, "chapters for other file should still exist")
+}
+
+func TestDeleteBook_DeletesChapters(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	_, book := setupTestLibraryAndBook(t, db)
+	now := time.Now()
+
+	// Create two files for the book
+	file1 := &models.File{
+		LibraryID:     book.LibraryID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeM4B,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/test/audiobook1.m4b",
+		FilesizeBytes: 1000,
+	}
+	err := svc.CreateFile(ctx, file1)
+	require.NoError(t, err)
+
+	file2 := &models.File{
+		LibraryID:     book.LibraryID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/test/book.epub",
+		FilesizeBytes: 2000,
+	}
+	err = svc.CreateFile(ctx, file2)
+	require.NoError(t, err)
+
+	// Add chapters to both files
+	chapter1 := &models.Chapter{FileID: file1.ID, Title: "Ch1", SortOrder: 0, CreatedAt: now, UpdatedAt: now}
+	chapter2 := &models.Chapter{FileID: file2.ID, Title: "Ch2", SortOrder: 0, CreatedAt: now, UpdatedAt: now}
+	_, err = db.NewInsert().Model(chapter1).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(chapter2).Exec(ctx)
+	require.NoError(t, err)
+
+	// Delete the book
+	err = svc.DeleteBook(ctx, book.ID)
+	require.NoError(t, err)
+
+	// Verify all chapters are gone
+	var chapterCount int
+	err = db.NewSelect().TableExpr("chapters").
+		Where("file_id IN (?)", bun.In([]int{file1.ID, file2.ID})).
+		ColumnExpr("count(*)").
+		Scan(ctx, &chapterCount)
+	require.NoError(t, err)
+	assert.Equal(t, 0, chapterCount, "all chapters should be deleted when book is deleted")
+}
+
 func TestPromoteNextPrimaryFile(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/worker/scan_orphans.go
+++ b/pkg/worker/scan_orphans.go
@@ -220,8 +220,8 @@ func (w *Worker) cleanupOrphanedFiles(
 	}
 
 	jobLog.Info("batch orphan cleanup complete", logger.Data{
-		"partial_files_deleted":  len(partialOrphanFileIDs),
-		"promoted_files_deleted": len(promotedBookOrphanFileIDs),
-		"books_deleted":          len(bookIDsToDelete),
+		"partial_files_attempted":  len(partialOrphanFileIDs),
+		"promoted_files_attempted": len(promotedBookOrphanFileIDs),
+		"books_attempted":          len(bookIDsToDelete),
 	})
 }


### PR DESCRIPTION
## Summary
- **DeleteFile** and **DeleteBook** relied on `ON DELETE CASCADE` for chapter cleanup, but `PRAGMA foreign_keys` is never enabled — leaving orphaned chapter rows on every single-file/book deletion. Added explicit chapter deletion matching the existing pattern in `DeleteFilesByIDs`/`DeleteBooksByIDs`.
- Renamed orphan cleanup log fields from `*_deleted` to `*_attempted` since they report attempted counts, not confirmed deletions.

## Test plan
- `TestDeleteFile_DeletesChapters` verifies chapters are removed when a file is deleted, and chapters for other files are untouched
- `TestDeleteBook_DeletesChapters` verifies all chapters across all files are removed when a book is deleted
- All existing tests continue to pass (`mise check:quiet`)