### PR TITLE
[Feature] Add enricher cover resolution gate and page-based format protection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,14 +67,14 @@ var p payload
 c.Bind(&p)
 ```
 
-**CoverImagePath stores filename only** — `file.CoverImagePath` stores just the filename (e.g., `book.cbz.cover.jpg`), NOT the full path. The full path is constructed at runtime. Always use `filepath.Base()` when updating:
+**CoverImageFilename stores filename only** — `file.CoverImageFilename` stores just the filename (e.g., `book.cbz.cover.jpg`), NOT the full path. The full path is constructed at runtime. Always use `filepath.Base()` when updating:
 ```go
 // ❌ WRONG - stores full path, breaks cover serving
-file.CoverImagePath = &fullPath
+file.CoverImageFilename = &fullPath
 
 // ✅ CORRECT - stores filename only
 filename := filepath.Base(fullPath)
-file.CoverImagePath = &filename
+file.CoverImageFilename = &filename
 ```
 
 **JSON field naming is snake_case** — All JSON request/response payloads use `snake_case` (e.g., `created_at`, not `createdAt`). Go struct tags: `json:"snake_case_name"`.

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -61,7 +61,7 @@ import { usePluginIdentifierTypes } from "@/hooks/queries/plugins";
 import { usePublishersList } from "@/hooks/queries/publishers";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
-import { cn } from "@/libraries/utils";
+import { cn, isPageBasedFileType } from "@/libraries/utils";
 import {
   FileRoleMain,
   FileRoleSupplement,
@@ -102,6 +102,7 @@ export function FileEditDialog({
   const [narratorSearch, setNarratorSearch] = useState("");
   const debouncedNarratorSearch = useDebounce(narratorSearch, 200);
   const [narratorOpen, setNarratorOpen] = useState(false);
+  const isPageBased = isPageBasedFileType(file.file_type);
   const [coverCacheBuster, setCoverCacheBuster] = useState(() => Date.now());
   const [coverPagePickerOpen, setCoverPagePickerOpen] = useState(false);
   const [pendingCoverPage, setPendingCoverPage] = useState<number | null>(null);
@@ -660,7 +661,7 @@ export function FileEditDialog({
                       )}
                     >
                       {/* Non-page-based: Show pending preview or current cover */}
-                      {file.cover_page == null && (
+                      {!isPageBased && (
                         <>
                           {pendingCoverPreview ? (
                             <img
@@ -686,7 +687,7 @@ export function FileEditDialog({
                         </>
                       )}
                       {/* Page-based: Show pending page or current cover */}
-                      {file.cover_page != null && (
+                      {isPageBased && (
                         <>
                           {pendingCoverPage !== null &&
                           pendingCoverPage !== file.cover_page ? (
@@ -712,7 +713,7 @@ export function FileEditDialog({
                       )}
                     </div>
                     {/* Page number badge */}
-                    {file.cover_page != null &&
+                    {isPageBased &&
                       (pendingCoverPage ?? file.cover_page) != null && (
                         <div className="absolute bottom-1.5 left-1.5 px-1.5 py-0.5 rounded bg-black/70 text-white text-xs font-medium">
                           Page {(pendingCoverPage ?? file.cover_page)! + 1}
@@ -723,7 +724,7 @@ export function FileEditDialog({
                   {/* Action buttons and status */}
                   <div className="flex flex-col gap-2 pt-1">
                     {/* Upload button — hidden for files with page-derived covers */}
-                    {file.cover_page == null && (
+                    {!isPageBased && (
                       <>
                         <input
                           accept="image/jpeg,image/png,image/webp"
@@ -753,7 +754,7 @@ export function FileEditDialog({
                       </>
                     )}
                     {/* Select page button */}
-                    {file.cover_page != null && (
+                    {isPageBased && (
                       <Button
                         disabled={setCoverPageMutation.isPending}
                         onClick={() => setCoverPagePickerOpen(true)}
@@ -770,8 +771,8 @@ export function FileEditDialog({
                       </Button>
                     )}
                     {/* Unsaved indicator */}
-                    {((file.cover_page == null && pendingCoverFile) ||
-                      (file.cover_page != null &&
+                    {((!isPageBased && pendingCoverFile) ||
+                      (isPageBased &&
                         pendingCoverPage !== null &&
                         pendingCoverPage !== file.cover_page)) && (
                       <span className="text-xs text-orange-500 font-medium">
@@ -783,7 +784,7 @@ export function FileEditDialog({
               </div>
 
               {/* Page Picker Dialog */}
-              {file.cover_page != null && file.page_count != null && (
+              {isPageBased && file.page_count != null && (
                 <PagePicker
                   currentPage={pendingCoverPage ?? file.cover_page ?? null}
                   fileId={file.id}

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -343,11 +343,11 @@ export function IdentifyBookDialog({
                     >
                       <div className="flex gap-3">
                         {/* Cover thumbnail */}
-                        {result.image_url || result.cover_url ? (
+                        {result.cover_url ? (
                           <img
                             alt=""
                             className="w-16 h-24 object-cover rounded shrink-0 bg-muted"
-                            src={result.image_url || result.cover_url}
+                            src={result.cover_url}
                           />
                         ) : (
                           <div className="w-16 h-24 rounded shrink-0 bg-muted flex items-center justify-center text-muted-foreground text-xs">

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -343,11 +343,11 @@ export function IdentifyBookDialog({
                     >
                       <div className="flex gap-3">
                         {/* Cover thumbnail */}
-                        {result.image_url ? (
+                        {result.image_url || result.cover_url ? (
                           <img
                             alt=""
                             className="w-16 h-24 object-cover rounded shrink-0 bg-muted"
-                            src={result.image_url}
+                            src={result.image_url || result.cover_url}
                           />
                         ) : (
                           <div className="w-16 h-24 rounded shrink-0 bg-muted flex items-center justify-center text-muted-foreground text-xs">

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -523,7 +523,7 @@ export function IdentifyReviewForm({
   // Cover state — page-based formats (CBZ, PDF) derive covers from page
   // content and shouldn't be overwritten by plugin images.
   const coverEditable = !isPageBasedFileType(file?.file_type);
-  const newCoverUrl = result.image_url || result.cover_url;
+  const newCoverUrl = result.cover_url;
   const currentCoverUrl = file?.cover_image_filename
     ? `/api/books/files/${file.id}/cover?t=${new Date(file.updated_at).getTime()}`
     : undefined;

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -25,7 +25,7 @@ import {
   usePluginIdentifierTypes,
   type PluginSearchResult,
 } from "@/hooks/queries/plugins";
-import { cn } from "@/libraries/utils";
+import { cn, isPageBasedFileType } from "@/libraries/utils";
 import type { Book, File } from "@/types";
 import { formatIdentifierType, formatMetadataFieldLabel } from "@/utils/format";
 
@@ -520,9 +520,9 @@ export function IdentifyReviewForm({
     defaults.identifiers.value,
   );
 
-  // Cover state — files with cover_page (CBZ, PDF) derive covers from page
+  // Cover state — page-based formats (CBZ, PDF) derive covers from page
   // content and shouldn't be overwritten by plugin images.
-  const coverEditable = file?.cover_page == null;
+  const coverEditable = !isPageBasedFileType(file?.file_type);
   const newCoverUrl = result.image_url || result.cover_url;
   const currentCoverUrl = file?.cover_image_filename
     ? `/api/books/files/${file.id}/cover?t=${new Date(file.updated_at).getTime()}`

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -511,7 +511,6 @@ export interface PluginSearchResult {
   title: string;
   authors?: Array<{ name: string; role?: string }>;
   description?: string;
-  image_url?: string;
   release_date?: string;
   publisher?: string;
   subtitle?: string;

--- a/app/libraries/utils.ts
+++ b/app/libraries/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Returns true for file types that derive covers from page content (CBZ, PDF).
+ * These formats should never have their covers replaced by external sources.
+ */
+export const isPageBasedFileType = (fileType: string | undefined): boolean =>
+  fileType === "cbz" || fileType === "pdf";

--- a/docs/superpowers/plans/2026-03-29-enricher-cover-resolution-gate.md
+++ b/docs/superpowers/plans/2026-03-29-enricher-cover-resolution-gate.md
@@ -1,0 +1,1010 @@
+# Enricher Cover Resolution Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make enricher covers actually get saved to disk, gated by a resolution check (only apply if higher resolution than current cover), with page-based formats (CBZ/PDF) always blocking external covers.
+
+**Architecture:** Post-enrichment cover upgrade approach — keep existing flow, add an `upgradeEnricherCover` step after enrichers run in both scan paths. Guards change from `CoverPage != nil` to file type checks via a centralized helper. Resolution comparison uses `image.DecodeConfig` (header-only, no full decode).
+
+**Tech Stack:** Go (backend), React/TypeScript (frontend), SQLite (database)
+
+---
+
+### Task 1: Add `IsPageBasedFileType` Helper (Backend)
+
+**Files:**
+- Modify: `pkg/models/file.go`
+
+- [ ] **Step 1: Add the helper function**
+
+Add after the `CoverExtension()` method at the end of `pkg/models/file.go`:
+
+```go
+// IsPageBasedFileType returns true for file types that derive covers from page
+// content (CBZ, PDF). These formats should never have their covers replaced by
+// external sources (plugins, uploads).
+func IsPageBasedFileType(fileType string) bool {
+	return fileType == FileTypeCBZ || fileType == FileTypePDF
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && go build ./pkg/models/`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/models/file.go
+git commit -m "[Backend] Add IsPageBasedFileType helper for cover protection guards"
+```
+
+---
+
+### Task 2: Add `isPageBasedFileType` Helper (Frontend)
+
+**Files:**
+- Modify: `app/libraries/utils.ts`
+
+- [ ] **Step 1: Add the frontend helper**
+
+Add to the end of `app/libraries/utils.ts`:
+
+```ts
+/**
+ * Returns true for file types that derive covers from page content (CBZ, PDF).
+ * These formats should never have their covers replaced by external sources.
+ */
+export const isPageBasedFileType = (fileType: string | undefined): boolean =>
+  fileType === "cbz" || fileType === "pdf";
+```
+
+Note: The parameter accepts `string | undefined` because `file?.file_type` can be undefined when the file object is optional.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && pnpm lint:types`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/libraries/utils.ts
+git commit -m "[Frontend] Add isPageBasedFileType helper for cover protection guards"
+```
+
+---
+
+### Task 3: Add Image Resolution Helpers
+
+**Files:**
+- Modify: `pkg/fileutils/operations.go`
+- Create: `pkg/fileutils/resolution_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `pkg/fileutils/resolution_test.go`:
+
+```go
+package fileutils
+
+import (
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestJPEG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
+	return buf.Bytes()
+}
+
+func createTestPNG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 0, G: 0, B: 255, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+func TestImageResolution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns width * height for JPEG", func(t *testing.T) {
+		t.Parallel()
+		data := createTestJPEG(800, 1200)
+		assert.Equal(t, 800*1200, ImageResolution(data))
+	})
+
+	t.Run("returns width * height for PNG", func(t *testing.T) {
+		t.Parallel()
+		data := createTestPNG(640, 480)
+		assert.Equal(t, 640*480, ImageResolution(data))
+	})
+
+	t.Run("returns 0 for invalid data", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, ImageResolution([]byte("not an image")))
+	})
+
+	t.Run("returns 0 for empty data", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, ImageResolution(nil))
+	})
+}
+
+func TestImageFileResolution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns resolution for JPEG file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.jpg")
+		os.WriteFile(path, createTestJPEG(1024, 768), 0644)
+		assert.Equal(t, 1024*768, ImageFileResolution(path))
+	})
+
+	t.Run("returns resolution for PNG file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.png")
+		os.WriteFile(path, createTestPNG(500, 700), 0644)
+		assert.Equal(t, 500*700, ImageFileResolution(path))
+	})
+
+	t.Run("returns 0 for nonexistent file", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, ImageFileResolution("/nonexistent/path.jpg"))
+	})
+
+	t.Run("returns 0 for non-image file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.txt")
+		os.WriteFile(path, []byte("hello"), 0644)
+		assert.Equal(t, 0, ImageFileResolution(path))
+	})
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && go test ./pkg/fileutils/ -run "TestImageResolution|TestImageFileResolution" -v`
+Expected: FAIL — `ImageResolution` and `ImageFileResolution` are not defined
+
+- [ ] **Step 3: Implement the functions**
+
+Add to the end of `pkg/fileutils/operations.go` (before the closing of the file):
+
+```go
+// ImageResolution returns the total pixel count (width * height) of an image
+// by reading only the image header (no full decode). Returns 0 if the image
+// cannot be decoded.
+func ImageResolution(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return 0
+	}
+	return cfg.Width * cfg.Height
+}
+
+// ImageFileResolution returns the total pixel count of an image file on disk.
+// Returns 0 if the file cannot be read or decoded.
+func ImageFileResolution(path string) int {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	cfg, _, err := image.DecodeConfig(f)
+	if err != nil {
+		return 0
+	}
+	return cfg.Width * cfg.Height
+}
+```
+
+No new imports needed — `bytes`, `image`, and `os` are already imported in `operations.go`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && go test ./pkg/fileutils/ -run "TestImageResolution|TestImageFileResolution" -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/fileutils/operations.go pkg/fileutils/resolution_test.go
+git commit -m "[Backend] Add ImageResolution and ImageFileResolution helpers"
+```
+
+---
+
+### Task 4: PDF Parser — Always Set CoverPage
+
+**Files:**
+- Modify: `pkg/pdf/pdf.go`
+- Modify: `pkg/pdf/CLAUDE.md`
+
+- [ ] **Step 1: Write a test verifying CoverPage is always set**
+
+Check if there's an existing test for the failed-extraction case. The PDF test file creates fixtures in `TestMain`. We need to verify that even when cover extraction fails, `CoverPage` is still set to 0.
+
+Read the existing PDF test to understand the pattern, then add a test assertion. For now, let's first make the code change since the existing tests should still pass, and we can verify the behavior by checking the returned metadata.
+
+- [ ] **Step 2: Update the PDF parser**
+
+In `pkg/pdf/pdf.go`, change lines 87-98 from:
+
+```go
+	// Extract cover image (best-effort: don't fail Parse if cover extraction fails).
+	// PDF covers are always derived from page 0, so set CoverPage to signal this
+	// is a page-based cover that should not be overwritten.
+	var coverData []byte
+	var coverMime string
+	var coverPage *int
+	if cd, cm, err := extractCover(path); err == nil {
+		coverData = cd
+		coverMime = cm
+		page0 := 0
+		coverPage = &page0
+	}
+```
+
+To:
+
+```go
+	// Extract cover image (best-effort: don't fail Parse if cover extraction fails).
+	// PDF is a page-based format — always set CoverPage to 0 regardless of whether
+	// cover extraction succeeds. This ensures the frontend shows the page picker
+	// and the file type guard blocks external covers consistently.
+	page0 := 0
+	coverPage := &page0
+	var coverData []byte
+	var coverMime string
+	if cd, cm, err := extractCover(path); err == nil {
+		coverData = cd
+		coverMime = cm
+	}
+```
+
+- [ ] **Step 3: Run existing PDF tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && go test ./pkg/pdf/ -v`
+Expected: All PASS
+
+- [ ] **Step 4: Update `pkg/pdf/CLAUDE.md`**
+
+In `pkg/pdf/CLAUDE.md`, find the "Cover Extraction" section and add a note after the "### Tier 2" subsection:
+
+```markdown
+### CoverPage Always Set
+
+`CoverPage` is always set to `0` for PDF files, even when cover extraction fails. This ensures:
+- The frontend shows the page picker (not the upload button)
+- File type guards consistently block external covers for PDFs
+- The data is consistent: PDFs are page-based formats
+
+Do NOT conditionally set `CoverPage` based on extraction success. The file type (`models.IsPageBasedFileType`) is the authoritative guard for cover protection, and `CoverPage` serves as page selection data.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/pdf/pdf.go pkg/pdf/CLAUDE.md
+git commit -m "[Backend] PDF parser: always set CoverPage to 0 regardless of extraction success"
+```
+
+---
+
+### Task 5: Change Backend Guards to File Type
+
+**Files:**
+- Modify: `pkg/books/handlers.go`
+- Modify: `pkg/worker/scan_unified.go`
+- Modify: `pkg/worker/scan_enricher_test.go`
+
+- [ ] **Step 1: Update cover upload guard in handlers.go**
+
+In `pkg/books/handlers.go`, change lines 1248-1252 from:
+
+```go
+	// Files with cover_page derive their cover from page content (CBZ, PDF) and
+	// cannot have it replaced by upload.
+	if file.CoverPage != nil {
+		return errcodes.ValidationError("Cover upload is not supported for this file type.")
+	}
+```
+
+To:
+
+```go
+	// Page-based formats (CBZ, PDF) derive their cover from page content and
+	// cannot have it replaced by upload.
+	if models.IsPageBasedFileType(file.FileType) {
+		return errcodes.ValidationError("Cover upload is not supported for this file type.")
+	}
+```
+
+- [ ] **Step 2: Update enricher cover guard in scan_unified.go**
+
+In `pkg/worker/scan_unified.go`, change lines 2768-2775 from:
+
+```go
+	// Files with CoverPage derive covers from page content (CBZ, PDF) and must
+	// not have them replaced by enricher-downloaded images.
+	if metadata.CoverPage != nil {
+		enrichedMeta.CoverData = metadata.CoverData
+		enrichedMeta.CoverMimeType = metadata.CoverMimeType
+		enrichedMeta.CoverPage = metadata.CoverPage
+		enrichedMeta.FieldDataSources["cover"] = metadata.SourceForField("cover")
+	}
+```
+
+To:
+
+```go
+	// Page-based formats (CBZ, PDF) derive covers from page content and must
+	// not have them replaced by enricher-downloaded images.
+	if models.IsPageBasedFileType(file.FileType) {
+		enrichedMeta.CoverData = metadata.CoverData
+		enrichedMeta.CoverMimeType = metadata.CoverMimeType
+		enrichedMeta.CoverPage = metadata.CoverPage
+		enrichedMeta.FieldDataSources["cover"] = metadata.SourceForField("cover")
+	}
+```
+
+- [ ] **Step 3: Update enricher tests**
+
+In `pkg/worker/scan_enricher_test.go`, update the two `CoverPage != nil` checks.
+
+Change the test at line ~469 (inside `TestCoverPageProtection_CoverPageSet_EnricherCoverReverted`). Replace:
+
+```go
+	// 3. Apply CoverPage protection (as runMetadataEnrichers does)
+	if fileMetadata.CoverPage != nil {
+```
+
+With:
+
+```go
+	// 3. Apply page-based file type protection (as runMetadataEnrichers does)
+	// In production, this checks models.IsPageBasedFileType(file.FileType).
+	// For this test, we simulate by checking CoverPage since we're testing the
+	// CBZ case where CoverPage is always set.
+	if fileMetadata.CoverPage != nil {
+```
+
+Change the test at line ~513 (inside `TestCoverPageProtection_NoCoverPage_EnricherCoverPreserved`). Replace:
+
+```go
+	// CoverPage protection should NOT trigger (no CoverPage)
+	if fileMetadata.CoverPage != nil {
+```
+
+With:
+
+```go
+	// Page-based file type protection should NOT trigger (EPUB is not page-based)
+	// In production, this checks models.IsPageBasedFileType(file.FileType).
+	// For this test, the EPUB case naturally has no CoverPage, same result.
+	if fileMetadata.CoverPage != nil {
+```
+
+Note: These tests simulate the enricher merge manually (without calling `runMetadataEnrichers`), so they use `CoverPage != nil` as a proxy for the file type check. The test comments clarify this. The actual production code uses `models.IsPageBasedFileType`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && go test ./pkg/worker/ -run "TestCoverPage" -v && go test ./pkg/books/ -v`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/books/handlers.go pkg/worker/scan_unified.go pkg/worker/scan_enricher_test.go
+git commit -m "[Backend] Change cover protection guards from CoverPage to file type checks"
+```
+
+---
+
+### Task 6: Change Frontend Guards to File Type
+
+**Files:**
+- Modify: `app/components/library/IdentifyReviewForm.tsx`
+- Modify: `app/components/library/FileEditDialog.tsx`
+
+- [ ] **Step 1: Update IdentifyReviewForm**
+
+In `app/components/library/IdentifyReviewForm.tsx`, add the import at the top (with other imports from `@/libraries/utils`):
+
+```ts
+import { isPageBasedFileType } from "@/libraries/utils";
+```
+
+Then change line 523-525 from:
+
+```tsx
+  // Cover state — files with cover_page (CBZ, PDF) derive covers from page
+  // content and shouldn't be overwritten by plugin images.
+  const coverEditable = file?.cover_page == null;
+```
+
+To:
+
+```tsx
+  // Cover state — page-based formats (CBZ, PDF) derive covers from page
+  // content and shouldn't be overwritten by plugin images.
+  const coverEditable = !isPageBasedFileType(file?.file_type);
+```
+
+- [ ] **Step 2: Update FileEditDialog — add import**
+
+In `app/components/library/FileEditDialog.tsx`, add the import:
+
+```ts
+import { isPageBasedFileType } from "@/libraries/utils";
+```
+
+Note: `cn` is likely already imported from this file. If so, combine the imports:
+
+```ts
+import { cn, isPageBasedFileType } from "@/libraries/utils";
+```
+
+- [ ] **Step 3: Update FileEditDialog — add derived constant**
+
+Early in the component (near line 106 where other state is declared), add a derived constant:
+
+```tsx
+const isPageBased = isPageBasedFileType(file.file_type);
+```
+
+- [ ] **Step 4: Update FileEditDialog — replace guard checks**
+
+Replace all **guard-style** `file.cover_page == null` and `file.cover_page != null` checks with `!isPageBased` and `isPageBased` respectively. These are the lines that control which UI to show (upload vs page picker):
+
+| Line | Current | New |
+|------|---------|-----|
+| ~663 | `{file.cover_page == null && (` | `{!isPageBased && (` |
+| ~689 | `{file.cover_page != null && (` | `{isPageBased && (` |
+| ~715 | `{file.cover_page != null &&` | `{isPageBased &&` |
+| ~726 | `{file.cover_page == null && (` | `{!isPageBased && (` |
+| ~756 | `{file.cover_page != null && (` | `{isPageBased && (` |
+| ~773 | `{((file.cover_page == null && pendingCoverFile) ||` | `{((!isPageBased && pendingCoverFile) ||` |
+| ~774 | `(file.cover_page != null &&` | `(isPageBased &&` |
+| ~786 | `{file.cover_page != null && file.page_count != null && (` | `{isPageBased && file.page_count != null && (` |
+
+**DO NOT change** lines that use `file.cover_page` as **data** (value display, comparison):
+- Line ~692: `pendingCoverPage !== file.cover_page` — comparing values, keep as-is
+- Line ~718: `(pendingCoverPage ?? file.cover_page)! + 1` — displaying page number, keep as-is
+- Line ~776: `pendingCoverPage !== file.cover_page` — comparing values, keep as-is
+- Line ~788: `currentPage={pendingCoverPage ?? file.cover_page ?? null}` — page picker value, keep as-is
+
+- [ ] **Step 5: Run type checks and linting**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && pnpm lint:types && pnpm lint:eslint`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/components/library/IdentifyReviewForm.tsx app/components/library/FileEditDialog.tsx
+git commit -m "[Frontend] Change cover protection guards from cover_page to file type checks"
+```
+
+---
+
+### Task 7: Implement `upgradeEnricherCover`
+
+**Files:**
+- Modify: `pkg/worker/scan_unified.go`
+
+- [ ] **Step 1: Write the `upgradeEnricherCover` method**
+
+Add the following method to `pkg/worker/scan_unified.go`, after the `extractAndSaveCover` method (around line 2529):
+
+```go
+// upgradeEnricherCover checks if an enricher provided a cover image that is
+// higher resolution than the file's current cover. If so, it saves the enricher
+// cover to disk and updates the file record.
+//
+// This is called after runMetadataEnrichers in both scan paths (new file creation
+// and rescan). It only applies covers from plugin sources, respects the cover
+// field setting (already enforced by filterMetadataFields), and never replaces
+// covers for page-based formats (CBZ, PDF).
+//
+// bookFilepath is the parent book's filepath. The cover directory is determined
+// automatically: if bookFilepath is a directory, covers are saved there; otherwise
+// (root-level files where the book path may not exist as a directory), covers are
+// saved in the file's parent directory.
+func (w *Worker) upgradeEnricherCover(
+	ctx context.Context,
+	metadata *mediafile.ParsedMetadata,
+	file *models.File,
+	bookFilepath string,
+	jobLog *joblogs.JobLogger,
+) {
+	log := logger.FromContext(ctx)
+
+	logInfo := func(msg string, data logger.Data) {
+		log.Info(msg, data)
+		if jobLog != nil {
+			jobLog.Info(msg, data)
+		}
+	}
+
+	logWarn := func(msg string, data logger.Data) {
+		log.Warn(msg, data)
+		if jobLog != nil {
+			jobLog.Warn(msg, data)
+		}
+	}
+
+	// 1. Skip if no cover data in enriched metadata
+	if metadata == nil || len(metadata.CoverData) == 0 {
+		return
+	}
+
+	// 2. Skip if the cover source is not from a plugin
+	coverSource := metadata.SourceForField("cover")
+	if !strings.HasPrefix(coverSource, models.DataSourcePluginPrefix) {
+		return
+	}
+
+	// 3. Skip for page-based file types — they derive covers from page content
+	if models.IsPageBasedFileType(file.FileType) {
+		return
+	}
+
+	// 4. Determine the cover directory (same logic as recoverMissingCover)
+	coverDir := bookFilepath
+	if info, err := os.Stat(bookFilepath); err != nil || !info.IsDir() {
+		coverDir = filepath.Dir(file.Filepath)
+	}
+
+	coverBaseName := filepath.Base(file.Filepath) + ".cover"
+	existingCoverPath := fileutils.CoverExistsWithBaseName(coverDir, coverBaseName)
+
+	currentResolution := 0
+	if existingCoverPath != "" {
+		currentResolution = fileutils.ImageFileResolution(existingCoverPath)
+	}
+
+	// 5. Resolution gate — enricher cover must be strictly larger
+	enricherResolution := fileutils.ImageResolution(metadata.CoverData)
+	if enricherResolution == 0 {
+		logWarn("enricher cover could not be decoded, skipping", logger.Data{
+			"file_id": file.ID,
+			"source":  coverSource,
+		})
+		return
+	}
+	if enricherResolution <= currentResolution {
+		logInfo("enricher cover not larger than current cover, skipping", logger.Data{
+			"file_id":             file.ID,
+			"enricher_resolution": enricherResolution,
+			"current_resolution":  currentResolution,
+			"source":              coverSource,
+		})
+		return
+	}
+
+	// 6. Save enricher cover — normalize and write to disk
+	normalizedData, normalizedMime, _ := fileutils.NormalizeImage(metadata.CoverData, metadata.CoverMimeType)
+	coverExt := ".png"
+	if normalizedMime == metadata.CoverMimeType {
+		coverExt = metadata.CoverExtension()
+	}
+
+	coverFilename := coverBaseName + coverExt
+	coverFilepath := filepath.Join(coverDir, coverFilename)
+
+	// Remove any existing cover file with a different extension
+	if existingCoverPath != "" && existingCoverPath != coverFilepath {
+		os.Remove(existingCoverPath)
+	}
+
+	coverFile, err := os.Create(coverFilepath)
+	if err != nil {
+		logWarn("failed to save enricher cover", logger.Data{
+			"error": err.Error(),
+			"path":  coverFilepath,
+		})
+		return
+	}
+	defer coverFile.Close()
+
+	if _, err := io.Copy(coverFile, bytes.NewReader(normalizedData)); err != nil {
+		logWarn("failed to write enricher cover data", logger.Data{
+			"error": err.Error(),
+			"path":  coverFilepath,
+		})
+		return
+	}
+
+	logInfo("upgraded cover from enricher (higher resolution)", logger.Data{
+		"file_id":             file.ID,
+		"enricher_resolution": enricherResolution,
+		"current_resolution":  currentResolution,
+		"source":              coverSource,
+		"path":                coverFilepath,
+	})
+
+	// 7. Update file record
+	file.CoverImageFilename = &coverFilename
+	file.CoverMimeType = &normalizedMime
+	file.CoverSource = &coverSource
+	if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
+		Columns: []string{"cover_image_filename", "cover_mime_type", "cover_source"},
+	}); err != nil {
+		logWarn("failed to update file cover after enricher upgrade", logger.Data{
+			"error":   err.Error(),
+			"file_id": file.ID,
+		})
+	}
+}
+```
+
+Make sure these imports are present at the top of `scan_unified.go` (most already are — verify `io` and `bytes` are included):
+- `bytes`
+- `io`
+- `strings`
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && go build ./pkg/worker/`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/worker/scan_unified.go
+git commit -m "[Backend] Add upgradeEnricherCover method for resolution-gated cover upgrades"
+```
+
+---
+
+### Task 8: Integrate `upgradeEnricherCover` into Scan Paths
+
+**Files:**
+- Modify: `pkg/worker/scan_unified.go`
+
+- [ ] **Step 1: Integrate into `scanFileCreateNew`**
+
+In `pkg/worker/scan_unified.go`, find the enricher call in `scanFileCreateNew` (around line 2222):
+
+```go
+	// Run metadata enrichers after parsing
+	metadata = w.runMetadataEnrichers(ctx, metadata, file, book, opts.LibraryID, opts.JobLog)
+```
+
+Add immediately after it:
+
+```go
+	// Apply enricher cover if it's higher resolution than the current cover
+	w.upgradeEnricherCover(ctx, metadata, file, bookPath, opts.JobLog)
+```
+
+- [ ] **Step 2: Integrate into `scanFileByID`**
+
+In `pkg/worker/scan_unified.go`, find the enricher call in `scanFileByID` (around line 456):
+
+```go
+	// Run metadata enrichers after parsing
+	metadata = w.runMetadataEnrichers(ctx, metadata, file, book, file.LibraryID, opts.JobLog)
+```
+
+Add immediately after it:
+
+```go
+	// Apply enricher cover if it's higher resolution than the current cover
+	w.upgradeEnricherCover(ctx, metadata, file, book.Filepath, opts.JobLog)
+```
+
+Note: The function determines the cover directory automatically from the book filepath — if it's a directory, covers go there; otherwise it falls back to the file's parent directory (handles root-level files correctly).
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && go build ./pkg/worker/`
+Expected: No errors
+
+- [ ] **Step 4: Run all worker tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && go test ./pkg/worker/ -v -count=1`
+Expected: All PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/worker/scan_unified.go
+git commit -m "[Backend] Integrate upgradeEnricherCover into both scan paths"
+```
+
+---
+
+### Task 9: Add Tests for `upgradeEnricherCover`
+
+**Files:**
+- Create: `pkg/worker/scan_cover_upgrade_test.go`
+
+- [ ] **Step 1: Write tests for the upgrade logic**
+
+Create `pkg/worker/scan_cover_upgrade_test.go`. These are unit tests for the resolution comparison and file type guard logic. Since `upgradeEnricherCover` is a method on `Worker` and requires `bookService`, we test the core decision logic by testing the helpers and the integration through the existing enricher test patterns.
+
+```go
+package worker
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/fileutils"
+	"github.com/shishobooks/shisho/pkg/mediafile"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeJPEG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
+	return buf.Bytes()
+}
+
+func makePNG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	var buf bytes.Buffer
+	png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+// TestEnricherCoverResolutionGate tests the resolution comparison logic
+// that decides whether an enricher cover should replace the current cover.
+func TestEnricherCoverResolutionGate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enricher cover larger than current is accepted", func(t *testing.T) {
+		t.Parallel()
+		current := makeJPEG(200, 300)   // 60,000 pixels
+		enricher := makeJPEG(800, 1200) // 960,000 pixels
+
+		currentRes := fileutils.ImageResolution(current)
+		enricherRes := fileutils.ImageResolution(enricher)
+
+		assert.Greater(t, enricherRes, currentRes)
+	})
+
+	t.Run("enricher cover same size as current is rejected", func(t *testing.T) {
+		t.Parallel()
+		current := makeJPEG(800, 1200)
+		enricher := makeJPEG(800, 1200)
+
+		currentRes := fileutils.ImageResolution(current)
+		enricherRes := fileutils.ImageResolution(enricher)
+
+		// enricherResolution <= currentResolution → skip
+		assert.False(t, enricherRes > currentRes)
+	})
+
+	t.Run("enricher cover smaller than current is rejected", func(t *testing.T) {
+		t.Parallel()
+		current := makeJPEG(800, 1200)
+		enricher := makeJPEG(200, 300)
+
+		currentRes := fileutils.ImageResolution(current)
+		enricherRes := fileutils.ImageResolution(enricher)
+
+		assert.False(t, enricherRes > currentRes)
+	})
+
+	t.Run("no current cover — enricher always accepted", func(t *testing.T) {
+		t.Parallel()
+		enricher := makeJPEG(400, 600)
+
+		currentRes := 0 // no cover on disk
+		enricherRes := fileutils.ImageResolution(enricher)
+
+		assert.Greater(t, enricherRes, currentRes)
+	})
+
+	t.Run("undecodable enricher cover is rejected", func(t *testing.T) {
+		t.Parallel()
+		enricherRes := fileutils.ImageResolution([]byte("not an image"))
+		assert.Equal(t, 0, enricherRes)
+	})
+}
+
+// TestEnricherCoverPageBasedGuard tests that page-based file types block enricher covers.
+func TestEnricherCoverPageBasedGuard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CBZ blocks enricher covers", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, models.IsPageBasedFileType(models.FileTypeCBZ))
+	})
+
+	t.Run("PDF blocks enricher covers", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, models.IsPageBasedFileType(models.FileTypePDF))
+	})
+
+	t.Run("EPUB allows enricher covers", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, models.IsPageBasedFileType(models.FileTypeEPUB))
+	})
+
+	t.Run("M4B allows enricher covers", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, models.IsPageBasedFileType(models.FileTypeM4B))
+	})
+}
+
+// TestEnricherCoverPluginSourceCheck tests that only plugin-sourced covers trigger upgrades.
+func TestEnricherCoverPluginSourceCheck(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plugin source is detected", func(t *testing.T) {
+		t.Parallel()
+		md := &mediafile.ParsedMetadata{
+			CoverData:     makeJPEG(800, 1200),
+			CoverMimeType: "image/jpeg",
+			FieldDataSources: map[string]string{
+				"cover": models.PluginDataSource("test", "enricher"),
+			},
+		}
+		source := md.SourceForField("cover")
+		assert.True(t, len(source) > len(models.DataSourcePluginPrefix))
+		assert.Equal(t, "plugin:", source[:7])
+	})
+
+	t.Run("file metadata source is not a plugin", func(t *testing.T) {
+		t.Parallel()
+		md := &mediafile.ParsedMetadata{
+			CoverData:     makeJPEG(800, 1200),
+			CoverMimeType: "image/jpeg",
+			DataSource:    models.DataSourceEPUBMetadata,
+		}
+		source := md.SourceForField("cover")
+		assert.NotEqual(t, "plugin:", source[:7])
+	})
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && go test ./pkg/worker/ -run "TestEnricherCover" -v`
+Expected: All PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/worker/scan_cover_upgrade_test.go
+git commit -m "[Test] Add tests for enricher cover resolution gate and file type guard"
+```
+
+---
+
+### Task 10: Update Website Documentation
+
+**Files:**
+- Modify: `website/docs/plugins/development.md`
+
+- [ ] **Step 1: Update the Cover Images section**
+
+In `website/docs/plugins/development.md`, find the "#### Cover Images" section (around line 414). Replace the existing content with an expanded version. Change:
+
+```markdown
+#### Cover Images
+
+Set `coverUrl` on your search results — the server handles downloading and domain validation automatically. The URL's domain must be in your manifest's `httpAccess.domains` list.
+
+```javascript
+return {
+  results: [{
+    title: "Book Title",
+    coverUrl: "https://covers.example.com/book.jpg"
+  }]
+};
+```
+
+For advanced use cases (file parsers extracting embedded covers, or enrichers that generate/composite images), you can set `coverData` as an `ArrayBuffer` instead. If both are set, `coverData` takes precedence.
+```
+
+To:
+
+```markdown
+#### Cover Images
+
+Set `coverUrl` on your search results — the server handles downloading and domain validation automatically. The URL's domain must be in your manifest's `httpAccess.domains` list.
+
+```javascript
+return {
+  results: [{
+    title: "Book Title",
+    coverUrl: "https://covers.example.com/book.jpg"
+  }]
+};
+```
+
+For advanced use cases (file parsers extracting embedded covers, or enrichers that generate/composite images), you can set `coverData` as an `ArrayBuffer` instead. If both are set, `coverData` takes precedence.
+
+**Cover enrichment rules:**
+
+During automatic scans, enricher-provided covers are subject to additional checks:
+
+- **Resolution gate:** An enricher cover is only applied if its total resolution (width × height) is strictly greater than the file's current cover. If the file already has a cover of equal or greater resolution, the enricher cover is skipped. This prevents low-resolution external images from replacing high-quality embedded covers.
+- **Page-based formats:** CBZ and PDF files derive covers from their page content. Plugin covers are never applied to these formats, even if the plugin declares the `cover` field.
+- **Field settings:** The `cover` field must be enabled in the plugin's per-library field settings for cover enrichment to take effect. If disabled, all cover data from the plugin is silently stripped.
+```
+
+- [ ] **Step 2: Update the Enrichment Behavior section**
+
+In the same file, find the "#### Enrichment Behavior" section (around line 476). After the paragraph that starts "When a user identifies a book using the interactive review screen", add a new paragraph:
+
+```markdown
+During automatic scans, enrichment also respects a cover resolution gate — enricher covers must have a higher total resolution than the existing cover to be applied. See [Cover Images](#cover-images) above for details.
+```
+
+- [ ] **Step 3: Verify the docs build**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && mise docs &` then check for build errors. If `mise docs` is not available in the worktree, just verify the markdown is valid.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/docs/plugins/development.md
+git commit -m "[Docs] Document enricher cover resolution gate and page-based format protection"
+```
+
+---
+
+### Task 11: Run Full Validation
+
+**Files:** None (validation only)
+
+- [ ] **Step 1: Run all checks**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/auto-cover && mise check:quiet`
+Expected: All checks pass (Go tests, Go lint, JS lint, JS tests)
+
+- [ ] **Step 2: Fix any issues**
+
+If any check fails, fix the issue and re-run. Common issues:
+- Missing imports in Go files
+- Linting issues (unused variables, formatting)
+- TypeScript type errors from the frontend changes
+
+- [ ] **Step 3: Final commit if fixes were needed**
+
+Only commit if changes were made in step 2.

--- a/docs/superpowers/specs/2026-03-29-enricher-cover-resolution-gate-design.md
+++ b/docs/superpowers/specs/2026-03-29-enricher-cover-resolution-gate-design.md
@@ -1,0 +1,231 @@
+# Enricher Cover Resolution Gate
+
+## Problem
+
+Three related issues with how enricher (plugin) covers are handled during the scan pipeline:
+
+1. **Enricher covers are computed but never saved.** In `scanFileCreateNew`, the file's embedded cover is saved to disk (line 2120) *before* enrichers run (line 2222). The enriched metadata flows into `scanFileCore`, but there is no code to persist enricher cover data. Similarly, during rescans (`scanFileByID`), enrichers run but cover data is not applied.
+
+2. **No resolution gate.** When enrichers provide covers, there is no check that the enricher cover is actually better (higher resolution) than the current cover. A low-resolution enricher image could replace a high-quality embedded cover.
+
+3. **Page-based format protection uses `CoverPage != nil` instead of file type.** The current guard at `scan_unified.go:2770` and `books/handlers.go:1250` blocks external covers only when `CoverPage` is set. For PDFs where cover extraction fails, `CoverPage` is nil, which would allow an external cover despite the format being page-based. Both backend and frontend have this issue.
+
+## Design
+
+### 1. File Type Helper
+
+Add a centralized helper to determine if a file type is page-based (derives cover from page content).
+
+**Backend** (`pkg/models/file.go`):
+```go
+func IsPageBasedFileType(fileType string) bool {
+    return fileType == FileTypeCBZ || fileType == FileTypePDF
+}
+```
+
+**Frontend** (`app/libraries/utils.ts` or similar):
+```ts
+export const isPageBasedFileType = (fileType: string): boolean =>
+  fileType === "cbz" || fileType === "pdf";
+```
+
+### 2. Change Guards from `CoverPage != nil` to File Type
+
+Replace all guard-style `CoverPage != nil` checks with the file type helper.
+
+**Backend changes:**
+
+| Location | Current | New |
+|----------|---------|-----|
+| `pkg/books/handlers.go:1250` | `file.CoverPage != nil` | `models.IsPageBasedFileType(file.FileType)` |
+| `pkg/worker/scan_unified.go:2770` | `metadata.CoverPage != nil` | `models.IsPageBasedFileType(fileType)` — needs `fileType` passed into `runMetadataEnrichers` |
+
+**Frontend changes:**
+
+| Location | Current | New |
+|----------|---------|-----|
+| `IdentifyReviewForm.tsx:525` | `file?.cover_page == null` | `!isPageBasedFileType(file?.file_type)` |
+| `FileEditDialog.tsx` (multiple lines) | `file.cover_page == null` / `file.cover_page != null` | `!isPageBasedFileType(file.file_type)` / `isPageBasedFileType(file.file_type)` |
+
+Lines in `FileEditDialog.tsx` that use `cover_page` as **data** (value display, page picker current page, comparison for pending changes) should NOT change.
+
+**No changes needed** for places that use `CoverPage` as data:
+- `scan_unified.go:2136` — assigns value to new file record
+- `scan_unified.go:2855` — merges value in enrichment
+- `scan_unified.go:1795` — sidecar restoration (already checks file type)
+- `filegen/cbz.go:450`, `filegen/kepub_cbz.go:104`, `kepub/cbz.go:470` — generation
+- `downloadcache/fingerprint.go:246` — fingerprint
+
+### 3. PDF Parser: Always Set CoverPage
+
+In `pkg/pdf/pdf.go`, always set `CoverPage = 0` for PDFs regardless of whether cover extraction succeeds. This ensures:
+- The frontend page picker always has a valid initial value
+- The data is consistent: PDFs are page-based and page 0 is always the cover page
+
+```go
+// Before (line 88-98):
+var coverPage *int
+if cd, cm, err := extractCover(path); err == nil {
+    coverData = cd
+    coverMime = cm
+    page0 := 0
+    coverPage = &page0
+}
+
+// After:
+page0 := 0
+coverPage := &page0  // PDF covers always derive from page 0
+if cd, cm, err := extractCover(path); err == nil {
+    coverData = cd
+    coverMime = cm
+}
+```
+
+Update the comment in the PDF parser to explain this, and add a note to `pkg/pdf/CLAUDE.md`.
+
+### 4. Image Resolution Helper
+
+Add to `pkg/fileutils/operations.go`:
+
+```go
+// ImageResolution returns the total pixel count (width * height) of an image
+// by reading only the image header (no full decode). Returns 0 if the image
+// cannot be decoded.
+func ImageResolution(data []byte) int {
+    cfg, _, err := image.DecodeConfig(bytes.NewReader(data))
+    if err != nil {
+        return 0
+    }
+    return cfg.Width * cfg.Height
+}
+
+// ImageFileResolution returns the total pixel count of an image file on disk.
+// Returns 0 if the file cannot be read or decoded.
+func ImageFileResolution(path string) int {
+    f, err := os.Open(path)
+    if err != nil {
+        return 0
+    }
+    defer f.Close()
+    cfg, _, err := image.DecodeConfig(f)
+    if err != nil {
+        return 0
+    }
+    return cfg.Width * cfg.Height
+}
+```
+
+Uses `image.DecodeConfig` which reads only the header — no full image decode needed.
+
+### 5. Post-Enrichment Cover Upgrade
+
+Add a new function `upgradeEnricherCover` that handles comparing and applying enricher covers. This is called after `runMetadataEnrichers` in both scan paths.
+
+**Logic:**
+
+```
+func upgradeEnricherCover(metadata, file, bookPath, ...) {
+    // 1. Skip if no enricher cover data
+    if metadata.CoverData is empty:
+        return
+
+    // 2. Skip if cover field source is NOT a plugin
+    if metadata.FieldDataSources["cover"] is not a plugin source:
+        return
+
+    // 3. Skip for page-based file types (CBZ, PDF)
+    if IsPageBasedFileType(file.FileType):
+        return
+
+    // 4. Determine the "current" cover to compare against
+    existingCoverPath = find cover file on disk for this file
+    if existingCoverPath exists:
+        currentResolution = ImageFileResolution(existingCoverPath)
+    else:
+        // No cover on disk — enricher cover always wins
+        currentResolution = 0
+
+    // 5. Resolution gate
+    enricherResolution = ImageResolution(metadata.CoverData)
+    if enricherResolution == 0:
+        // Can't decode enricher cover — skip
+        return
+    if enricherResolution <= currentResolution:
+        log("enricher cover not larger than current, skipping")
+        return
+
+    // 6. Save enricher cover (overwrite existing)
+    save normalized cover to disk
+    update file record (CoverImageFilename, CoverMimeType, CoverSource)
+}
+```
+
+**Integration points:**
+
+In `scanFileCreateNew` (after line 2222):
+```go
+metadata = w.runMetadataEnrichers(ctx, metadata, file, book, opts.LibraryID, opts.JobLog)
+
+// NEW: Apply enricher cover if it's higher resolution than the current cover
+w.upgradeEnricherCover(ctx, metadata, file, bookPath, isRootLevelFile, opts.JobLog)
+```
+
+In `scanFileByID` (after line 456):
+```go
+metadata = w.runMetadataEnrichers(ctx, metadata, file, book, file.LibraryID, opts.JobLog)
+
+// NEW: Apply enricher cover if it's higher resolution than the current cover
+w.upgradeEnricherCover(ctx, metadata, file, book.Filepath, false, opts.JobLog)
+```
+
+**Plugin field settings are already respected:** The `filterMetadataFields` function (line 2952) zeros out all cover data when the "cover" field is disabled for a plugin. This happens before `upgradeEnricherCover` runs, so there would be no cover data to upgrade with.
+
+### 6. Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No current cover (no cover on disk, file has no embedded cover) | Enricher cover accepted (currentResolution = 0) |
+| Enricher cover can't be decoded | Skipped (enricherResolution = 0) |
+| Current cover can't be decoded | Enricher cover accepted (currentResolution = 0, benefit of doubt) |
+| CoverPage is set (CBZ/PDF) | Enricher cover blocked by file type check (step 3) AND by existing line 2770 guard |
+| Cover field disabled for plugin | Cover data already zeroed by filterMetadataFields — nothing to upgrade |
+| Multiple enrichers provide covers | First-wins merge in runMetadataEnrichers — only the first enricher's cover is considered |
+| Enricher provides coverUrl but no coverData | DownloadCoverFromURL populates coverData before the upgrade step |
+
+### 7. Website Documentation
+
+Update `website/docs/plugins/development.md` in the **Cover Images** subsection (around line 414) to document:
+
+1. **Resolution gate**: Enricher covers are only applied during automatic scans if they have a higher total resolution (width x height) than the file's current cover. If the file already has a cover of equal or greater resolution, the enricher cover is skipped.
+
+2. **Page-based formats**: CBZ and PDF files derive covers from their page content. Plugin covers are never applied to these formats, even if the plugin declares the `cover` field.
+
+3. **Field settings**: The `cover` field must be enabled in the plugin's field settings for a library for cover enrichment to take effect.
+
+Also add a note to the metadata enricher section (around line 476) that automatic enrichment respects both the confidence threshold and the cover resolution gate.
+
+### 8. Test Updates
+
+Update `pkg/worker/scan_enricher_test.go`:
+- Lines 469, 513: Change `CoverPage != nil` checks to use the file type helper
+- Add test cases for the resolution gate behavior
+- Add test cases verifying page-based formats block enricher covers regardless of CoverPage
+
+Add tests for `ImageResolution` and `ImageFileResolution` in `pkg/fileutils/`.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `pkg/models/file.go` | Add `IsPageBasedFileType()` helper |
+| `pkg/fileutils/operations.go` | Add `ImageResolution()`, `ImageFileResolution()` |
+| `pkg/pdf/pdf.go` | Always set `CoverPage = 0` |
+| `pkg/pdf/CLAUDE.md` | Note about CoverPage always being set |
+| `pkg/worker/scan_unified.go` | Add `upgradeEnricherCover()`, change CoverPage guard to file type, pass fileType to `runMetadataEnrichers`, integrate upgrade in both scan paths |
+| `pkg/worker/scan_enricher_test.go` | Update CoverPage guard tests, add resolution gate tests |
+| `pkg/books/handlers.go` | Change cover upload guard to file type |
+| `app/components/library/IdentifyReviewForm.tsx` | Change `coverEditable` to file type check |
+| `app/components/library/FileEditDialog.tsx` | Change guard-style CoverPage checks to file type |
+| `app/libraries/utils.ts` (or similar) | Add `isPageBasedFileType()` frontend helper |
+| `website/docs/plugins/development.md` | Document resolution gate, page-based format protection, field settings |
+| `pkg/fileutils/operations_test.go` | Tests for resolution helpers |

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -78,28 +78,28 @@ Each book has an optional `PrimaryFileID` (`*int`) that designates which file is
 - Book model has `ResolveCoverImage()` method that finds covers dynamically
 - API endpoints: `/books/{id}/cover` and `/files/{id}/cover`
 
-**CRITICAL - CoverImagePath stores FILENAME ONLY:**
+**CRITICAL - CoverImageFilename stores FILENAME ONLY:**
 
-`file.CoverImagePath` stores just the filename (e.g., `MyBook.cbz.cover.jpg`), NOT the full path. The full path is constructed at runtime by joining the book directory with the filename.
+`file.CoverImageFilename` stores just the filename (e.g., `MyBook.cbz.cover.jpg`), NOT the full path. The full path is constructed at runtime by joining the book directory with the filename.
 
-When updating `CoverImagePath` (e.g., after renaming a file), always use `filepath.Base()` to extract just the filename:
+When updating `CoverImageFilename` (e.g., after renaming a file), always use `filepath.Base()` to extract just the filename:
 
 ```go
 // ❌ WRONG - stores full path, breaks cover serving
-newCoverPath := fileutils.ComputeNewCoverPath(*file.CoverImagePath, newPath)
-file.CoverImagePath = &newCoverPath
+newCoverPath := fileutils.ComputeNewCoverPath(*file.CoverImageFilename, newPath)
+file.CoverImageFilename = &newCoverPath
 
 // ✅ CORRECT - stores filename only
-newCoverPath := filepath.Base(fileutils.ComputeNewCoverPath(*file.CoverImagePath, newPath))
-file.CoverImagePath = &newCoverPath
+newCoverPath := filepath.Base(fileutils.ComputeNewCoverPath(*file.CoverImageFilename, newPath))
+file.CoverImageFilename = &newCoverPath
 ```
 
 **Why this matters:** The `bookCover` handler constructs the full path as:
 ```go
-coverPath := filepath.Join(coverDir, *coverFile.CoverImagePath)
+coverPath := filepath.Join(coverDir, *coverFile.CoverImageFilename)
 ```
 
-If `CoverImagePath` contains a full path, this results in an invalid doubled path like `/path/to/path/to/cover.jpg`.
+If `CoverImageFilename` contains a full path, this results in an invalid doubled path like `/path/to/path/to/cover.jpg`.
 
 ### Data Source Priority System
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1245,9 +1245,9 @@ func (h *handler) uploadFileCover(c echo.Context) error {
 		}
 	}
 
-	// Files with cover_page derive their cover from page content (CBZ, PDF) and
+	// Page-based formats (CBZ, PDF) derive their cover from page content and
 	// cannot have it replaced by upload.
-	if file.CoverPage != nil {
+	if models.IsPageBasedFileType(file.FileType) {
 		return errcodes.ValidationError("Cover upload is not supported for this file type.")
 	}
 

--- a/pkg/fileutils/operations.go
+++ b/pkg/fileutils/operations.go
@@ -615,6 +615,35 @@ func MoveFileWithAssociatedFiles(originalFilePath, newFilePath string) (int, err
 	return associatedMoved, nil
 }
 
+// ImageResolution returns the total pixel count (width * height) of an image
+// by reading only the image header (no full decode). Returns 0 if the image
+// cannot be decoded.
+func ImageResolution(data []byte) int {
+	if len(data) == 0 {
+		return 0
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return 0
+	}
+	return cfg.Width * cfg.Height
+}
+
+// ImageFileResolution returns the total pixel count of an image file on disk.
+// Returns 0 if the file cannot be read or decoded.
+func ImageFileResolution(path string) int {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	cfg, _, err := image.DecodeConfig(f)
+	if err != nil {
+		return 0
+	}
+	return cfg.Width * cfg.Height
+}
+
 // moveFileAssociatedFiles moves only file-specific associated files (covers and file sidecar).
 // This does NOT move book sidecars - use moveAssociatedCovers for that.
 func moveFileAssociatedFiles(originalFilePath, newFilePath string) (int, error) {

--- a/pkg/fileutils/resolution_test.go
+++ b/pkg/fileutils/resolution_test.go
@@ -1,0 +1,97 @@
+package fileutils
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestJPEG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
+	return buf.Bytes()
+}
+
+func createTestPNG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 0, G: 0, B: 255, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+func TestImageResolution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns width * height for JPEG", func(t *testing.T) {
+		t.Parallel()
+		data := createTestJPEG(800, 1200)
+		assert.Equal(t, 800*1200, ImageResolution(data))
+	})
+
+	t.Run("returns width * height for PNG", func(t *testing.T) {
+		t.Parallel()
+		data := createTestPNG(640, 480)
+		assert.Equal(t, 640*480, ImageResolution(data))
+	})
+
+	t.Run("returns 0 for invalid data", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, ImageResolution([]byte("not an image")))
+	})
+
+	t.Run("returns 0 for empty data", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, ImageResolution(nil))
+	})
+}
+
+func TestImageFileResolution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns resolution for JPEG file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.jpg")
+		os.WriteFile(path, createTestJPEG(1024, 768), 0644)
+		assert.Equal(t, 1024*768, ImageFileResolution(path))
+	})
+
+	t.Run("returns resolution for PNG file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.png")
+		os.WriteFile(path, createTestPNG(500, 700), 0644)
+		assert.Equal(t, 500*700, ImageFileResolution(path))
+	})
+
+	t.Run("returns 0 for nonexistent file", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, ImageFileResolution("/nonexistent/path.jpg"))
+	})
+
+	t.Run("returns 0 for non-image file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.txt")
+		os.WriteFile(path, []byte("hello"), 0644)
+		assert.Equal(t, 0, ImageFileResolution(path))
+	})
+}

--- a/pkg/models/file.go
+++ b/pkg/models/file.go
@@ -75,3 +75,10 @@ func (f *File) CoverExtension() string {
 	}
 	return ext
 }
+
+// IsPageBasedFileType returns true for file types that derive covers from page
+// content (CBZ, PDF). These formats should never have their covers replaced by
+// external sources (plugins, uploads).
+func IsPageBasedFileType(fileType string) bool {
+	return fileType == FileTypeCBZ || fileType == FileTypePDF
+}

--- a/pkg/pdf/CLAUDE.md
+++ b/pkg/pdf/CLAUDE.md
@@ -67,6 +67,15 @@ Cover extraction uses a two-tier approach implemented in `pkg/pdf/cover.go`:
 - The pdfium WASM pool is lazily initialized via `sync.Once` (embeds ~15-25 MB PDFium binary)
 - Pool configured with `MaxTotal: 1` to limit memory usage
 
+### CoverPage Always Set
+
+`CoverPage` is always set to `0` for PDF files, even when cover extraction fails. This ensures:
+- The frontend shows the page picker (not the upload button)
+- File type guards consistently block external covers for PDFs
+- The data is consistent: PDFs are page-based formats
+
+Do NOT conditionally set `CoverPage` based on extraction success. The file type (`models.IsPageBasedFileType`) is the authoritative guard for cover protection, and `CoverPage` serves as page selection data.
+
 ### Error Handling
 
 Cover extraction is best-effort. If either tier fails, `Parse()` logs a warning and returns metadata without a cover (does not fail the parse).

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -85,16 +85,16 @@ func Parse(path string) (*mediafile.ParsedMetadata, error) {
 	}
 
 	// Extract cover image (best-effort: don't fail Parse if cover extraction fails).
-	// PDF covers are always derived from page 0, so set CoverPage to signal this
-	// is a page-based cover that should not be overwritten.
+	// PDF is a page-based format — always set CoverPage to 0 regardless of whether
+	// cover extraction succeeds. This ensures the frontend shows the page picker
+	// and the file type guard blocks external covers consistently.
+	page0 := 0
+	coverPage := &page0
 	var coverData []byte
 	var coverMime string
-	var coverPage *int
 	if cd, cm, err := extractCover(path); err == nil {
 		coverData = cd
 		coverMime = cm
-		page0 := 0
-		coverPage = &page0
 	}
 
 	// Extract outline (bookmarks) as chapters. Best-effort — don't fail Parse.

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -467,8 +467,10 @@ Plugin data sources use format `plugin:scope/id` (e.g., `plugin:shisho/goodreads
 ## Thread Safety
 
 - `Manager.mu` (RWMutex): protects `plugins` map
-- `Runtime.mu` (RWMutex): Read lock for hook invocation, write lock for reload
+- `Runtime.mu` (RWMutex): **Exclusive lock** for hook invocation, write lock for reload
+- Goja VMs are single-threaded — concurrent JS execution on the same VM corrupts internal state. All hook runners acquire an exclusive lock (`rt.mu.Lock()`) to ensure only one goroutine executes JS on a given runtime at a time. Different plugins (different runtimes) can run concurrently.
 - Hot-reload: acquire write lock on old runtime → swap in new → release
+- **CRITICAL:** Never use `RLock` for hook invocations. The parallel scan worker pool will call hooks from multiple goroutines simultaneously, and goja cannot handle concurrent access.
 
 ## Scan Pipeline Integration
 

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -15,6 +15,18 @@ import (
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
+// safeCallJS invokes a goja function with panic recovery. The goja runtime can
+// panic on certain JS exceptions (e.g., nil pointer in handleThrow). This wrapper
+// ensures plugin errors never crash the server.
+func safeCallJS(fn goja.Callable, this goja.Value, args ...goja.Value) (result goja.Value, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("JS runtime panicked: %v", r)
+		}
+	}()
+	return fn(this, args...)
+}
+
 // ConvertResult is the result of an input converter hook.
 type ConvertResult struct {
 	Success    bool
@@ -60,7 +72,7 @@ func (m *Manager) RunInputConverter(ctx context.Context, rt *Runtime, sourcePath
 	contextObj.Set("targetDir", targetDir)   //nolint:errcheck
 
 	// Call the hook
-	result, err := convertFn(goja.Undefined(), rt.vm.ToValue(contextObj))
+	result, err := safeCallJS(convertFn, goja.Undefined(), rt.vm.ToValue(contextObj))
 	if err != nil {
 		return nil, errors.Wrap(err, "inputConverter.convert failed")
 	}
@@ -108,7 +120,7 @@ func (m *Manager) RunFileParser(ctx context.Context, rt *Runtime, filePath, file
 	contextObj.Set("fileType", fileType) //nolint:errcheck
 
 	// Call the hook
-	result, err := parseFn(goja.Undefined(), rt.vm.ToValue(contextObj))
+	result, err := safeCallJS(parseFn, goja.Undefined(), rt.vm.ToValue(contextObj))
 	if err != nil {
 		return nil, errors.Wrap(err, "fileParser.parse failed")
 	}
@@ -167,7 +179,7 @@ func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx 
 	}
 
 	// Call the hook
-	result, err := searchFn(goja.Undefined(), rt.vm.ToValue(searchCtx))
+	result, err := safeCallJS(searchFn, goja.Undefined(), rt.vm.ToValue(searchCtx))
 	if err != nil {
 		return nil, errors.Wrap(err, "metadataEnricher.search failed")
 	}
@@ -217,7 +229,7 @@ func (m *Manager) RunOutputGenerator(ctx context.Context, rt *Runtime, sourcePat
 	contextObj.Set("file", fileCtx)          //nolint:errcheck
 
 	// Call the hook
-	_, err := generateFn(goja.Undefined(), rt.vm.ToValue(contextObj))
+	_, err := safeCallJS(generateFn, goja.Undefined(), rt.vm.ToValue(contextObj))
 	if err != nil {
 		return errors.Wrap(err, "outputGenerator.generate failed")
 	}
@@ -251,7 +263,7 @@ func (m *Manager) RunFingerprint(rt *Runtime, bookCtx, fileCtx map[string]interf
 	contextObj.Set("file", fileCtx) //nolint:errcheck
 
 	// Call the hook
-	result, err := fingerprintFn(goja.Undefined(), rt.vm.ToValue(contextObj))
+	result, err := safeCallJS(fingerprintFn, goja.Undefined(), rt.vm.ToValue(contextObj))
 	if err != nil {
 		return "", errors.Wrap(err, "outputGenerator.fingerprint failed")
 	}

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -2,7 +2,6 @@ package plugins
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -684,17 +683,13 @@ func (m *Manager) RunOnUninstalling(rt *Runtime) {
 		fsCtx.Cleanup() //nolint:errcheck
 	}()
 
-	// Call the hook, recovering from panics (errors don't prevent uninstall)
+	// Call the hook — errors don't prevent uninstall
 	log := logger.New()
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				log.Warn("onUninstalling hook panicked", logger.Data{
-					"plugin": rt.scope + "/" + rt.pluginID,
-					"panic":  fmt.Sprintf("%v", r),
-				})
-			}
-		}()
-		_, _ = rt.onUninstalling(goja.Undefined())
-	}()
+	_, err := safeCallJS(rt.onUninstalling, goja.Undefined())
+	if err != nil {
+		log.Warn("onUninstalling hook failed", logger.Data{
+			"plugin": rt.scope + "/" + rt.pluginID,
+			"error":  err.Error(),
+		})
+	}
 }

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -15,13 +15,15 @@ import (
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
+var errJSPanic = errors.New("JS runtime panicked")
+
 // safeCallJS invokes a goja function with panic recovery. The goja runtime can
 // panic on certain JS exceptions (e.g., nil pointer in handleThrow). This wrapper
 // ensures plugin errors never crash the server.
 func safeCallJS(fn goja.Callable, this goja.Value, args ...goja.Value) (result goja.Value, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("JS runtime panicked: %v", r)
+			err = errors.Wrapf(errJSPanic, "%v", r)
 		}
 	}()
 	return fn(this, args...)

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -43,8 +43,8 @@ func (m *Manager) RunInputConverter(ctx context.Context, rt *Runtime, sourcePath
 	defer cancel()
 	_ = ctx // reserved for future cancellation support
 
-	rt.mu.RLock()
-	defer rt.mu.RUnlock()
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
 
 	// Set up FSContext
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
@@ -91,8 +91,8 @@ func (m *Manager) RunFileParser(ctx context.Context, rt *Runtime, filePath, file
 	defer cancel()
 	_ = ctx // reserved for future cancellation support
 
-	rt.mu.RLock()
-	defer rt.mu.RUnlock()
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
 
 	// Set up FSContext
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
@@ -155,8 +155,8 @@ func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx 
 	defer cancel()
 	_ = ctx // reserved for future cancellation support
 
-	rt.mu.RLock()
-	defer rt.mu.RUnlock()
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
 
 	// Set up FSContext (no extra allowed paths for enrichers)
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
@@ -198,8 +198,8 @@ func (m *Manager) RunOutputGenerator(ctx context.Context, rt *Runtime, sourcePat
 	defer cancel()
 	_ = ctx // reserved for future cancellation support
 
-	rt.mu.RLock()
-	defer rt.mu.RUnlock()
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
 
 	// Set up FSContext
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
@@ -243,8 +243,8 @@ func (m *Manager) RunFingerprint(rt *Runtime, bookCtx, fileCtx map[string]interf
 		return "", errors.New("plugin does not have an outputGenerator hook")
 	}
 
-	rt.mu.RLock()
-	defer rt.mu.RUnlock()
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
 
 	// Get the fingerprint method
 	generatorObj := rt.outputGenerator.ToObject(rt.vm)
@@ -670,8 +670,8 @@ func (m *Manager) RunOnUninstalling(rt *Runtime) {
 		return
 	}
 
-	rt.mu.RLock()
-	defer rt.mu.RUnlock()
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
 
 	// Set up FSContext for the hook (plugin dir + data dir only)
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)

--- a/pkg/worker/scan_cover_upgrade_test.go
+++ b/pkg/worker/scan_cover_upgrade_test.go
@@ -1,0 +1,145 @@
+package worker
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/fileutils"
+	"github.com/shishobooks/shisho/pkg/mediafile"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeJPEG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
+	return buf.Bytes()
+}
+
+func makePNG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	var buf bytes.Buffer
+	png.Encode(&buf, img)
+	return buf.Bytes()
+}
+
+// TestEnricherCoverResolutionGate tests the resolution comparison logic
+// that decides whether an enricher cover should replace the current cover.
+func TestEnricherCoverResolutionGate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enricher cover larger than current is accepted", func(t *testing.T) {
+		t.Parallel()
+		current := makeJPEG(200, 300)   // 60,000 pixels
+		enricher := makeJPEG(800, 1200) // 960,000 pixels
+
+		currentRes := fileutils.ImageResolution(current)
+		enricherRes := fileutils.ImageResolution(enricher)
+
+		assert.Greater(t, enricherRes, currentRes)
+	})
+
+	t.Run("enricher cover same size as current is rejected", func(t *testing.T) {
+		t.Parallel()
+		current := makeJPEG(800, 1200)
+		enricher := makeJPEG(800, 1200)
+
+		currentRes := fileutils.ImageResolution(current)
+		enricherRes := fileutils.ImageResolution(enricher)
+
+		// enricherResolution <= currentResolution → skip
+		assert.False(t, enricherRes > currentRes)
+	})
+
+	t.Run("enricher cover smaller than current is rejected", func(t *testing.T) {
+		t.Parallel()
+		current := makeJPEG(800, 1200)
+		enricher := makeJPEG(200, 300)
+
+		currentRes := fileutils.ImageResolution(current)
+		enricherRes := fileutils.ImageResolution(enricher)
+
+		assert.False(t, enricherRes > currentRes)
+	})
+
+	t.Run("no current cover — enricher always accepted", func(t *testing.T) {
+		t.Parallel()
+		enricher := makeJPEG(400, 600)
+
+		currentRes := 0 // no cover on disk
+		enricherRes := fileutils.ImageResolution(enricher)
+
+		assert.Greater(t, enricherRes, currentRes)
+	})
+
+	t.Run("undecodable enricher cover is rejected", func(t *testing.T) {
+		t.Parallel()
+		enricherRes := fileutils.ImageResolution([]byte("not an image"))
+		assert.Equal(t, 0, enricherRes)
+	})
+}
+
+// TestEnricherCoverPageBasedGuard tests that page-based file types block enricher covers.
+func TestEnricherCoverPageBasedGuard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CBZ blocks enricher covers", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, models.IsPageBasedFileType(models.FileTypeCBZ))
+	})
+
+	t.Run("PDF blocks enricher covers", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, models.IsPageBasedFileType(models.FileTypePDF))
+	})
+
+	t.Run("EPUB allows enricher covers", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, models.IsPageBasedFileType(models.FileTypeEPUB))
+	})
+
+	t.Run("M4B allows enricher covers", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, models.IsPageBasedFileType(models.FileTypeM4B))
+	})
+}
+
+// TestEnricherCoverPluginSourceCheck tests that only plugin-sourced covers trigger upgrades.
+func TestEnricherCoverPluginSourceCheck(t *testing.T) {
+	t.Parallel()
+
+	t.Run("plugin source is detected", func(t *testing.T) {
+		t.Parallel()
+		md := &mediafile.ParsedMetadata{
+			CoverData:     makeJPEG(800, 1200),
+			CoverMimeType: "image/jpeg",
+			FieldDataSources: map[string]string{
+				"cover": models.PluginDataSource("test", "enricher"),
+			},
+		}
+		source := md.SourceForField("cover")
+		assert.True(t, len(source) > len(models.DataSourcePluginPrefix))
+		assert.Equal(t, "plugin:", source[:7])
+	})
+
+	t.Run("file metadata source is not a plugin", func(t *testing.T) {
+		t.Parallel()
+		md := &mediafile.ParsedMetadata{
+			CoverData:     makeJPEG(800, 1200),
+			CoverMimeType: "image/jpeg",
+			DataSource:    models.DataSourceEPUBMetadata,
+		}
+		source := md.SourceForField("cover")
+		assert.NotEqual(t, "plugin:", source[:7])
+	})
+}

--- a/pkg/worker/scan_cover_upgrade_test.go
+++ b/pkg/worker/scan_cover_upgrade_test.go
@@ -5,7 +5,6 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
-	"image/png"
 	"testing"
 
 	"github.com/shishobooks/shisho/pkg/fileutils"
@@ -23,13 +22,6 @@ func makeJPEG(width, height int) []byte {
 	}
 	var buf bytes.Buffer
 	jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
-	return buf.Bytes()
-}
-
-func makePNG(width, height int) []byte {
-	img := image.NewRGBA(image.Rect(0, 0, width, height))
-	var buf bytes.Buffer
-	png.Encode(&buf, img)
 	return buf.Bytes()
 }
 
@@ -58,7 +50,7 @@ func TestEnricherCoverResolutionGate(t *testing.T) {
 		enricherRes := fileutils.ImageResolution(enricher)
 
 		// enricherResolution <= currentResolution → skip
-		assert.False(t, enricherRes > currentRes)
+		assert.LessOrEqual(t, enricherRes, currentRes)
 	})
 
 	t.Run("enricher cover smaller than current is rejected", func(t *testing.T) {
@@ -69,7 +61,7 @@ func TestEnricherCoverResolutionGate(t *testing.T) {
 		currentRes := fileutils.ImageResolution(current)
 		enricherRes := fileutils.ImageResolution(enricher)
 
-		assert.False(t, enricherRes > currentRes)
+		assert.LessOrEqual(t, enricherRes, currentRes)
 	})
 
 	t.Run("no current cover — enricher always accepted", func(t *testing.T) {
@@ -128,7 +120,7 @@ func TestEnricherCoverPluginSourceCheck(t *testing.T) {
 			},
 		}
 		source := md.SourceForField("cover")
-		assert.True(t, len(source) > len(models.DataSourcePluginPrefix))
+		assert.Greater(t, len(source), len(models.DataSourcePluginPrefix))
 		assert.Equal(t, "plugin:", source[:7])
 	})
 

--- a/pkg/worker/scan_enricher_test.go
+++ b/pkg/worker/scan_enricher_test.go
@@ -465,7 +465,10 @@ func TestCoverPageProtection_EnricherCannotOverridePageCover(t *testing.T) {
 	require.NotNil(t, enrichedMeta.CoverPage)
 	assert.Equal(t, 0, *enrichedMeta.CoverPage)
 
-	// 3. Apply CoverPage protection (as runMetadataEnrichers does)
+	// 3. Apply page-based file type protection (as runMetadataEnrichers does)
+	// In production, this checks models.IsPageBasedFileType(file.FileType).
+	// For this test, we simulate by checking CoverPage since we're testing the
+	// CBZ case where CoverPage is always set.
 	if fileMetadata.CoverPage != nil {
 		enrichedMeta.CoverData = fileMetadata.CoverData
 		enrichedMeta.CoverMimeType = fileMetadata.CoverMimeType
@@ -509,7 +512,9 @@ func TestCoverPageProtection_NoCoverPage_EnricherCoverPreserved(t *testing.T) {
 	mergeEnrichedMetadata(&enrichedMeta, enricherResult, enricherSource)
 	mergeEnrichedMetadata(&enrichedMeta, fileMetadata, fileSource)
 
-	// CoverPage protection should NOT trigger (no CoverPage)
+	// Page-based file type protection should NOT trigger (EPUB is not page-based)
+	// In production, this checks models.IsPageBasedFileType(file.FileType).
+	// For this test, the EPUB case naturally has no CoverPage, same result.
 	if fileMetadata.CoverPage != nil {
 		enrichedMeta.CoverData = fileMetadata.CoverData
 		enrichedMeta.CoverMimeType = fileMetadata.CoverMimeType

--- a/pkg/worker/scan_enricher_test.go
+++ b/pkg/worker/scan_enricher_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/shishobooks/shisho/pkg/mediafile"
+	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -466,10 +467,8 @@ func TestCoverPageProtection_EnricherCannotOverridePageCover(t *testing.T) {
 	assert.Equal(t, 0, *enrichedMeta.CoverPage)
 
 	// 3. Apply page-based file type protection (as runMetadataEnrichers does)
-	// In production, this checks models.IsPageBasedFileType(file.FileType).
-	// For this test, we simulate by checking CoverPage since we're testing the
-	// CBZ case where CoverPage is always set.
-	if fileMetadata.CoverPage != nil {
+	fileType := models.FileTypeCBZ
+	if models.IsPageBasedFileType(fileType) {
 		enrichedMeta.CoverData = fileMetadata.CoverData
 		enrichedMeta.CoverMimeType = fileMetadata.CoverMimeType
 		enrichedMeta.CoverPage = fileMetadata.CoverPage
@@ -513,9 +512,8 @@ func TestCoverPageProtection_NoCoverPage_EnricherCoverPreserved(t *testing.T) {
 	mergeEnrichedMetadata(&enrichedMeta, fileMetadata, fileSource)
 
 	// Page-based file type protection should NOT trigger (EPUB is not page-based)
-	// In production, this checks models.IsPageBasedFileType(file.FileType).
-	// For this test, the EPUB case naturally has no CoverPage, same result.
-	if fileMetadata.CoverPage != nil {
+	fileType := models.FileTypeEPUB
+	if models.IsPageBasedFileType(fileType) {
 		enrichedMeta.CoverData = fileMetadata.CoverData
 		enrichedMeta.CoverMimeType = fileMetadata.CoverMimeType
 		enrichedMeta.CoverPage = fileMetadata.CoverPage

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -455,6 +455,9 @@ func (w *Worker) scanFileByID(ctx context.Context, opts ScanOptions, cache *Scan
 	// Run metadata enrichers after parsing
 	metadata = w.runMetadataEnrichers(ctx, metadata, file, book, file.LibraryID, opts.JobLog)
 
+	// Apply enricher cover if it's higher resolution than the current cover
+	w.upgradeEnricherCover(ctx, metadata, file, book.Filepath, opts.JobLog)
+
 	// Use scanFileCore for all metadata updates, sidecars, and search index
 	// This is a resync (FileID mode), so pass isResync=true to enable book organization
 	result, err := w.scanFileCore(ctx, file, book, metadata, opts.ForceRefresh, true, opts.JobLog, cache)
@@ -2220,6 +2223,9 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 
 	// Run metadata enrichers after parsing
 	metadata = w.runMetadataEnrichers(ctx, metadata, file, book, opts.LibraryID, opts.JobLog)
+
+	// Apply enricher cover if it's higher resolution than the current cover
+	w.upgradeEnricherCover(ctx, metadata, file, bookPath, opts.JobLog)
 
 	// Use scanFileCore to handle all metadata updates (authors, series, etc.)
 	// This is a batch scan (FilePath mode), so pass isResync=false to skip book organization

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2765,9 +2765,9 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 	// This gives enrichers priority over file metadata (priority 2 > priority 3).
 	mergeEnrichedMetadata(&enrichedMeta, metadata, metadata.DataSource)
 
-	// Files with CoverPage derive covers from page content (CBZ, PDF) and must
+	// Page-based formats (CBZ, PDF) derive covers from page content and must
 	// not have them replaced by enricher-downloaded images.
-	if metadata.CoverPage != nil {
+	if models.IsPageBasedFileType(file.FileType) {
 		enrichedMeta.CoverData = metadata.CoverData
 		enrichedMeta.CoverMimeType = metadata.CoverMimeType
 		enrichedMeta.CoverPage = metadata.CoverPage

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2528,6 +2528,146 @@ func (w *Worker) extractAndSaveCover(
 	return coverFilename, normalizedMime, false, nil
 }
 
+// upgradeEnricherCover checks if an enricher provided a cover image that is
+// higher resolution than the file's current cover. If so, it saves the enricher
+// cover to disk and updates the file record.
+//
+// This is called after runMetadataEnrichers in both scan paths (new file creation
+// and rescan). It only applies covers from plugin sources, respects the cover
+// field setting (already enforced by filterMetadataFields), and never replaces
+// covers for page-based formats (CBZ, PDF).
+//
+// bookFilepath is the parent book's filepath. The cover directory is determined
+// automatically: if bookFilepath is a directory, covers are saved there; otherwise
+// (root-level files where the book path may not exist as a directory), covers are
+// saved in the file's parent directory.
+func (w *Worker) upgradeEnricherCover(
+	ctx context.Context,
+	metadata *mediafile.ParsedMetadata,
+	file *models.File,
+	bookFilepath string,
+	jobLog *joblogs.JobLogger,
+) {
+	log := logger.FromContext(ctx)
+
+	logInfo := func(msg string, data logger.Data) {
+		log.Info(msg, data)
+		if jobLog != nil {
+			jobLog.Info(msg, data)
+		}
+	}
+
+	logWarn := func(msg string, data logger.Data) {
+		log.Warn(msg, data)
+		if jobLog != nil {
+			jobLog.Warn(msg, data)
+		}
+	}
+
+	// 1. Skip if no cover data in enriched metadata
+	if metadata == nil || len(metadata.CoverData) == 0 {
+		return
+	}
+
+	// 2. Skip if the cover source is not from a plugin
+	coverSource := metadata.SourceForField("cover")
+	if !strings.HasPrefix(coverSource, models.DataSourcePluginPrefix) {
+		return
+	}
+
+	// 3. Skip for page-based file types — they derive covers from page content
+	if models.IsPageBasedFileType(file.FileType) {
+		return
+	}
+
+	// 4. Determine the cover directory (same logic as recoverMissingCover)
+	coverDir := bookFilepath
+	if info, err := os.Stat(bookFilepath); err != nil || !info.IsDir() {
+		coverDir = filepath.Dir(file.Filepath)
+	}
+
+	coverBaseName := filepath.Base(file.Filepath) + ".cover"
+	existingCoverPath := fileutils.CoverExistsWithBaseName(coverDir, coverBaseName)
+
+	currentResolution := 0
+	if existingCoverPath != "" {
+		currentResolution = fileutils.ImageFileResolution(existingCoverPath)
+	}
+
+	// 5. Resolution gate — enricher cover must be strictly larger
+	enricherResolution := fileutils.ImageResolution(metadata.CoverData)
+	if enricherResolution == 0 {
+		logWarn("enricher cover could not be decoded, skipping", logger.Data{
+			"file_id": file.ID,
+			"source":  coverSource,
+		})
+		return
+	}
+	if enricherResolution <= currentResolution {
+		logInfo("enricher cover not larger than current cover, skipping", logger.Data{
+			"file_id":             file.ID,
+			"enricher_resolution": enricherResolution,
+			"current_resolution":  currentResolution,
+			"source":              coverSource,
+		})
+		return
+	}
+
+	// 6. Save enricher cover — normalize and write to disk
+	normalizedData, normalizedMime, _ := fileutils.NormalizeImage(metadata.CoverData, metadata.CoverMimeType)
+	coverExt := ".png"
+	if normalizedMime == metadata.CoverMimeType {
+		coverExt = metadata.CoverExtension()
+	}
+
+	coverFilename := coverBaseName + coverExt
+	coverFilepath := filepath.Join(coverDir, coverFilename)
+
+	// Remove any existing cover file with a different extension
+	if existingCoverPath != "" && existingCoverPath != coverFilepath {
+		os.Remove(existingCoverPath)
+	}
+
+	coverFile, err := os.Create(coverFilepath)
+	if err != nil {
+		logWarn("failed to save enricher cover", logger.Data{
+			"error": err.Error(),
+			"path":  coverFilepath,
+		})
+		return
+	}
+	defer coverFile.Close()
+
+	if _, err := io.Copy(coverFile, bytes.NewReader(normalizedData)); err != nil {
+		logWarn("failed to write enricher cover data", logger.Data{
+			"error": err.Error(),
+			"path":  coverFilepath,
+		})
+		return
+	}
+
+	logInfo("upgraded cover from enricher (higher resolution)", logger.Data{
+		"file_id":             file.ID,
+		"enricher_resolution": enricherResolution,
+		"current_resolution":  currentResolution,
+		"source":              coverSource,
+		"path":                coverFilepath,
+	})
+
+	// 7. Update file record
+	file.CoverImageFilename = &coverFilename
+	file.CoverMimeType = &normalizedMime
+	file.CoverSource = &coverSource
+	if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
+		Columns: []string{"cover_image_filename", "cover_mime_type", "cover_source"},
+	}); err != nil {
+		logWarn("failed to update file cover after enricher upgrade", logger.Data{
+			"error":   err.Error(),
+			"file_id": file.ID,
+		})
+	}
+}
+
 // parseFileMetadata extracts metadata from a file based on its type.
 // For built-in types (epub, cbz, m4b), uses the native parsers.
 // For other types, falls back to plugin file parsers if available.

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -426,6 +426,14 @@ return {
 
 For advanced use cases (file parsers extracting embedded covers, or enrichers that generate/composite images), you can set `coverData` as an `ArrayBuffer` instead. If both are set, `coverData` takes precedence.
 
+**Cover enrichment rules:**
+
+During automatic scans, enricher-provided covers are subject to additional checks:
+
+- **Resolution gate:** An enricher cover is only applied if its total resolution (width × height) is strictly greater than the file's current cover. If the file already has a cover of equal or greater resolution, the enricher cover is skipped. This prevents low-resolution external images from replacing high-quality embedded covers.
+- **Page-based formats:** CBZ and PDF files derive covers from their page content. Plugin covers are never applied to these formats, even if the plugin declares the `cover` field.
+- **Field settings:** The `cover` field must be enabled in the plugin's per-library field settings for cover enrichment to take effect. If disabled, all cover data from the plugin is silently stripped.
+
 #### File Hints
 
 The `context.file` object provides read-only metadata about the file being enriched. Use it to narrow your search — for example, filtering audiobook results by duration or distinguishing a comic from a novel by page count:
@@ -478,6 +486,8 @@ return {
 When a user identifies a book using the interactive review screen, they choose which fields to keep on a field-by-field basis. During automatic scans, the first search result's metadata is applied for all enabled fields.
 
 Enricher values **override** file-embedded metadata for the same field. If a file has a bad title and your enricher returns a corrected title, the enricher's value wins. Among multiple enrichers, the first one (in user-defined order) to provide a value for a field wins. File-embedded metadata is only used as a fallback for fields that no enricher provided.
+
+During automatic scans, enrichment also respects a cover resolution gate — enricher covers must have a higher total resolution than the existing cover to be applied. See [Cover Images](#cover-images) above for details.
 
 Only fields declared in the manifest's `fields` array will be applied. Any returned fields not in the declared list are silently stripped. Users can further disable individual fields in the plugin settings.
 


### PR DESCRIPTION
## Summary
- Enricher-provided covers are now actually saved to disk (previously computed but discarded), gated by a resolution check — only applied if the enricher cover has strictly more total pixels (width × height) than the current cover
- CBZ and PDF files now block external covers via file type checks (`IsPageBasedFileType`) instead of `CoverPage != nil`, closing a gap where PDFs with failed cover extraction could receive plugin covers
- Frontend (IdentifyReviewForm, FileEditDialog) and backend (handlers, scan pipeline) guards updated consistently; PDF parser always sets CoverPage=0

## Test plan
- Resolution helper tests verify pixel count comparison for JPEG/PNG, invalid data, missing files
- Enricher cover tests verify file type guard (CBZ/PDF blocked, EPUB/M4B allowed), resolution gate logic, and plugin source detection
- Existing worker, PDF, books, and fileutils tests all pass
- Full validation suite passes (`mise check:quiet` — Go tests, Go lint, JS lint, JS tests)