### PR TITLE
[Backend] Change Docker container port from 8080 to 5173

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,7 @@
 # Shisho Production Configuration
 # Serves frontend on / and proxies /api/* to the Go backend
 
-:8080 {
+:5173 {
     # Logging
     log {
         output stdout

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,10 +110,10 @@ ENV PGID=1000
 ENV STARTUP_TIMEOUT_SECONDS=120
 
 # Expose HTTP port
-EXPOSE 8080
+EXPOSE 5173
 
 # Health check (start-period allows time for initial migrations on slow storage)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=120s --retries=3 \
-    CMD wget -q --spider http://localhost:8080/health || exit 1
+    CMD wget -q --spider http://localhost:5173/health || exit 1
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ services:
     container_name: shisho
     restart: unless-stopped
     ports:
-      - "5173:8080"
+      - "5173:5173"
     volumes:
       # Persistent data (database)
       - ./data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     container_name: shisho
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "5173:5173"
     volumes:
       # Persistent data (database)
       - shisho-data:/app/data

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -131,7 +131,7 @@ If new icon directories are added under `src/theme/`, add corresponding exceptio
 
 ## Common Mistakes
 
-- **Editing versioned_docs directly** — These are snapshots. Edit `docs/` for unreleased content; versioned docs are regenerated on release.
+- **Editing versioned_docs directly** — These are point-in-time snapshots of how the app worked at that release. They should rarely be updated. For example, if the Docker container port changes, only update `docs/` — the old versioned docs correctly reflect what the port was at that version. Only edit versioned docs for factual errors that were wrong at the time of release (e.g., a broken link), not to backport current behavior.
 - **Forgetting `sidebar_position`** — Pages without it appear in alphabetical order. Always set explicit positions.
 - **Running `pnpm install` instead of `mise setup`** — In a new worktree, `mise setup` handles both root and website deps.
 - **Missing `.gitignore` exception for new Icon dirs** — New swizzled `Icon/` subdirectories won't be tracked without an exception.

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -17,7 +17,7 @@ services:
     container_name: shisho
     restart: unless-stopped
     ports:
-      - "5173:8080"
+      - "5173:5173"
     volumes:
       - ./data:/data
       - ./config:/config

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -98,7 +98,7 @@ const dockerCompose = `services:
     container_name: shisho
     restart: unless-stopped
     ports:
-      - "5173:8080"
+      - "5173:5173"
     volumes:
       - ./data:/data
       - ./config:/config


### PR DESCRIPTION
## Summary
- Changes the Docker container's internal port (Caddy) from 8080 to 5173
- Updates Caddyfile, Dockerfile (EXPOSE + healthcheck), docker-compose.yml, README, docs site homepage, and getting-started guide
- Adds guidance to website CLAUDE.md clarifying that versioned docs are point-in-time snapshots and should not be updated to reflect current behavior

## Test plan
- Build the Docker image and verify Caddy listens on 5173
- Verify the healthcheck hits localhost:5173/health
- Review all docker-compose examples show `5173:5173` port mapping
- Confirm versioned docs still show the old `5173:8080` mapping (intentionally unchanged)