### PR TITLE
[Feature] Add PDF cover page selection

### DIFF
--- a/app/components/files/ChapterRow.tsx
+++ b/app/components/files/ChapterRow.tsx
@@ -38,6 +38,7 @@ import {
   FileTypeCBZ,
   FileTypeEPUB,
   FileTypeM4B,
+  FileTypePDF,
   type Chapter,
   type FileType,
 } from "@/types";
@@ -153,10 +154,10 @@ export interface ChapterRowProps {
   playingChapterIndex?: number | null;
   onPlay?: (chapterIndex: number, timestampMs: number) => void;
   onStop?: () => void;
-  // CBZ view mode: navigation to reader
+  // Page-based view mode: navigation to reader
   libraryId?: number;
   bookId?: number;
-  // CBZ
+  // Page-based (CBZ, PDF)
   fileId?: number;
   pageCount?: number;
   // M4B
@@ -190,6 +191,8 @@ const ChapterRow = (props: ChapterRowProps) => {
   const hasChildren = children.length > 0;
   const isEpub = fileType === FileTypeEPUB;
   const isCbz = fileType === FileTypeCBZ;
+  const isPdf = fileType === FileTypePDF;
+  const isPageBased = isCbz || isPdf;
   const isM4b = fileType === FileTypeM4B;
   const isPlaying =
     chapterIndex != null && playingChapterIndex === chapterIndex;
@@ -439,8 +442,8 @@ const ChapterRow = (props: ChapterRowProps) => {
     );
   }
 
-  // CBZ edit mode
-  if (isEditing && isCbz) {
+  // Page-based edit mode (CBZ, PDF)
+  if (isEditing && isPageBased) {
     return (
       <div className="flex items-center gap-3 py-2 border-b border-border last:border-b-0">
         {/* Small thumbnail with hover preview (clickable to open page picker) */}
@@ -629,7 +632,7 @@ const ChapterRow = (props: ChapterRowProps) => {
         ) : null}
 
         {/* Page thumbnail with hover preview */}
-        {isCbz && chapter.start_page != null && fileId != null && (
+        {isPageBased && chapter.start_page != null && fileId != null && (
           <PagePreview
             fileId={fileId}
             page={chapter.start_page}
@@ -637,8 +640,8 @@ const ChapterRow = (props: ChapterRowProps) => {
           />
         )}
 
-        {/* Chapter title - clickable for CBZ to open reader at this chapter */}
-        {isCbz &&
+        {/* Chapter title - clickable for page-based files to open reader at this chapter */}
+        {isPageBased &&
         libraryId &&
         bookId &&
         fileId &&
@@ -654,7 +657,7 @@ const ChapterRow = (props: ChapterRowProps) => {
         )}
 
         {/* Position display based on file type (1-indexed for user display) */}
-        {isCbz && chapter.start_page != null && (
+        {isPageBased && chapter.start_page != null && (
           <span className="text-muted-foreground text-sm">
             Page {chapter.start_page + 1}
           </span>

--- a/app/components/files/ChapterRow.tsx
+++ b/app/components/files/ChapterRow.tsx
@@ -1,10 +1,10 @@
-import CBZPagePicker from "./CBZPagePicker";
-import CBZPagePreview from "./CBZPagePreview";
 import {
   countDescendants,
   formatTimestampMs,
   parseTimestampMs,
 } from "./chapterUtils";
+import PagePicker from "./PagePicker";
+import PagePreview from "./PagePreview";
 import {
   ChevronDown,
   ChevronLeft,
@@ -445,7 +445,7 @@ const ChapterRow = (props: ChapterRowProps) => {
       <div className="flex items-center gap-3 py-2 border-b border-border last:border-b-0">
         {/* Small thumbnail with hover preview (clickable to open page picker) */}
         {fileId != null && (
-          <CBZPagePreview
+          <PagePreview
             fileId={fileId}
             onClick={() => setPagePickerOpen(true)}
             page={currentPage}
@@ -508,7 +508,7 @@ const ChapterRow = (props: ChapterRowProps) => {
 
         {/* Page picker dialog */}
         {fileId != null && (
-          <CBZPagePicker
+          <PagePicker
             currentPage={currentPage}
             fileId={fileId}
             key={fileId}
@@ -628,9 +628,9 @@ const ChapterRow = (props: ChapterRowProps) => {
           <div className="w-5" />
         ) : null}
 
-        {/* CBZ: Page thumbnail with hover preview */}
+        {/* Page thumbnail with hover preview */}
         {isCbz && chapter.start_page != null && fileId != null && (
-          <CBZPagePreview
+          <PagePreview
             fileId={fileId}
             page={chapter.start_page}
             thumbnailSize={60}

--- a/app/components/files/ChapterRow.tsx
+++ b/app/components/files/ChapterRow.tsx
@@ -144,7 +144,7 @@ export interface ChapterRowProps {
   onStartTimestampChange?: (ms: number) => void;
   onDelete?: () => void;
   onValidationChange?: (chapterId: number, hasError: boolean) => void;
-  // CBZ edit mode: called when page input loses focus (for reordering)
+  // Page-based edit mode: called when page input loses focus (for reordering)
   onBlur?: () => void;
   // EPUB edit mode: callbacks for child chapter editing (curried by index)
   onChildTitleChange?: (childIndex: number) => (title: string) => void;
@@ -168,7 +168,7 @@ export interface ChapterRowProps {
  * Renders a single chapter row with type-specific display.
  *
  * View mode: Displays chapter title, position (based on file type), and thumbnail/play button.
- * Edit mode: Supports inline editing for EPUB (titles only), CBZ (titles + pages), and M4B (titles + timestamps).
+ * Edit mode: Supports inline editing for EPUB (titles only), CBZ/PDF (titles + pages), and M4B (titles + timestamps).
  *
  * Handles recursive rendering of children chapters (for EPUB hierarchy).
  */
@@ -206,7 +206,7 @@ const ChapterRow = (props: ChapterRowProps) => {
   // State for delete confirmation dialog (EPUB only)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-  // CBZ edit mode state: local page value and validation
+  // Page-based edit mode state: local page value and validation
   // Internal data is 0-indexed, but UI displays 1-indexed
   const currentPage = chapter.start_page ?? 0;
   const [localPageValue, setLocalPageValue] = useState(String(currentPage + 1));
@@ -233,13 +233,13 @@ const ChapterRow = (props: ChapterRowProps) => {
     setHasTimestampError(false);
   }, [chapter.start_timestamp_ms]);
 
-  // CBZ helper: Validate page number (1-indexed display value)
+  // Page helper: Validate page number (1-indexed display value)
   const pageCount = props.pageCount ?? 0;
   const validatePage = (displayValue: number): boolean => {
     return displayValue >= 1 && displayValue <= pageCount;
   };
 
-  // CBZ handler: Page input change (input is 1-indexed, convert to 0-indexed for storage)
+  // Page handler: Page input change (input is 1-indexed, convert to 0-indexed for storage)
   const handlePageInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setLocalPageValue(value);
@@ -256,7 +256,7 @@ const ChapterRow = (props: ChapterRowProps) => {
     }
   };
 
-  // CBZ handler: Decrement page
+  // Page handler: Decrement page
   const handleDecrementPage = () => {
     const newPage = Math.max(0, currentPage - 1);
     setLocalPageValue(String(newPage + 1)); // Display is 1-indexed
@@ -265,7 +265,7 @@ const ChapterRow = (props: ChapterRowProps) => {
     props.onBlur?.();
   };
 
-  // CBZ handler: Increment page
+  // Page handler: Increment page
   const handleIncrementPage = () => {
     const newPage = Math.min(pageCount - 1, currentPage + 1);
     setLocalPageValue(String(newPage + 1)); // Display is 1-indexed
@@ -274,7 +274,7 @@ const ChapterRow = (props: ChapterRowProps) => {
     props.onBlur?.();
   };
 
-  // CBZ handler: Page selection from picker (receives 0-indexed page)
+  // Page handler: Page selection from picker (receives 0-indexed page)
   const handlePageSelect = (page: number) => {
     setLocalPageValue(String(page + 1)); // Display is 1-indexed
     setHasPageError(false);
@@ -498,7 +498,7 @@ const ChapterRow = (props: ChapterRowProps) => {
           </Button>
         </div>
 
-        {/* Delete button (immediate, no confirmation for CBZ) */}
+        {/* Delete button (immediate, no confirmation for page-based files) */}
         <Button
           onClick={() => props.onDelete?.()}
           size="icon"

--- a/app/components/files/FileChaptersTab.tsx
+++ b/app/components/files/FileChaptersTab.tsx
@@ -25,6 +25,7 @@ import {
   FileTypeCBZ,
   FileTypeEPUB,
   FileTypeM4B,
+  FileTypePDF,
   type Chapter,
   type ChapterInput,
   type File,
@@ -59,7 +60,7 @@ const createNewChapter = (fileType: string): ChapterInput => {
     children: [],
   };
 
-  if (fileType === FileTypeCBZ) {
+  if (fileType === FileTypeCBZ || fileType === FileTypePDF) {
     chapter.start_page = 0;
   } else if (fileType === FileTypeM4B) {
     chapter.start_timestamp_ms = 0;
@@ -581,11 +582,14 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     // Empty state (or edit mode with new chapters from empty state)
     if (chapters.length === 0) {
       const canAddChapters =
-        file.file_type === FileTypeCBZ || file.file_type === FileTypeM4B;
+        file.file_type === FileTypeCBZ ||
+        file.file_type === FileTypePDF ||
+        file.file_type === FileTypeM4B;
 
       // When editing with chapters (entered via Add Chapter button), show edit UI
       if (isEditing && editedChapters.length > 0) {
-        const isCbz = file.file_type === FileTypeCBZ;
+        const isPageBased =
+          file.file_type === FileTypeCBZ || file.file_type === FileTypePDF;
         const isM4b = file.file_type === FileTypeM4B;
         const maxDurationMs = file.audiobook_duration_seconds
           ? file.audiobook_duration_seconds * 1000
@@ -612,7 +616,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
                 key={`edit-${index}`}
                 maxDurationMs={isM4b ? maxDurationMs : undefined}
                 onBlur={
-                  isCbz
+                  isPageBased
                     ? handleBlurReorder
                     : isM4b
                       ? handleTimestampBlurReorder
@@ -623,7 +627,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
                 }
                 onPlay={isM4b ? handleChapterPlay : undefined}
                 onStartPageChange={
-                  isCbz
+                  isPageBased
                     ? (page) =>
                         setEditedChapters((prev) =>
                           updateChapterStartPage(prev, index, page),
@@ -650,13 +654,13 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
                         handleValidationChange(index, hasError)
                     : undefined
                 }
-                pageCount={isCbz ? (file.page_count ?? 0) : undefined}
+                pageCount={isPageBased ? (file.page_count ?? 0) : undefined}
                 playingChapterIndex={isM4b ? playingChapterIndex : undefined}
               />
             ))}
 
-            {/* Add Chapter button for CBZ */}
-            {isCbz && (
+            {/* Add Chapter button for page-based files */}
+            {isPageBased && (
               <Button
                 className="mt-2"
                 onClick={handleAddChapter}
@@ -698,11 +702,11 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
       );
     }
 
-    // Check for CBZ uncovered pages (first chapter starts after page 0)
+    // Check for uncovered pages (first chapter starts after page 0)
+    const isPageBased =
+      file.file_type === FileTypeCBZ || file.file_type === FileTypePDF;
     const firstChapterStartPage =
-      file.file_type === FileTypeCBZ && chapters.length > 0
-        ? chapters[0].start_page
-        : null;
+      isPageBased && chapters.length > 0 ? chapters[0].start_page : null;
     const hasUncoveredPages =
       firstChapterStartPage != null && firstChapterStartPage > 0;
 
@@ -712,7 +716,6 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     // Edit mode rendering
     if (isEditing) {
       const isEpub = file.file_type === FileTypeEPUB;
-      const isCbz = file.file_type === FileTypeCBZ;
       const isM4b = file.file_type === FileTypeM4B;
       const maxDurationMs = file.audiobook_duration_seconds
         ? file.audiobook_duration_seconds * 1000
@@ -745,7 +748,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
               key={`edit-${index}`}
               maxDurationMs={isM4b ? maxDurationMs : undefined}
               onBlur={
-                isCbz
+                isPageBased
                   ? handleBlurReorder
                   : isM4b
                     ? handleTimestampBlurReorder
@@ -762,7 +765,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
               }
               onPlay={isM4b ? handleChapterPlay : undefined}
               onStartPageChange={
-                isCbz
+                isPageBased
                   ? (page) =>
                       setEditedChapters((prev) =>
                         updateChapterStartPage(prev, index, page),
@@ -789,13 +792,13 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
                       handleValidationChange(index, hasError)
                   : undefined
               }
-              pageCount={isCbz ? (file.page_count ?? 0) : undefined}
+              pageCount={isPageBased ? (file.page_count ?? 0) : undefined}
               playingChapterIndex={isM4b ? playingChapterIndex : undefined}
             />
           ))}
 
-          {/* Add Chapter button for CBZ */}
-          {isCbz && (
+          {/* Add Chapter button for page-based files */}
+          {isPageBased && (
             <Button
               className="mt-2"
               onClick={handleAddChapter}

--- a/app/components/files/FileChaptersTab.tsx
+++ b/app/components/files/FileChaptersTab.tsx
@@ -51,7 +51,7 @@ interface FileChaptersTabProps {
 
 /**
  * Creates a new chapter with appropriate defaults based on file type.
- * - CBZ: start_page defaults to 0
+ * - CBZ/PDF: start_page defaults to 0
  * - M4B: start_timestamp_ms defaults to 0
  */
 const createNewChapter = (fileType: string): ChapterInput => {
@@ -298,7 +298,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     };
 
     /**
-     * Handles clicking the uncovered pages warning for CBZ files.
+     * Handles clicking the uncovered pages warning for page-based files.
      * Adds a new chapter at page 0 and enters edit mode.
      */
     const handleAddChapterAtPageZero = () => {
@@ -385,7 +385,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     };
 
     /**
-     * Handles adding a new chapter for CBZ files.
+     * Handles adding a new chapter for page-based files.
      * Defaults:
      * - Start page: last chapter's start_page + 1 (or 0 if no chapters)
      * - Title: pattern detection from last chapter title
@@ -834,7 +834,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
           <audio ref={audioRef} src={`/api/books/files/${file.id}/stream`} />
         )}
 
-        {/* CBZ uncovered pages warning (display uses 1-indexed page numbers) */}
+        {/* Uncovered pages warning (display uses 1-indexed page numbers) */}
         {hasUncoveredPages && (
           <button
             className="w-full flex items-center gap-3 py-2 px-3 mb-2 border border-amber-500/50 bg-amber-500/10 rounded-md text-left hover:bg-amber-500/20 transition-colors cursor-pointer"

--- a/app/components/files/PagePicker.tsx
+++ b/app/components/files/PagePicker.tsx
@@ -47,14 +47,36 @@ const PagePicker = ({
   const thumbnailStripRef = useRef<HTMLDivElement>(null);
   const thumbnailRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
 
+  // Progressive thumbnail loading: main preview loads first, then thumbnails
+  // expand outward from the focused page. Only applies on initial open —
+  // once thumbnails are unlocked, navigating uses browser cache.
+  const [previewLoaded, setPreviewLoaded] = useState(false);
+  const [thumbnailLoadRadius, setThumbnailLoadRadius] = useState(0);
+
   // Reset state when dialog opens
   const handleOpenChange = (newOpen: boolean) => {
     if (newOpen) {
       setFocusedPage(currentPage ?? 0);
       setLoadedPage(null);
+      setPreviewLoaded(false);
+      setThumbnailLoadRadius(0);
     }
     onOpenChange(newOpen);
   };
+
+  // After the main preview loads, progressively expand thumbnail loading
+  useEffect(() => {
+    if (!previewLoaded || !open) return;
+
+    const maxRadius = 20;
+    if (thumbnailLoadRadius >= maxRadius) return;
+
+    const timer = setTimeout(() => {
+      setThumbnailLoadRadius((prev) => Math.min(prev + 3, maxRadius));
+    }, 50);
+
+    return () => clearTimeout(timer);
+  }, [previewLoaded, thumbnailLoadRadius, open]);
 
   // Navigate to previous/next page
   const goToPrevious = useCallback(() => {
@@ -225,7 +247,10 @@ const PagePicker = ({
             <img
               alt={`Page ${focusedPage + 1}`}
               className="max-h-full max-w-full object-contain rounded shadow-2xl"
-              onLoad={() => setLoadedPage(focusedPage)}
+              onLoad={() => {
+                setLoadedPage(focusedPage);
+                if (!previewLoaded) setPreviewLoaded(true);
+              }}
               src={`/api/books/files/${fileId}/page/${focusedPage}`}
             />
           </div>
@@ -273,12 +298,17 @@ const PagePicker = ({
                     style={{ width: "72px", height: "96px" }}
                     type="button"
                   >
-                    <img
-                      alt={`Page ${page + 1}`}
-                      className="w-full h-full object-contain"
-                      loading="lazy"
-                      src={`/api/books/files/${fileId}/page/${page}`}
-                    />
+                    {previewLoaded &&
+                    Math.abs(page - focusedPage) <= thumbnailLoadRadius ? (
+                      <img
+                        alt={`Page ${page + 1}`}
+                        className="w-full h-full object-contain"
+                        loading="lazy"
+                        src={`/api/books/files/${fileId}/page/${page}`}
+                      />
+                    ) : (
+                      <div className="w-full h-full bg-muted animate-pulse" />
+                    )}
                     <div
                       className={cn(
                         "absolute bottom-0 left-0 right-0 text-xs text-center py-0.5 font-medium tabular-nums",

--- a/app/components/files/PagePicker.tsx
+++ b/app/components/files/PagePicker.tsx
@@ -17,7 +17,7 @@ import { FormDialog } from "@/components/ui/form-dialog";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import { cn } from "@/libraries/utils";
 
-export interface CBZPagePickerProps {
+export interface PagePickerProps {
   fileId: number;
   pageCount: number;
   currentPage: number | null;
@@ -28,10 +28,10 @@ export interface CBZPagePickerProps {
 }
 
 /**
- * Dialog for selecting a page from a CBZ file.
+ * Dialog for selecting a page from a file.
  * Shows a large preview of the focused page with a scrollable thumbnail strip below.
  */
-const CBZPagePicker = ({
+const PagePicker = ({
   fileId,
   pageCount,
   currentPage,
@@ -39,7 +39,7 @@ const CBZPagePicker = ({
   open,
   onOpenChange,
   title = "Select Page",
-}: CBZPagePickerProps) => {
+}: PagePickerProps) => {
   // Track the currently focused/previewed page (not necessarily the selected one)
   const [focusedPage, setFocusedPage] = useState<number>(currentPage ?? 0);
   // Track the last loaded page to avoid flashing during transitions
@@ -344,4 +344,4 @@ const CBZPagePicker = ({
   );
 };
 
-export default CBZPagePicker;
+export default PagePicker;

--- a/app/components/files/PagePreview.tsx
+++ b/app/components/files/PagePreview.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/hover-card";
 import { cn } from "@/libraries/utils";
 
-export interface CBZPagePreviewProps {
+export interface PagePreviewProps {
   fileId: number;
   /** 0-indexed page number */
   page: number;
@@ -27,12 +27,12 @@ export interface CBZPagePreviewProps {
 }
 
 /**
- * CBZ page thumbnail with hover preview.
+ * Page thumbnail with hover preview.
  *
  * Shows a small thumbnail that displays a larger preview on hover.
  * Can wrap custom children or render a default thumbnail.
  */
-const CBZPagePreview = ({
+const PagePreview = ({
   fileId,
   page,
   thumbnailSize = 60,
@@ -41,7 +41,7 @@ const CBZPagePreview = ({
   className,
   onClick,
   children,
-}: CBZPagePreviewProps) => {
+}: PagePreviewProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const [previewLoading, setPreviewLoading] = useState(true);
@@ -138,4 +138,4 @@ const CBZPagePreview = ({
   );
 };
 
-export default CBZPagePreview;
+export default PagePreview;

--- a/app/components/files/PageThumbnail.tsx
+++ b/app/components/files/PageThumbnail.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { cn } from "@/libraries/utils";
 
-export interface CBZPageThumbnailProps {
+export interface PageThumbnailProps {
   fileId: number;
   page: number;
   size?: number;
@@ -10,17 +10,17 @@ export interface CBZPageThumbnailProps {
 }
 
 /**
- * Renders a thumbnail image for a CBZ page.
+ * Renders a thumbnail image for a page.
  *
  * Shows a grey placeholder while loading and displays the page number
  * if the image fails to load.
  */
-const CBZPageThumbnail = ({
+const PageThumbnail = ({
   fileId,
   page,
   size = 60,
   onClick,
-}: CBZPageThumbnailProps) => {
+}: PageThumbnailProps) => {
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
 
@@ -68,4 +68,4 @@ const CBZPageThumbnail = ({
   );
 };
 
-export default CBZPageThumbnail;
+export default PageThumbnail;

--- a/app/components/library/FileEditDialog.test.tsx
+++ b/app/components/library/FileEditDialog.test.tsx
@@ -64,7 +64,7 @@ vi.mock("@/components/files/PagePicker", () => ({
     open: boolean;
   }) =>
     open ? (
-      <div data-testid="cbz-page-picker">
+      <div data-testid="page-picker">
         <button data-testid="select-page-5" onClick={() => onSelect(5)}>
           Select Page 5
         </button>
@@ -286,7 +286,7 @@ describe("FileEditDialog", () => {
 
       // Wait for picker to appear
       await waitFor(() => {
-        expect(screen.getByTestId("cbz-page-picker")).toBeInTheDocument();
+        expect(screen.getByTestId("page-picker")).toBeInTheDocument();
       });
 
       // Select a different page
@@ -294,7 +294,7 @@ describe("FileEditDialog", () => {
 
       // Verify the cover page change is reflected (picker should close)
       await waitFor(() => {
-        expect(screen.queryByTestId("cbz-page-picker")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("page-picker")).not.toBeInTheDocument();
       });
 
       // At this point, pendingCoverPage should be 5, hasChanges should be true

--- a/app/components/library/FileEditDialog.test.tsx
+++ b/app/components/library/FileEditDialog.test.tsx
@@ -54,8 +54,8 @@ vi.mock("@/hooks/queries/plugins", () => ({
   usePluginIdentifierTypes: () => ({ data: [] }),
 }));
 
-// Mock CBZPagePicker
-vi.mock("@/components/files/CBZPagePicker", () => ({
+// Mock PagePicker
+vi.mock("@/components/files/PagePicker", () => ({
   default: ({
     onSelect,
     open,

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
-import CBZPagePicker from "@/components/files/CBZPagePicker";
+import PagePicker from "@/components/files/PagePicker";
 import CoverPlaceholder from "@/components/library/CoverPlaceholder";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -782,9 +782,9 @@ export function FileEditDialog({
                 </div>
               </div>
 
-              {/* CBZ Page Picker Dialog */}
+              {/* Page Picker Dialog */}
               {file.file_type === FileTypeCBZ && file.page_count != null && (
-                <CBZPagePicker
+                <PagePicker
                   currentPage={pendingCoverPage ?? file.cover_page ?? null}
                   fileId={file.id}
                   onOpenChange={setCoverPagePickerOpen}

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -659,7 +659,7 @@ export function FileEditDialog({
                           : "aspect-[2/3]",
                       )}
                     >
-                      {/* Non-CBZ: Show pending preview or current cover */}
+                      {/* Non-page-based: Show pending preview or current cover */}
                       {file.cover_page == null && (
                         <>
                           {pendingCoverPreview ? (
@@ -685,7 +685,7 @@ export function FileEditDialog({
                           )}
                         </>
                       )}
-                      {/* CBZ: Show pending page or current cover */}
+                      {/* Page-based: Show pending page or current cover */}
                       {file.cover_page != null && (
                         <>
                           {pendingCoverPage !== null &&
@@ -711,7 +711,7 @@ export function FileEditDialog({
                         </>
                       )}
                     </div>
-                    {/* Page number badge for CBZ */}
+                    {/* Page number badge */}
                     {file.cover_page != null &&
                       (pendingCoverPage ?? file.cover_page) != null && (
                         <div className="absolute bottom-1.5 left-1.5 px-1.5 py-0.5 rounded bg-black/70 text-white text-xs font-medium">
@@ -752,7 +752,7 @@ export function FileEditDialog({
                         </Button>
                       </>
                     )}
-                    {/* CBZ: Select page button */}
+                    {/* Select page button */}
                     {file.cover_page != null && (
                       <Button
                         disabled={setCoverPageMutation.isPending}

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -660,7 +660,7 @@ export function FileEditDialog({
                       )}
                     >
                       {/* Non-CBZ: Show pending preview or current cover */}
-                      {file.file_type !== FileTypeCBZ && (
+                      {file.cover_page == null && (
                         <>
                           {pendingCoverPreview ? (
                             <img
@@ -686,7 +686,7 @@ export function FileEditDialog({
                         </>
                       )}
                       {/* CBZ: Show pending page or current cover */}
-                      {file.file_type === FileTypeCBZ && (
+                      {file.cover_page != null && (
                         <>
                           {pendingCoverPage !== null &&
                           pendingCoverPage !== file.cover_page ? (
@@ -712,7 +712,7 @@ export function FileEditDialog({
                       )}
                     </div>
                     {/* Page number badge for CBZ */}
-                    {file.file_type === FileTypeCBZ &&
+                    {file.cover_page != null &&
                       (pendingCoverPage ?? file.cover_page) != null && (
                         <div className="absolute bottom-1.5 left-1.5 px-1.5 py-0.5 rounded bg-black/70 text-white text-xs font-medium">
                           Page {(pendingCoverPage ?? file.cover_page)! + 1}
@@ -753,7 +753,7 @@ export function FileEditDialog({
                       </>
                     )}
                     {/* CBZ: Select page button */}
-                    {file.file_type === FileTypeCBZ && (
+                    {file.cover_page != null && (
                       <Button
                         disabled={setCoverPageMutation.isPending}
                         onClick={() => setCoverPagePickerOpen(true)}
@@ -770,8 +770,8 @@ export function FileEditDialog({
                       </Button>
                     )}
                     {/* Unsaved indicator */}
-                    {((file.file_type !== FileTypeCBZ && pendingCoverFile) ||
-                      (file.file_type === FileTypeCBZ &&
+                    {((file.cover_page == null && pendingCoverFile) ||
+                      (file.cover_page != null &&
                         pendingCoverPage !== null &&
                         pendingCoverPage !== file.cover_page)) && (
                       <span className="text-xs text-orange-500 font-medium">
@@ -783,7 +783,7 @@ export function FileEditDialog({
               </div>
 
               {/* Page Picker Dialog */}
-              {file.file_type === FileTypeCBZ && file.page_count != null && (
+              {file.cover_page != null && file.page_count != null && (
                 <PagePicker
                   currentPage={pendingCoverPage ?? file.cover_page ?? null}
                   fileId={file.id}

--- a/docs/superpowers/plans/2026-03-28-pdf-cover-page-selection.md
+++ b/docs/superpowers/plans/2026-03-28-pdf-cover-page-selection.md
@@ -1,0 +1,445 @@
+# PDF Cover Page Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to select which page of a PDF to use as the cover image, using the same page picker UI that CBZ files use.
+
+**Architecture:** Remove the CBZ-only restriction from the cover page handler, route to the correct page cache by file type, and use `cover_page != null` as the universal discriminator for the page-based cover workflow in the frontend.
+
+**Tech Stack:** Go (Echo handlers, pdfpages cache), React/TypeScript (PagePicker component, FileEditDialog)
+
+---
+
+### Task 1: Rename CBZ Page Components to Generic Names
+
+Rename the three CBZ-specific page components to generic names and update all imports.
+
+**Files:**
+- Rename: `app/components/files/CBZPagePicker.tsx` → `app/components/files/PagePicker.tsx`
+- Rename: `app/components/files/CBZPagePreview.tsx` → `app/components/files/PagePreview.tsx`
+- Rename: `app/components/files/CBZPageThumbnail.tsx` → `app/components/files/PageThumbnail.tsx`
+- Modify: `app/components/library/FileEditDialog.tsx` (import path)
+- Modify: `app/components/library/FileEditDialog.test.tsx` (mock path)
+- Modify: `app/components/files/ChapterRow.tsx` (import paths)
+
+- [ ] **Step 1: Rename `CBZPagePicker.tsx` → `PagePicker.tsx`**
+
+Rename the file and update internal names:
+
+```bash
+mv app/components/files/CBZPagePicker.tsx app/components/files/PagePicker.tsx
+```
+
+In `app/components/files/PagePicker.tsx`:
+- Rename interface `CBZPagePickerProps` → `PagePickerProps`
+- Rename component `CBZPagePicker` → `PagePicker`
+- Update JSDoc comment: "Dialog for selecting a page from a file." (remove "CBZ")
+- Update default export
+
+- [ ] **Step 2: Rename `CBZPagePreview.tsx` → `PagePreview.tsx`**
+
+```bash
+mv app/components/files/CBZPagePreview.tsx app/components/files/PagePreview.tsx
+```
+
+In `app/components/files/PagePreview.tsx`:
+- Rename interface `CBZPagePreviewProps` → `PagePreviewProps`
+- Rename component `CBZPagePreview` → `PagePreview`
+- Update JSDoc comments (remove "CBZ" references)
+- Update default export
+
+- [ ] **Step 3: Rename `CBZPageThumbnail.tsx` → `PageThumbnail.tsx`**
+
+```bash
+mv app/components/files/CBZPageThumbnail.tsx app/components/files/PageThumbnail.tsx
+```
+
+In `app/components/files/PageThumbnail.tsx`:
+- Rename interface `CBZPageThumbnailProps` → `PageThumbnailProps`
+- Rename component `CBZPageThumbnail` → `PageThumbnail`
+- Update JSDoc comments (remove "CBZ" references)
+- Update default export
+
+- [ ] **Step 4: Update all imports**
+
+In `app/components/library/FileEditDialog.tsx` (line 15):
+```tsx
+// Old
+import CBZPagePicker from "@/components/files/CBZPagePicker";
+// New
+import PagePicker from "@/components/files/PagePicker";
+```
+
+Also update the JSX usage (line 787):
+```tsx
+// Old
+<CBZPagePicker
+// New
+<PagePicker
+```
+
+In `app/components/library/FileEditDialog.test.tsx` (line 58):
+```tsx
+// Old
+vi.mock("@/components/files/CBZPagePicker", () => ({
+// New
+vi.mock("@/components/files/PagePicker", () => ({
+```
+
+In `app/components/files/ChapterRow.tsx` (lines 1-2):
+```tsx
+// Old
+import CBZPagePicker from "./CBZPagePicker";
+import CBZPagePreview from "./CBZPagePreview";
+// New
+import PagePicker from "./PagePicker";
+import PagePreview from "./PagePreview";
+```
+
+Also update all JSX usages of `CBZPagePicker` → `PagePicker` and `CBZPagePreview` → `PagePreview` in ChapterRow.tsx (lines 448, 511, 633).
+
+- [ ] **Step 5: Run lint to verify no broken imports**
+
+Run: `pnpm lint:types`
+Expected: PASS (no type errors)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A app/components/files/PagePicker.tsx app/components/files/PagePreview.tsx \
+  app/components/files/PageThumbnail.tsx app/components/library/FileEditDialog.tsx \
+  app/components/library/FileEditDialog.test.tsx app/components/files/ChapterRow.tsx
+git commit -m "[Frontend] Rename CBZ page components to generic PagePicker/PagePreview/PageThumbnail"
+```
+
+---
+
+### Task 2: Update Backend Handler to Support PDF
+
+Remove the CBZ-only file type restriction and route to the correct page cache based on file type.
+
+**Files:**
+- Modify: `pkg/books/handlers_cover_page.go:19-68`
+
+- [ ] **Step 1: Write the failing test — PDF cover page selection**
+
+In `pkg/books/handlers_cover_page_test.go`, add a new test after the existing "sets cover page and extracts cover image" test. This test creates a PDF file (using a real PDF rendered via pdfpages), sets cover page 0, and verifies the cover is extracted.
+
+However, PDF page rendering requires the pdfium WASM runtime which is heavy for unit tests. Instead, the test should verify the **handler logic** — that PDF files are accepted and routed to the pdfPageCache. We can test with a mock-like approach: create a PDF file record and use the pdfPageCache. Since we can't easily create a real PDF in tests, we'll test the validation path instead.
+
+Add this test to `pkg/books/handlers_cover_page_test.go` inside `TestUpdateFileCoverPage`:
+
+```go
+t.Run("returns 400 for file without page count", func(t *testing.T) {
+    // This test already exists — skip
+})
+
+t.Run("accepts PDF file type", func(t *testing.T) {
+    t.Parallel()
+    db := setupTestDB(t)
+    ctx := context.Background()
+    e := echo.New()
+    bookService := NewService(db)
+
+    h := &handler{
+        bookService: bookService,
+        // Note: no pageCache or pdfPageCache — we test that validation passes
+        // and the handler reaches the page extraction step (which will fail
+        // because pdfPageCache is nil, but that proves the file type check passed)
+    }
+
+    // Create test library
+    library := &models.Library{
+        Name:                     "Test Library",
+        CoverAspectRatio:         "book",
+        DownloadFormatPreference: models.DownloadFormatOriginal,
+    }
+    _, err := db.NewInsert().Model(library).Exec(ctx)
+    require.NoError(t, err)
+
+    bookDir := filepath.Join(t.TempDir(), "Test Book")
+    err = os.MkdirAll(bookDir, 0755)
+    require.NoError(t, err)
+
+    book := &models.Book{
+        LibraryID:       library.ID,
+        Title:           "Test Book",
+        TitleSource:     models.DataSourceFilepath,
+        SortTitle:       "Test Book",
+        SortTitleSource: models.DataSourceFilepath,
+        AuthorSource:    models.DataSourceFilepath,
+        Filepath:        bookDir,
+    }
+    _, err = db.NewInsert().Model(book).Exec(ctx)
+    require.NoError(t, err)
+
+    // Create PDF file with page count
+    pageCount := 10
+    file := &models.File{
+        LibraryID:     library.ID,
+        BookID:        book.ID,
+        FileType:      models.FileTypePDF,
+        FileRole:      models.FileRoleMain,
+        Filepath:      filepath.Join(bookDir, "test.pdf"),
+        FilesizeBytes: 1000,
+        PageCount:     &pageCount,
+    }
+    _, err = db.NewInsert().Model(file).Exec(ctx)
+    require.NoError(t, err)
+
+    payload := map[string]int{"page": 0}
+    body, _ := json.Marshal(payload)
+    req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+    req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+    rec := httptest.NewRecorder()
+    c := e.NewContext(req, rec)
+    c.SetParamNames("id")
+    c.SetParamValues(strconv.Itoa(file.ID))
+
+    err = h.updateFileCoverPage(c)
+    // The handler should pass validation (not return "file type not supported")
+    // but will fail at page extraction since pdfPageCache is nil.
+    // We verify it's NOT a validation error about file type.
+    require.Error(t, err)
+    assert.NotContains(t, err.Error(), "does not support page-based covers")
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/pdf-cover && go test ./pkg/books/ -run TestUpdateFileCoverPage/accepts_PDF_file_type -v`
+Expected: FAIL — the handler returns "Cover page selection is only available for CBZ files"
+
+- [ ] **Step 3: Update the handler to accept any file with pages**
+
+In `pkg/books/handlers_cover_page.go`, make these changes:
+
+Replace lines 55-58 (the CBZ-only validation):
+```go
+// Old
+// Validate file type is CBZ
+if file.FileType != models.FileTypeCBZ {
+    return errcodes.ValidationError("Cover page selection is only available for CBZ files")
+}
+```
+
+With:
+```go
+// New — validate file has pages (CBZ, PDF, or any future page-based format)
+if file.PageCount == nil {
+    return errcodes.ValidationError("This file does not support page-based covers")
+}
+```
+
+Remove the existing `PageCount == nil` check from line 61 since it's now handled above. The bounds check becomes:
+```go
+// Validate page is within bounds
+if payload.Page < 0 || payload.Page >= *file.PageCount {
+    return errcodes.ValidationError("Page number is out of bounds")
+}
+```
+
+Replace line 66 (the page extraction) which currently only uses `h.pageCache`:
+```go
+// Old
+cachedPath, mimeType, err := h.pageCache.GetPage(file.Filepath, file.ID, payload.Page)
+if err != nil {
+    log.Error("failed to extract page from CBZ", logger.Data{"error": err.Error(), "page": payload.Page})
+    return errcodes.ValidationError("Failed to extract page from CBZ file")
+}
+```
+
+With file-type-aware cache routing:
+```go
+// New
+var cachedPath, mimeType string
+switch file.FileType {
+case models.FileTypeCBZ:
+    cachedPath, mimeType, err = h.pageCache.GetPage(file.Filepath, file.ID, payload.Page)
+case models.FileTypePDF:
+    cachedPath, mimeType, err = h.pdfPageCache.GetPage(file.Filepath, file.ID, payload.Page)
+default:
+    return errcodes.ValidationError("This file does not support page-based covers")
+}
+if err != nil {
+    log.Error("failed to extract cover page", logger.Data{"error": err.Error(), "page": payload.Page, "file_type": file.FileType})
+    return errcodes.ValidationError("Failed to extract page from file")
+}
+```
+
+Update the log message on line 112:
+```go
+// Old
+log.Info("set CBZ cover page", logger.Data{
+// New
+log.Info("set cover page", logger.Data{
+```
+
+Update the comment on line 19:
+```go
+// Old
+// updateFileCoverPagePayload is the request body for setting a CBZ cover page.
+// New
+// updateFileCoverPagePayload is the request body for setting a cover page.
+```
+
+Update the comment on line 24:
+```go
+// Old
+// updateFileCoverPage handles PUT /files/:id/cover-page
+// Sets the cover page for a CBZ file and extracts it as an external cover image.
+// New
+// updateFileCoverPage handles PUT /files/:id/cover-page
+// Sets the cover page for a page-based file (CBZ, PDF) and extracts it as an external cover image.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/pdf-cover && go test ./pkg/books/ -run TestUpdateFileCoverPage/accepts_PDF_file_type -v`
+Expected: PASS
+
+- [ ] **Step 5: Update the "returns 400 for non-CBZ file" test**
+
+The existing test at line 299 creates an EPUB file (which has no page count) and expects rejection. Update the test name and assertion to match the new error message.
+
+In `pkg/books/handlers_cover_page_test.go`, rename the test:
+```go
+// Old
+t.Run("returns 400 for non-CBZ file", func(t *testing.T) {
+// New
+t.Run("returns 400 for file without pages", func(t *testing.T) {
+```
+
+The test body already creates an EPUB file without `PageCount`, so it will correctly hit the new `PageCount == nil` validation. No other changes needed — the test uses `require.Error(t, err)` which is sufficient.
+
+- [ ] **Step 6: Run all cover page tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/pdf-cover && go test ./pkg/books/ -run TestUpdateFileCoverPage -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/books/handlers_cover_page.go pkg/books/handlers_cover_page_test.go
+git commit -m "[Backend] Support PDF cover page selection in updateFileCoverPage handler"
+```
+
+---
+
+### Task 3: Update Frontend to Use `cover_page` as Discriminator
+
+Replace all `file.file_type === FileTypeCBZ` checks in the cover section of FileEditDialog with `file.cover_page != null`.
+
+**Files:**
+- Modify: `app/components/library/FileEditDialog.tsx:650-796`
+
+- [ ] **Step 1: Identify all CBZ file type checks in the cover section**
+
+In `app/components/library/FileEditDialog.tsx`, the cover section (lines 650-796) has these checks to update:
+
+1. Line 663: `file.file_type !== FileTypeCBZ` — controls showing upload-style cover preview
+2. Line 689: `file.file_type === FileTypeCBZ` — controls showing page-style cover preview
+3. Line 715: `file.file_type === FileTypeCBZ` — controls page number badge
+4. Line 756: `file.file_type === FileTypeCBZ` — controls "Select page" button
+5. Line 773: `file.file_type !== FileTypeCBZ` / line 774: `file.file_type === FileTypeCBZ` — unsaved indicator logic
+6. Line 786: `file.file_type === FileTypeCBZ` — page picker dialog rendering
+
+- [ ] **Step 2: Create a helper variable and update all checks**
+
+At the start of the cover section rendering (or near the existing state variables), the component already has access to `file.cover_page`. Use it directly in conditionals.
+
+Replace each check:
+
+Line 663 — cover thumbnail for non-page files:
+```tsx
+// Old
+{file.file_type !== FileTypeCBZ && (
+// New
+{file.cover_page == null && (
+```
+
+Line 689 — cover thumbnail for page-based files:
+```tsx
+// Old
+{file.file_type === FileTypeCBZ && (
+// New
+{file.cover_page != null && (
+```
+
+Line 715-716 — page number badge:
+```tsx
+// Old
+{file.file_type === FileTypeCBZ &&
+  (pendingCoverPage ?? file.cover_page) != null && (
+// New (cover_page is already non-null from outer condition, but pendingCoverPage may differ)
+{file.cover_page != null &&
+  (pendingCoverPage ?? file.cover_page) != null && (
+```
+
+Line 756 — "Select page" button:
+```tsx
+// Old
+{file.file_type === FileTypeCBZ && (
+// New
+{file.cover_page != null && (
+```
+
+Lines 773-774 — unsaved indicator:
+```tsx
+// Old
+{((file.file_type !== FileTypeCBZ && pendingCoverFile) ||
+  (file.file_type === FileTypeCBZ &&
+    pendingCoverPage !== null &&
+    pendingCoverPage !== file.cover_page)) && (
+// New
+{((file.cover_page == null && pendingCoverFile) ||
+  (file.cover_page != null &&
+    pendingCoverPage !== null &&
+    pendingCoverPage !== file.cover_page)) && (
+```
+
+Line 786 — page picker dialog:
+```tsx
+// Old
+{file.file_type === FileTypeCBZ && file.page_count != null && (
+  <CBZPagePicker
+// New
+{file.cover_page != null && file.page_count != null && (
+  <PagePicker
+```
+
+- [ ] **Step 3: Remove unused `FileTypeCBZ` import if no longer needed**
+
+Check if `FileTypeCBZ` is still used elsewhere in the file (e.g., line 569 for `canBeMainFile`). If it's still used, keep the import. If not, remove it.
+
+Line 569 still uses `FileTypeCBZ`:
+```tsx
+const canBeMainFile = [FileTypeCBZ, FileTypeEPUB, FileTypeM4B].includes(
+```
+
+So keep the import. No change needed here.
+
+- [ ] **Step 4: Run lint and unit tests**
+
+Run: `pnpm lint:types && pnpm exec vitest run app/components/library/FileEditDialog.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/FileEditDialog.tsx
+git commit -m "[Frontend] Use cover_page as discriminator for page-based cover workflow"
+```
+
+---
+
+### Task 4: Run Full Checks
+
+- [ ] **Step 1: Run mise check:quiet**
+
+Run: `mise check:quiet`
+Expected: All checks pass
+
+- [ ] **Step 2: Commit any fixes if needed**
+
+If any lint or test issues arise, fix and commit.

--- a/docs/superpowers/specs/2026-03-28-pdf-cover-page-selection-design.md
+++ b/docs/superpowers/specs/2026-03-28-pdf-cover-page-selection-design.md
@@ -1,0 +1,57 @@
+# PDF Cover Page Selection
+
+## Summary
+
+Extend cover page selection (currently CBZ-only) to work for PDF files. Users can select which page of a PDF to use as the cover, just like CBZ. The selected page is rendered out as a cover image the same way page 0 is during the initial scan.
+
+## Discriminator
+
+The single discriminator for the cover page workflow is `cover_page != null`. If a file has `cover_page` set, it gets the page picker. If not, it gets the upload workflow. This is future-proof — a hypothetical page-based format that doesn't set `cover_page` during scan won't get the cover page workflow.
+
+## Changes
+
+### Backend: `pkg/books/handlers_cover_page.go`
+
+- Remove the `file.FileType != FileTypeCBZ` validation check
+- Replace with `file.PageCount == nil` to validate bounds (cover_page already implies page support, but we need page count for bounds checking)
+- Route to the correct page cache internally based on file type:
+  - CBZ: `h.pageCache.GetPage()`
+  - PDF: `h.pdfPageCache.GetPage()`
+- Update error messages to be format-agnostic (e.g., "Cover page selection requires a file with pages" instead of "only available for CBZ files")
+
+### Frontend: `app/components/library/FileEditDialog.tsx`
+
+Replace all `file.file_type === FileTypeCBZ` checks in the cover section with `file.cover_page != null`:
+
+- **Cover thumbnail**: Show pending page preview vs current cover
+- **Page number badge**: Show "Page N" overlay
+- **"Select page" button**: Show for files with cover_page
+- **Unsaved changes indicator**: Detect pending cover page changes
+- **Page picker dialog**: Render when cover_page is set and file has page_count
+
+The upload button is already hidden via the existing `file.cover_page == null` check — no change needed.
+
+### Component Rename
+
+Rename CBZ-specific component names to generic names:
+
+| Old | New |
+|-----|-----|
+| `CBZPagePicker.tsx` | `PagePicker.tsx` |
+| `CBZPagePreview.tsx` | `PagePreview.tsx` |
+| `CBZPageThumbnail.tsx` | `PageThumbnail.tsx` |
+
+Update all imports across the codebase.
+
+### Tests: `pkg/books/handlers_cover_page_test.go`
+
+- Add a PDF test case that sets a cover page and verifies the cover image is extracted
+- Update the "rejects non-CBZ files" test to use EPUB (a format without pages) and update the error message assertion
+
+## What stays the same
+
+- `GET /files/:id/page/:pageNum` already handles both CBZ and PDF
+- Upload rejection for files with `cover_page` set (line ~1250 in handlers.go)
+- Sidecar writing works generically
+- Scan worker already sets `CoverPage = 0` for PDFs during initial scan
+- `cover_page` field in database model already exists and is used for PDFs

--- a/pkg/books/handlers_cover_page.go
+++ b/pkg/books/handlers_cover_page.go
@@ -16,13 +16,13 @@ import (
 	"github.com/shishobooks/shisho/pkg/sidecar"
 )
 
-// updateFileCoverPagePayload is the request body for setting a CBZ cover page.
+// updateFileCoverPagePayload is the request body for setting a cover page.
 type updateFileCoverPagePayload struct {
 	Page int `json:"page"` // 0-indexed page number
 }
 
 // updateFileCoverPage handles PUT /files/:id/cover-page
-// Sets the cover page for a CBZ file and extracts it as an external cover image.
+// Sets the cover page for a page-based file (CBZ, PDF) and extracts it as an external cover image.
 func (h *handler) updateFileCoverPage(c echo.Context) error {
 	ctx := c.Request().Context()
 	log := logger.FromContext(ctx)
@@ -52,21 +52,29 @@ func (h *handler) updateFileCoverPage(c echo.Context) error {
 		}
 	}
 
-	// Validate file type is CBZ
-	if file.FileType != models.FileTypeCBZ {
-		return errcodes.ValidationError("Cover page selection is only available for CBZ files")
+	// Validate file has pages
+	if file.PageCount == nil {
+		return errcodes.ValidationError("This file does not support page-based covers")
 	}
 
 	// Validate page is within bounds
-	if file.PageCount == nil || payload.Page < 0 || payload.Page >= *file.PageCount {
+	if payload.Page < 0 || payload.Page >= *file.PageCount {
 		return errcodes.ValidationError("Page number is out of bounds")
 	}
 
-	// Extract the page image using the page cache
-	cachedPath, mimeType, err := h.pageCache.GetPage(file.Filepath, file.ID, payload.Page)
+	// Extract the page image using the appropriate page cache
+	var cachedPath, mimeType string
+	switch file.FileType {
+	case models.FileTypeCBZ:
+		cachedPath, mimeType, err = h.pageCache.GetPage(file.Filepath, file.ID, payload.Page)
+	case models.FileTypePDF:
+		cachedPath, mimeType, err = h.pdfPageCache.GetPage(file.Filepath, file.ID, payload.Page)
+	default:
+		return errcodes.ValidationError("This file does not support page-based covers")
+	}
 	if err != nil {
-		log.Error("failed to extract page from CBZ", logger.Data{"error": err.Error(), "page": payload.Page})
-		return errcodes.ValidationError("Failed to extract page from CBZ file")
+		log.Error("failed to extract cover page", logger.Data{"error": err.Error(), "page": payload.Page, "file_type": file.FileType})
+		return errcodes.ValidationError("Failed to extract page from file")
 	}
 
 	// Determine cover directory (same logic as fileCover and uploadFileCover)
@@ -109,7 +117,7 @@ func (h *handler) updateFileCoverPage(c echo.Context) error {
 		return errcodes.ValidationError("Failed to save cover image")
 	}
 
-	log.Info("set CBZ cover page", logger.Data{
+	log.Info("set cover page", logger.Data{
 		"file_id":    file.ID,
 		"page":       payload.Page,
 		"cover_path": coverFilePath,

--- a/pkg/books/handlers_cover_page_test.go
+++ b/pkg/books/handlers_cover_page_test.go
@@ -64,6 +64,7 @@ func createTestCBZWithPages(t *testing.T, path string, numPages int) {
 func TestUpdateFileCoverPage(t *testing.T) {
 	t.Parallel()
 	t.Run("sets cover page and extracts cover image", func(t *testing.T) {
+		t.Parallel()
 		db := setupTestDB(t)
 		ctx := context.Background()
 		cfg := &config.Config{CacheDir: t.TempDir()}
@@ -154,6 +155,7 @@ func TestUpdateFileCoverPage(t *testing.T) {
 	})
 
 	t.Run("returns 400 for invalid page number", func(t *testing.T) {
+		t.Parallel()
 		db := setupTestDB(t)
 		ctx := context.Background()
 		cfg := &config.Config{CacheDir: t.TempDir()}
@@ -226,6 +228,7 @@ func TestUpdateFileCoverPage(t *testing.T) {
 	})
 
 	t.Run("returns 400 for negative page number", func(t *testing.T) {
+		t.Parallel()
 		db := setupTestDB(t)
 		ctx := context.Background()
 		cfg := &config.Config{CacheDir: t.TempDir()}

--- a/pkg/books/handlers_cover_page_test.go
+++ b/pkg/books/handlers_cover_page_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/cbzpages"
 	"github.com/shishobooks/shisho/pkg/config"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/pdfpages"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -296,7 +297,77 @@ func TestUpdateFileCoverPage(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("returns 400 for non-CBZ file", func(t *testing.T) {
+	t.Run("accepts PDF file type", func(t *testing.T) {
+		t.Parallel()
+		db := setupTestDB(t)
+		ctx := context.Background()
+		cfg := &config.Config{CacheDir: t.TempDir()}
+		e := echo.New()
+		bookService := NewService(db)
+		pdfPageCache := pdfpages.NewCache(cfg.CacheDir, 150, 85)
+
+		h := &handler{
+			bookService:  bookService,
+			pdfPageCache: pdfPageCache,
+		}
+
+		library := &models.Library{
+			Name:                     "Test Library",
+			CoverAspectRatio:         "book",
+			DownloadFormatPreference: models.DownloadFormatOriginal,
+		}
+		_, err := db.NewInsert().Model(library).Exec(ctx)
+		require.NoError(t, err)
+
+		bookDir := filepath.Join(t.TempDir(), "Test Book")
+		err = os.MkdirAll(bookDir, 0755)
+		require.NoError(t, err)
+
+		book := &models.Book{
+			LibraryID:       library.ID,
+			Title:           "Test Book",
+			TitleSource:     models.DataSourceFilepath,
+			SortTitle:       "Test Book",
+			SortTitleSource: models.DataSourceFilepath,
+			AuthorSource:    models.DataSourceFilepath,
+			Filepath:        bookDir,
+		}
+		_, err = db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+
+		pageCount := 10
+		file := &models.File{
+			LibraryID:     library.ID,
+			BookID:        book.ID,
+			FileType:      models.FileTypePDF,
+			FileRole:      models.FileRoleMain,
+			Filepath:      filepath.Join(bookDir, "test.pdf"),
+			FilesizeBytes: 1000,
+			PageCount:     &pageCount,
+		}
+		_, err = db.NewInsert().Model(file).Exec(ctx)
+		require.NoError(t, err)
+
+		payload := map[string]int{"page": 0}
+		body, _ := json.Marshal(payload)
+		req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(strconv.Itoa(file.ID))
+
+		err = h.updateFileCoverPage(c)
+		// Handler should pass validation but fail at extraction (PDF file doesn't exist on disk).
+		// Key: it should NOT return a validation error about file type.
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "does not support page-based covers")
+		assert.NotContains(t, err.Error(), "only available for CBZ files")
+		assert.Contains(t, err.Error(), "Failed to extract page from file")
+	})
+
+	t.Run("returns 400 for file without pages", func(t *testing.T) {
+		t.Parallel()
 		db := setupTestDB(t)
 		ctx := context.Background()
 		cfg := &config.Config{CacheDir: t.TempDir()}

--- a/pkg/cbz/CLAUDE.md
+++ b/pkg/cbz/CLAUDE.md
@@ -346,7 +346,7 @@ type ParsedChapter struct {
 
 This applies to:
 - `ChapterRow.tsx` - page display and edit inputs
-- `CBZPagePicker.tsx` - page selection dialog
+- `PagePicker.tsx` - page selection dialog
 - `CBZReader.tsx` - reader page counter
 - `FileChaptersTab.tsx` - uncovered pages warning
 

--- a/pkg/downloadcache/fingerprint.go
+++ b/pkg/downloadcache/fingerprint.go
@@ -242,7 +242,7 @@ func ComputeFingerprint(book *models.Book, file *models.File) (*Fingerprint, err
 		}
 	}
 
-	// Add cover page for CBZ files
+	// Add cover page for page-based files (CBZ, PDF)
 	if file.CoverPage != nil {
 		fp.CoverPage = file.CoverPage
 	}

--- a/pkg/downloadcache/fingerprint.go
+++ b/pkg/downloadcache/fingerprint.go
@@ -34,7 +34,7 @@ type Fingerprint struct {
 	Imprint           *string                 `json:"imprint,omitempty"`
 	ReleaseDate       *time.Time              `json:"release_date,omitempty"`
 	Cover             *FingerprintCover       `json:"cover,omitempty"`
-	CoverPage         *int                    `json:"cover_page,omitempty"` // For CBZ files: page index of cover
+	CoverPage         *int                    `json:"cover_page,omitempty"` // For page-based files (CBZ, PDF): page index of cover
 	Chapters          []FingerprintChapter    `json:"chapters,omitempty"`
 	Format            string                  `json:"format,omitempty"`             // Download format: original, kepub, or plugin:<id>
 	Name              *string                 `json:"name,omitempty"`               // File name (edition name)

--- a/pkg/models/file.go
+++ b/pkg/models/file.go
@@ -37,10 +37,10 @@ type File struct {
 	CoverImageFilename       *string           `json:"cover_image_filename"`
 	CoverMimeType            *string           `json:"cover_mime_type"`
 	CoverSource              *string           `json:"cover_source" tstype:"DataSource"`
-	CoverPage                *int              `json:"cover_page"` // 0-indexed page number for CBZ cover, NULL for EPUB/M4B
+	CoverPage                *int              `json:"cover_page"` // 0-indexed page number for CBZ/PDF cover, NULL for EPUB/M4B
 	Name                     *string           `json:"name"`
 	NameSource               *string           `json:"name_source" tstype:"DataSource"`
-	PageCount                *int              `json:"page_count"` // Number of pages for CBZ files, NULL for EPUB/M4B
+	PageCount                *int              `json:"page_count"` // Number of pages for CBZ/PDF files, NULL for EPUB/M4B
 	AudiobookDurationSeconds *float64          `json:"audiobook_duration_seconds"`
 	AudiobookBitrateBps      *int              `json:"audiobook_bitrate_bps"`
 	AudiobookCodec           *string           `json:"audiobook_codec"`


### PR DESCRIPTION
## Summary
- Extend cover page selection to PDF files — users can now select which page of a PDF to use as the cover, just like CBZ
- Backend handler (`updateFileCoverPage`) no longer rejects non-CBZ files; routes to the correct page cache (CBZ or PDF) based on file type
- Frontend uses `cover_page != null` as the universal discriminator instead of checking file type, so both CBZ and PDF files get the page picker workflow
- Renamed CBZ-specific components (`CBZPagePicker`, `CBZPagePreview`, `CBZPageThumbnail`) to generic names (`PagePicker`, `PagePreview`, `PageThumbnail`)

## Test plan
- Open the edit dialog for a PDF file that has been scanned (will have `cover_page` set to 0)
- Verify the "Select page" button appears instead of the "Upload cover" button
- Click "Select page" and browse PDF pages in the picker dialog
- Select a different page and save — verify the cover updates
- Verify CBZ cover page selection still works as before
- Run `mise check:quiet` — all checks pass