### PR TITLE
[Feature] Refine identify workflow with cover, date, identifier, and UI improvements

### DIFF
--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -68,7 +68,6 @@ import {
   FileTypeCBZ,
   FileTypeEPUB,
   FileTypeM4B,
-  FileTypePDF,
   type File,
   type FileRole,
 } from "@/types";
@@ -723,37 +722,36 @@ export function FileEditDialog({
 
                   {/* Action buttons and status */}
                   <div className="flex flex-col gap-2 pt-1">
-                    {/* Upload button — hidden for page-derived covers (CBZ via cover_page, PDF) */}
-                    {file.cover_page == null &&
-                      file.file_type !== FileTypePDF && (
-                        <>
-                          <input
-                            accept="image/jpeg,image/png,image/webp"
-                            className="hidden"
-                            onChange={handleCoverUpload}
-                            ref={fileInputRef}
-                            type="file"
-                          />
-                          <Button
-                            disabled={uploadCoverMutation.isPending}
-                            onClick={() => fileInputRef.current?.click()}
-                            size="sm"
-                            type="button"
-                            variant="outline"
-                          >
-                            {uploadCoverMutation.isPending ? (
-                              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                            ) : (
-                              <Upload className="h-4 w-4 mr-2" />
-                            )}
-                            {file.cover_mime_type ||
-                            file.cover_image_filename ||
-                            pendingCoverFile
-                              ? "Replace cover"
-                              : "Upload cover"}
-                          </Button>
-                        </>
-                      )}
+                    {/* Upload button — hidden for files with page-derived covers */}
+                    {file.cover_page == null && (
+                      <>
+                        <input
+                          accept="image/jpeg,image/png,image/webp"
+                          className="hidden"
+                          onChange={handleCoverUpload}
+                          ref={fileInputRef}
+                          type="file"
+                        />
+                        <Button
+                          disabled={uploadCoverMutation.isPending}
+                          onClick={() => fileInputRef.current?.click()}
+                          size="sm"
+                          type="button"
+                          variant="outline"
+                        >
+                          {uploadCoverMutation.isPending ? (
+                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                          ) : (
+                            <Upload className="h-4 w-4 mr-2" />
+                          )}
+                          {file.cover_mime_type ||
+                          file.cover_image_filename ||
+                          pendingCoverFile
+                            ? "Replace cover"
+                            : "Upload cover"}
+                        </Button>
+                      </>
+                    )}
                     {/* CBZ: Select page button */}
                     {file.file_type === FileTypeCBZ && (
                       <Button

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -722,8 +722,8 @@ export function FileEditDialog({
 
                   {/* Action buttons and status */}
                   <div className="flex flex-col gap-2 pt-1">
-                    {/* Non-CBZ: Upload button */}
-                    {file.file_type !== FileTypeCBZ && (
+                    {/* Upload button — hidden for files with cover_page (CBZ, PDF) */}
+                    {file.cover_page == null && (
                       <>
                         <input
                           accept="image/jpeg,image/png,image/webp"

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -68,6 +68,7 @@ import {
   FileTypeCBZ,
   FileTypeEPUB,
   FileTypeM4B,
+  FileTypePDF,
   type File,
   type FileRole,
 } from "@/types";
@@ -722,36 +723,37 @@ export function FileEditDialog({
 
                   {/* Action buttons and status */}
                   <div className="flex flex-col gap-2 pt-1">
-                    {/* Upload button — hidden for files with cover_page (CBZ, PDF) */}
-                    {file.cover_page == null && (
-                      <>
-                        <input
-                          accept="image/jpeg,image/png,image/webp"
-                          className="hidden"
-                          onChange={handleCoverUpload}
-                          ref={fileInputRef}
-                          type="file"
-                        />
-                        <Button
-                          disabled={uploadCoverMutation.isPending}
-                          onClick={() => fileInputRef.current?.click()}
-                          size="sm"
-                          type="button"
-                          variant="outline"
-                        >
-                          {uploadCoverMutation.isPending ? (
-                            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                          ) : (
-                            <Upload className="h-4 w-4 mr-2" />
-                          )}
-                          {file.cover_mime_type ||
-                          file.cover_image_filename ||
-                          pendingCoverFile
-                            ? "Replace cover"
-                            : "Upload cover"}
-                        </Button>
-                      </>
-                    )}
+                    {/* Upload button — hidden for page-derived covers (CBZ via cover_page, PDF) */}
+                    {file.cover_page == null &&
+                      file.file_type !== FileTypePDF && (
+                        <>
+                          <input
+                            accept="image/jpeg,image/png,image/webp"
+                            className="hidden"
+                            onChange={handleCoverUpload}
+                            ref={fileInputRef}
+                            type="file"
+                          />
+                          <Button
+                            disabled={uploadCoverMutation.isPending}
+                            onClick={() => fileInputRef.current?.click()}
+                            size="sm"
+                            type="button"
+                            variant="outline"
+                          >
+                            {uploadCoverMutation.isPending ? (
+                              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                            ) : (
+                              <Upload className="h-4 w-4 mr-2" />
+                            )}
+                            {file.cover_mime_type ||
+                            file.cover_image_filename ||
+                            pendingCoverFile
+                              ? "Replace cover"
+                              : "Upload cover"}
+                          </Button>
+                        </>
+                      )}
                     {/* CBZ: Select page button */}
                     {file.file_type === FileTypeCBZ && (
                       <Button

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -135,7 +135,7 @@ export function IdentifyBookDialog({
       onOpenChange={onOpenChange}
       open={open}
     >
-      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto overflow-x-hidden">
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto overflow-x-hidden [&>*]:min-w-0">
         <DialogHeader className="pr-8">
           <DialogTitle>Identify Book</DialogTitle>
           <DialogDescription>

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -522,7 +522,7 @@ export function IdentifyReviewForm({
 
   // Cover state — files with a cover_page (e.g. CBZ, PDF) derive covers from
   // page content and shouldn't be overwritten by plugin images.
-  const coverEditable = file?.cover_page == null;
+  const coverEditable = file?.cover_page == null && file?.file_type !== "pdf";
   const newCoverUrl = result.image_url || result.cover_url;
   const currentCoverUrl = file?.cover_image_filename
     ? `/api/books/files/${file.id}/cover?t=${new Date(file.updated_at).getTime()}`

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -67,10 +67,18 @@ function useImageDimensions(src: string | undefined) {
       setDims(null);
       return;
     }
+    let cancelled = false;
     const img = new Image();
-    img.onload = () => setDims({ w: img.naturalWidth, h: img.naturalHeight });
-    img.onerror = () => setDims(null);
+    img.onload = () => {
+      if (!cancelled) setDims({ w: img.naturalWidth, h: img.naturalHeight });
+    };
+    img.onerror = () => {
+      if (!cancelled) setDims(null);
+    };
     img.src = src;
+    return () => {
+      cancelled = true;
+    };
   }, [src]);
 
   return dims;
@@ -1100,7 +1108,7 @@ function IdentifierTagInput({
           </span>
           {!disabled && (
             <button
-              className="shrink-0 rounded-sm hover:bg-muted-foreground/20 p.5 cursor-pointer"
+              className="shrink-0 rounded-sm hover:bg-muted-foreground/20 p-0.5 cursor-pointer"
               onClick={() => onChange(value.filter((_, j) => j !== i))}
               type="button"
             >

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -1,5 +1,12 @@
 import equal from "fast-deep-equal";
-import { ArrowLeft, ChevronDown, ChevronUp, Loader2, X } from "lucide-react";
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  Loader2,
+  X,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -15,11 +22,12 @@ import {
 } from "@/components/ui/tooltip";
 import {
   usePluginApply,
+  usePluginIdentifierTypes,
   type PluginSearchResult,
 } from "@/hooks/queries/plugins";
 import { cn } from "@/libraries/utils";
 import type { Book, File } from "@/types";
-import { formatMetadataFieldLabel } from "@/utils/format";
+import { formatIdentifierType, formatMetadataFieldLabel } from "@/utils/format";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -49,6 +57,24 @@ interface IdentifierEntry {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/** Load natural dimensions of an image URL. */
+function useImageDimensions(src: string | undefined) {
+  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+
+  useEffect(() => {
+    if (!src) {
+      setDims(null);
+      return;
+    }
+    const img = new Image();
+    img.onload = () => setDims({ w: img.naturalWidth, h: img.naturalHeight });
+    img.onerror = () => setDims(null);
+    img.src = src;
+  }, [src]);
+
+  return dims;
+}
 
 /** Determine field status and default value for a scalar field. */
 function resolveScalar(
@@ -122,7 +148,13 @@ function resolveIdentifiers(
   ) {
     return { value: current, status: "unchanged" };
   }
-  return { value: incoming, status: "changed" };
+  // Merge: keep all current, add new incoming identifiers
+  const existingKeys = new Set(current.map(key));
+  const merged = [
+    ...current,
+    ...incoming.filter((id) => !existingKeys.has(key(id))),
+  ];
+  return { value: merged, status: "changed" };
 }
 
 /** Extract current file from book. */
@@ -171,8 +203,8 @@ function CurrentBar({
   onUseCurrent?: () => void;
 }) {
   return (
-    <div className="flex items-center justify-between gap-2 border-l-2 border-muted-foreground/30 bg-muted/50 rounded-r-md px-3 py-1.5 text-sm text-muted-foreground">
-      <span className="min-w-0 truncate">{children}</span>
+    <div className="flex items-start justify-between gap-2 border-l-2 border-muted-foreground/30 bg-muted/50 rounded-r-md px-3 py-1.5 text-sm text-muted-foreground">
+      <span className="min-w-0 break-words">{children}</span>
       {onUseCurrent && (
         <Button
           className="shrink-0 text-xs h-6 px-2"
@@ -370,6 +402,7 @@ export function IdentifyReviewForm({
 }: IdentifyReviewFormProps) {
   const file = findFile(book, fileId);
   const applyMutation = usePluginApply();
+  const { data: pluginIdentifierTypes } = usePluginIdentifierTypes();
   const disabledFields = useMemo(
     () => new Set(result.disabled_fields ?? []),
     [result.disabled_fields],
@@ -441,7 +474,7 @@ export function IdentifyReviewForm({
       imprint: resolveScalar(file?.imprint?.name, result.imprint),
       releaseDate: resolveScalar(
         file?.release_date ? file.release_date.split("T")[0] : undefined,
-        result.release_date,
+        result.release_date ? result.release_date.split("T")[0] : undefined,
       ),
       url: resolveScalar(file?.url, result.url),
       identifiers: resolveIdentifiers(currentIdentifiers, incomingIdentifiers),
@@ -479,15 +512,19 @@ export function IdentifyReviewForm({
     defaults.identifiers.value,
   );
 
-  // Cover state
+  // Cover state — files with a cover_page (e.g. CBZ, PDF) derive covers from
+  // page content and shouldn't be overwritten by plugin images.
+  const coverEditable = file?.cover_page == null;
   const newCoverUrl = result.image_url || result.cover_url;
-  const currentCoverUrl = file
+  const currentCoverUrl = file?.cover_image_filename
     ? `/api/books/files/${file.id}/cover?t=${new Date(file.updated_at).getTime()}`
     : undefined;
-  const hasCoverChoice = !!newCoverUrl;
+  const hasCoverChoice = !!newCoverUrl && coverEditable;
   const [coverSelection, setCoverSelection] = useState<"current" | "new">(
     newCoverUrl && !isDisabled("cover") ? "new" : "current",
   );
+  const currentCoverDims = useImageDimensions(currentCoverUrl);
+  const newCoverDims = useImageDimensions(newCoverUrl);
 
   // ---- Unsaved changes tracking ----
   const hasChanges = useMemo(() => {
@@ -535,7 +572,7 @@ export function IdentifyReviewForm({
   }, [hasChanges, onHasChangesChange]);
 
   // ---- Submit ----
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const fields: Record<string, unknown> = {
       title,
       subtitle,
@@ -560,24 +597,21 @@ export function IdentifyReviewForm({
       fields.cover_url = newCoverUrl;
     }
 
-    applyMutation.mutate(
-      {
+    try {
+      await applyMutation.mutateAsync({
         book_id: book.id,
         file_id: fileId,
         fields,
         plugin_scope: result.plugin_scope,
         plugin_id: result.plugin_id,
-      },
-      {
-        onSuccess: () => {
-          toast.success("Metadata applied successfully.");
-          onClose();
-        },
-        onError: (err) => {
-          toast.error(err.message || "Failed to apply metadata.");
-        },
-      },
-    );
+      });
+      toast.success("Metadata applied successfully.");
+      onClose();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to apply metadata.";
+      toast.error(message);
+    }
   };
 
   // ---- Render ----
@@ -664,6 +698,20 @@ export function IdentifyReviewForm({
                 Use new
               </span>
             </button>
+          </div>
+          <div className="flex gap-4 text-xs text-muted-foreground">
+            {currentCoverUrl && (
+              <span className="w-[calc(6rem+4px)] text-center">
+                {currentCoverDims
+                  ? `${currentCoverDims.w} × ${currentCoverDims.h}`
+                  : "\u00A0"}
+              </span>
+            )}
+            <span className="w-[calc(6rem+4px)] text-center">
+              {newCoverDims
+                ? `${newCoverDims.w} × ${newCoverDims.h}`
+                : "\u00A0"}
+            </span>
           </div>
         </div>
       )}
@@ -915,11 +963,31 @@ export function IdentifyReviewForm({
         onUseCurrent={() => setUrl(file?.url ?? "")}
         status={defaults.url.status}
       >
-        <Input
-          disabled={isDisabled("url")}
-          onChange={(e) => setUrl(e.target.value)}
-          value={url}
-        />
+        <div className="flex gap-2">
+          <Input
+            className="flex-1"
+            disabled={isDisabled("url")}
+            onChange={(e) => setUrl(e.target.value)}
+            value={url}
+          />
+          <Button
+            asChild={!!url.trim()}
+            disabled={!url.trim()}
+            size="icon"
+            type="button"
+            variant="outline"
+          >
+            {url.trim() ? (
+              <a href={url.trim()} rel="noopener noreferrer" target="_blank">
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            ) : (
+              <span>
+                <ExternalLink className="h-4 w-4" />
+              </span>
+            )}
+          </Button>
+        </div>
       </FieldWrapper>
 
       {/* Identifiers */}
@@ -947,12 +1015,16 @@ export function IdentifyReviewForm({
               }
             >
               {currentIdentifiers
-                .map((id) => `${id.type}:${id.value}`)
+                .map(
+                  (id) =>
+                    `${formatIdentifierType(id.type, pluginIdentifierTypes)}: ${id.value}`,
+                )
                 .join(", ")}
             </CurrentBar>
           )}
         <IdentifierTagInput
           disabled={isDisabled("identifiers")}
+          identifierTypes={pluginIdentifierTypes}
           onChange={setIdentifiers}
           value={identifiers}
         />
@@ -999,35 +1071,21 @@ function IdentifierTagInput({
   value,
   onChange,
   disabled,
+  identifierTypes,
 }: {
   value: IdentifierEntry[];
   onChange: (ids: IdentifierEntry[]) => void;
   disabled?: boolean;
+  identifierTypes?: Array<{ id: string; name: string }>;
 }) {
-  const [input, setInput] = useState("");
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && input.trim()) {
-      e.preventDefault();
-      const colonIndex = input.indexOf(":");
-      if (colonIndex > 0) {
-        const type = input.slice(0, colonIndex).trim();
-        const val = input.slice(colonIndex + 1).trim();
-        if (type && val) {
-          onChange([...value, { type, value: val }]);
-          setInput("");
-        }
-      }
-    }
-    if (e.key === "Backspace" && !input && value.length > 0) {
-      onChange(value.slice(0, -1));
-    }
-  };
+  if (value.length === 0) {
+    return <p className="text-sm text-muted-foreground">No identifiers</p>;
+  }
 
   return (
     <div
       className={cn(
-        "flex flex-wrap gap-1.5 rounded-md border border-input bg-transparent p-2 min-h-[36px]",
+        "flex flex-wrap gap-1.5",
         disabled && "opacity-50 cursor-not-allowed",
       )}
     >
@@ -1038,11 +1096,11 @@ function IdentifierTagInput({
           variant="secondary"
         >
           <span className="truncate" title={`${id.type}:${id.value}`}>
-            {id.type}:{id.value}
+            {formatIdentifierType(id.type, identifierTypes)}: {id.value}
           </span>
           {!disabled && (
             <button
-              className="shrink-0 rounded-sm hover:bg-muted-foreground/20 p-0.5 cursor-pointer"
+              className="shrink-0 rounded-sm hover:bg-muted-foreground/20 p.5 cursor-pointer"
               onClick={() => onChange(value.filter((_, j) => j !== i))}
               type="button"
             >
@@ -1051,16 +1109,6 @@ function IdentifierTagInput({
           )}
         </Badge>
       ))}
-      {!disabled && (
-        <input
-          className="flex-1 min-w-[120px] bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder={value.length === 0 ? "type:value (press Enter)" : ""}
-          type="text"
-          value={input}
-        />
-      )}
     </div>
   );
 }

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -520,9 +520,9 @@ export function IdentifyReviewForm({
     defaults.identifiers.value,
   );
 
-  // Cover state — files with a cover_page (e.g. CBZ, PDF) derive covers from
-  // page content and shouldn't be overwritten by plugin images.
-  const coverEditable = file?.cover_page == null && file?.file_type !== "pdf";
+  // Cover state — files with cover_page (CBZ, PDF) derive covers from page
+  // content and shouldn't be overwritten by plugin images.
+  const coverEditable = file?.cover_page == null;
   const newCoverUrl = result.image_url || result.cover_url;
   const currentCoverUrl = file?.cover_image_filename
     ? `/api/books/files/${file.id}/cover?t=${new Date(file.updated_at).getTime()}`

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -556,13 +556,15 @@ export const usePluginApply = () => {
     mutationFn: (payload) => {
       return API.request("POST", "/plugins/apply", payload);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [BooksQueryKey.ListBooks],
-      });
-      queryClient.invalidateQueries({
-        queryKey: [BooksQueryKey.RetrieveBook],
-      });
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [BooksQueryKey.ListBooks],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [BooksQueryKey.RetrieveBook],
+        }),
+      ]);
     },
   });
 };

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1245,9 +1245,10 @@ func (h *handler) uploadFileCover(c echo.Context) error {
 		}
 	}
 
-	// Files with a cover_page derive their cover from page content and cannot have it replaced by upload
-	if file.CoverPage != nil {
-		return errcodes.ValidationError("Cover upload is not supported for this file type. Use the cover page selector instead.")
+	// Files with page-derived covers cannot have them replaced by upload:
+	// CBZ uses cover_page, PDF renders from page content.
+	if file.CoverPage != nil || file.FileType == models.FileTypePDF {
+		return errcodes.ValidationError("Cover upload is not supported for this file type.")
 	}
 
 	// Get the parent book for the cover directory

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1245,6 +1245,11 @@ func (h *handler) uploadFileCover(c echo.Context) error {
 		}
 	}
 
+	// Files with a cover_page derive their cover from page content and cannot have it replaced by upload
+	if file.CoverPage != nil {
+		return errcodes.ValidationError("Cover upload is not supported for this file type. Use the cover page selector instead.")
+	}
+
 	// Get the parent book for the cover directory
 	book, err := h.bookService.RetrieveBook(ctx, RetrieveBookOptions{
 		ID: &file.BookID,

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1245,9 +1245,9 @@ func (h *handler) uploadFileCover(c echo.Context) error {
 		}
 	}
 
-	// Files with page-derived covers cannot have them replaced by upload:
-	// CBZ uses cover_page, PDF renders from page content.
-	if file.CoverPage != nil || file.FileType == models.FileTypePDF {
+	// Files with cover_page derive their cover from page content (CBZ, PDF) and
+	// cannot have it replaced by upload.
+	if file.CoverPage != nil {
 		return errcodes.ValidationError("Cover upload is not supported for this file type.")
 	}
 

--- a/pkg/books/handlers_cover_page_test.go
+++ b/pkg/books/handlers_cover_page_test.go
@@ -8,8 +8,10 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -461,4 +463,87 @@ func TestUpdateFileCoverPage(t *testing.T) {
 		err = h.updateFileCoverPage(c)
 		require.Error(t, err)
 	})
+}
+
+// TestUploadFileCover_RejectsFileWithCoverPage verifies that the uploadFileCover
+// handler returns a validation error when the target file has CoverPage set,
+// since page-based covers (CBZ/PDF) should not be overwritten by uploads.
+func TestUploadFileCover_RejectsFileWithCoverPage(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	bookService := NewService(db)
+
+	h := &handler{
+		bookService: bookService,
+	}
+
+	// Create test library
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create book directory
+	bookDir := filepath.Join(t.TempDir(), "Test Book")
+	err = os.MkdirAll(bookDir, 0755)
+	require.NoError(t, err)
+
+	// Create book
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create file with CoverPage set (simulates CBZ/PDF)
+	coverPage := 0
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeCBZ,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath.Join(bookDir, "test.cbz"),
+		FilesizeBytes: 1000,
+		CoverPage:     &coverPage,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Build multipart form with a JPEG cover image
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	partHeader := make(textproto.MIMEHeader)
+	partHeader.Set("Content-Disposition", `form-data; name="cover"; filename="cover.jpg"`)
+	partHeader.Set("Content-Type", "image/jpeg")
+	part, err := writer.CreatePart(partHeader)
+	require.NoError(t, err)
+
+	// Write a minimal valid JPEG
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	err = jpeg.Encode(part, img, nil)
+	require.NoError(t, err)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set(echo.HeaderContentType, writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(file.ID))
+
+	err = h.uploadFileCover(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cover upload is not supported")
 }

--- a/pkg/books/handlers_cover_page_test.go
+++ b/pkg/books/handlers_cover_page_test.go
@@ -588,7 +588,8 @@ func TestUploadFileCover_RejectsPDFFile(t *testing.T) {
 	_, err = db.NewInsert().Model(book).Exec(ctx)
 	require.NoError(t, err)
 
-	// Create PDF file (no CoverPage set — PDFs don't use cover_page)
+	// Create PDF file with CoverPage set (scanner sets cover_page=0 for PDFs)
+	pdfCoverPage := 0
 	file := &models.File{
 		LibraryID:     library.ID,
 		BookID:        book.ID,
@@ -596,6 +597,7 @@ func TestUploadFileCover_RejectsPDFFile(t *testing.T) {
 		FileRole:      models.FileRoleMain,
 		Filepath:      filepath.Join(bookDir, "test.pdf"),
 		FilesizeBytes: 1000,
+		CoverPage:     &pdfCoverPage,
 	}
 	_, err = db.NewInsert().Model(file).Exec(ctx)
 	require.NoError(t, err)

--- a/pkg/books/handlers_cover_page_test.go
+++ b/pkg/books/handlers_cover_page_test.go
@@ -547,3 +547,81 @@ func TestUploadFileCover_RejectsFileWithCoverPage(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Cover upload is not supported")
 }
+
+// TestUploadFileCover_RejectsPDFFile verifies that the uploadFileCover handler
+// returns a validation error for PDF files, since PDF covers are rendered from
+// page content and should not be overwritten.
+func TestUploadFileCover_RejectsPDFFile(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	bookService := NewService(db)
+
+	h := &handler{
+		bookService: bookService,
+	}
+
+	// Create test library
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	bookDir := filepath.Join(t.TempDir(), "Test Book")
+	err = os.MkdirAll(bookDir, 0755)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create PDF file (no CoverPage set — PDFs don't use cover_page)
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypePDF,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath.Join(bookDir, "test.pdf"),
+		FilesizeBytes: 1000,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Build multipart form with a JPEG cover image
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	partHeader := make(textproto.MIMEHeader)
+	partHeader.Set("Content-Disposition", `form-data; name="cover"; filename="cover.jpg"`)
+	partHeader.Set("Content-Type", "image/jpeg")
+	part, err := writer.CreatePart(partHeader)
+	require.NoError(t, err)
+
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	err = jpeg.Encode(part, img, nil)
+	require.NoError(t, err)
+	writer.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/", &body)
+	req.Header.Set(echo.HeaderContentType, writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(file.ID))
+
+	err = h.uploadFileCover(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cover upload is not supported")
+}

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -85,11 +85,16 @@ func Parse(path string) (*mediafile.ParsedMetadata, error) {
 	}
 
 	// Extract cover image (best-effort: don't fail Parse if cover extraction fails).
+	// PDF covers are always derived from page 0, so set CoverPage to signal this
+	// is a page-based cover that should not be overwritten.
 	var coverData []byte
 	var coverMime string
+	var coverPage *int
 	if cd, cm, err := extractCover(path); err == nil {
 		coverData = cd
 		coverMime = cm
+		page0 := 0
+		coverPage = &page0
 	}
 
 	// Extract outline (bookmarks) as chapters. Best-effort — don't fail Parse.
@@ -114,6 +119,7 @@ func Parse(path string) (*mediafile.ParsedMetadata, error) {
 		PageCount:     pageCount,
 		CoverData:     coverData,
 		CoverMimeType: coverMime,
+		CoverPage:     coverPage,
 		Chapters:      chapters,
 		DataSource:    models.DataSourcePDFMetadata,
 	}, nil

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1654,8 +1654,8 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 	}
 
 	// Apply cover data (caller is responsible for downloading cover URLs before calling persistMetadata).
-	// Skip for files with page-derived covers: CBZ uses cover_page, PDF renders from page content.
-	if len(md.CoverData) > 0 && targetFile != nil && targetFile.CoverPage == nil && targetFile.FileType != models.FileTypePDF {
+	// Skip for files with cover_page — their covers are derived from page content (CBZ, PDF).
+	if len(md.CoverData) > 0 && targetFile != nil && targetFile.CoverPage == nil {
 		coverDir := book.Filepath
 		coverBaseName := filepath.Base(targetFile.Filepath) + ".cover"
 

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1654,8 +1654,8 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 	}
 
 	// Apply cover data (caller is responsible for downloading cover URLs before calling persistMetadata).
-	// Skip for files with a cover_page — their covers are derived from page content (e.g. CBZ, PDF).
-	if len(md.CoverData) > 0 && targetFile != nil && targetFile.CoverPage == nil {
+	// Skip for files with page-derived covers: CBZ uses cover_page, PDF renders from page content.
+	if len(md.CoverData) > 0 && targetFile != nil && targetFile.CoverPage == nil && targetFile.FileType != models.FileTypePDF {
 		coverDir := book.Filepath
 		coverBaseName := filepath.Base(targetFile.Filepath) + ".cover"
 

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1653,8 +1653,9 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 		}
 	}
 
-	// Apply cover data (caller is responsible for downloading cover URLs before calling persistMetadata)
-	if len(md.CoverData) > 0 && targetFile != nil {
+	// Apply cover data (caller is responsible for downloading cover URLs before calling persistMetadata).
+	// Skip for files with a cover_page — their covers are derived from page content (e.g. CBZ, PDF).
+	if len(md.CoverData) > 0 && targetFile != nil && targetFile.CoverPage == nil {
 		coverDir := book.Filepath
 		coverBaseName := filepath.Base(targetFile.Filepath) + ".cover"
 

--- a/pkg/worker/scan_enricher_test.go
+++ b/pkg/worker/scan_enricher_test.go
@@ -420,3 +420,106 @@ func TestMergeEnrichedMetadata_NoEnrichers_FileParserOnly(t *testing.T) {
 	assert.Equal(t, "File Author", enrichedMeta.Authors[0].Name)
 	assert.Equal(t, "File Description", enrichedMeta.Description)
 }
+
+// TestCoverPageProtection_EnricherCannotOverridePageCover verifies that when a
+// file parser sets CoverPage (e.g. CBZ/PDF), the enricher's downloaded cover
+// image does not replace the file parser's page-derived cover. This simulates
+// the post-merge logic in runMetadataEnrichers.
+func TestCoverPageProtection_EnricherCannotOverridePageCover(t *testing.T) {
+	t.Parallel()
+
+	fileCoverPage := 0
+	fileSource := "cbz_metadata"
+
+	// File parser provides cover from page content
+	fileMetadata := &mediafile.ParsedMetadata{
+		Title:         "My CBZ Book",
+		CoverData:     []byte("page-derived cover"),
+		CoverMimeType: "image/jpeg",
+		CoverPage:     &fileCoverPage,
+		DataSource:    fileSource,
+		FieldDataSources: map[string]string{
+			"cover": fileSource,
+		},
+	}
+
+	// Enricher provides a downloaded cover image (no CoverPage)
+	enricherSource := "plugin:test/enricher"
+	enricherResult := &mediafile.ParsedMetadata{
+		CoverData:     []byte("enricher-downloaded cover"),
+		CoverMimeType: "image/png",
+	}
+
+	// Simulate runMetadataEnrichers merge order:
+	// 1. Enricher results merge first into empty target
+	var enrichedMeta mediafile.ParsedMetadata
+	mergeEnrichedMetadata(&enrichedMeta, enricherResult, enricherSource)
+
+	// 2. File parser merges as fallback
+	mergeEnrichedMetadata(&enrichedMeta, fileMetadata, fileSource)
+
+	// At this point, enricher's CoverData is in enrichedMeta (it merged first).
+	// But CoverPage came from file parser (enricher didn't set it).
+	// Verify the problematic intermediate state:
+	assert.Equal(t, []byte("enricher-downloaded cover"), enrichedMeta.CoverData)
+	require.NotNil(t, enrichedMeta.CoverPage)
+	assert.Equal(t, 0, *enrichedMeta.CoverPage)
+
+	// 3. Apply CoverPage protection (as runMetadataEnrichers does)
+	if fileMetadata.CoverPage != nil {
+		enrichedMeta.CoverData = fileMetadata.CoverData
+		enrichedMeta.CoverMimeType = fileMetadata.CoverMimeType
+		enrichedMeta.CoverPage = fileMetadata.CoverPage
+		enrichedMeta.FieldDataSources["cover"] = fileMetadata.SourceForField("cover")
+	}
+
+	// File parser's cover should be restored
+	assert.Equal(t, []byte("page-derived cover"), enrichedMeta.CoverData)
+	assert.Equal(t, "image/jpeg", enrichedMeta.CoverMimeType)
+	require.NotNil(t, enrichedMeta.CoverPage)
+	assert.Equal(t, 0, *enrichedMeta.CoverPage)
+	assert.Equal(t, fileSource, enrichedMeta.FieldDataSources["cover"])
+}
+
+// TestCoverPageProtection_NoCoverPage_EnricherCoverPreserved verifies that when
+// a file parser does NOT set CoverPage (e.g. EPUB/M4B), the enricher's cover
+// is preserved as normal.
+func TestCoverPageProtection_NoCoverPage_EnricherCoverPreserved(t *testing.T) {
+	t.Parallel()
+
+	fileSource := "epub_metadata"
+
+	// File parser provides cover but no CoverPage
+	fileMetadata := &mediafile.ParsedMetadata{
+		Title:         "My EPUB Book",
+		CoverData:     []byte("epub-embedded cover"),
+		CoverMimeType: "image/jpeg",
+		DataSource:    fileSource,
+	}
+
+	// Enricher provides a better cover
+	enricherSource := "plugin:test/enricher"
+	enricherResult := &mediafile.ParsedMetadata{
+		CoverData:     []byte("enricher high-res cover"),
+		CoverMimeType: "image/png",
+	}
+
+	// Simulate runMetadataEnrichers merge order
+	var enrichedMeta mediafile.ParsedMetadata
+	mergeEnrichedMetadata(&enrichedMeta, enricherResult, enricherSource)
+	mergeEnrichedMetadata(&enrichedMeta, fileMetadata, fileSource)
+
+	// CoverPage protection should NOT trigger (no CoverPage)
+	if fileMetadata.CoverPage != nil {
+		enrichedMeta.CoverData = fileMetadata.CoverData
+		enrichedMeta.CoverMimeType = fileMetadata.CoverMimeType
+		enrichedMeta.CoverPage = fileMetadata.CoverPage
+		enrichedMeta.FieldDataSources["cover"] = fileMetadata.SourceForField("cover")
+	}
+
+	// Enricher's cover should be preserved
+	assert.Equal(t, []byte("enricher high-res cover"), enrichedMeta.CoverData)
+	assert.Equal(t, "image/png", enrichedMeta.CoverMimeType)
+	assert.Nil(t, enrichedMeta.CoverPage)
+	assert.Equal(t, enricherSource, enrichedMeta.FieldDataSources["cover"])
+}

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2696,6 +2696,15 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 	// This gives enrichers priority over file metadata (priority 2 > priority 3).
 	mergeEnrichedMetadata(&enrichedMeta, metadata, metadata.DataSource)
 
+	// If the file parser set CoverPage, the cover is derived from page content
+	// (e.g. CBZ/PDF) and must not be replaced by an enricher-downloaded image.
+	if metadata.CoverPage != nil {
+		enrichedMeta.CoverData = metadata.CoverData
+		enrichedMeta.CoverMimeType = metadata.CoverMimeType
+		enrichedMeta.CoverPage = metadata.CoverPage
+		enrichedMeta.FieldDataSources["cover"] = metadata.SourceForField("cover")
+	}
+
 	// Copy technical fields that enrichers don't provide
 	enrichedMeta.Duration = metadata.Duration
 	enrichedMeta.BitrateBps = metadata.BitrateBps

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2696,9 +2696,9 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 	// This gives enrichers priority over file metadata (priority 2 > priority 3).
 	mergeEnrichedMetadata(&enrichedMeta, metadata, metadata.DataSource)
 
-	// If the file parser set CoverPage, the cover is derived from page content
-	// (e.g. CBZ/PDF) and must not be replaced by an enricher-downloaded image.
-	if metadata.CoverPage != nil {
+	// Files with page-derived covers must not have them replaced by enricher images:
+	// CBZ uses CoverPage, PDF renders from page content.
+	if metadata.CoverPage != nil || file.FileType == models.FileTypePDF {
 		enrichedMeta.CoverData = metadata.CoverData
 		enrichedMeta.CoverMimeType = metadata.CoverMimeType
 		enrichedMeta.CoverPage = metadata.CoverPage

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2696,9 +2696,9 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 	// This gives enrichers priority over file metadata (priority 2 > priority 3).
 	mergeEnrichedMetadata(&enrichedMeta, metadata, metadata.DataSource)
 
-	// Files with page-derived covers must not have them replaced by enricher images:
-	// CBZ uses CoverPage, PDF renders from page content.
-	if metadata.CoverPage != nil || file.FileType == models.FileTypePDF {
+	// Files with CoverPage derive covers from page content (CBZ, PDF) and must
+	// not have them replaced by enricher-downloaded images.
+	if metadata.CoverPage != nil {
 		enrichedMeta.CoverData = metadata.CoverData
 		enrichedMeta.CoverMimeType = metadata.CoverMimeType
 		enrichedMeta.CoverPage = metadata.CoverPage


### PR DESCRIPTION
## Summary
- Fix broken cover image placeholder, normalize release dates, and merge identifiers by default instead of replacing
- Prevent cover overwrites for page-based formats (CBZ/PDF) across identify UI, plugin apply, upload API, and scan enricher pipeline
- UI polish: add cover resolution display, external link button for URLs, formatted identifier labels with read-only list, constrain dialog width on wide screens, and await query invalidation so covers refresh immediately

## Test plan
- Open identify dialog for a book without a cover — should show only the new cover option, no broken image
- Identify a book where both current and incoming have the same release date with/without time suffix — should show "Unchanged" not "Changed"
- Identify a book that has existing identifiers — default should merge current + incoming, "Use current" reverts to current only
- Identify a CBZ or PDF file — cover section should not appear
- Upload a cover for a CBZ/PDF file via the file edit dialog — upload button should be hidden
- Apply changes in identify — cover should refresh on the book detail page without manual reload
- On a wide screen, dialog content should not overflow past the dialog border
- Identifiers section should show formatted labels (e.g. "ISBN-13" not "isbn_13") with no text input