### PR TITLE
[Feature] Enforce plugin minShishoVersion with UI compatibility indicators

### DIFF
--- a/app/components/pages/AdminPlugins.tsx
+++ b/app/components/pages/AdminPlugins.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   ArrowDown,
   ArrowUp,
   ChevronDown,
@@ -352,15 +353,14 @@ const BrowseTab = () => {
 
   const handleInstall = () => {
     if (!installTarget) return;
-    const latestVersion = installTarget.versions[0];
+    const compatibleVersion = installTarget.versions.find((v) => v.compatible);
+    if (!compatibleVersion) return;
     installPlugin.mutate(
       {
         scope: installTarget.scope,
         id: installTarget.id,
         name: installTarget.name,
-        version: latestVersion?.version,
-        download_url: latestVersion?.download_url,
-        sha256: latestVersion?.sha256,
+        version: compatibleVersion.version,
       },
       { onSuccess: () => setInstallTarget(null) },
     );
@@ -388,6 +388,9 @@ const BrowseTab = () => {
                   {alreadyInstalled && (
                     <Badge variant="subtle">Installed</Badge>
                   )}
+                  {!plugin.compatible && (
+                    <Badge variant="destructive">Incompatible</Badge>
+                  )}
                 </div>
                 {plugin.description && (
                   <p className="mt-1 text-xs text-muted-foreground">
@@ -399,10 +402,16 @@ const BrowseTab = () => {
                     by {plugin.author}
                   </p>
                 )}
+                {!plugin.compatible && (
+                  <p className="mt-1 flex items-center gap-1 text-xs text-destructive">
+                    <AlertTriangle className="h-3 w-3" />
+                    Requires a newer version of Shisho
+                  </p>
+                )}
               </div>
 
               <div className="flex shrink-0 items-center gap-2">
-                {canWrite && !alreadyInstalled && (
+                {canWrite && !alreadyInstalled && plugin.compatible && (
                   <Button
                     onClick={() => setInstallTarget(plugin)}
                     size="sm"

--- a/app/components/pages/AdminPlugins.tsx
+++ b/app/components/pages/AdminPlugins.tsx
@@ -371,7 +371,8 @@ const BrowseTab = () => {
       <div className="space-y-3">
         {available.map((plugin) => {
           const alreadyInstalled = isInstalled(plugin.scope, plugin.id);
-          const latestVersion = plugin.versions[0];
+          const latestVersion =
+            plugin.versions.find((v) => v.compatible) ?? plugin.versions[0];
 
           return (
             <div

--- a/app/components/plugins/CapabilitiesWarning.tsx
+++ b/app/components/plugins/CapabilitiesWarning.tsx
@@ -56,7 +56,8 @@ export const CapabilitiesWarning = ({
 }: CapabilitiesWarningProps) => {
   if (!plugin) return null;
 
-  const latestVersion = plugin.versions[0];
+  const latestVersion =
+    plugin.versions.find((v) => v.compatible) ?? plugin.versions[0];
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
@@ -101,7 +102,7 @@ export const CapabilitiesWarning = ({
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <span>Version: {latestVersion.version}</span>
             <Badge variant="outline">
-              Manifest v{latestVersion.manifest_version}
+              Manifest v{latestVersion.manifestVersion}
             </Badge>
           </div>
         )}

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -26,11 +26,13 @@ export {
 
 export interface PluginVersion {
   version: string;
-  min_app_version: string;
+  minShishoVersion: string;
+  compatible: boolean;
   changelog: string;
-  download_url: string;
+  downloadUrl: string;
   sha256: string;
-  manifest_version: number;
+  manifestVersion: number;
+  releaseDate: string;
 }
 
 export interface AvailablePlugin {
@@ -43,6 +45,7 @@ export interface AvailablePlugin {
   homepage: string;
   imageUrl: string;
   versions: PluginVersion[];
+  compatible: boolean;
 }
 
 // --- Query Keys ---

--- a/docs/superpowers/plans/2026-04-05-plugin-min-version-enforcement.md
+++ b/docs/superpowers/plans/2026-04-05-plugin-min-version-enforcement.md
@@ -1,0 +1,656 @@
+# Plugin Min-Version Enforcement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce `minShishoVersion` from repository.json so incompatible plugin versions can't be installed, and incompatible plugins are clearly marked in the UI.
+
+**Architecture:** Add `version.IsCompatible()` filtering to the three backend paths that use repository data (browse, install, update-check). Annotate available plugin API responses with a `compatible` boolean on both plugin and version levels. Update the BrowseTab frontend to show incompatibility state and prevent install of incompatible plugins.
+
+**Tech Stack:** Go (Echo handlers, version package), React/TypeScript (Tanstack Query hooks, shadcn/ui components)
+
+---
+
+### Task 1: Add `minShishoVersion` filtering to `findPluginInRepos`
+
+This is the install/update path — must block incompatible versions.
+
+**Files:**
+- Modify: `pkg/plugins/repository.go:100-113`
+- Test: `pkg/plugins/repository_test.go`
+
+- [ ] **Step 1: Write test for new `FilterVersionCompatibleVersions` function**
+
+In `pkg/plugins/repository_test.go`, add:
+
+```go
+func TestFilterVersionCompatibleVersions(t *testing.T) {
+	t.Parallel()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "0.1.0", ManifestVersion: 1},
+		{Version: "2.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+		{Version: "1.1.0", MinShishoVersion: "", ManifestVersion: 1},
+	}
+
+	compatible := FilterVersionCompatibleVersions(versions)
+	require.Len(t, compatible, 2)
+	assert.Equal(t, "1.0.0", compatible[0].Version)
+	assert.Equal(t, "1.1.0", compatible[1].Version)
+}
+
+func TestFilterVersionCompatibleVersions_AllIncompatible(t *testing.T) {
+	t.Parallel()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+		{Version: "2.0.0", MinShishoVersion: "100.0.0", ManifestVersion: 1},
+	}
+
+	compatible := FilterVersionCompatibleVersions(versions)
+	assert.Empty(t, compatible)
+}
+
+func TestFilterVersionCompatibleVersions_Empty(t *testing.T) {
+	t.Parallel()
+
+	compatible := FilterVersionCompatibleVersions(nil)
+	assert.Empty(t, compatible)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -run TestFilterVersionCompatibleVersions -v`
+Expected: FAIL — `FilterVersionCompatibleVersions` undefined
+
+- [ ] **Step 3: Implement `FilterVersionCompatibleVersions`**
+
+In `pkg/plugins/repository.go`, add after `FilterCompatibleVersions`:
+
+```go
+// FilterVersionCompatibleVersions returns only versions whose minShishoVersion
+// is satisfied by the running Shisho version.
+func FilterVersionCompatibleVersions(versions []PluginVersion) []PluginVersion {
+	var compatible []PluginVersion
+	for _, v := range versions {
+		if version.IsCompatible(v.MinShishoVersion) {
+			compatible = append(compatible, v)
+		}
+	}
+	return compatible
+}
+```
+
+Add `"github.com/shishobooks/shisho/pkg/version"` to the imports.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -run TestFilterVersionCompatibleVersions -v`
+Expected: PASS (all 3 tests). Note: in dev mode `version.Version` is `"dev"`, which `IsCompatible` treats as always compatible. The test for "99.0.0" works because `isVersionCompatible("dev", "99.0.0")` returns true. We need to override `version.Version` for the incompatible tests.
+
+- [ ] **Step 5: Fix tests — set `version.Version` to a real version**
+
+Update the two tests that check filtering:
+
+```go
+func TestFilterVersionCompatibleVersions(t *testing.T) {
+	t.Parallel()
+
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "0.1.0", ManifestVersion: 1},
+		{Version: "2.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+		{Version: "1.1.0", MinShishoVersion: "", ManifestVersion: 1},
+	}
+
+	compatible := FilterVersionCompatibleVersions(versions)
+	require.Len(t, compatible, 2)
+	assert.Equal(t, "1.0.0", compatible[0].Version)
+	assert.Equal(t, "1.1.0", compatible[1].Version)
+}
+
+func TestFilterVersionCompatibleVersions_AllIncompatible(t *testing.T) {
+	t.Parallel()
+
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+		{Version: "2.0.0", MinShishoVersion: "100.0.0", ManifestVersion: 1},
+	}
+
+	compatible := FilterVersionCompatibleVersions(versions)
+	assert.Empty(t, compatible)
+}
+```
+
+`TestFilterVersionCompatibleVersions_Empty` doesn't need the override since there are no versions to check.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -run TestFilterVersionCompatibleVersions -v`
+Expected: PASS (all 3 tests)
+
+- [ ] **Step 7: Apply `FilterVersionCompatibleVersions` in `findPluginInRepos`**
+
+In `pkg/plugins/handler.go`, in the `findPluginInRepos` method (around line 301), change:
+
+```go
+			compatible := FilterCompatibleVersions(p.Versions)
+```
+
+to:
+
+```go
+			compatible := FilterVersionCompatibleVersions(FilterCompatibleVersions(p.Versions))
+```
+
+- [ ] **Step 8: Run full plugin test suite**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -v -count=1`
+Expected: All existing tests pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/plugins/repository.go pkg/plugins/repository_test.go pkg/plugins/handler.go
+git commit -m "[Backend] Add minShishoVersion filtering to plugin install/update path"
+```
+
+---
+
+### Task 2: Add `minShishoVersion` filtering to `CheckForUpdates`
+
+**Files:**
+- Modify: `pkg/plugins/manager.go:461-488`
+- Test: `pkg/plugins/update_check_test.go`
+
+- [ ] **Step 1: Write test for minShishoVersion filtering in CheckForUpdates**
+
+In `pkg/plugins/update_check_test.go`, add:
+
+```go
+func TestManager_CheckForUpdates_MinShishoVersionFiltered(t *testing.T) {
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	db := setupTestDB(t)
+	service := NewService(db)
+	mgr := NewManager(service, t.TempDir(), "")
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "official",
+		ID:          "my-plugin",
+		Name:        "My Plugin",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err := service.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	repo := &models.PluginRepository{
+		URL:        "https://raw.githubusercontent.com/test/repo/main/manifest.json",
+		Scope:      "official",
+		Name:       strPtr("Official Repo"),
+		IsOfficial: true,
+		Enabled:    true,
+	}
+	err = service.AddRepository(ctx, repo)
+	require.NoError(t, err)
+
+	mgr.fetchRepo = func(_ string) (*RepositoryManifest, error) {
+		return &RepositoryManifest{
+			RepositoryVersion: 1,
+			Scope:             "official",
+			Name:              "Official Repo",
+			Plugins: []AvailablePlugin{
+				{
+					ID:   "my-plugin",
+					Name: "My Plugin",
+					Versions: []PluginVersion{
+						{Version: "1.0.0", ManifestVersion: 1, MinShishoVersion: "0.1.0"},
+						{Version: "1.5.0", ManifestVersion: 1, MinShishoVersion: "0.5.0"},
+						{Version: "2.0.0", ManifestVersion: 1, MinShishoVersion: "99.0.0"},
+					},
+				},
+			},
+		}, nil
+	}
+
+	err = mgr.CheckForUpdates(ctx)
+	require.NoError(t, err)
+
+	// Should flag 1.5.0 as available, not 2.0.0 (incompatible minShishoVersion)
+	updated, err := service.RetrievePlugin(ctx, "official", "my-plugin")
+	require.NoError(t, err)
+	require.NotNil(t, updated.UpdateAvailableVersion)
+	assert.Equal(t, "1.5.0", *updated.UpdateAvailableVersion)
+}
+```
+
+Add `"github.com/shishobooks/shisho/pkg/version"` to the imports in `update_check_test.go`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -run TestManager_CheckForUpdates_MinShishoVersionFiltered -v`
+Expected: FAIL — asserts `1.5.0` but gets `2.0.0`
+
+- [ ] **Step 3: Add version filtering to `CheckForUpdates`**
+
+In `pkg/plugins/manager.go`, in the `CheckForUpdates` method (around line 478), change:
+
+```go
+			compatible := FilterCompatibleVersions(available.Versions)
+```
+
+to:
+
+```go
+			compatible := FilterVersionCompatibleVersions(FilterCompatibleVersions(available.Versions))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -run TestManager_CheckForUpdates_MinShishoVersionFiltered -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full update check tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -run TestManager_CheckForUpdates -v`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/plugins/manager.go pkg/plugins/update_check_test.go
+git commit -m "[Backend] Filter incompatible minShishoVersion in update checks"
+```
+
+---
+
+### Task 3: Add compatibility annotations to available plugins API response
+
+**Files:**
+- Modify: `pkg/plugins/handler.go:649-704` and `772-817`
+- Test: `pkg/plugins/repository_test.go` (unit test for the annotation helper)
+
+- [ ] **Step 1: Write test for `annotateVersionCompatibility` helper**
+
+In `pkg/plugins/repository_test.go`, add:
+
+```go
+func TestAnnotateVersionCompatibility(t *testing.T) {
+	t.Parallel()
+
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "0.5.0", ManifestVersion: 1},
+		{Version: "2.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+		{Version: "1.1.0", MinShishoVersion: "", ManifestVersion: 1},
+	}
+
+	annotated := AnnotateVersionCompatibility(versions)
+	require.Len(t, annotated, 3)
+
+	assert.True(t, annotated[0].Compatible)   // 0.5.0 <= 1.0.0
+	assert.False(t, annotated[1].Compatible)   // 99.0.0 > 1.0.0
+	assert.True(t, annotated[2].Compatible)    // empty = compatible
+
+	// Verify original fields preserved
+	assert.Equal(t, "1.0.0", annotated[0].Version)
+	assert.Equal(t, "2.0.0", annotated[1].Version)
+	assert.Equal(t, "1.1.0", annotated[2].Version)
+}
+
+func TestAnnotateVersionCompatibility_AllIncompatible(t *testing.T) {
+	t.Parallel()
+
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+	}
+
+	annotated := AnnotateVersionCompatibility(versions)
+	require.Len(t, annotated, 1)
+	assert.False(t, annotated[0].Compatible)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -run TestAnnotateVersionCompatibility -v`
+Expected: FAIL — `AnnotateVersionCompatibility` undefined
+
+- [ ] **Step 3: Add `AnnotatedPluginVersion` type and `AnnotateVersionCompatibility` function**
+
+In `pkg/plugins/repository.go`, add:
+
+```go
+// AnnotatedPluginVersion extends PluginVersion with a compatibility flag.
+type AnnotatedPluginVersion struct {
+	PluginVersion
+	Compatible bool `json:"compatible"`
+}
+
+// AnnotateVersionCompatibility annotates each version with whether it is
+// compatible with the running Shisho version based on minShishoVersion.
+func AnnotateVersionCompatibility(versions []PluginVersion) []AnnotatedPluginVersion {
+	result := make([]AnnotatedPluginVersion, len(versions))
+	for i, v := range versions {
+		result[i] = AnnotatedPluginVersion{
+			PluginVersion: v,
+			Compatible:    version.IsCompatible(v.MinShishoVersion),
+		}
+	}
+	return result
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -run TestAnnotateVersionCompatibility -v`
+Expected: PASS
+
+- [ ] **Step 5: Update `availablePluginResponse` to use annotated versions**
+
+In `pkg/plugins/handler.go`, change the `availablePluginResponse` struct:
+
+```go
+type availablePluginResponse struct {
+	Scope       string                    `json:"scope"`
+	ID          string                    `json:"id"`
+	Name        string                    `json:"name"`
+	Overview    string                    `json:"overview"`
+	Description string                    `json:"description"`
+	Author      string                    `json:"author"`
+	Homepage    string                    `json:"homepage"`
+	Versions    []AnnotatedPluginVersion  `json:"versions"`
+	Compatible  bool                      `json:"compatible"`
+}
+```
+
+- [ ] **Step 6: Update `listAvailable` handler to annotate versions**
+
+In `pkg/plugins/handler.go`, update the `listAvailable` method. Change the plugin loop body (around line 681-696):
+
+```go
+		for _, p := range manifest.Plugins {
+			compatible := FilterCompatibleVersions(p.Versions)
+			if len(compatible) == 0 {
+				continue
+			}
+
+			annotated := AnnotateVersionCompatibility(compatible)
+			hasCompatible := false
+			for _, v := range annotated {
+				if v.Compatible {
+					hasCompatible = true
+					break
+				}
+			}
+
+			result = append(result, availablePluginResponse{
+				Scope:       manifest.Scope,
+				ID:          p.ID,
+				Name:        p.Name,
+				Overview:    p.Overview,
+				Description: p.Description,
+				Author:      p.Author,
+				Homepage:    p.Homepage,
+				Versions:    annotated,
+				Compatible:  hasCompatible,
+			})
+		}
+```
+
+- [ ] **Step 7: Update `retrieveAvailable` handler the same way**
+
+In `pkg/plugins/handler.go`, update the `retrieveAvailable` method (around line 799-812):
+
+```go
+			compatible := FilterCompatibleVersions(p.Versions)
+			if len(compatible) == 0 {
+				continue
+			}
+
+			annotated := AnnotateVersionCompatibility(compatible)
+			hasCompatible := false
+			for _, v := range annotated {
+				if v.Compatible {
+					hasCompatible = true
+					break
+				}
+			}
+
+			return errors.WithStack(c.JSON(http.StatusOK, availablePluginResponse{
+				Scope:       manifest.Scope,
+				ID:          p.ID,
+				Name:        p.Name,
+				Overview:    p.Overview,
+				Description: p.Description,
+				Author:      p.Author,
+				Homepage:    p.Homepage,
+				Versions:    annotated,
+				Compatible:  hasCompatible,
+			}))
+```
+
+- [ ] **Step 8: Run full plugin test suite**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/plugins/repository.go pkg/plugins/repository_test.go pkg/plugins/handler.go
+git commit -m "[Backend] Add compatibility annotations to available plugins API"
+```
+
+---
+
+### Task 4: Update frontend types and BrowseTab UI
+
+**Files:**
+- Modify: `app/hooks/queries/plugins.ts:27-46`
+- Modify: `app/components/pages/AdminPlugins.tsx:317-441`
+
+- [ ] **Step 1: Update `PluginVersion` and `AvailablePlugin` TypeScript interfaces**
+
+In `app/hooks/queries/plugins.ts`, change the `PluginVersion` interface to match the actual JSON field names from the server (the current snake_case names are wrong — the server sends camelCase):
+
+```typescript
+export interface PluginVersion {
+  version: string;
+  minShishoVersion: string;
+  compatible: boolean;
+  changelog: string;
+  downloadUrl: string;
+  sha256: string;
+  manifestVersion: number;
+  releaseDate: string;
+}
+```
+
+Update `AvailablePlugin` to add `compatible`:
+
+```typescript
+export interface AvailablePlugin {
+  scope: string;
+  id: string;
+  name: string;
+  overview: string;
+  description: string;
+  author: string;
+  homepage: string;
+  imageUrl: string;
+  versions: PluginVersion[];
+  compatible: boolean;
+}
+```
+
+- [ ] **Step 2: Update `InstallPluginPayload` to match**
+
+In the same file, the `InstallPluginPayload` uses `download_url` which is what the *install endpoint* expects (snake_case, since the Go `installPayload` struct uses `json:"download_url"`). This is correct — it's a different struct from `PluginVersion`. Leave it as-is.
+
+- [ ] **Step 3: Update `CapabilitiesWarning` to use new field names**
+
+In `app/components/plugins/CapabilitiesWarning.tsx`, update the reference to `manifest_version` (line 104):
+
+```tsx
+            Manifest v{latestVersion.manifestVersion}
+```
+
+- [ ] **Step 4: Update `BrowseTab` to show compatibility state**
+
+In `app/components/pages/AdminPlugins.tsx`, add `AlertTriangle` to the lucide imports:
+
+```typescript
+import {
+  AlertTriangle,
+  ArrowDown,
+  // ... rest of existing imports
+```
+
+Then update the `BrowseTab` component. Replace the `handleInstall` function:
+
+```typescript
+  const handleInstall = () => {
+    if (!installTarget) return;
+    const compatibleVersion = installTarget.versions.find((v) => v.compatible);
+    if (!compatibleVersion) return;
+    installPlugin.mutate(
+      {
+        scope: installTarget.scope,
+        id: installTarget.id,
+        name: installTarget.name,
+        version: compatibleVersion.version,
+      },
+      { onSuccess: () => setInstallTarget(null) },
+    );
+  };
+```
+
+Note: we no longer pass `download_url` and `sha256` — the backend's `findPluginInRepos` resolves those. This was already the effective behavior since the old field names (`download_url`, `sha256`) didn't match the JSON (`downloadUrl`, `sha256`) and resolved to `undefined`.
+
+Update the plugin card rendering inside the `available.map()` callback. Replace the existing return block (the `<div>` with key):
+
+```tsx
+          return (
+            <div
+              className="flex items-start justify-between gap-4 rounded-md border border-border p-4"
+              key={`${plugin.scope}/${plugin.id}`}
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-medium">{plugin.name}</h3>
+                  {latestVersion && (
+                    <Badge variant="outline">{latestVersion.version}</Badge>
+                  )}
+                  <Badge variant="secondary">{plugin.scope}</Badge>
+                  {alreadyInstalled && (
+                    <Badge variant="subtle">Installed</Badge>
+                  )}
+                  {!plugin.compatible && (
+                    <Badge variant="destructive">Incompatible</Badge>
+                  )}
+                </div>
+                {plugin.description && (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {plugin.description}
+                  </p>
+                )}
+                {plugin.author && (
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    by {plugin.author}
+                  </p>
+                )}
+                {!plugin.compatible && (
+                  <p className="mt-1 flex items-center gap-1 text-xs text-destructive">
+                    <AlertTriangle className="h-3 w-3" />
+                    Requires a newer version of Shisho
+                  </p>
+                )}
+              </div>
+
+              <div className="flex shrink-0 items-center gap-2">
+                {canWrite && !alreadyInstalled && plugin.compatible && (
+                  <Button
+                    onClick={() => setInstallTarget(plugin)}
+                    size="sm"
+                    variant="outline"
+                  >
+                    Install
+                  </Button>
+                )}
+                {plugin.homepage && (
+                  <a
+                    className="text-muted-foreground hover:text-foreground"
+                    href={plugin.homepage}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </a>
+                )}
+              </div>
+            </div>
+          );
+```
+
+Key changes:
+- Show "Incompatible" destructive badge when `!plugin.compatible`
+- Show "Requires a newer version of Shisho" warning text when incompatible
+- Only show Install button when `plugin.compatible` is true
+
+- [ ] **Step 5: Update `CapabilitiesWarning` to use first compatible version**
+
+In `app/components/plugins/CapabilitiesWarning.tsx`, change line 59:
+
+```tsx
+  const latestVersion = plugin.versions.find((v) => v.compatible) ?? plugin.versions[0];
+```
+
+This picks the first compatible version for display. Falls back to `versions[0]` defensively (should never happen since the Install button is hidden for fully incompatible plugins).
+
+- [ ] **Step 6: Run linting**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && pnpm lint:types && pnpm lint:eslint`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/hooks/queries/plugins.ts app/components/pages/AdminPlugins.tsx app/components/plugins/CapabilitiesWarning.tsx
+git commit -m "[Frontend] Show plugin version compatibility in Browse tab"
+```
+
+---
+
+### Task 5: Final validation
+
+- [ ] **Step 1: Run full backend tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && go test ./pkg/plugins/ -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 2: Run full check suite**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/min-version && mise check:quiet`
+Expected: All checks pass
+
+- [ ] **Step 3: Commit any fixes if needed**

--- a/docs/superpowers/specs/2026-04-05-plugin-min-version-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-05-plugin-min-version-enforcement-design.md
@@ -1,0 +1,139 @@
+# Plugin Min-Version Enforcement
+
+## Problem
+
+The `minShishoVersion` field exists in both `repository.json` plugin versions and plugin manifests, but it is only checked at runtime when loading an already-installed plugin (`runtime.go`). The three critical paths that interact with repository data — browsing available plugins, installing plugins, and checking for updates — all ignore `minShishoVersion`. This means:
+
+1. Users can download and install plugins that are guaranteed to fail on load
+2. The Browse tab gives no indication that a plugin/version is incompatible
+3. Update checks can flag versions the user can't actually run
+
+## Design
+
+### Backend
+
+#### 1. Version-aware filtering in `findPluginInRepos` and `CheckForUpdates`
+
+Both `findPluginInRepos()` (used for install and update) and `CheckForUpdates()` currently call `FilterCompatibleVersions()` which only checks `manifestVersion`. After this filter, add a second filter using `version.IsCompatible(v.MinShishoVersion)` to exclude versions whose `minShishoVersion` exceeds the running Shisho version.
+
+This prevents installation or update to an incompatible version.
+
+#### 2. Compatibility annotations in `listAvailable` / `getAvailable` responses
+
+The Browse tab should show ALL versions (not filter them out) but annotate each with compatibility status. Introduce a response wrapper:
+
+```go
+type availablePluginVersionResponse struct {
+    PluginVersion
+    Compatible bool `json:"compatible"`
+}
+```
+
+And add a top-level `Compatible` field to `availablePluginResponse`:
+
+```go
+type availablePluginResponse struct {
+    Scope       string                          `json:"scope"`
+    ID          string                          `json:"id"`
+    Name        string                          `json:"name"`
+    Overview    string                          `json:"overview"`
+    Description string                          `json:"description"`
+    Author      string                          `json:"author"`
+    Homepage    string                          `json:"homepage"`
+    Versions    []availablePluginVersionResponse `json:"versions"`
+    Compatible  bool                            `json:"compatible"`
+}
+```
+
+`Compatible` on the plugin level is `true` if at least one version has `compatible: true`. Each version's `compatible` field is set by calling `version.IsCompatible(v.MinShishoVersion)`.
+
+Both `listAvailable` and `getAvailable` handlers use this response format.
+
+The `overview` field is also added to the response (it was previously missing from `availablePluginResponse` despite being present on `AvailablePlugin`).
+
+#### 3. Install endpoint guard
+
+The install handler (`handler.install`) should reject requests for specific versions that fail the `minShishoVersion` check. When the frontend sends a `download_url` + `sha256` for a specific version, the backend currently trusts it. Add a `min_shisho_version` field to `installPayload` so the backend can verify compatibility before downloading. If incompatible, return a 400 validation error.
+
+When no explicit download URL is provided (install by scope+id), the `findPluginInRepos` path already handles this via the filtering in point 1.
+
+### Frontend
+
+#### 4. TypeScript type updates
+
+Update `PluginVersion` interface to include `compatible`:
+
+```typescript
+export interface PluginVersion {
+  version: string;
+  min_app_version: string;
+  compatible: boolean;
+  changelog: string;
+  download_url: string;
+  sha256: string;
+  manifest_version: number;
+}
+```
+
+Update `AvailablePlugin` to include `compatible`:
+
+```typescript
+export interface AvailablePlugin {
+  // ...existing fields...
+  compatible: boolean;
+}
+```
+
+#### 5. BrowseTab UI changes
+
+**Fully incompatible plugins** (`plugin.compatible === false`):
+- Show an "Incompatible" badge (destructive variant) where the Install button would be
+- Add explanatory text: "Requires Shisho vX.Y.Z+" (using the lowest `min_app_version` across all versions, since that's the "closest" to being reachable)
+
+**Partially compatible plugins** (some versions compatible, some not):
+- Show the Install button as normal — the install flow will pick the latest compatible version
+- The version badge next to the name shows the latest compatible version (first version where `compatible === true`)
+
+#### 6. Install flow: pick latest compatible version
+
+`handleInstall` in `BrowseTab` currently picks `versions[0]`. Change to pick the first version where `compatible === true`. The `CapabilitiesWarning` dialog also receives the correct compatible version.
+
+### What's NOT changing
+
+- The runtime version check in `LoadPlugin()` stays as-is — it's a safety net for manually installed plugins or plugins installed before this feature
+- `FilterCompatibleVersions()` keeps its current behavior (manifest version only) — it's a separate concern
+- No new API endpoints — all changes are to existing response shapes and filtering logic
+
+## Testing
+
+### Backend tests
+
+- `FilterCompatibleVersions` behavior unchanged (existing tests pass)
+- `findPluginInRepos` with mixed compatible/incompatible versions: returns only compatible
+- `findPluginInRepos` with all incompatible versions: returns not-found error
+- `CheckForUpdates` skips incompatible versions when determining latest update
+- `listAvailable` response includes `compatible` field on both plugin and version levels
+- Install endpoint rejects incompatible `min_shisho_version`
+
+### Frontend
+
+- BrowseTab renders "Incompatible" badge when `compatible === false`
+- BrowseTab renders Install button when `compatible === true`
+- Install handler selects first compatible version, not `versions[0]`
+
+## Files to modify
+
+### Backend
+- `pkg/plugins/repository.go` — no changes to `FilterCompatibleVersions`, but may add a helper
+- `pkg/plugins/handler.go` — `listAvailable`, `getAvailable`, `findPluginInRepos`, `install` handlers; `availablePluginResponse` type
+- `pkg/plugins/manager.go` — `CheckForUpdates` filtering
+- `pkg/plugins/handler.go` — `installPayload` struct (add `min_shisho_version`)
+
+### Frontend
+- `app/hooks/queries/plugins.ts` — `PluginVersion` and `AvailablePlugin` types
+- `app/components/pages/AdminPlugins.tsx` — `BrowseTab` component
+
+### Tests
+- `pkg/plugins/handler_test.go` or relevant test files
+- `pkg/plugins/manager_test.go` — `CheckForUpdates` tests
+- `pkg/plugins/update_check_test.go` — if update check tests live here

--- a/docs/superpowers/specs/2026-04-05-plugin-min-version-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-05-plugin-min-version-enforcement-design.md
@@ -51,11 +51,9 @@ Both `listAvailable` and `getAvailable` handlers use this response format.
 
 The `overview` field is also added to the response (it was previously missing from `availablePluginResponse` despite being present on `AvailablePlugin`).
 
-#### 3. Install endpoint guard
+#### 3. Install endpoint — no payload changes needed
 
-The install handler (`handler.install`) should reject requests for specific versions that fail the `minShishoVersion` check. When the frontend sends a `download_url` + `sha256` for a specific version, the backend currently trusts it. Add a `min_shisho_version` field to `installPayload` so the backend can verify compatibility before downloading. If incompatible, return a 400 validation error.
-
-When no explicit download URL is provided (install by scope+id), the `findPluginInRepos` path already handles this via the filtering in point 1.
+The frontend's install flow always goes through the `findPluginInRepos` path (scope+id lookup), which gets minShishoVersion filtering from point 1. The `download_url`/`sha256` fields in `installPayload` exist for direct-URL installs but the Browse UI doesn't use them. The runtime version check in `LoadPlugin()` remains as a safety net for any direct-URL installs.
 
 ### Frontend
 
@@ -66,12 +64,13 @@ Update `PluginVersion` interface to include `compatible`:
 ```typescript
 export interface PluginVersion {
   version: string;
-  min_app_version: string;
+  minShishoVersion: string;
   compatible: boolean;
   changelog: string;
-  download_url: string;
+  downloadUrl: string;
   sha256: string;
-  manifest_version: number;
+  manifestVersion: number;
+  releaseDate: string;
 }
 ```
 
@@ -88,7 +87,7 @@ export interface AvailablePlugin {
 
 **Fully incompatible plugins** (`plugin.compatible === false`):
 - Show an "Incompatible" badge (destructive variant) where the Install button would be
-- Add explanatory text: "Requires Shisho vX.Y.Z+" (using the lowest `min_app_version` across all versions, since that's the "closest" to being reachable)
+- Add explanatory text: "Requires a newer version of Shisho"
 
 **Partially compatible plugins** (some versions compatible, some not):
 - Show the Install button as normal — the install flow will pick the latest compatible version
@@ -113,7 +112,7 @@ export interface AvailablePlugin {
 - `findPluginInRepos` with all incompatible versions: returns not-found error
 - `CheckForUpdates` skips incompatible versions when determining latest update
 - `listAvailable` response includes `compatible` field on both plugin and version levels
-- Install endpoint rejects incompatible `min_shisho_version`
+- Install via `findPluginInRepos` skips incompatible versions
 
 ### Frontend
 
@@ -127,7 +126,6 @@ export interface AvailablePlugin {
 - `pkg/plugins/repository.go` — no changes to `FilterCompatibleVersions`, but may add a helper
 - `pkg/plugins/handler.go` — `listAvailable`, `getAvailable`, `findPluginInRepos`, `install` handlers; `availablePluginResponse` type
 - `pkg/plugins/manager.go` — `CheckForUpdates` filtering
-- `pkg/plugins/handler.go` — `installPayload` struct (add `min_shisho_version`)
 
 ### Frontend
 - `app/hooks/queries/plugins.ts` — `PluginVersion` and `AvailablePlugin` types

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -298,7 +298,7 @@ func (h *handler) findPluginInRepos(c echo.Context, scope, pluginID, version str
 				continue
 			}
 
-			compatible := FilterCompatibleVersions(p.Versions)
+			compatible := FilterVersionCompatibleVersions(FilterCompatibleVersions(p.Versions))
 			if len(compatible) == 0 {
 				continue
 			}

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -648,13 +648,15 @@ func (h *handler) syncRepository(c echo.Context) error {
 
 // availablePluginResponse is the response format for available plugins.
 type availablePluginResponse struct {
-	Scope       string          `json:"scope"`
-	ID          string          `json:"id"`
-	Name        string          `json:"name"`
-	Description string          `json:"description"`
-	Author      string          `json:"author"`
-	Homepage    string          `json:"homepage"`
-	Versions    []PluginVersion `json:"versions"`
+	Scope       string                   `json:"scope"`
+	ID          string                   `json:"id"`
+	Name        string                   `json:"name"`
+	Overview    string                   `json:"overview"`
+	Description string                   `json:"description"`
+	Author      string                   `json:"author"`
+	Homepage    string                   `json:"homepage"`
+	Versions    []AnnotatedPluginVersion `json:"versions"`
+	Compatible  bool                     `json:"compatible"`
 }
 
 // listAvailable aggregates plugins from all enabled repositories.
@@ -684,14 +686,25 @@ func (h *handler) listAvailable(c echo.Context) error {
 				continue
 			}
 
+			annotated := AnnotateVersionCompatibility(compatible)
+			hasCompatible := false
+			for _, v := range annotated {
+				if v.Compatible {
+					hasCompatible = true
+					break
+				}
+			}
+
 			result = append(result, availablePluginResponse{
 				Scope:       manifest.Scope,
 				ID:          p.ID,
 				Name:        p.Name,
+				Overview:    p.Overview,
 				Description: p.Description,
 				Author:      p.Author,
 				Homepage:    p.Homepage,
-				Versions:    compatible,
+				Versions:    annotated,
+				Compatible:  hasCompatible,
 			})
 		}
 	}
@@ -801,14 +814,25 @@ func (h *handler) retrieveAvailable(c echo.Context) error {
 				continue
 			}
 
+			annotated := AnnotateVersionCompatibility(compatible)
+			hasCompatible := false
+			for _, v := range annotated {
+				if v.Compatible {
+					hasCompatible = true
+					break
+				}
+			}
+
 			return errors.WithStack(c.JSON(http.StatusOK, availablePluginResponse{
 				Scope:       manifest.Scope,
 				ID:          p.ID,
 				Name:        p.Name,
+				Overview:    p.Overview,
 				Description: p.Description,
 				Author:      p.Author,
 				Homepage:    p.Homepage,
-				Versions:    compatible,
+				Versions:    annotated,
+				Compatible:  hasCompatible,
 			}))
 		}
 	}

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -475,7 +475,7 @@ func (m *Manager) CheckForUpdates(ctx context.Context) error {
 				if available.ID != plugin.ID {
 					continue
 				}
-				compatible := FilterCompatibleVersions(available.Versions)
+				compatible := FilterVersionCompatibleVersions(FilterCompatibleVersions(available.Versions))
 				if len(compatible) == 0 {
 					continue
 				}

--- a/pkg/plugins/repository.go
+++ b/pkg/plugins/repository.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/version"
 )
 
 // AllowedFetchHosts lists the allowed host prefixes for repository manifest URLs.
@@ -107,6 +108,18 @@ func FilterCompatibleVersions(versions []PluginVersion) []PluginVersion {
 				compatible = append(compatible, v)
 				break
 			}
+		}
+	}
+	return compatible
+}
+
+// FilterVersionCompatibleVersions returns only versions whose minShishoVersion
+// is satisfied by the running Shisho version.
+func FilterVersionCompatibleVersions(versions []PluginVersion) []PluginVersion {
+	var compatible []PluginVersion
+	for _, v := range versions {
+		if version.IsCompatible(v.MinShishoVersion) {
+			compatible = append(compatible, v)
 		}
 	}
 	return compatible

--- a/pkg/plugins/repository.go
+++ b/pkg/plugins/repository.go
@@ -113,6 +113,25 @@ func FilterCompatibleVersions(versions []PluginVersion) []PluginVersion {
 	return compatible
 }
 
+// AnnotatedPluginVersion extends PluginVersion with a compatibility flag.
+type AnnotatedPluginVersion struct {
+	PluginVersion
+	Compatible bool `json:"compatible"`
+}
+
+// AnnotateVersionCompatibility annotates each version with whether it is
+// compatible with the running Shisho version based on minShishoVersion.
+func AnnotateVersionCompatibility(versions []PluginVersion) []AnnotatedPluginVersion {
+	result := make([]AnnotatedPluginVersion, len(versions))
+	for i, v := range versions {
+		result[i] = AnnotatedPluginVersion{
+			PluginVersion: v,
+			Compatible:    version.IsCompatible(v.MinShishoVersion),
+		}
+	}
+	return result
+}
+
 // FilterVersionCompatibleVersions returns only versions whose minShishoVersion
 // is satisfied by the running Shisho version.
 func FilterVersionCompatibleVersions(versions []PluginVersion) []PluginVersion {

--- a/pkg/plugins/repository_test.go
+++ b/pkg/plugins/repository_test.go
@@ -196,3 +196,45 @@ func TestFilterVersionCompatibleVersions_Empty(t *testing.T) {
 	compatible := FilterVersionCompatibleVersions(nil)
 	assert.Empty(t, compatible)
 }
+
+func TestAnnotateVersionCompatibility(t *testing.T) {
+	t.Parallel()
+
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "0.5.0", ManifestVersion: 1},
+		{Version: "2.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+		{Version: "1.1.0", MinShishoVersion: "", ManifestVersion: 1},
+	}
+
+	annotated := AnnotateVersionCompatibility(versions)
+	require.Len(t, annotated, 3)
+
+	assert.True(t, annotated[0].Compatible)  // 0.5.0 <= 1.0.0
+	assert.False(t, annotated[1].Compatible) // 99.0.0 > 1.0.0
+	assert.True(t, annotated[2].Compatible)  // empty = compatible
+
+	// Verify original fields preserved
+	assert.Equal(t, "1.0.0", annotated[0].Version)
+	assert.Equal(t, "2.0.0", annotated[1].Version)
+	assert.Equal(t, "1.1.0", annotated[2].Version)
+}
+
+func TestAnnotateVersionCompatibility_AllIncompatible(t *testing.T) {
+	t.Parallel()
+
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+	}
+
+	annotated := AnnotateVersionCompatibility(versions)
+	require.Len(t, annotated, 1)
+	assert.False(t, annotated[0].Compatible)
+}

--- a/pkg/plugins/repository_test.go
+++ b/pkg/plugins/repository_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/shishobooks/shisho/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -151,5 +152,47 @@ func TestFilterCompatibleVersions_NoMatch(t *testing.T) {
 
 func TestFilterCompatibleVersions_Empty(t *testing.T) {
 	compatible := FilterCompatibleVersions(nil)
+	assert.Empty(t, compatible)
+}
+
+func TestFilterVersionCompatibleVersions(t *testing.T) {
+	t.Parallel()
+
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "0.1.0", ManifestVersion: 1},
+		{Version: "2.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+		{Version: "1.1.0", MinShishoVersion: "", ManifestVersion: 1},
+	}
+
+	compatible := FilterVersionCompatibleVersions(versions)
+	require.Len(t, compatible, 2)
+	assert.Equal(t, "1.0.0", compatible[0].Version)
+	assert.Equal(t, "1.1.0", compatible[1].Version)
+}
+
+func TestFilterVersionCompatibleVersions_AllIncompatible(t *testing.T) {
+	t.Parallel()
+
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	versions := []PluginVersion{
+		{Version: "1.0.0", MinShishoVersion: "99.0.0", ManifestVersion: 1},
+		{Version: "2.0.0", MinShishoVersion: "100.0.0", ManifestVersion: 1},
+	}
+
+	compatible := FilterVersionCompatibleVersions(versions)
+	assert.Empty(t, compatible)
+}
+
+func TestFilterVersionCompatibleVersions_Empty(t *testing.T) {
+	t.Parallel()
+
+	compatible := FilterVersionCompatibleVersions(nil)
 	assert.Empty(t, compatible)
 }

--- a/pkg/plugins/repository_test.go
+++ b/pkg/plugins/repository_test.go
@@ -156,8 +156,6 @@ func TestFilterCompatibleVersions_Empty(t *testing.T) {
 }
 
 func TestFilterVersionCompatibleVersions(t *testing.T) {
-	t.Parallel()
-
 	origVersion := version.Version
 	version.Version = "1.0.0"
 	defer func() { version.Version = origVersion }()
@@ -175,8 +173,6 @@ func TestFilterVersionCompatibleVersions(t *testing.T) {
 }
 
 func TestFilterVersionCompatibleVersions_AllIncompatible(t *testing.T) {
-	t.Parallel()
-
 	origVersion := version.Version
 	version.Version = "1.0.0"
 	defer func() { version.Version = origVersion }()
@@ -198,8 +194,6 @@ func TestFilterVersionCompatibleVersions_Empty(t *testing.T) {
 }
 
 func TestAnnotateVersionCompatibility(t *testing.T) {
-	t.Parallel()
-
 	origVersion := version.Version
 	version.Version = "1.0.0"
 	defer func() { version.Version = origVersion }()
@@ -224,8 +218,6 @@ func TestAnnotateVersionCompatibility(t *testing.T) {
 }
 
 func TestAnnotateVersionCompatibility_AllIncompatible(t *testing.T) {
-	t.Parallel()
-
 	origVersion := version.Version
 	version.Version = "1.0.0"
 	defer func() { version.Version = origVersion }()

--- a/pkg/plugins/update_check_test.go
+++ b/pkg/plugins/update_check_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -405,4 +406,64 @@ func TestManager_CheckForUpdates_ScopeMismatch(t *testing.T) {
 	updated, err := service.RetrievePlugin(ctx, "community", "my-plugin")
 	require.NoError(t, err)
 	assert.Nil(t, updated.UpdateAvailableVersion)
+}
+
+func TestManager_CheckForUpdates_MinShishoVersionFiltered(t *testing.T) {
+	origVersion := version.Version
+	version.Version = "1.0.0"
+	defer func() { version.Version = origVersion }()
+
+	db := setupTestDB(t)
+	service := NewService(db)
+	mgr := NewManager(service, t.TempDir(), "")
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "official",
+		ID:          "my-plugin",
+		Name:        "My Plugin",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err := service.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	repo := &models.PluginRepository{
+		URL:        "https://raw.githubusercontent.com/test/repo/main/manifest.json",
+		Scope:      "official",
+		Name:       strPtr("Official Repo"),
+		IsOfficial: true,
+		Enabled:    true,
+	}
+	err = service.AddRepository(ctx, repo)
+	require.NoError(t, err)
+
+	mgr.fetchRepo = func(_ string) (*RepositoryManifest, error) {
+		return &RepositoryManifest{
+			RepositoryVersion: 1,
+			Scope:             "official",
+			Name:              "Official Repo",
+			Plugins: []AvailablePlugin{
+				{
+					ID:   "my-plugin",
+					Name: "My Plugin",
+					Versions: []PluginVersion{
+						{Version: "1.0.0", ManifestVersion: 1, MinShishoVersion: "0.1.0"},
+						{Version: "1.5.0", ManifestVersion: 1, MinShishoVersion: "0.5.0"},
+						{Version: "2.0.0", ManifestVersion: 1, MinShishoVersion: "99.0.0"},
+					},
+				},
+			},
+		}, nil
+	}
+
+	err = mgr.CheckForUpdates(ctx)
+	require.NoError(t, err)
+
+	// Should flag 1.5.0 as available, not 2.0.0 (incompatible minShishoVersion)
+	updated, err := service.RetrievePlugin(ctx, "official", "my-plugin")
+	require.NoError(t, err)
+	require.NotNil(t, updated.UpdateAvailableVersion)
+	assert.Equal(t, "1.5.0", *updated.UpdateAvailableVersion)
 }

--- a/website/docs/plugins/repositories.md
+++ b/website/docs/plugins/repositories.md
@@ -36,7 +36,7 @@ Each plugin version in a repository includes:
 - A **minimum Shisho version** for compatibility filtering
 - A **changelog** describing what changed
 
-Shisho only shows plugin versions that are compatible with your current server version.
+Plugin versions that require a newer version of Shisho are marked as **Incompatible** in the Browse tab and cannot be installed. Compatible versions remain installable as normal.
 
 ## Creating a Plugin Repository
 


### PR DESCRIPTION
## Summary
- Enforce `minShishoVersion` from plugin repository.json entries so incompatible plugin versions can't be installed or flagged as updates
- Annotate the available plugins API response with per-version and per-plugin `compatible` booleans so the frontend can display compatibility state
- Show "Incompatible" badge and hide Install button in the Browse tab for plugins that require a newer Shisho version

## Test plan
- Verify `FilterVersionCompatibleVersions` filters out versions whose `minShishoVersion` exceeds the running Shisho version
- Verify `CheckForUpdates` skips incompatible versions when determining latest available update
- Verify `listAvailable` and `retrieveAvailable` API responses include `compatible` field on both version and plugin levels
- Verify the Browse tab shows "Incompatible" badge for fully incompatible plugins and hides the Install button
- Verify the Install flow picks the first compatible version for partially compatible plugins
- Run `mise check:quiet` — all checks pass (lint, test, test:js, lint:js)