### PR TITLE
[Fix] Resolve false "Changed" badges in identify workflow

### DIFF
--- a/app/components/library/IdentifyReviewForm.test.ts
+++ b/app/components/library/IdentifyReviewForm.test.ts
@@ -1,0 +1,57 @@
+import { resolveIdentifiers } from "./identify-utils";
+import { describe, expect, it } from "vitest";
+
+describe("resolveIdentifiers", () => {
+  it("returns unchanged when identifiers are identical", () => {
+    const current = [
+      { type: "goodreads", value: "56377548" },
+      { type: "uuid", value: "abc-123" },
+    ];
+    const incoming = [
+      { type: "goodreads", value: "56377548" },
+      { type: "uuid", value: "abc-123" },
+    ];
+    const result = resolveIdentifiers(current, incoming);
+    expect(result.status).toBe("unchanged");
+    expect(result.value).toEqual(current);
+  });
+
+  it("returns unchanged when current is a superset of incoming", () => {
+    const current = [
+      { type: "goodreads", value: "56377548" },
+      { type: "uuid", value: "abc-123" },
+    ];
+    const incoming = [{ type: "goodreads", value: "56377548" }];
+    const result = resolveIdentifiers(current, incoming);
+    expect(result.status).toBe("unchanged");
+    expect(result.value).toEqual(current);
+  });
+
+  it("returns changed when incoming has a new identifier", () => {
+    const current = [{ type: "uuid", value: "abc-123" }];
+    const incoming = [
+      { type: "uuid", value: "abc-123" },
+      { type: "goodreads", value: "56377548" },
+    ];
+    const result = resolveIdentifiers(current, incoming);
+    expect(result.status).toBe("changed");
+    expect(result.value).toEqual([
+      { type: "uuid", value: "abc-123" },
+      { type: "goodreads", value: "56377548" },
+    ]);
+  });
+
+  it("returns new when current is empty", () => {
+    const incoming = [{ type: "goodreads", value: "56377548" }];
+    const result = resolveIdentifiers([], incoming);
+    expect(result.status).toBe("new");
+    expect(result.value).toEqual(incoming);
+  });
+
+  it("returns unchanged when incoming is empty", () => {
+    const current = [{ type: "uuid", value: "abc-123" }];
+    const result = resolveIdentifiers(current, []);
+    expect(result.status).toBe("unchanged");
+    expect(result.value).toEqual(current);
+  });
+});

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -1,3 +1,8 @@
+import {
+  resolveIdentifiers,
+  type FieldStatus,
+  type IdentifierEntry,
+} from "./identify-utils";
 import equal from "fast-deep-equal";
 import {
   ArrowLeft,
@@ -42,16 +47,9 @@ interface IdentifyReviewFormProps {
   onHasChangesChange?: (hasChanges: boolean) => void;
 }
 
-type FieldStatus = "unchanged" | "changed" | "new";
-
 interface AuthorEntry {
   name: string;
   role?: string;
-}
-
-interface IdentifierEntry {
-  type: string;
-  value: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -137,32 +135,6 @@ function resolveAuthors(
     return { value: current, status: "unchanged" };
   }
   return { value: incoming, status: "changed" };
-}
-
-function resolveIdentifiers(
-  current: IdentifierEntry[],
-  incoming: IdentifierEntry[],
-): { value: IdentifierEntry[]; status: FieldStatus } {
-  if (current.length === 0 && incoming.length > 0)
-    return { value: incoming, status: "new" };
-  if (current.length > 0 && incoming.length === 0)
-    return { value: current, status: "unchanged" };
-  const key = (id: IdentifierEntry) => `${id.type}:${id.value}`;
-  const curKeys = current.map(key).sort();
-  const incKeys = incoming.map(key).sort();
-  if (
-    curKeys.length === incKeys.length &&
-    curKeys.every((v, i) => v === incKeys[i])
-  ) {
-    return { value: current, status: "unchanged" };
-  }
-  // Merge: keep all current, add new incoming identifiers
-  const existingKeys = new Set(current.map(key));
-  const merged = [
-    ...current,
-    ...incoming.filter((id) => !existingKeys.has(key(id))),
-  ];
-  return { value: merged, status: "changed" };
 }
 
 /** Extract current file from book. */
@@ -534,6 +506,20 @@ export function IdentifyReviewForm({
   const currentCoverDims = useImageDimensions(currentCoverUrl);
   const newCoverDims = useImageDimensions(newCoverUrl);
 
+  // When both cover dimensions are loaded and match exactly, default to keeping current
+  const coverDimsMatch =
+    !!currentCoverDims &&
+    !!newCoverDims &&
+    currentCoverDims.w === newCoverDims.w &&
+    currentCoverDims.h === newCoverDims.h;
+  const [coverDimsApplied, setCoverDimsApplied] = useState(false);
+  useEffect(() => {
+    if (coverDimsMatch && !coverDimsApplied) {
+      setCoverSelection("current");
+      setCoverDimsApplied(true);
+    }
+  }, [coverDimsMatch, coverDimsApplied]);
+
   // ---- Unsaved changes tracking ----
   const hasChanges = useMemo(() => {
     return (
@@ -552,7 +538,9 @@ export function IdentifyReviewForm({
       url !== defaults.url.value ||
       !equal(identifiers, defaults.identifiers.value) ||
       coverSelection !==
-        (newCoverUrl && !disabledFields.has("cover") ? "new" : "current")
+        (newCoverUrl && !disabledFields.has("cover") && !coverDimsMatch
+          ? "new"
+          : "current")
     );
   }, [
     title,
@@ -573,6 +561,7 @@ export function IdentifyReviewForm({
     defaults,
     newCoverUrl,
     disabledFields,
+    coverDimsMatch,
   ]);
 
   useEffect(() => {
@@ -651,7 +640,7 @@ export function IdentifyReviewForm({
             <Label>{formatMetadataFieldLabel("cover")}</Label>
             <StatusBadge
               status={
-                isDisabled("cover")
+                isDisabled("cover") || coverDimsMatch
                   ? "unchanged"
                   : currentCoverUrl
                     ? "changed"

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -512,13 +512,12 @@ export function IdentifyReviewForm({
     !!newCoverDims &&
     currentCoverDims.w === newCoverDims.w &&
     currentCoverDims.h === newCoverDims.h;
-  const [coverDimsApplied, setCoverDimsApplied] = useState(false);
+  const [coverUserTouched, setCoverUserTouched] = useState(false);
   useEffect(() => {
-    if (coverDimsMatch && !coverDimsApplied) {
+    if (coverDimsMatch && !coverUserTouched) {
       setCoverSelection("current");
-      setCoverDimsApplied(true);
     }
-  }, [coverDimsMatch, coverDimsApplied]);
+  }, [coverDimsMatch, coverUserTouched]);
 
   // ---- Unsaved changes tracking ----
   const hasChanges = useMemo(() => {
@@ -660,7 +659,10 @@ export function IdentifyReviewForm({
                   isDisabled("cover") && "opacity-60 cursor-not-allowed",
                 )}
                 disabled={isDisabled("cover")}
-                onClick={() => setCoverSelection("current")}
+                onClick={() => {
+                  setCoverSelection("current");
+                  setCoverUserTouched(true);
+                }}
                 type="button"
               >
                 <img
@@ -683,7 +685,10 @@ export function IdentifyReviewForm({
                 isDisabled("cover") && "opacity-60 cursor-not-allowed",
               )}
               disabled={isDisabled("cover")}
-              onClick={() => setCoverSelection("new")}
+              onClick={() => {
+                setCoverSelection("new");
+                setCoverUserTouched(true);
+              }}
               type="button"
             >
               <img

--- a/app/components/library/identify-utils.ts
+++ b/app/components/library/identify-utils.ts
@@ -1,0 +1,33 @@
+export type FieldStatus = "unchanged" | "changed" | "new";
+
+export interface IdentifierEntry {
+  type: string;
+  value: string;
+}
+
+export function resolveIdentifiers(
+  current: IdentifierEntry[],
+  incoming: IdentifierEntry[],
+): { value: IdentifierEntry[]; status: FieldStatus } {
+  if (current.length === 0 && incoming.length > 0)
+    return { value: incoming, status: "new" };
+  if (current.length > 0 && incoming.length === 0)
+    return { value: current, status: "unchanged" };
+  const key = (id: IdentifierEntry) => `${id.type}:${id.value}`;
+  const curKeys = current.map(key).sort();
+  const incKeys = incoming.map(key).sort();
+  if (
+    curKeys.length === incKeys.length &&
+    curKeys.every((v, i) => v === incKeys[i])
+  ) {
+    return { value: current, status: "unchanged" };
+  }
+  // Merge: keep all current, add new incoming identifiers
+  const existingKeys = new Set(current.map(key));
+  const newFromIncoming = incoming.filter((id) => !existingKeys.has(key(id)));
+  if (newFromIncoming.length === 0) {
+    // Incoming is a subset of current — nothing new to add
+    return { value: current, status: "unchanged" };
+  }
+  return { value: [...current, ...newFromIncoming], status: "changed" };
+}

--- a/pkg/htmlutil/strip.go
+++ b/pkg/htmlutil/strip.go
@@ -8,8 +8,11 @@ import (
 // tagPattern matches HTML tags including self-closing tags.
 var tagPattern = regexp.MustCompile(`<[^>]*>`)
 
-// multipleSpacesPattern matches multiple consecutive whitespace characters.
-var multipleSpacesPattern = regexp.MustCompile(`\s{2,}`)
+// multipleSpacesPattern matches multiple consecutive spaces/tabs (not newlines).
+var multipleSpacesPattern = regexp.MustCompile(`[^\S\n]{2,}`)
+
+// threeOrMoreNewlines matches 3+ consecutive newlines (with optional whitespace-only lines between them).
+var threeOrMoreNewlines = regexp.MustCompile(`\n(\s*\n){2,}`)
 
 // StripTags removes all HTML tags from a string and normalizes whitespace.
 // It converts block-level tags (p, div, br, etc.) to newlines to preserve
@@ -19,10 +22,14 @@ func StripTags(html string) string {
 		return ""
 	}
 
-	// Replace block-level elements with newlines to preserve paragraph structure
-	// This includes common block tags that typically create visual breaks
-	blockTags := []string{"</p>", "</div>", "<br>", "<br/>", "<br />", "</li>", "</h1>", "</h2>", "</h3>", "</h4>", "</h5>", "</h6>"}
+	// Replace paragraph close tags with double newlines to preserve paragraph breaks
 	result := html
+	for _, tag := range []string{"</p>", "</P>"} {
+		result = strings.ReplaceAll(result, tag, "\n\n")
+	}
+
+	// Replace other block-level elements with single newlines
+	blockTags := []string{"</div>", "<br>", "<br/>", "<br />", "</li>", "</h1>", "</h2>", "</h3>", "</h4>", "</h5>", "</h6>"}
 	for _, tag := range blockTags {
 		result = strings.ReplaceAll(result, tag, "\n")
 		// Also handle uppercase variants
@@ -35,24 +42,18 @@ func StripTags(html string) string {
 	// Decode common HTML entities
 	result = decodeHTMLEntities(result)
 
-	// Normalize whitespace: collapse multiple spaces/tabs to single space
-	// but preserve intentional newlines (from block tags)
+	// Normalize whitespace: collapse multiple spaces/tabs to single space per line
 	lines := strings.Split(result, "\n")
 	for i, line := range lines {
-		// Collapse multiple spaces within each line
 		line = multipleSpacesPattern.ReplaceAllString(line, " ")
 		lines[i] = strings.TrimSpace(line)
 	}
+	result = strings.Join(lines, "\n")
 
-	// Rejoin lines, removing empty ones and collapsing multiple newlines
-	var nonEmptyLines []string
-	for _, line := range lines {
-		if line != "" {
-			nonEmptyLines = append(nonEmptyLines, line)
-		}
-	}
+	// Collapse 3+ consecutive newlines to double newlines (preserve paragraph breaks)
+	result = threeOrMoreNewlines.ReplaceAllString(result, "\n\n")
 
-	return strings.Join(nonEmptyLines, "\n")
+	return strings.TrimSpace(result)
 }
 
 // decodeHTMLEntities decodes common HTML entities to their character equivalents.

--- a/pkg/htmlutil/strip_test.go
+++ b/pkg/htmlutil/strip_test.go
@@ -32,7 +32,7 @@ func TestStripTags(t *testing.T) {
 		{
 			name:     "multiple paragraphs",
 			input:    "<p>First paragraph</p><p>Second paragraph</p>",
-			expected: "First paragraph\nSecond paragraph",
+			expected: "First paragraph\n\nSecond paragraph",
 		},
 		{
 			name:     "div with content",
@@ -57,7 +57,7 @@ func TestStripTags(t *testing.T) {
 		{
 			name:     "complex html from screenshot",
 			input:    `<div><p style="font-weight: 600">The apocalypse <em>will</em> be televised!</p><p>A man. His ex-girlfriend's cat.</p></div>`,
-			expected: "The apocalypse will be televised!\nA man. His ex-girlfriend's cat.",
+			expected: "The apocalypse will be televised!\n\nA man. His ex-girlfriend's cat.",
 		},
 		{
 			name:     "html entities",
@@ -98,6 +98,26 @@ func TestStripTags(t *testing.T) {
 			name:     "preserves content between inline tags",
 			input:    "This is <strong>very</strong> important",
 			expected: "This is very important",
+		},
+		{
+			name:     "preserves double newlines in plain text",
+			input:    "First paragraph\n\nSecond paragraph",
+			expected: "First paragraph\n\nSecond paragraph",
+		},
+		{
+			name:     "preserves multiple paragraph breaks in plain text",
+			input:    "Paragraph one\n\nParagraph two\n\nParagraph three",
+			expected: "Paragraph one\n\nParagraph two\n\nParagraph three",
+		},
+		{
+			name:     "collapses three or more newlines to double",
+			input:    "First\n\n\nSecond\n\n\n\nThird",
+			expected: "First\n\nSecond\n\nThird",
+		},
+		{
+			name:     "html paragraphs produce double newlines",
+			input:    "<p>First paragraph</p><p>Second paragraph</p><p>Third paragraph</p>",
+			expected: "First paragraph\n\nSecond paragraph\n\nThird paragraph",
 		},
 	}
 

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -330,7 +330,7 @@ func parseSearchResponse(vm *goja.Runtime, val goja.Value, pluginScope, pluginID
 
 		md := mediafile.ParsedMetadata{
 			Title:       getStringField(itemObj, "title"),
-			Description: getStringField(itemObj, "description"),
+			Description: htmlutil.StripTags(getStringField(itemObj, "description")),
 			Publisher:   getStringField(itemObj, "publisher"),
 			Subtitle:    getStringField(itemObj, "subtitle"),
 			Series:      getStringField(itemObj, "series"),

--- a/pkg/plugins/hooks_search_result_test.go
+++ b/pkg/plugins/hooks_search_result_test.go
@@ -154,6 +154,25 @@ func TestParseSearchResponse_Confidence(t *testing.T) {
 	assert.Nil(t, resp.Results[2].Confidence)
 }
 
+func TestParseSearchResponse_DescriptionHTMLStripped(t *testing.T) {
+	t.Parallel()
+
+	vm := goja.New()
+	val, err := vm.RunString(`({
+		results: [{
+			title: "Test Book",
+			description: "<p>First paragraph.</p><p>Second paragraph.</p>"
+		}]
+	})`)
+	require.NoError(t, err)
+
+	resp := parseSearchResponse(vm, val, "s", "p")
+	require.Len(t, resp.Results, 1)
+
+	// Description should have HTML stripped, with paragraph breaks preserved
+	assert.Equal(t, "First paragraph.\n\nSecond paragraph.", resp.Results[0].Description)
+}
+
 func TestParseSearchResponse_NilInput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- **Descriptions**: `StripTags` now preserves paragraph breaks (`\n\n`) instead of collapsing them to single newlines. `</p>` tags produce double newlines. Search results are sanitized with `StripTags` before returning to the frontend, matching what gets stored in the database.
- **Identifiers**: `resolveIdentifiers` now returns "unchanged" when current identifiers are a superset of incoming (e.g., current has `[goodreads, uuid]` but plugin only returns `[goodreads]`).
- **Covers**: When both cover dimensions match exactly (same width and height), the selection defaults to "current" and the badge shows "unchanged". Users can still manually select the new cover if they determine it's visually different.

## Test plan
- Identify a book that already has a description with paragraph breaks — verify "Changed" badge no longer appears when re-identifying
- Identify a book that has more identifiers than the plugin returns (e.g., UUID from file + Goodreads from plugin) — verify identifiers show as "unchanged"
- Identify a book where the cover is the same resolution — verify cover defaults to "Keep current" and shows "unchanged"
- Verify that genuinely different descriptions, new identifiers, and different-resolution covers still correctly show "Changed"/"New" badges
- Run `mise check:quiet` — all checks pass