### PR TITLE
[Frontend] Improve plugin settings order tab UX

### DIFF
--- a/app/components/pages/AdminPlugins.tsx
+++ b/app/components/pages/AdminPlugins.tsx
@@ -1,11 +1,12 @@
+import { useQueries } from "@tanstack/react-query";
 import {
   AlertTriangle,
   ArrowDown,
   ArrowUp,
-  ChevronDown,
   Download,
   ExternalLink,
   FolderSearch,
+  ListOrdered,
   Loader2,
   Package,
   Plus,
@@ -14,7 +15,7 @@ import {
   Star,
   Trash2,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 
@@ -37,6 +38,7 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   PluginStatusActive,
+  QueryKey,
   useAddRepository,
   useInstallPlugin,
   usePluginOrder,
@@ -58,6 +60,7 @@ import {
 } from "@/hooks/queries/plugins";
 import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { API } from "@/libraries/api";
 
 // --- Installed Tab ---
 
@@ -453,20 +456,50 @@ const BrowseTab = () => {
 // --- Order Tab ---
 
 const HOOK_TYPES: { label: string; value: PluginHookType }[] = [
-  { label: "Input Converter", value: "inputConverter" },
-  { label: "File Parser", value: "fileParser" },
-  { label: "Output Generator", value: "outputGenerator" },
   { label: "Metadata Enricher", value: "metadataEnricher" },
+  { label: "File Parser", value: "fileParser" },
+  { label: "Input Converter", value: "inputConverter" },
+  { label: "Output Generator", value: "outputGenerator" },
 ];
 
 const OrderTab = () => {
   const { hasPermission } = useAuth();
   const canWrite = hasPermission("config", "write");
   const [selectedHookType, setSelectedHookType] =
-    useState<PluginHookType>("fileParser");
+    useState<PluginHookType>("metadataEnricher");
+  const [hasAutoSelected, setHasAutoSelected] = useState(false);
   const { data: order, isLoading, error } = usePluginOrder(selectedHookType);
   const setPluginOrder = useSetPluginOrder();
   const { data: plugins } = usePluginsInstalled();
+
+  // Prefetch all hook type orders to find the first non-empty one
+  const allOrders = useQueries({
+    queries: HOOK_TYPES.map((ht) => ({
+      queryKey: [QueryKey.PluginOrder, ht.value],
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        API.request<PluginOrder[]>(
+          "GET",
+          `/plugins/order/${ht.value}`,
+          null,
+          null,
+          signal,
+        ),
+    })),
+  });
+
+  // Auto-select the first non-empty hook type once data loads
+  useEffect(() => {
+    if (hasAutoSelected) return;
+    const allLoaded = allOrders.every((q) => q.isSuccess);
+    if (!allLoaded) return;
+    const firstNonEmpty = HOOK_TYPES.find(
+      (_, i) => (allOrders[i].data?.length ?? 0) > 0,
+    );
+    if (firstNonEmpty) {
+      setSelectedHookType(firstNonEmpty.value);
+    }
+    setHasAutoSelected(true);
+  }, [allOrders, hasAutoSelected]);
 
   const [localOrder, setLocalOrder] = useState<PluginOrder[] | null>(null);
 
@@ -553,7 +586,7 @@ const OrderTab = () => {
 
       {displayOrder.length === 0 ? (
         <div className="py-8 text-center">
-          <ChevronDown className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+          <ListOrdered className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
           <p className="text-sm text-muted-foreground">
             No plugins registered for this hook type.
           </p>

--- a/app/components/pages/AdminPlugins.tsx
+++ b/app/components/pages/AdminPlugins.tsx
@@ -1,4 +1,3 @@
-import { useQueries } from "@tanstack/react-query";
 import {
   AlertTriangle,
   ArrowDown,
@@ -38,8 +37,8 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   PluginStatusActive,
-  QueryKey,
   useAddRepository,
+  useAllPluginOrders,
   useInstallPlugin,
   usePluginOrder,
   usePluginRepositories,
@@ -60,7 +59,6 @@ import {
 } from "@/hooks/queries/plugins";
 import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { API } from "@/libraries/api";
 
 // --- Installed Tab ---
 
@@ -473,33 +471,20 @@ const OrderTab = () => {
   const { data: plugins } = usePluginsInstalled();
 
   // Prefetch all hook type orders to find the first non-empty one
-  const allOrders = useQueries({
-    queries: HOOK_TYPES.map((ht) => ({
-      queryKey: [QueryKey.PluginOrder, ht.value],
-      queryFn: ({ signal }: { signal: AbortSignal }) =>
-        API.request<PluginOrder[]>(
-          "GET",
-          `/plugins/order/${ht.value}`,
-          null,
-          null,
-          signal,
-        ),
-    })),
-  });
+  const allOrders = useAllPluginOrders(HOOK_TYPES.map((ht) => ht.value));
+  const firstNonEmptyHookType = allOrders.every((q) => q.isSuccess)
+    ? (HOOK_TYPES.find((_, i) => (allOrders[i].data?.length ?? 0) > 0)?.value ??
+      null)
+    : undefined; // undefined = still loading, null = all empty
 
   // Auto-select the first non-empty hook type once data loads
   useEffect(() => {
-    if (hasAutoSelected) return;
-    const allLoaded = allOrders.every((q) => q.isSuccess);
-    if (!allLoaded) return;
-    const firstNonEmpty = HOOK_TYPES.find(
-      (_, i) => (allOrders[i].data?.length ?? 0) > 0,
-    );
-    if (firstNonEmpty) {
-      setSelectedHookType(firstNonEmpty.value);
+    if (hasAutoSelected || firstNonEmptyHookType === undefined) return;
+    if (firstNonEmptyHookType) {
+      setSelectedHookType(firstNonEmptyHookType);
     }
     setHasAutoSelected(true);
-  }, [allOrders, hasAutoSelected]);
+  }, [firstNonEmptyHookType, hasAutoSelected]);
 
   const [localOrder, setLocalOrder] = useState<PluginOrder[] | null>(null);
 

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
 import { API, type ShishoAPIError } from "@/libraries/api";
@@ -101,18 +106,26 @@ export const usePluginsAvailable = () => {
   });
 };
 
+const pluginOrderQuery = (hookType: string) => ({
+  queryKey: [QueryKey.PluginOrder, hookType],
+  queryFn: ({ signal }: { signal: AbortSignal }) => {
+    return API.request<PluginOrder[]>(
+      "GET",
+      `/plugins/order/${hookType}`,
+      null,
+      null,
+      signal,
+    );
+  },
+});
+
 export const usePluginOrder = (hookType: string) => {
-  return useQuery<PluginOrder[], ShishoAPIError>({
-    queryKey: [QueryKey.PluginOrder, hookType],
-    queryFn: ({ signal }) => {
-      return API.request(
-        "GET",
-        `/plugins/order/${hookType}`,
-        null,
-        null,
-        signal,
-      );
-    },
+  return useQuery<PluginOrder[], ShishoAPIError>(pluginOrderQuery(hookType));
+};
+
+export const useAllPluginOrders = (hookTypes: string[]) => {
+  return useQueries({
+    queries: hookTypes.map((ht) => pluginOrderQuery(ht)),
   });
 };
 


### PR DESCRIPTION
## Summary
- Reorder hook type dropdown to: Metadata Enricher, File Parser, Input Converter, Output Generator
- Default to Metadata Enricher when no plugins are installed; auto-select the first non-empty hook type when plugins exist
- Replace chevron-down icon with list-ordered icon in the empty state placeholder

## Test plan
- Open plugin settings order tab with no plugins installed — should default to Metadata Enricher
- Install a plugin that registers for a specific hook type — order tab should auto-select that hook type on load
- Verify dropdown shows items in the new order: Metadata Enricher, File Parser, Input Converter, Output Generator
- Select a hook type with no plugins — empty state should show the list-ordered icon