### PR TITLE
[Feature] Add three-state plugin mode (Enabled / Manual Only / Disabled)

### DIFF
--- a/app/components/library/LibraryPluginsTab.tsx
+++ b/app/components/library/LibraryPluginsTab.tsx
@@ -12,7 +12,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
 import {
   useLibraryPluginOrder,
   useResetLibraryPluginOrder,
@@ -58,7 +57,7 @@ const LibraryPluginsTab = ({ libraryId, onHasChangesChange }: Props) => {
         (item, i) =>
           item.scope !== data?.plugins?.[i]?.scope ||
           item.id !== data?.plugins?.[i]?.id ||
-          item.enabled !== data?.plugins?.[i]?.enabled,
+          item.mode !== data?.plugins?.[i]?.mode,
       ));
 
   // Notify parent of changes
@@ -77,12 +76,12 @@ const LibraryPluginsTab = ({ libraryId, onHasChangesChange }: Props) => {
     setLocalPlugins(newPlugins);
   };
 
-  const handleToggle = (index: number) => {
+  const handleModeChange = (
+    index: number,
+    mode: LibraryPluginOrderPlugin["mode"],
+  ) => {
     const newPlugins = [...displayPlugins];
-    newPlugins[index] = {
-      ...newPlugins[index],
-      enabled: !newPlugins[index].enabled,
-    };
+    newPlugins[index] = { ...newPlugins[index], mode };
     setLocalPlugins(newPlugins);
   };
 
@@ -98,7 +97,7 @@ const LibraryPluginsTab = ({ libraryId, onHasChangesChange }: Props) => {
         plugins: displayPlugins.map((p) => ({
           scope: p.scope,
           id: p.id,
-          enabled: p.enabled,
+          mode: p.mode,
         })),
       },
       {
@@ -184,7 +183,11 @@ const LibraryPluginsTab = ({ libraryId, onHasChangesChange }: Props) => {
           {displayPlugins.map((plugin, index) => (
             <div
               className={`flex items-center justify-between gap-3 rounded-md border p-3 ${
-                plugin.enabled ? "border-border" : "border-border/50 opacity-60"
+                plugin.mode === "disabled"
+                  ? "border-border/50 opacity-60"
+                  : plugin.mode === "manual_only"
+                    ? "border-border/70 opacity-80"
+                    : "border-border"
               }`}
               key={`${plugin.scope}/${plugin.id}`}
             >
@@ -197,10 +200,26 @@ const LibraryPluginsTab = ({ libraryId, onHasChangesChange }: Props) => {
               </div>
               {(isCustomized || localPlugins) && (
                 <div className="flex items-center gap-2">
-                  <Switch
-                    checked={plugin.enabled}
-                    onCheckedChange={() => handleToggle(index)}
-                  />
+                  <Select
+                    onValueChange={(value) =>
+                      handleModeChange(
+                        index,
+                        value as LibraryPluginOrderPlugin["mode"],
+                      )
+                    }
+                    value={plugin.mode}
+                  >
+                    <SelectTrigger className="w-[140px] h-8 text-xs">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="enabled">Enabled</SelectItem>
+                      {selectedHookType === "metadataEnricher" && (
+                        <SelectItem value="manual_only">Manual Only</SelectItem>
+                      )}
+                      <SelectItem value="disabled">Disabled</SelectItem>
+                    </SelectContent>
+                  </Select>
                   <Button
                     disabled={index === 0}
                     onClick={() => handleMove(index, "up")}

--- a/app/components/pages/AdminPlugins.tsx
+++ b/app/components/pages/AdminPlugins.tsx
@@ -55,6 +55,7 @@ import {
   type AvailablePlugin,
   type Plugin,
   type PluginHookType,
+  type PluginMode,
   type PluginOrder,
 } from "@/hooks/queries/plugins";
 import { useAuth } from "@/hooks/useAuth";
@@ -512,7 +513,7 @@ const OrderTab = () => {
     setLocalOrder(newOrder);
   };
 
-  const handleModeChange = (index: number, mode: string) => {
+  const handleModeChange = (index: number, mode: PluginMode) => {
     const newOrder = [...displayOrder];
     newOrder[index] = { ...newOrder[index], mode };
     setLocalOrder(newOrder);
@@ -612,7 +613,9 @@ const OrderTab = () => {
               {canWrite && (
                 <div className="flex items-center gap-1">
                   <Select
-                    onValueChange={(value) => handleModeChange(index, value)}
+                    onValueChange={(value) =>
+                      handleModeChange(index, value as PluginMode)
+                    }
                     value={item.mode}
                   >
                     <SelectTrigger className="w-[140px] h-8 text-xs">

--- a/app/components/pages/AdminPlugins.tsx
+++ b/app/components/pages/AdminPlugins.tsx
@@ -497,7 +497,8 @@ const OrderTab = () => {
       localOrder.some(
         (item, i) =>
           item.scope !== order?.[i]?.scope ||
-          item.plugin_id !== order?.[i]?.plugin_id,
+          item.plugin_id !== order?.[i]?.plugin_id ||
+          item.mode !== order?.[i]?.mode,
       ));
 
   const handleMove = (index: number, direction: "up" | "down") => {
@@ -511,11 +512,21 @@ const OrderTab = () => {
     setLocalOrder(newOrder);
   };
 
+  const handleModeChange = (index: number, mode: string) => {
+    const newOrder = [...displayOrder];
+    newOrder[index] = { ...newOrder[index], mode };
+    setLocalOrder(newOrder);
+  };
+
   const handleSave = () => {
     setPluginOrder.mutate(
       {
         hookType: selectedHookType,
-        order: displayOrder.map((o) => ({ scope: o.scope, id: o.plugin_id })),
+        order: displayOrder.map((o) => ({
+          scope: o.scope,
+          id: o.plugin_id,
+          mode: o.mode,
+        })),
       },
       {
         onSuccess: () => {
@@ -580,7 +591,13 @@ const OrderTab = () => {
         <div className="space-y-2">
           {displayOrder.map((item, index) => (
             <div
-              className="flex items-center justify-between gap-3 rounded-md border border-border p-3"
+              className={`flex items-center justify-between gap-3 rounded-md border p-3 ${
+                item.mode === "disabled"
+                  ? "border-border/50 opacity-60"
+                  : item.mode === "manual_only"
+                    ? "border-border/70 opacity-80"
+                    : "border-border"
+              }`}
               key={`${item.scope}/${item.plugin_id}`}
             >
               <div className="flex items-center gap-3">
@@ -594,6 +611,21 @@ const OrderTab = () => {
               </div>
               {canWrite && (
                 <div className="flex items-center gap-1">
+                  <Select
+                    onValueChange={(value) => handleModeChange(index, value)}
+                    value={item.mode}
+                  >
+                    <SelectTrigger className="w-[140px] h-8 text-xs">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="enabled">Enabled</SelectItem>
+                      {selectedHookType === "metadataEnricher" && (
+                        <SelectItem value="manual_only">Manual Only</SelectItem>
+                      )}
+                      <SelectItem value="disabled">Disabled</SelectItem>
+                    </SelectContent>
+                  </Select>
                   <Button
                     disabled={index === 0}
                     onClick={() => handleMove(index, "up")}

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -9,16 +9,17 @@ import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
 import { API, type ShishoAPIError } from "@/libraries/api";
 import type {
   Plugin,
+  PluginHookConfig,
   PluginIdentifierType,
-  PluginOrder,
   PluginRepository,
 } from "@/types/generated/models";
 
 // Re-export generated types so consumers can import from this module
+// PluginHookConfig is re-exported as PluginOrder for backward compatibility
 export type {
   Plugin,
+  PluginHookConfig as PluginOrder,
   PluginHookType,
-  PluginOrder,
   PluginRepository,
   PluginStatus,
 } from "@/types/generated/models";
@@ -109,7 +110,7 @@ export const usePluginsAvailable = () => {
 const pluginOrderQuery = (hookType: string) => ({
   queryKey: [QueryKey.PluginOrder, hookType],
   queryFn: ({ signal }: { signal: AbortSignal }) => {
-    return API.request<PluginOrder[]>(
+    return API.request<PluginHookConfig[]>(
       "GET",
       `/plugins/order/${hookType}`,
       null,
@@ -120,7 +121,9 @@ const pluginOrderQuery = (hookType: string) => ({
 });
 
 export const usePluginOrder = (hookType: string) => {
-  return useQuery<PluginOrder[], ShishoAPIError>(pluginOrderQuery(hookType));
+  return useQuery<PluginHookConfig[], ShishoAPIError>(
+    pluginOrderQuery(hookType),
+  );
 };
 
 export const useAllPluginOrders = (hookTypes: string[]) => {
@@ -291,7 +294,7 @@ export const useSetPluginOrder = () => {
   return useMutation<
     void,
     ShishoAPIError,
-    { hookType: string; order: { scope: string; id: string }[] }
+    { hookType: string; order: { scope: string; id: string; mode: string }[] }
   >({
     mutationFn: ({ hookType, order }) => {
       return API.request("PUT", `/plugins/order/${hookType}`, { order });
@@ -430,7 +433,7 @@ export interface LibraryPluginOrderPlugin {
   scope: string;
   id: string;
   name: string;
-  enabled: boolean;
+  mode: "enabled" | "manual_only" | "disabled";
 }
 
 export interface LibraryPluginOrderResponse {
@@ -465,7 +468,7 @@ export const useSetLibraryPluginOrder = () => {
     {
       libraryId: string;
       hookType: string;
-      plugins: { scope: string; id: string; enabled: boolean }[];
+      plugins: { scope: string; id: string; mode: string }[];
     }
   >({
     mutationFn: ({ libraryId, hookType, plugins }) => {

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -427,13 +427,17 @@ export const useSyncRepository = () => {
   });
 };
 
+// --- Plugin Mode ---
+
+export type PluginMode = "enabled" | "manual_only" | "disabled";
+
 // --- Per-Library Plugin Order ---
 
 export interface LibraryPluginOrderPlugin {
   scope: string;
   id: string;
   name: string;
-  mode: "enabled" | "manual_only" | "disabled";
+  mode: PluginMode;
 }
 
 export interface LibraryPluginOrderResponse {

--- a/docs/superpowers/plans/2026-04-05-library-plugin-mode.md
+++ b/docs/superpowers/plans/2026-04-05-library-plugin-mode.md
@@ -1,0 +1,1261 @@
+# Library Plugin Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace binary enabled/disabled toggle on plugin order with a three-state mode (Enabled / Manual Only / Disabled), applying at both global and per-library levels.
+
+**Architecture:** Database migration renames `plugin_order` → `plugin_hook_config` and `library_plugins` → `library_plugin_hook_config`, adds a `mode` column to both tables. Go models, service, manager, and handlers are updated. A new `GetManualRuntimes` method returns plugins with mode `enabled` or `manual_only`. Frontend replaces toggle switches with dropdowns.
+
+**Tech Stack:** Go (Bun ORM, Echo), SQLite, React (TypeScript), Tanstack Query, shadcn/ui
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `pkg/models/plugin.go` | Rename structs, add `Mode` field, add mode constants |
+| Create | `pkg/migrations/20260405000000_plugin_hook_config_mode.go` | Migration: rename tables, add mode column, migrate data |
+| Modify | `pkg/plugins/service.go` | Update all queries to use renamed models |
+| Modify | `pkg/plugins/service_test.go` | Update tests for renamed models + mode field |
+| Modify | `pkg/plugins/manager.go` | Filter by mode in `GetOrderedRuntimes`, add `GetManualRuntimes` |
+| Modify | `pkg/plugins/manager_test.go` | Update existing tests, add mode-aware tests |
+| Modify | `pkg/plugins/handler.go` | Update payload types, handler logic, manual search |
+| Modify | `app/hooks/queries/plugins.ts` | Replace `enabled` with `mode` in types and mutations |
+| Modify | `app/components/library/LibraryPluginsTab.tsx` | Replace toggle with mode dropdown |
+| Modify | `app/components/pages/AdminPlugins.tsx` | Add mode dropdown to global order |
+| Modify | `pkg/plugins/CLAUDE.md` | Update table names and field references |
+
+---
+
+### Task 1: Database Migration
+
+**Files:**
+- Create: `pkg/migrations/20260405000000_plugin_hook_config_mode.go`
+
+- [ ] **Step 1: Write the migration file**
+
+```go
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		// Rename plugin_order → plugin_hook_config and add mode column
+		_, err := db.Exec(`ALTER TABLE plugin_order RENAME TO plugin_hook_config`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE plugin_hook_config ADD COLUMN mode TEXT NOT NULL DEFAULT 'enabled'`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Rename library_plugins → library_plugin_hook_config, add mode, migrate, drop enabled
+		_, err = db.Exec(`ALTER TABLE library_plugins RENAME TO library_plugin_hook_config`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config ADD COLUMN mode TEXT NOT NULL DEFAULT 'enabled'`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`UPDATE library_plugin_hook_config SET mode = CASE WHEN enabled THEN 'enabled' ELSE 'disabled' END`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config DROP COLUMN enabled`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Rename the index
+		_, err = db.Exec(`DROP INDEX IF EXISTS idx_library_plugins_order`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`CREATE INDEX idx_library_plugin_hook_config_order ON library_plugin_hook_config(library_id, hook_type, position)`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		// Reverse index rename
+		_, err := db.Exec(`DROP INDEX IF EXISTS idx_library_plugin_hook_config_order`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Reverse library table: add enabled back, migrate, drop mode, rename
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT true`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`UPDATE library_plugin_hook_config SET enabled = (mode = 'enabled')`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config DROP COLUMN mode`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config RENAME TO library_plugins`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`CREATE INDEX idx_library_plugins_order ON library_plugins(library_id, hook_type, position)`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Reverse global table: drop mode, rename
+		_, err = db.Exec(`ALTER TABLE plugin_hook_config DROP COLUMN mode`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`ALTER TABLE plugin_hook_config RENAME TO plugin_order`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}
+```
+
+- [ ] **Step 2: Run the migration to verify it works**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/library-plugin && mise db:migrate`
+Expected: Migration applies successfully
+
+- [ ] **Step 3: Verify rollback works**
+
+Run: `mise db:rollback && mise db:migrate`
+Expected: Rollback and re-migrate succeed
+
+- [ ] **Step 4: Commit**
+
+```
+[Backend] Add migration for plugin_hook_config rename and mode column
+```
+
+---
+
+### Task 2: Update Go Models
+
+**Files:**
+- Modify: `pkg/models/plugin.go`
+
+- [ ] **Step 1: Add mode constants and rename structs**
+
+Add mode constants after the existing `PluginStatus` constants block (around line 30):
+
+```go
+// PluginMode represents the execution mode for a plugin in hook order.
+const (
+	PluginModeEnabled    = "enabled"
+	PluginModeManualOnly = "manual_only"
+	PluginModeDisabled   = "disabled"
+)
+```
+
+Replace the `PluginOrder` struct (lines 85-92):
+
+```go
+type PluginHookConfig struct {
+	bun.BaseModel `bun:"table:plugin_hook_config,alias:phc" tstype:"-"`
+
+	HookType string `bun:",pk" json:"hook_type" tstype:"PluginHookType"`
+	Scope    string `bun:",pk" json:"scope"`
+	PluginID string `bun:",pk" json:"plugin_id"`
+	Position int    `bun:",notnull" json:"position"`
+	Mode     string `bun:",notnull,default:'enabled'" json:"mode"`
+}
+```
+
+Replace the `LibraryPlugin` struct (lines 101-110):
+
+```go
+type LibraryPluginHookConfig struct {
+	bun.BaseModel `bun:"table:library_plugin_hook_config,alias:lphc" tstype:"-"`
+
+	LibraryID int    `bun:",pk" json:"library_id"`
+	HookType  string `bun:",pk" json:"hook_type" tstype:"PluginHookType"`
+	Scope     string `bun:",pk" json:"scope"`
+	PluginID  string `bun:",pk" json:"plugin_id"`
+	Position  int    `bun:",notnull" json:"position"`
+	Mode      string `bun:",notnull,default:'enabled'" json:"mode"`
+}
+```
+
+- [ ] **Step 2: Run tygo to regenerate TypeScript types**
+
+Run: `mise tygo`
+Expected: Types regenerated. `app/types/generated/models.ts` will have `PluginHookConfig` (with `mode`) and `LibraryPluginHookConfig` (with `mode`, without `enabled`).
+
+- [ ] **Step 3: Verify the build compiles (expect errors — we'll fix in subsequent tasks)**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/library-plugin && go build ./... 2>&1 | head -30`
+Expected: Compile errors referencing old type names `PluginOrder` and `LibraryPlugin`. This is expected — we fix them in the next tasks.
+
+- [ ] **Step 4: Commit**
+
+```
+[Backend] Rename PluginOrder/LibraryPlugin models, add Mode field
+```
+
+---
+
+### Task 3: Update Service Layer
+
+**Files:**
+- Modify: `pkg/plugins/service.go`
+
+All references to old model names and fields need updating. The changes are mechanical renames.
+
+- [ ] **Step 1: Update GetOrder and SetOrder**
+
+In `GetOrder` (line 164): change `[]*models.PluginOrder` to `[]*models.PluginHookConfig` and update the model reference:
+
+```go
+func (s *Service) GetOrder(ctx context.Context, hookType string) ([]*models.PluginHookConfig, error) {
+	var orders []*models.PluginHookConfig
+	err := s.db.NewSelect().Model(&orders).
+		Where("hook_type = ?", hookType).
+		OrderExpr("position ASC").
+		Scan(ctx)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return orders, nil
+}
+```
+
+In `SetOrder` (line 177): change `[]models.PluginOrder` to `[]models.PluginHookConfig` and update model references:
+
+```go
+func (s *Service) SetOrder(ctx context.Context, hookType string, entries []models.PluginHookConfig) error {
+	return s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		_, err := tx.NewDelete().Model((*models.PluginHookConfig)(nil)).
+			Where("hook_type = ?", hookType).
+			Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		for i := range entries {
+			entries[i].HookType = hookType
+			entries[i].Position = i
+		}
+
+		if len(entries) > 0 {
+			_, err = tx.NewInsert().Model(&entries).Exec(ctx)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	})
+}
+```
+
+- [ ] **Step 2: Update AppendToOrder**
+
+In `AppendToOrder` (line 202): update model references:
+
+```go
+func (s *Service) AppendToOrder(ctx context.Context, hookType, scope, pluginID string) error {
+	var maxPos int
+	err := s.db.NewSelect().Model((*models.PluginHookConfig)(nil)).
+		ColumnExpr("COALESCE(MAX(position), -1)").
+		Where("hook_type = ?", hookType).
+		Scan(ctx, &maxPos)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	order := &models.PluginHookConfig{
+		HookType: hookType,
+		Scope:    scope,
+		PluginID: pluginID,
+		Position: maxPos + 1,
+		Mode:     models.PluginModeEnabled,
+	}
+	_, err = s.db.NewInsert().Model(order).Exec(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 3: Update GetLibraryOrder and SetLibraryOrder**
+
+In `GetLibraryOrder` (line 370): change `[]*models.LibraryPlugin` to `[]*models.LibraryPluginHookConfig`:
+
+```go
+func (s *Service) GetLibraryOrder(ctx context.Context, libraryID int, hookType string) ([]*models.LibraryPluginHookConfig, error) {
+	var entries []*models.LibraryPluginHookConfig
+	err := s.db.NewSelect().Model(&entries).
+		Where("library_id = ? AND hook_type = ?", libraryID, hookType).
+		OrderExpr("position ASC").
+		Scan(ctx)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return entries, nil
+}
+```
+
+In `SetLibraryOrder` (line 384): change `[]models.LibraryPlugin` to `[]models.LibraryPluginHookConfig` and update all model references:
+
+```go
+func (s *Service) SetLibraryOrder(ctx context.Context, libraryID int, hookType string, entries []models.LibraryPluginHookConfig) error {
+	return s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		customization := &models.LibraryPluginCustomization{
+			LibraryID: libraryID,
+			HookType:  hookType,
+		}
+		_, err := tx.NewInsert().Model(customization).
+			On("CONFLICT (library_id, hook_type) DO NOTHING").
+			Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = tx.NewDelete().Model((*models.LibraryPluginHookConfig)(nil)).
+			Where("library_id = ? AND hook_type = ?", libraryID, hookType).
+			Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		for i := range entries {
+			entries[i].LibraryID = libraryID
+			entries[i].HookType = hookType
+			entries[i].Position = i
+		}
+		if len(entries) > 0 {
+			_, err = tx.NewInsert().Model(&entries).Exec(ctx)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	})
+}
+```
+
+- [ ] **Step 4: Update ResetLibraryOrder and ResetAllLibraryOrders**
+
+In `ResetLibraryOrder` (line 423): replace `(*models.LibraryPlugin)(nil)` with `(*models.LibraryPluginHookConfig)(nil)`.
+
+In `ResetAllLibraryOrders` (line 439): same replacement.
+
+- [ ] **Step 5: Verify the service compiles**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/library-plugin && go build ./pkg/plugins/...`
+Expected: May still have errors in handler/manager — those are next. Service itself should be clean.
+
+- [ ] **Step 6: Commit**
+
+```
+[Backend] Update plugin service layer for renamed models and mode field
+```
+
+---
+
+### Task 4: Update Manager — Mode Filtering and GetManualRuntimes
+
+**Files:**
+- Modify: `pkg/plugins/manager.go`
+
+- [ ] **Step 1: Update GetOrderedRuntimes to filter by mode**
+
+Replace the current `GetOrderedRuntimes` method (lines 271-315) with mode-aware filtering on both paths:
+
+```go
+func (m *Manager) GetOrderedRuntimes(ctx context.Context, hookType string, libraryID int) ([]*Runtime, error) {
+	if libraryID > 0 {
+		customized, err := m.service.IsLibraryCustomized(ctx, libraryID, hookType)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to check library customization for hook type %s", hookType)
+		}
+		if customized {
+			entries, err := m.service.GetLibraryOrder(ctx, libraryID, hookType)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to get library order for hook type %s", hookType)
+			}
+			var runtimes []*Runtime
+			m.mu.RLock()
+			for _, entry := range entries {
+				if entry.Mode != models.PluginModeEnabled {
+					continue
+				}
+				key := pluginKey(entry.Scope, entry.PluginID)
+				if rt, ok := m.plugins[key]; ok {
+					runtimes = append(runtimes, rt)
+				}
+			}
+			m.mu.RUnlock()
+			return runtimes, nil
+		}
+	}
+
+	orders, err := m.service.GetOrder(ctx, hookType)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get order for hook type %s", hookType)
+	}
+
+	var runtimes []*Runtime
+	m.mu.RLock()
+	for _, order := range orders {
+		if order.Mode != models.PluginModeEnabled {
+			continue
+		}
+		key := pluginKey(order.Scope, order.PluginID)
+		if rt, ok := m.plugins[key]; ok {
+			runtimes = append(runtimes, rt)
+		}
+	}
+	m.mu.RUnlock()
+
+	return runtimes, nil
+}
+```
+
+- [ ] **Step 2: Add GetManualRuntimes method**
+
+Add this method directly after `GetOrderedRuntimes`:
+
+```go
+// GetManualRuntimes returns runtimes for manual identification — includes mode "enabled" and "manual_only".
+// Same library/global fallback logic as GetOrderedRuntimes.
+func (m *Manager) GetManualRuntimes(ctx context.Context, hookType string, libraryID int) ([]*Runtime, error) {
+	if libraryID > 0 {
+		customized, err := m.service.IsLibraryCustomized(ctx, libraryID, hookType)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to check library customization for hook type %s", hookType)
+		}
+		if customized {
+			entries, err := m.service.GetLibraryOrder(ctx, libraryID, hookType)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to get library order for hook type %s", hookType)
+			}
+			var runtimes []*Runtime
+			m.mu.RLock()
+			for _, entry := range entries {
+				if entry.Mode == models.PluginModeDisabled {
+					continue
+				}
+				key := pluginKey(entry.Scope, entry.PluginID)
+				if rt, ok := m.plugins[key]; ok {
+					runtimes = append(runtimes, rt)
+				}
+			}
+			m.mu.RUnlock()
+			return runtimes, nil
+		}
+	}
+
+	orders, err := m.service.GetOrder(ctx, hookType)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get order for hook type %s", hookType)
+	}
+
+	var runtimes []*Runtime
+	m.mu.RLock()
+	for _, order := range orders {
+		if order.Mode == models.PluginModeDisabled {
+			continue
+		}
+		key := pluginKey(order.Scope, order.PluginID)
+		if rt, ok := m.plugins[key]; ok {
+			runtimes = append(runtimes, rt)
+		}
+	}
+	m.mu.RUnlock()
+
+	return runtimes, nil
+}
+```
+
+- [ ] **Step 3: Verify the manager compiles**
+
+Run: `go build ./pkg/plugins/...`
+Expected: May still have errors in handler — that's next.
+
+- [ ] **Step 4: Commit**
+
+```
+[Backend] Add mode filtering to GetOrderedRuntimes, add GetManualRuntimes
+```
+
+---
+
+### Task 5: Update Handler — Payload Types and Endpoints
+
+**Files:**
+- Modify: `pkg/plugins/handler.go`
+
+- [ ] **Step 1: Update global order payload types and handler**
+
+Update `orderEntry` (line 128) to include mode:
+
+```go
+type orderEntry struct {
+	Scope string `json:"scope" validate:"required"`
+	ID    string `json:"id" validate:"required"`
+	Mode  string `json:"mode"`
+}
+```
+
+Update `setOrder` handler (line 520) to pass mode through:
+
+```go
+func (h *handler) setOrder(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	hookType := c.Param("hookType")
+
+	var payload setOrderPayload
+	if err := c.Bind(&payload); err != nil {
+		return errors.WithStack(err)
+	}
+
+	orderEntries := make([]models.PluginHookConfig, len(payload.Order))
+	for i, entry := range payload.Order {
+		mode := entry.Mode
+		if mode == "" {
+			mode = models.PluginModeEnabled
+		}
+		orderEntries[i] = models.PluginHookConfig{
+			Scope:    entry.Scope,
+			PluginID: entry.ID,
+			Mode:     mode,
+		}
+	}
+
+	if err := h.service.SetOrder(ctx, hookType, orderEntries); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+```
+
+- [ ] **Step 2: Update library order payload types**
+
+Replace `libraryOrderEntry` (line 953):
+
+```go
+type libraryOrderEntry struct {
+	Scope string `json:"scope" validate:"required"`
+	ID    string `json:"id" validate:"required"`
+	Mode  string `json:"mode"`
+}
+```
+
+Replace `libraryOrderPlugin` (line 968):
+
+```go
+type libraryOrderPlugin struct {
+	Scope string `json:"scope"`
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Mode  string `json:"mode"`
+}
+```
+
+- [ ] **Step 3: Update getLibraryOrder handler**
+
+Update `getLibraryOrder` (line 975) to use `Mode` instead of `Enabled`:
+
+In the customized branch (building `libraryOrderPlugin`):
+```go
+plugins = append(plugins, libraryOrderPlugin{
+	Scope: entry.Scope,
+	ID:    entry.PluginID,
+	Name:  name,
+	Mode:  entry.Mode,
+})
+```
+
+In the non-customized branch (building from global order):
+```go
+plugins = append(plugins, libraryOrderPlugin{
+	Scope: order.Scope,
+	ID:    order.PluginID,
+	Name:  name,
+	Mode:  order.Mode,
+})
+```
+
+- [ ] **Step 4: Update setLibraryOrder handler**
+
+Update `setLibraryOrder` (line 1033) to use `Mode` instead of `Enabled`:
+
+```go
+entries := make([]models.LibraryPluginHookConfig, len(payload.Plugins))
+for i, p := range payload.Plugins {
+	mode := p.Mode
+	if mode == "" {
+		mode = models.PluginModeEnabled
+	}
+	entries[i] = models.LibraryPluginHookConfig{
+		Scope:    p.Scope,
+		PluginID: p.ID,
+		Mode:     mode,
+	}
+}
+```
+
+- [ ] **Step 5: Update resetLibraryOrder and resetAllLibraryOrders**
+
+In `resetLibraryOrder` (line 1063) and `resetAllLibraryOrders` (line 1079): service calls don't reference the model type directly, so these should be fine. Verify no compile errors.
+
+- [ ] **Step 6: Update searchMetadata handler to use GetManualRuntimes**
+
+At line 1301, change:
+```go
+runtimes, err := h.manager.GetOrderedRuntimes(ctx, models.PluginHookMetadataEnricher, 0)
+```
+to:
+```go
+runtimes, err := h.manager.GetManualRuntimes(ctx, models.PluginHookMetadataEnricher, book.LibraryID)
+```
+
+The `book` variable is already populated a few lines later (line 1312). The book retrieval needs to happen before the runtimes call. Reorder the handler logic:
+
+Move the book retrieval block (lines 1311-1328: the `var book *models.Book` block including library access check) to **before** the `GetManualRuntimes` call. Then pass `book.LibraryID` to `GetManualRuntimes`. The reordered flow:
+
+1. Bind payload
+2. Retrieve book and check library access
+3. Get manual runtimes (using `book.LibraryID`)
+4. Build search context and run searches
+
+- [ ] **Step 7: Verify the entire backend compiles**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/library-plugin && go build ./...`
+Expected: Clean compilation
+
+- [ ] **Step 8: Commit**
+
+```
+[Backend] Update handlers for mode field, use GetManualRuntimes for manual search
+```
+
+---
+
+### Task 6: Update Backend Tests
+
+**Files:**
+- Modify: `pkg/plugins/service_test.go`
+- Modify: `pkg/plugins/manager_test.go`
+
+- [ ] **Step 1: Update service_test.go — rename types**
+
+In `TestService_GetOrder_SetOrder` (line 258): change `models.PluginOrder` to `models.PluginHookConfig`:
+
+```go
+entries := []models.PluginHookConfig{
+	{Scope: "community", PluginID: "plugin-b"},
+	{Scope: "community", PluginID: "plugin-a"},
+	{Scope: "shisho", PluginID: "plugin-c"},
+}
+```
+
+Same for the `newEntries` block.
+
+In `TestService_AppendToOrder` (line 307): verify mode is set. Add assertion after the first append:
+
+```go
+assert.Equal(t, models.PluginModeEnabled, orders[0].Mode)
+```
+
+- [ ] **Step 2: Add a test for SetOrder with mode**
+
+Add a new test after `TestService_AppendToOrder`:
+
+```go
+func TestService_SetOrder_WithMode(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	insertTestPlugin(t, db, "community", "plugin-a")
+	insertTestPlugin(t, db, "community", "plugin-b")
+
+	entries := []models.PluginHookConfig{
+		{Scope: "community", PluginID: "plugin-a", Mode: models.PluginModeEnabled},
+		{Scope: "community", PluginID: "plugin-b", Mode: models.PluginModeManualOnly},
+	}
+	err := svc.SetOrder(ctx, models.PluginHookMetadataEnricher, entries)
+	require.NoError(t, err)
+
+	orders, err := svc.GetOrder(ctx, models.PluginHookMetadataEnricher)
+	require.NoError(t, err)
+	require.Len(t, orders, 2)
+	assert.Equal(t, models.PluginModeEnabled, orders[0].Mode)
+	assert.Equal(t, models.PluginModeManualOnly, orders[1].Mode)
+}
+```
+
+- [ ] **Step 3: Update manager_test.go — WithLibrary test**
+
+In `TestManager_GetOrderedRuntimes_WithLibrary` (line 399): update `models.PluginOrder` to `models.PluginHookConfig` and `models.LibraryPlugin` to `models.LibraryPluginHookConfig`:
+
+```go
+err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginHookConfig{
+	{Scope: "test", PluginID: "enricher1"},
+	{Scope: "test", PluginID: "enricher2"},
+})
+```
+
+```go
+err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+	{Scope: "test", PluginID: "enricher2", Mode: models.PluginModeEnabled},
+	{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeDisabled},
+})
+```
+
+In `TestManager_GetOrderedRuntimes_GlobalDisabledExcluded` (line 461): same renames:
+
+```go
+err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginHookConfig{...})
+err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+	{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeEnabled},
+	{Scope: "test", PluginID: "enricher2", Mode: models.PluginModeEnabled},
+})
+```
+
+- [ ] **Step 4: Add tests for manual_only mode and GetManualRuntimes**
+
+Add a new test:
+
+```go
+func TestManager_GetManualRuntimes(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	mgr := &Manager{
+		service: svc,
+		plugins: make(map[string]*Runtime),
+	}
+
+	library := insertTestLibrary(t, db, "Test Library")
+
+	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Status: models.PluginStatusActive}
+	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Status: models.PluginStatusActive}
+	p3 := &models.Plugin{Scope: "test", ID: "enricher3", Name: "Enricher 3", Version: "1.0.0", Status: models.PluginStatusActive}
+	_, err := db.NewInsert().Model(p1).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(p2).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(p3).Exec(ctx)
+	require.NoError(t, err)
+
+	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginHookConfig{
+		{Scope: "test", PluginID: "enricher1"},
+		{Scope: "test", PluginID: "enricher2"},
+		{Scope: "test", PluginID: "enricher3"},
+	})
+	require.NoError(t, err)
+
+	rt1 := &Runtime{scope: "test", pluginID: "enricher1"}
+	rt2 := &Runtime{scope: "test", pluginID: "enricher2"}
+	rt3 := &Runtime{scope: "test", pluginID: "enricher3"}
+	mgr.plugins["test/enricher1"] = rt1
+	mgr.plugins["test/enricher2"] = rt2
+	mgr.plugins["test/enricher3"] = rt3
+
+	// Set library order: enricher1=enabled, enricher2=manual_only, enricher3=disabled
+	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeEnabled},
+		{Scope: "test", PluginID: "enricher2", Mode: models.PluginModeManualOnly},
+		{Scope: "test", PluginID: "enricher3", Mode: models.PluginModeDisabled},
+	})
+	require.NoError(t, err)
+
+	// GetOrderedRuntimes: only "enabled" — enricher1
+	runtimes, err := mgr.GetOrderedRuntimes(ctx, "metadataEnricher", library.ID)
+	require.NoError(t, err)
+	require.Len(t, runtimes, 1)
+	assert.Equal(t, "enricher1", runtimes[0].pluginID)
+
+	// GetManualRuntimes: "enabled" + "manual_only" — enricher1, enricher2
+	runtimes, err = mgr.GetManualRuntimes(ctx, "metadataEnricher", library.ID)
+	require.NoError(t, err)
+	require.Len(t, runtimes, 2)
+	assert.Equal(t, "enricher1", runtimes[0].pluginID)
+	assert.Equal(t, "enricher2", runtimes[1].pluginID)
+}
+```
+
+- [ ] **Step 5: Add test for global mode filtering**
+
+```go
+func TestManager_GetOrderedRuntimes_GlobalModeFiltering(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	mgr := &Manager{
+		service: svc,
+		plugins: make(map[string]*Runtime),
+	}
+
+	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Status: models.PluginStatusActive}
+	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Status: models.PluginStatusActive}
+	_, err := db.NewInsert().Model(p1).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(p2).Exec(ctx)
+	require.NoError(t, err)
+
+	// Global order: enricher1=enabled, enricher2=manual_only
+	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginHookConfig{
+		{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeEnabled},
+		{Scope: "test", PluginID: "enricher2", Mode: models.PluginModeManualOnly},
+	})
+	require.NoError(t, err)
+
+	rt1 := &Runtime{scope: "test", pluginID: "enricher1"}
+	rt2 := &Runtime{scope: "test", pluginID: "enricher2"}
+	mgr.plugins["test/enricher1"] = rt1
+	mgr.plugins["test/enricher2"] = rt2
+
+	// Auto-scan (libraryID=0, falls back to global): only enricher1
+	runtimes, err := mgr.GetOrderedRuntimes(ctx, "metadataEnricher", 0)
+	require.NoError(t, err)
+	require.Len(t, runtimes, 1)
+	assert.Equal(t, "enricher1", runtimes[0].pluginID)
+
+	// Manual (libraryID=0, falls back to global): enricher1 + enricher2
+	runtimes, err = mgr.GetManualRuntimes(ctx, "metadataEnricher", 0)
+	require.NoError(t, err)
+	require.Len(t, runtimes, 2)
+	assert.Equal(t, "enricher1", runtimes[0].pluginID)
+	assert.Equal(t, "enricher2", runtimes[1].pluginID)
+}
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/library-plugin && go test ./pkg/plugins/... -v -count=1 2>&1 | tail -30`
+Expected: All tests pass
+
+- [ ] **Step 7: Commit**
+
+```
+[Test] Update plugin service/manager tests for mode field
+```
+
+---
+
+### Task 7: Update Frontend Query Hooks
+
+**Files:**
+- Modify: `app/hooks/queries/plugins.ts`
+
+- [ ] **Step 1: Update LibraryPluginOrderPlugin interface**
+
+Replace `enabled: boolean` with `mode` (line 413-418):
+
+```typescript
+export interface LibraryPluginOrderPlugin {
+  scope: string;
+  id: string;
+  name: string;
+  mode: "enabled" | "manual_only" | "disabled";
+}
+```
+
+- [ ] **Step 2: Update useSetPluginOrder mutation type**
+
+At line 272, update the mutation variables type to include mode:
+
+```typescript
+export const useSetPluginOrder = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    void,
+    ShishoAPIError,
+    {
+      hookType: string;
+      order: { scope: string; id: string; mode: string }[];
+    }
+  >({
+    mutationFn: ({ hookType, order }) => {
+      return API.request("PUT", `/plugins/order/${hookType}`, { order });
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.PluginOrder, variables.hookType],
+      });
+    },
+  });
+};
+```
+
+- [ ] **Step 3: Update useSetLibraryPluginOrder mutation type**
+
+At line 444, replace `enabled: boolean` with `mode: string`:
+
+```typescript
+export const useSetLibraryPluginOrder = () => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    void,
+    ShishoAPIError,
+    {
+      libraryId: string;
+      hookType: string;
+      plugins: { scope: string; id: string; mode: string }[];
+    }
+  >({
+    mutationFn: ({ libraryId, hookType, plugins }) => {
+      return API.request(
+        "PUT",
+        `/libraries/${libraryId}/plugins/order/${hookType}`,
+        { plugins },
+      );
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["libraries", variables.libraryId, "plugins", "order"],
+      });
+    },
+  });
+};
+```
+
+- [ ] **Step 4: Commit**
+
+```
+[Frontend] Update plugin query hooks for mode field
+```
+
+---
+
+### Task 8: Update LibraryPluginsTab — Replace Toggle with Dropdown
+
+**Files:**
+- Modify: `app/components/library/LibraryPluginsTab.tsx`
+
+- [ ] **Step 1: Replace the toggle handler with a mode handler**
+
+Remove the `handleToggle` function (lines 80-87) and replace with:
+
+```typescript
+const handleModeChange = (index: number, mode: LibraryPluginOrderPlugin["mode"]) => {
+  const newPlugins = [...displayPlugins];
+  newPlugins[index] = {
+    ...newPlugins[index],
+    mode,
+  };
+  setLocalPlugins(newPlugins);
+};
+```
+
+- [ ] **Step 2: Update the hasChanged comparison**
+
+Change line 61 from `item.enabled !== data?.plugins?.[i]?.enabled` to `item.mode !== data?.plugins?.[i]?.mode`.
+
+- [ ] **Step 3: Update handleSave to send mode instead of enabled**
+
+Replace the save mutation call (lines 93-113) to send `mode`:
+
+```typescript
+const handleSave = () => {
+  setOrder.mutate(
+    {
+      libraryId,
+      hookType: selectedHookType,
+      plugins: displayPlugins.map((p) => ({
+        scope: p.scope,
+        id: p.id,
+        mode: p.mode,
+      })),
+    },
+    {
+      onSuccess: () => {
+        setLocalPlugins(null);
+        toast.success("Library plugin order saved.");
+      },
+      onError: (err) => {
+        toast.error(`Failed to save: ${err.message}`);
+      },
+    },
+  );
+};
+```
+
+- [ ] **Step 4: Update the plugin row rendering — replace Switch with Select**
+
+Remove `Switch` from imports and ensure `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue` are imported.
+
+Replace the `<Switch>` element in the plugin row (lines 200-203) with a mode select dropdown:
+
+```tsx
+<Select
+  onValueChange={(value) =>
+    handleModeChange(
+      index,
+      value as LibraryPluginOrderPlugin["mode"],
+    )
+  }
+  value={plugin.mode}
+>
+  <SelectTrigger className="w-[140px] h-8 text-xs">
+    <SelectValue />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectItem value="enabled">Enabled</SelectItem>
+    {selectedHookType === "metadataEnricher" && (
+      <SelectItem value="manual_only">
+        Manual Only
+      </SelectItem>
+    )}
+    <SelectItem value="disabled">Disabled</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+- [ ] **Step 5: Update the row styling for mode states**
+
+Replace the conditional class on the plugin row div (line 186-188) from:
+
+```tsx
+plugin.enabled ? "border-border" : "border-border/50 opacity-60"
+```
+
+to:
+
+```tsx
+plugin.mode === "disabled"
+  ? "border-border/50 opacity-60"
+  : plugin.mode === "manual_only"
+    ? "border-border/70 opacity-80"
+    : "border-border"
+```
+
+- [ ] **Step 6: Verify the component compiles**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/library-plugin && pnpm lint:types`
+Expected: No type errors
+
+- [ ] **Step 7: Commit**
+
+```
+[Frontend] Replace toggle with mode dropdown in LibraryPluginsTab
+```
+
+---
+
+### Task 9: Update AdminPlugins — Add Mode Dropdown to Global Order
+
+**Files:**
+- Modify: `app/components/pages/AdminPlugins.tsx`
+
+- [ ] **Step 1: Add local state type with mode**
+
+The global order currently uses `PluginOrder` from generated types (which now includes `mode`). The `localOrder` state needs to track mode changes.
+
+Update the `hasOrderChanged` comparison (line 466-473) to also detect mode changes:
+
+```typescript
+const hasOrderChanged =
+  localOrder !== null &&
+  (localOrder.length !== (order?.length ?? 0) ||
+    localOrder.some(
+      (item, i) =>
+        item.scope !== order?.[i]?.scope ||
+        item.plugin_id !== order?.[i]?.plugin_id ||
+        item.mode !== order?.[i]?.mode,
+    ));
+```
+
+- [ ] **Step 2: Add a mode change handler**
+
+Add after `handleMove`:
+
+```typescript
+const handleModeChange = (index: number, mode: string) => {
+  const newOrder = [...displayOrder];
+  newOrder[index] = { ...newOrder[index], mode };
+  setLocalOrder(newOrder);
+};
+```
+
+- [ ] **Step 3: Update handleSave to include mode**
+
+Update the save mutation (line 486-501) to include mode:
+
+```typescript
+const handleSave = () => {
+  setPluginOrder.mutate(
+    {
+      hookType: selectedHookType,
+      order: displayOrder.map((o) => ({
+        scope: o.scope,
+        id: o.plugin_id,
+        mode: o.mode,
+      })),
+    },
+    {
+      onSuccess: () => {
+        setLocalOrder(null);
+        toast.success("Plugin order saved.");
+      },
+      onError: (err) => {
+        toast.error(`Failed to save order: ${err.message}`);
+      },
+    },
+  );
+};
+```
+
+- [ ] **Step 4: Add mode dropdown to each plugin row**
+
+Inside the plugin row div (after the name/badge section, within the `canWrite` conditional at line 567), add a mode select before the arrow buttons:
+
+```tsx
+{canWrite && (
+  <div className="flex items-center gap-1">
+    <Select
+      onValueChange={(value) => handleModeChange(index, value)}
+      value={item.mode}
+    >
+      <SelectTrigger className="w-[140px] h-8 text-xs">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="enabled">Enabled</SelectItem>
+        {selectedHookType === "metadataEnricher" && (
+          <SelectItem value="manual_only">
+            Manual Only
+          </SelectItem>
+        )}
+        <SelectItem value="disabled">Disabled</SelectItem>
+      </SelectContent>
+    </Select>
+    <Button
+      disabled={index === 0}
+      onClick={() => handleMove(index, "up")}
+      size="sm"
+      variant="ghost"
+    >
+      <ArrowUp className="h-4 w-4" />
+    </Button>
+    <Button
+      disabled={index === displayOrder.length - 1}
+      onClick={() => handleMove(index, "down")}
+      size="sm"
+      variant="ghost"
+    >
+      <ArrowDown className="h-4 w-4" />
+    </Button>
+  </div>
+)}
+```
+
+- [ ] **Step 5: Update row styling for mode states**
+
+Update the row div class (line 555) from:
+
+```tsx
+className="flex items-center justify-between gap-3 rounded-md border border-border p-3"
+```
+
+to:
+
+```tsx
+className={`flex items-center justify-between gap-3 rounded-md border p-3 ${
+  item.mode === "disabled"
+    ? "border-border/50 opacity-60"
+    : item.mode === "manual_only"
+      ? "border-border/70 opacity-80"
+      : "border-border"
+}`}
+```
+
+- [ ] **Step 6: Add Select imports**
+
+Ensure `Select`, `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue` are imported in AdminPlugins.tsx. Check existing imports — the component may already import `Select` for the hook type dropdown.
+
+- [ ] **Step 7: Verify the frontend compiles and lints**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/library-plugin && pnpm lint:types && pnpm lint:eslint`
+Expected: No errors
+
+- [ ] **Step 8: Commit**
+
+```
+[Frontend] Add mode dropdown to global plugin order in AdminPlugins
+```
+
+---
+
+### Task 10: Update CLAUDE.md and Run Full Checks
+
+**Files:**
+- Modify: `pkg/plugins/CLAUDE.md`
+
+- [ ] **Step 1: Update CLAUDE.md table names**
+
+In `pkg/plugins/CLAUDE.md`, find the Database Tables section and update:
+- `plugin_order` → `plugin_hook_config`
+- `library_plugins` → `library_plugin_hook_config`
+- Update the field descriptions to mention `mode` instead of or in addition to existing fields
+
+Find the `GetOrderedRuntimes` entry in the Manager Lifecycle table and add `GetManualRuntimes`:
+
+```
+| `GetManualRuntimes(ctx, hookType, libraryID)` | Manual identification | Get runtimes with mode enabled or manual_only |
+```
+
+- [ ] **Step 2: Run full check suite**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/library-plugin && mise check:quiet`
+Expected: All checks pass (Go tests, Go lint, JS lint)
+
+- [ ] **Step 3: Fix any issues found by check suite**
+
+If tests fail or lint errors appear, fix them. Common issues:
+- Scan plugin tests in `pkg/worker/scan_plugins_test.go` reference `models.PluginOrder` or `models.LibraryPlugin` — update to new names
+- Any remaining `Enabled` field references in test files
+
+- [ ] **Step 4: Commit**
+
+```
+[Docs] Update plugin CLAUDE.md for renamed tables and new mode field
+```
+
+---
+
+### Task 11: Update Documentation
+
+**Files:**
+- Modify: `website/docs/plugins/` (whichever page covers plugin ordering/configuration)
+
+- [ ] **Step 1: Find and update the relevant docs page**
+
+Search `website/docs/plugins/` for content about plugin order, library settings, or the enabled/disabled toggle. Update to describe the three modes:
+
+- **Enabled** — Plugin runs during automated scans and is available for manual identification
+- **Manual Only** — Plugin is skipped during automated scans but available for manual identification (metadata enrichers only)
+- **Disabled** — Plugin is completely unavailable for this library/globally
+
+Document that this applies at both global (Settings → Plugins → Order) and per-library (Library Settings → Plugin Order) levels.
+
+- [ ] **Step 2: Commit**
+
+```
+[Docs] Document three-state plugin mode in plugin docs
+```

--- a/docs/superpowers/specs/2026-04-05-library-plugin-mode-design.md
+++ b/docs/superpowers/specs/2026-04-05-library-plugin-mode-design.md
@@ -1,0 +1,200 @@
+# Library Plugin Mode: Three-State Plugin Control
+
+**Date:** 2026-04-05
+**Status:** Approved
+**Scope:** `pkg/models/`, `pkg/plugins/`, `app/components/library/`, `app/hooks/queries/`, database migration
+
+## Summary
+
+Replace the binary enabled/disabled toggle on per-library (and global) plugin order with a three-state mode control: **Enabled**, **Manual Only**, and **Disabled**. This clarifies the distinction between automated scan enrichment and manual identification availability, giving users granular control over how each plugin operates per hook type.
+
+Currently the toggle only affects automated scans but the UI doesn't communicate this. Manual identification always uses the global order, ignoring per-library settings entirely.
+
+---
+
+## Problem
+
+1. The current toggle in the library plugin order UI is ambiguous — toggling a plugin off looks like it fully disables the plugin, but it only affects automated scans. Manual identification ignores per-library settings (uses `libraryID=0`).
+2. There's no way to say "I want this enricher available for manual identification but not running on every scan."
+3. The global plugin order has no enabled/disabled concept at all — all plugins in the global order are always active.
+
+## States
+
+Three modes per plugin, per hook type:
+
+| Mode | Auto-Scan | Manual Identification |
+|------|-----------|----------------------|
+| **Enabled** | Runs in configured order | Available |
+| **Manual Only** | Skipped | Available |
+| **Disabled** | Skipped | Unavailable |
+
+- "Manual Only" is only meaningful for `metadataEnricher` hook type. Other hook types (inputConverter, fileParser, outputGenerator) only support Enabled/Disabled.
+- Per-library settings override global. When not customized, libraries inherit the global state.
+
+---
+
+## 1. Database Changes
+
+### Table Renames
+
+| Old Name | New Name |
+|----------|----------|
+| `plugin_order` | `plugin_hook_config` |
+| `library_plugins` | `library_plugin_hook_config` |
+
+### Schema Changes
+
+**`plugin_hook_config`** (renamed from `plugin_order`):
+- Add `mode TEXT NOT NULL DEFAULT 'enabled'`
+- Valid values: `enabled`, `manual_only`, `disabled`
+- All existing rows get `'enabled'`
+
+**`library_plugin_hook_config`** (renamed from `library_plugins`):
+- Add `mode TEXT NOT NULL DEFAULT 'enabled'`
+- Migrate existing data: `enabled=true` → `mode='enabled'`, `enabled=false` → `mode='disabled'`
+- Drop `enabled` column
+
+### Migration
+
+Single migration that:
+1. Renames `plugin_order` → `plugin_hook_config`, adds `mode` column defaulting to `'enabled'`
+2. Renames `library_plugins` → `library_plugin_hook_config`, adds `mode` column, migrates from `enabled` bool, drops `enabled` column
+3. Rollback reverses all changes
+
+---
+
+## 2. Backend Model Changes
+
+### `pkg/models/plugin.go`
+
+Update model structs:
+
+```go
+// PluginOrder → PluginHookConfig
+type PluginHookConfig struct {
+    bun.BaseModel `bun:"table:plugin_hook_config,alias:phc"`
+    HookType      string `bun:"hook_type,pk" json:"hook_type"`
+    Scope         string `bun:"scope,pk" json:"scope"`
+    PluginID      string `bun:"plugin_id,pk" json:"plugin_id"`
+    Position      int    `bun:"position" json:"position"`
+    Mode          string `bun:"mode" json:"mode"`
+}
+
+// LibraryPlugin → LibraryPluginHookConfig
+type LibraryPluginHookConfig struct {
+    bun.BaseModel `bun:"table:library_plugin_hook_config,alias:lphc"`
+    LibraryID     int    `bun:"library_id,pk" json:"library_id"`
+    HookType      string `bun:"hook_type,pk" json:"hook_type"`
+    Scope         string `bun:"scope,pk" json:"scope"`
+    PluginID      string `bun:"plugin_id,pk" json:"plugin_id"`
+    Position      int    `bun:"position" json:"position"`
+    Mode          string `bun:"mode" json:"mode"`
+}
+```
+
+Add mode constants:
+
+```go
+const (
+    PluginModeEnabled    = "enabled"
+    PluginModeManualOnly = "manual_only"
+    PluginModeDisabled   = "disabled"
+)
+```
+
+---
+
+## 3. Backend Service/Manager Changes
+
+### `pkg/plugins/service.go`
+
+Update all queries referencing old table names/models to use the renamed structs. No logic changes beyond the rename and replacing `Enabled bool` references with `Mode string`.
+
+### `pkg/plugins/manager.go`
+
+**Existing `GetOrderedRuntimes`** — filter changes from `!entry.Enabled` to `entry.Mode != PluginModeEnabled`:
+
+```go
+// For auto-scan: only mode="enabled" plugins run
+for _, entry := range entries {
+    if entry.Mode != models.PluginModeEnabled {
+        continue
+    }
+    // ...
+}
+```
+
+For the global fallback path, apply the same filter (currently returns all plugins unconditionally).
+
+**New `GetManualRuntimes`** — returns plugins with mode `enabled` OR `manual_only`:
+
+```go
+func (m *Manager) GetManualRuntimes(ctx context.Context, hookType string, libraryID int) ([]*Runtime, error) {
+    // Same structure as GetOrderedRuntimes but filters:
+    // entry.Mode == "enabled" || entry.Mode == "manual_only"
+}
+```
+
+### `pkg/plugins/handler.go`
+
+**Manual identification handler** (~line 1301):
+- Change `GetOrderedRuntimes(ctx, models.PluginHookMetadataEnricher, 0)` to `GetManualRuntimes(ctx, models.PluginHookMetadataEnricher, book.LibraryID)`
+- This makes manual search respect per-library plugin settings
+
+### API Payload Changes
+
+**Global order endpoints** (`GET/PUT /plugins/order/:hookType`):
+- Response/request includes `mode` field per plugin entry
+- Replace any `enabled` field with `mode`
+
+**Per-library order endpoints** (`GET/PUT /libraries/:libraryId/plugins/order/:hookType`):
+- Response/request replaces `enabled: bool` with `mode: string`
+
+---
+
+## 4. Frontend Changes
+
+### `app/hooks/queries/plugins.ts`
+
+Update `LibraryPluginOrderPlugin` interface:
+
+```typescript
+interface LibraryPluginOrderPlugin {
+  scope: string;
+  id: string;
+  name: string;
+  mode: "enabled" | "manual_only" | "disabled";  // replaces `enabled: boolean`
+}
+```
+
+Update mutations to send `mode` instead of `enabled`.
+
+### `app/components/library/LibraryPluginsTab.tsx`
+
+**Replace the toggle switch with a dropdown/select per plugin row:**
+
+- For `metadataEnricher` hook type: three options — Enabled, Manual Only, Disabled
+- For other hook types: two options — Enabled, Disabled
+
+**Visual treatment:**
+- **Enabled** — full opacity (as today when toggled on)
+- **Manual Only** — slightly muted style to distinguish from fully enabled
+- **Disabled** — reduced opacity (as today when toggled off)
+
+### `app/components/pages/AdminPlugins.tsx` (Global Plugin Order)
+
+Apply the same dropdown control to the global plugin order section in the admin plugins page. Currently the global order has no toggle at all — add the mode dropdown per plugin row, consistent with the per-library UI.
+
+---
+
+## 5. Documentation
+
+Update `website/docs/plugins/` to document the three modes and their behavior for both global and per-library configuration.
+
+---
+
+## Out of Scope
+
+- Changing the `library_plugin_customizations` table (keeps tracking whether a library has customized the order for a hook type)
+- Changing `plugin_field_settings` or `library_plugin_field_settings` (field-level enable/disable is orthogonal to this)
+- Adding mode to `plugins` table itself (global enable/disable of the plugin installation is a separate concern)

--- a/pkg/migrations/20260405000000_plugin_hook_config_mode.go
+++ b/pkg/migrations/20260405000000_plugin_hook_config_mode.go
@@ -1,0 +1,106 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		// 1. Rename plugin_order -> plugin_hook_config
+		_, err := db.Exec(`ALTER TABLE plugin_order RENAME TO plugin_hook_config`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 2. Add mode column to plugin_hook_config
+		_, err = db.Exec(`ALTER TABLE plugin_hook_config ADD COLUMN mode TEXT NOT NULL DEFAULT 'enabled'`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 3. Rename library_plugins -> library_plugin_hook_config
+		_, err = db.Exec(`ALTER TABLE library_plugins RENAME TO library_plugin_hook_config`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 4. Add mode column to library_plugin_hook_config
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config ADD COLUMN mode TEXT NOT NULL DEFAULT 'enabled'`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 5. Migrate enabled -> mode
+		_, err = db.Exec(`UPDATE library_plugin_hook_config SET mode = CASE WHEN enabled THEN 'enabled' ELSE 'disabled' END`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 6. Drop enabled column
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config DROP COLUMN enabled`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 7. Drop old index, create new one
+		_, err = db.Exec(`DROP INDEX IF EXISTS idx_library_plugins_order`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`CREATE INDEX idx_library_plugin_hook_config_order ON library_plugin_hook_config(library_id, hook_type, position)`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		// Reverse: drop new index
+		_, err := db.Exec(`DROP INDEX IF EXISTS idx_library_plugin_hook_config_order`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Add enabled column back
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT true`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Migrate mode -> enabled
+		_, err = db.Exec(`UPDATE library_plugin_hook_config SET enabled = CASE WHEN mode = 'enabled' THEN true ELSE false END`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Drop mode column
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config DROP COLUMN mode`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Rename library_plugin_hook_config -> library_plugins
+		_, err = db.Exec(`ALTER TABLE library_plugin_hook_config RENAME TO library_plugins`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Recreate old index
+		_, err = db.Exec(`CREATE INDEX idx_library_plugins_order ON library_plugins(library_id, hook_type, position)`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Drop mode column from plugin_hook_config
+		_, err = db.Exec(`ALTER TABLE plugin_hook_config DROP COLUMN mode`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Rename plugin_hook_config -> plugin_order
+		_, err = db.Exec(`ALTER TABLE plugin_hook_config RENAME TO plugin_order`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/plugin.go
+++ b/pkg/models/plugin.go
@@ -29,6 +29,13 @@ const (
 	PluginStatusNotSupported PluginStatus = -3
 )
 
+// Plugin mode constants for hook config entries.
+const (
+	PluginModeEnabled    = "enabled"
+	PluginModeManualOnly = "manual_only"
+	PluginModeDisabled   = "disabled"
+)
+
 type PluginRepository struct {
 	bun.BaseModel `bun:"table:plugin_repositories,alias:pr" tstype:"-"`
 
@@ -82,13 +89,14 @@ type PluginIdentifierType struct {
 	Pattern     *string `json:"pattern"`
 }
 
-type PluginOrder struct {
-	bun.BaseModel `bun:"table:plugin_order,alias:po" tstype:"-"`
+type PluginHookConfig struct {
+	bun.BaseModel `bun:"table:plugin_hook_config,alias:phc" tstype:"-"`
 
 	HookType string `bun:",pk" json:"hook_type" tstype:"PluginHookType"`
 	Scope    string `bun:",pk" json:"scope"`
 	PluginID string `bun:",pk" json:"plugin_id"`
 	Position int    `bun:",notnull" json:"position"`
+	Mode     string `bun:",notnull,default:'enabled'" json:"mode"`
 }
 
 type LibraryPluginCustomization struct {
@@ -98,15 +106,15 @@ type LibraryPluginCustomization struct {
 	HookType  string `bun:",pk" json:"hook_type" tstype:"PluginHookType"`
 }
 
-type LibraryPlugin struct {
-	bun.BaseModel `bun:"table:library_plugins,alias:lp" tstype:"-"`
+type LibraryPluginHookConfig struct {
+	bun.BaseModel `bun:"table:library_plugin_hook_config,alias:lphc" tstype:"-"`
 
 	LibraryID int    `bun:",pk" json:"library_id"`
 	HookType  string `bun:",pk" json:"hook_type" tstype:"PluginHookType"`
 	Scope     string `bun:",pk" json:"scope"`
 	PluginID  string `bun:",pk" json:"plugin_id"`
-	Enabled   bool   `bun:",notnull" json:"enabled"`
 	Position  int    `bun:",notnull" json:"position"`
+	Mode      string `bun:",notnull,default:'enabled'" json:"mode"`
 }
 
 // PluginFieldSetting stores global field enable/disable settings for a plugin.

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -459,7 +459,8 @@ Plugin data sources use format `plugin:scope/id` (e.g., `plugin:shisho/goodreads
 | `UnloadPlugin(scope, id)` | Uninstall/Disable | Remove from memory |
 | `ReloadPlugin(ctx, scope, id)` | Update/Hot-reload | Write-lock old runtime, swap new, wait for in-progress hooks |
 | `GetRuntime(scope, id)` | Any | Get loaded runtime (nil if not loaded) |
-| `GetOrderedRuntimes(ctx, hookType)` | Scan pipeline | Get runtimes for hook in user-defined order |
+| `GetOrderedRuntimes(ctx, hookType, libraryID)` | Scan pipeline | Get runtimes with mode "enabled" in user-defined order (per-library or global) |
+| `GetManualRuntimes(ctx, hookType, libraryID)` | Manual identification | Get runtimes with mode "enabled" or "manual_only" (per-library or global) |
 | `GetParserForType(fileType)` | File scanning | First runtime with fileParser for type |
 | `GetOutputGenerator(formatID)` | Output generation | PluginGenerator wrapping runtime |
 | `CheckForUpdates(ctx)` | Periodic/on-demand | Check repos for newer versions |
@@ -480,7 +481,7 @@ In `pkg/worker/scan_unified.go`:
 2. **Input conversion** - For converter source types, `RunInputConverter()` converts to supported format
 3. **File parsing** - `GetParserForType(ext)` finds plugin parser; validates MIME if declared; `RunFileParser()` extracts metadata
 4. **Metadata application** - Plugin metadata applied with priority 2 (overwrites filepath, preserves manual/sidecar)
-5. **Enrichment** - After file parsing, `GetOrderedRuntimes(ctx, "metadataEnricher")` runs enrichers in order. Each enricher's `search()` hook receives a flat context built from the book title (as `query`), first author name (as `author`), file identifiers (as `identifiers`), and a `file` object with read-only hints (`fileType`, `duration`, `pageCount`, `filesizeBytes`). The hook returns `SearchResponse` containing `[]ParsedMetadata` directly; the first result is used as-is (no conversion needed). If the first result has a `Confidence` field set, it is checked against the effective threshold (`getEnrichmentConfidenceThreshold` returns the per-plugin override if set, otherwise the global `EnrichmentConfidenceThreshold` from config, defaulting to 0.85). Results below threshold are skipped with a warning. Uses a two-phase merge: enricher results merge into an empty `ParsedMetadata` (first non-empty wins among enrichers), then file-parsed metadata fills remaining gaps as fallback. This gives enrichers priority over file-embedded metadata per-field.
+5. **Enrichment** - After file parsing, `GetOrderedRuntimes(ctx, "metadataEnricher", libraryID)` runs enrichers in order (only mode "enabled"; "manual_only" and "disabled" are skipped). Each enricher's `search()` hook receives a flat context built from the book title (as `query`), first author name (as `author`), file identifiers (as `identifiers`), and a `file` object with read-only hints (`fileType`, `duration`, `pageCount`, `filesizeBytes`). The hook returns `SearchResponse` containing `[]ParsedMetadata` directly; the first result is used as-is (no conversion needed). If the first result has a `Confidence` field set, it is checked against the effective threshold (`getEnrichmentConfidenceThreshold` returns the per-plugin override if set, otherwise the global `EnrichmentConfidenceThreshold` from config, defaulting to 0.85). Results below threshold are skipped with a warning. Uses a two-phase merge: enricher results merge into an empty `ParsedMetadata` (first non-empty wins among enrichers), then file-parsed metadata fills remaining gaps as fallback. This gives enrichers priority over file-embedded metadata per-field.
 
 ## Installation Flow
 
@@ -524,9 +525,18 @@ Repositories provide a `repository.json` manifest:
 | `plugin_configs` | `(scope, plugin_id, key)` | Configuration values (CASCADE delete) |
 | `plugin_repositories` | `url` (unique `scope`) | Repository sources |
 | `plugin_identifier_types` | `id` | Custom identifier types |
-| `plugin_order` | `(hook_type, scope, plugin_id)` | Execution order per hook |
+| `plugin_hook_config` | `(hook_type, scope, plugin_id)` | Execution order and mode per hook |
+| `library_plugin_hook_config` | `(library_id, hook_type, scope, plugin_id)` | Per-library execution order and mode per hook |
+| `library_plugin_customizations` | `(library_id, hook_type)` | Tracks which libraries have customized a hook type |
 | `plugin_field_settings` | `(scope, plugin_id, field)` | Global field enabled/disabled state |
 | `library_plugin_field_settings` | `(library_id, scope, plugin_id, field)` | Per-library field overrides |
+
+**Plugin mode (three-state):**
+- `enabled` — Plugin runs during automated scans and is available for manual identification
+- `manual_only` — Plugin is skipped during automated scans but remains available for manual identification (metadata enrichers only)
+- `disabled` — Plugin is completely unavailable for this context
+- Mode is stored in both `plugin_hook_config` (global) and `library_plugin_hook_config` (per-library)
+- `GetOrderedRuntimes` returns only `enabled` plugins; `GetManualRuntimes` returns `enabled` + `manual_only`
 
 **Field settings behavior:**
 - No rows = all declared fields enabled by default

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -28,6 +28,12 @@ import (
 
 const validRepoURLPrefix = "https://raw.githubusercontent.com/"
 
+var validPluginModes = map[string]bool{
+	models.PluginModeEnabled:    true,
+	models.PluginModeManualOnly: true,
+	models.PluginModeDisabled:   true,
+}
+
 // enrichDeps holds dependencies for metadata persistence (apply/enrich).
 // Uses interfaces to avoid circular imports with the books package.
 type enrichDeps struct {
@@ -533,6 +539,9 @@ func (h *handler) setOrder(c echo.Context) error {
 		mode := entry.Mode
 		if mode == "" {
 			mode = models.PluginModeEnabled
+		}
+		if !validPluginModes[mode] {
+			return errcodes.ValidationError(fmt.Sprintf("invalid mode %q for plugin %s/%s", mode, entry.Scope, entry.ID))
 		}
 		orderEntries[i] = models.PluginHookConfig{
 			Scope:    entry.Scope,
@@ -1079,6 +1088,9 @@ func (h *handler) setLibraryOrder(c echo.Context) error {
 		mode := p.Mode
 		if mode == "" {
 			mode = models.PluginModeEnabled
+		}
+		if !validPluginModes[mode] {
+			return errcodes.ValidationError(fmt.Sprintf("invalid mode %q for plugin %s/%s", mode, p.Scope, p.ID))
 		}
 		entries[i] = models.LibraryPluginHookConfig{
 			Scope:    p.Scope,

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -128,6 +128,7 @@ type updatePayload struct {
 type orderEntry struct {
 	Scope string `json:"scope" validate:"required"`
 	ID    string `json:"id" validate:"required"`
+	Mode  string `json:"mode"`
 }
 
 type setOrderPayload struct {
@@ -527,11 +528,16 @@ func (h *handler) setOrder(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	orderEntries := make([]models.PluginOrder, len(payload.Order))
+	orderEntries := make([]models.PluginHookConfig, len(payload.Order))
 	for i, entry := range payload.Order {
-		orderEntries[i] = models.PluginOrder{
+		mode := entry.Mode
+		if mode == "" {
+			mode = models.PluginModeEnabled
+		}
+		orderEntries[i] = models.PluginHookConfig{
 			Scope:    entry.Scope,
 			PluginID: entry.ID,
+			Mode:     mode,
 		}
 	}
 
@@ -975,9 +981,9 @@ func (h *handler) scan(c echo.Context) error {
 }
 
 type libraryOrderEntry struct {
-	Scope   string `json:"scope" validate:"required"`
-	ID      string `json:"id" validate:"required"`
-	Enabled bool   `json:"enabled"`
+	Scope string `json:"scope" validate:"required"`
+	ID    string `json:"id" validate:"required"`
+	Mode  string `json:"mode"`
 }
 
 type setLibraryOrderPayload struct {
@@ -990,10 +996,10 @@ type libraryOrderResponse struct {
 }
 
 type libraryOrderPlugin struct {
-	Scope   string `json:"scope"`
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Enabled bool   `json:"enabled"`
+	Scope string `json:"scope"`
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Mode  string `json:"mode"`
 }
 
 func (h *handler) getLibraryOrder(c echo.Context) error {
@@ -1023,10 +1029,10 @@ func (h *handler) getLibraryOrder(c echo.Context) error {
 				name = p.Name
 			}
 			plugins = append(plugins, libraryOrderPlugin{
-				Scope:   entry.Scope,
-				ID:      entry.PluginID,
-				Name:    name,
-				Enabled: entry.Enabled,
+				Scope: entry.Scope,
+				ID:    entry.PluginID,
+				Name:  name,
+				Mode:  entry.Mode,
 			})
 		}
 	} else {
@@ -1040,10 +1046,10 @@ func (h *handler) getLibraryOrder(c echo.Context) error {
 				name = p.Name
 			}
 			plugins = append(plugins, libraryOrderPlugin{
-				Scope:   order.Scope,
-				ID:      order.PluginID,
-				Name:    name,
-				Enabled: true,
+				Scope: order.Scope,
+				ID:    order.PluginID,
+				Name:  name,
+				Mode:  order.Mode,
 			})
 		}
 	}
@@ -1068,12 +1074,16 @@ func (h *handler) setLibraryOrder(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	entries := make([]models.LibraryPlugin, len(payload.Plugins))
+	entries := make([]models.LibraryPluginHookConfig, len(payload.Plugins))
 	for i, p := range payload.Plugins {
-		entries[i] = models.LibraryPlugin{
+		mode := p.Mode
+		if mode == "" {
+			mode = models.PluginModeEnabled
+		}
+		entries[i] = models.LibraryPluginHookConfig{
 			Scope:    p.Scope,
 			PluginID: p.ID,
-			Enabled:  p.Enabled,
+			Mode:     mode,
 		}
 	}
 
@@ -1312,7 +1322,8 @@ type EnrichSearchResult struct {
 	DisabledFields []string `json:"disabled_fields,omitempty"`
 }
 
-// searchMetadata runs search() across all enabled enricher plugins and returns aggregated results.
+// searchMetadata runs search() across all enricher plugins available for manual invocation
+// and returns aggregated results.
 func (h *handler) searchMetadata(c echo.Context) error {
 	ctx := c.Request().Context()
 
@@ -1321,19 +1332,9 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		return errcodes.ValidationError(err.Error())
 	}
 
-	// Get all enricher runtimes first — if none exist, return empty results immediately
-	runtimes, err := h.manager.GetOrderedRuntimes(ctx, models.PluginHookMetadataEnricher, 0)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	if len(runtimes) == 0 {
-		return c.JSON(http.StatusOK, map[string]interface{}{
-			"results": []EnrichSearchResult{},
-		})
-	}
-
-	// Look up the book with relations
+	// Look up the book with relations first (needed for library access check and libraryID)
 	var book *models.Book
+	var err error
 	if h.enrich != nil {
 		book, err = h.enrich.bookStore.RetrieveBook(ctx, payload.BookID)
 	} else if h.db != nil {
@@ -1359,6 +1360,17 @@ func (h *handler) searchMetadata(c echo.Context) error {
 	}
 	if !user.HasLibraryAccess(book.LibraryID) {
 		return errcodes.Forbidden("You don't have access to this library")
+	}
+
+	// Get enricher runtimes available for manual invocation using the book's library
+	runtimes, err := h.manager.GetManualRuntimes(ctx, models.PluginHookMetadataEnricher, book.LibraryID)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if len(runtimes) == 0 {
+		return c.JSON(http.StatusOK, map[string]interface{}{
+			"results": []EnrichSearchResult{},
+		})
 	}
 
 	// Build flat search context from payload

--- a/pkg/plugins/handler_library_test.go
+++ b/pkg/plugins/handler_library_test.go
@@ -25,7 +25,7 @@ func TestLibraryPluginOrder_GetDefault(t *testing.T) {
 	plugin := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Test Enricher", Version: "1.0.0", Status: models.PluginStatusActive}
 	_, err := db.NewInsert().Model(plugin).Exec(ctx)
 	require.NoError(t, err)
-	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginOrder{
+	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginHookConfig{
 		{Scope: "test", PluginID: "enricher1"},
 	})
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestLibraryPluginOrder_GetDefault(t *testing.T) {
 	require.Len(t, resp.Plugins, 1)
 	assert.Equal(t, "enricher1", resp.Plugins[0].ID)
 	assert.Equal(t, "Test Enricher", resp.Plugins[0].Name)
-	assert.True(t, resp.Plugins[0].Enabled)
+	assert.Equal(t, models.PluginModeEnabled, resp.Plugins[0].Mode)
 }
 
 func TestLibraryPluginOrder_SetAndGet(t *testing.T) {
@@ -70,7 +70,7 @@ func TestLibraryPluginOrder_SetAndGet(t *testing.T) {
 
 	// PUT - set custom order
 	e := echo.New()
-	payload := `{"plugins":[{"scope":"test","id":"enricher2","enabled":true},{"scope":"test","id":"enricher1","enabled":false}]}`
+	payload := `{"plugins":[{"scope":"test","id":"enricher2","mode":"enabled"},{"scope":"test","id":"enricher1","mode":"disabled"}]}`
 	req := httptest.NewRequest(http.MethodPut, "/", strings.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
@@ -100,9 +100,9 @@ func TestLibraryPluginOrder_SetAndGet(t *testing.T) {
 	assert.True(t, resp.Customized)
 	require.Len(t, resp.Plugins, 2)
 	assert.Equal(t, "enricher2", resp.Plugins[0].ID)
-	assert.True(t, resp.Plugins[0].Enabled)
+	assert.Equal(t, models.PluginModeEnabled, resp.Plugins[0].Mode)
 	assert.Equal(t, "enricher1", resp.Plugins[1].ID)
-	assert.False(t, resp.Plugins[1].Enabled)
+	assert.Equal(t, models.PluginModeDisabled, resp.Plugins[1].Mode)
 }
 
 func TestLibraryPluginOrder_ResetHookType(t *testing.T) {
@@ -118,8 +118,8 @@ func TestLibraryPluginOrder_ResetHookType(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set custom order first
-	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPlugin{
-		{Scope: "test", PluginID: "enricher1", Enabled: true},
+	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeEnabled},
 	})
 	require.NoError(t, err)
 
@@ -155,12 +155,12 @@ func TestLibraryPluginOrder_ResetAll(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set custom orders for multiple hook types
-	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPlugin{
-		{Scope: "test", PluginID: "enricher1", Enabled: true},
+	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeEnabled},
 	})
 	require.NoError(t, err)
-	err = svc.SetLibraryOrder(ctx, library.ID, "fileParser", []models.LibraryPlugin{
-		{Scope: "test", PluginID: "enricher1", Enabled: true},
+	err = svc.SetLibraryOrder(ctx, library.ID, "fileParser", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeEnabled},
 	})
 	require.NoError(t, err)
 

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -282,7 +282,7 @@ func (m *Manager) GetOrderedRuntimes(ctx context.Context, hookType string, libra
 			var runtimes []*Runtime
 			m.mu.RLock()
 			for _, entry := range entries {
-				if !entry.Enabled {
+				if entry.Mode != models.PluginModeEnabled {
 					continue
 				}
 				key := pluginKey(entry.Scope, entry.PluginID)
@@ -304,6 +304,62 @@ func (m *Manager) GetOrderedRuntimes(ctx context.Context, hookType string, libra
 	var runtimes []*Runtime
 	m.mu.RLock()
 	for _, order := range orders {
+		if order.Mode != models.PluginModeEnabled {
+			continue
+		}
+		key := pluginKey(order.Scope, order.PluginID)
+		if rt, ok := m.plugins[key]; ok {
+			runtimes = append(runtimes, rt)
+		}
+	}
+	m.mu.RUnlock()
+
+	return runtimes, nil
+}
+
+// GetManualRuntimes returns runtimes for a hook type that are available for manual invocation.
+// Both "enabled" and "manual_only" plugins are returned; only "disabled" are excluded.
+// If libraryID > 0 and the library has customized the order for this hook type,
+// uses the per-library order. Otherwise falls back to global order.
+func (m *Manager) GetManualRuntimes(ctx context.Context, hookType string, libraryID int) ([]*Runtime, error) {
+	if libraryID > 0 {
+		customized, err := m.service.IsLibraryCustomized(ctx, libraryID, hookType)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to check library customization for hook type %s", hookType)
+		}
+		if customized {
+			entries, err := m.service.GetLibraryOrder(ctx, libraryID, hookType)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to get library order for hook type %s", hookType)
+			}
+			var runtimes []*Runtime
+			m.mu.RLock()
+			for _, entry := range entries {
+				if entry.Mode == models.PluginModeDisabled {
+					continue
+				}
+				key := pluginKey(entry.Scope, entry.PluginID)
+				if rt, ok := m.plugins[key]; ok {
+					runtimes = append(runtimes, rt)
+				}
+			}
+			m.mu.RUnlock()
+			return runtimes, nil
+		}
+	}
+
+	// Fall back to global order
+	orders, err := m.service.GetOrder(ctx, hookType)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get order for hook type %s", hookType)
+	}
+
+	var runtimes []*Runtime
+	m.mu.RLock()
+	for _, order := range orders {
+		if order.Mode == models.PluginModeDisabled {
+			continue
+		}
 		key := pluginKey(order.Scope, order.PluginID)
 		if rt, ok := m.plugins[key]; ok {
 			runtimes = append(runtimes, rt)

--- a/pkg/plugins/manager_test.go
+++ b/pkg/plugins/manager_test.go
@@ -418,7 +418,7 @@ func TestManager_GetOrderedRuntimes_WithLibrary(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set global order
-	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginOrder{
+	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginHookConfig{
 		{Scope: "test", PluginID: "enricher1"},
 		{Scope: "test", PluginID: "enricher2"},
 	})
@@ -438,9 +438,9 @@ func TestManager_GetOrderedRuntimes_WithLibrary(t *testing.T) {
 	assert.Equal(t, "enricher2", runtimes[1].pluginID)
 
 	// Set library-specific order (enricher1 disabled, enricher2 enabled)
-	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPlugin{
-		{Scope: "test", PluginID: "enricher2", Enabled: true},
-		{Scope: "test", PluginID: "enricher1", Enabled: false},
+	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher2", Mode: models.PluginModeEnabled},
+		{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeDisabled},
 	})
 	require.NoError(t, err)
 
@@ -480,7 +480,7 @@ func TestManager_GetOrderedRuntimes_GlobalDisabledExcluded(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set global order with both plugins
-	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginOrder{
+	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginHookConfig{
 		{Scope: "test", PluginID: "enricher1"},
 		{Scope: "test", PluginID: "enricher2"},
 	})
@@ -491,9 +491,9 @@ func TestManager_GetOrderedRuntimes_GlobalDisabledExcluded(t *testing.T) {
 	mgr.plugins["test/enricher1"] = rt1
 
 	// Set library order with both enabled
-	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPlugin{
-		{Scope: "test", PluginID: "enricher1", Enabled: true},
-		{Scope: "test", PluginID: "enricher2", Enabled: true},
+	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeEnabled},
+		{Scope: "test", PluginID: "enricher2", Mode: models.PluginModeEnabled},
 	})
 	require.NoError(t, err)
 
@@ -644,4 +644,103 @@ func TestManager_LoadPlugin_NoMinVersion(t *testing.T) {
 
 	rt := mgr.GetRuntime("test", "simple-enricher")
 	require.NotNil(t, rt)
+}
+
+func TestManager_GetManualRuntimes(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	mgr := &Manager{
+		service: svc,
+		plugins: make(map[string]*Runtime),
+	}
+
+	library := insertTestLibrary(t, db, "Test Library")
+
+	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Status: models.PluginStatusActive}
+	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Status: models.PluginStatusActive}
+	p3 := &models.Plugin{Scope: "test", ID: "enricher3", Name: "Enricher 3", Version: "1.0.0", Status: models.PluginStatusActive}
+	_, err := db.NewInsert().Model(p1).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(p2).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(p3).Exec(ctx)
+	require.NoError(t, err)
+
+	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginHookConfig{
+		{Scope: "test", PluginID: "enricher1"},
+		{Scope: "test", PluginID: "enricher2"},
+		{Scope: "test", PluginID: "enricher3"},
+	})
+	require.NoError(t, err)
+
+	rt1 := &Runtime{scope: "test", pluginID: "enricher1"}
+	rt2 := &Runtime{scope: "test", pluginID: "enricher2"}
+	rt3 := &Runtime{scope: "test", pluginID: "enricher3"}
+	mgr.plugins["test/enricher1"] = rt1
+	mgr.plugins["test/enricher2"] = rt2
+	mgr.plugins["test/enricher3"] = rt3
+
+	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeEnabled},
+		{Scope: "test", PluginID: "enricher2", Mode: models.PluginModeManualOnly},
+		{Scope: "test", PluginID: "enricher3", Mode: models.PluginModeDisabled},
+	})
+	require.NoError(t, err)
+
+	// GetOrderedRuntimes: only "enabled" — enricher1
+	runtimes, err := mgr.GetOrderedRuntimes(ctx, "metadataEnricher", library.ID)
+	require.NoError(t, err)
+	require.Len(t, runtimes, 1)
+	assert.Equal(t, "enricher1", runtimes[0].pluginID)
+
+	// GetManualRuntimes: "enabled" + "manual_only" — enricher1, enricher2
+	runtimes, err = mgr.GetManualRuntimes(ctx, "metadataEnricher", library.ID)
+	require.NoError(t, err)
+	require.Len(t, runtimes, 2)
+	assert.Equal(t, "enricher1", runtimes[0].pluginID)
+	assert.Equal(t, "enricher2", runtimes[1].pluginID)
+}
+
+func TestManager_GetOrderedRuntimes_GlobalModeFiltering(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	mgr := &Manager{
+		service: svc,
+		plugins: make(map[string]*Runtime),
+	}
+
+	p1 := &models.Plugin{Scope: "test", ID: "enricher1", Name: "Enricher 1", Version: "1.0.0", Status: models.PluginStatusActive}
+	p2 := &models.Plugin{Scope: "test", ID: "enricher2", Name: "Enricher 2", Version: "1.0.0", Status: models.PluginStatusActive}
+	_, err := db.NewInsert().Model(p1).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(p2).Exec(ctx)
+	require.NoError(t, err)
+
+	err = svc.SetOrder(ctx, "metadataEnricher", []models.PluginHookConfig{
+		{Scope: "test", PluginID: "enricher1", Mode: models.PluginModeEnabled},
+		{Scope: "test", PluginID: "enricher2", Mode: models.PluginModeManualOnly},
+	})
+	require.NoError(t, err)
+
+	rt1 := &Runtime{scope: "test", pluginID: "enricher1"}
+	rt2 := &Runtime{scope: "test", pluginID: "enricher2"}
+	mgr.plugins["test/enricher1"] = rt1
+	mgr.plugins["test/enricher2"] = rt2
+
+	// Auto-scan: only enricher1
+	runtimes, err := mgr.GetOrderedRuntimes(ctx, "metadataEnricher", 0)
+	require.NoError(t, err)
+	require.Len(t, runtimes, 1)
+	assert.Equal(t, "enricher1", runtimes[0].pluginID)
+
+	// Manual: enricher1 + enricher2
+	runtimes, err = mgr.GetManualRuntimes(ctx, "metadataEnricher", 0)
+	require.NoError(t, err)
+	require.Len(t, runtimes, 2)
+	assert.Equal(t, "enricher1", runtimes[0].pluginID)
+	assert.Equal(t, "enricher2", runtimes[1].pluginID)
 }

--- a/pkg/plugins/service.go
+++ b/pkg/plugins/service.go
@@ -160,9 +160,9 @@ func (s *Service) GetConfigRaw(ctx context.Context, scope, pluginID, key string)
 	return cfg.Value, nil
 }
 
-// GetOrder returns the plugin order entries for a hook type, sorted by position.
-func (s *Service) GetOrder(ctx context.Context, hookType string) ([]*models.PluginOrder, error) {
-	var orders []*models.PluginOrder
+// GetOrder returns the plugin hook config entries for a hook type, sorted by position.
+func (s *Service) GetOrder(ctx context.Context, hookType string) ([]*models.PluginHookConfig, error) {
+	var orders []*models.PluginHookConfig
 	err := s.db.NewSelect().Model(&orders).
 		Where("hook_type = ?", hookType).
 		OrderExpr("position ASC").
@@ -173,10 +173,10 @@ func (s *Service) GetOrder(ctx context.Context, hookType string) ([]*models.Plug
 	return orders, nil
 }
 
-// SetOrder replaces all order entries for a hook type in a transaction.
-func (s *Service) SetOrder(ctx context.Context, hookType string, entries []models.PluginOrder) error {
+// SetOrder replaces all hook config entries for a hook type in a transaction.
+func (s *Service) SetOrder(ctx context.Context, hookType string, entries []models.PluginHookConfig) error {
 	return s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		_, err := tx.NewDelete().Model((*models.PluginOrder)(nil)).
+		_, err := tx.NewDelete().Model((*models.PluginHookConfig)(nil)).
 			Where("hook_type = ?", hookType).
 			Exec(ctx)
 		if err != nil {
@@ -198,10 +198,10 @@ func (s *Service) SetOrder(ctx context.Context, hookType string, entries []model
 	})
 }
 
-// AppendToOrder appends a plugin to the end of the order for a hook type.
+// AppendToOrder appends a plugin to the end of the hook config for a hook type.
 func (s *Service) AppendToOrder(ctx context.Context, hookType, scope, pluginID string) error {
 	var maxPos int
-	err := s.db.NewSelect().Model((*models.PluginOrder)(nil)).
+	err := s.db.NewSelect().Model((*models.PluginHookConfig)(nil)).
 		ColumnExpr("COALESCE(MAX(position), -1)").
 		Where("hook_type = ?", hookType).
 		Scan(ctx, &maxPos)
@@ -209,11 +209,12 @@ func (s *Service) AppendToOrder(ctx context.Context, hookType, scope, pluginID s
 		return errors.WithStack(err)
 	}
 
-	order := &models.PluginOrder{
+	order := &models.PluginHookConfig{
 		HookType: hookType,
 		Scope:    scope,
 		PluginID: pluginID,
 		Position: maxPos + 1,
+		Mode:     models.PluginModeEnabled,
 	}
 	_, err = s.db.NewInsert().Model(order).Exec(ctx)
 	if err != nil {
@@ -366,9 +367,9 @@ func (s *Service) IsLibraryCustomized(ctx context.Context, libraryID int, hookTy
 	return exists, nil
 }
 
-// GetLibraryOrder returns the per-library plugin order for a hook type, sorted by position.
-func (s *Service) GetLibraryOrder(ctx context.Context, libraryID int, hookType string) ([]*models.LibraryPlugin, error) {
-	var entries []*models.LibraryPlugin
+// GetLibraryOrder returns the per-library plugin hook config for a hook type, sorted by position.
+func (s *Service) GetLibraryOrder(ctx context.Context, libraryID int, hookType string) ([]*models.LibraryPluginHookConfig, error) {
+	var entries []*models.LibraryPluginHookConfig
 	err := s.db.NewSelect().Model(&entries).
 		Where("library_id = ? AND hook_type = ?", libraryID, hookType).
 		OrderExpr("position ASC").
@@ -379,9 +380,9 @@ func (s *Service) GetLibraryOrder(ctx context.Context, libraryID int, hookType s
 	return entries, nil
 }
 
-// SetLibraryOrder replaces all per-library plugin order entries for a hook type.
+// SetLibraryOrder replaces all per-library plugin hook config entries for a hook type.
 // Also creates the customization record if it doesn't exist.
-func (s *Service) SetLibraryOrder(ctx context.Context, libraryID int, hookType string, entries []models.LibraryPlugin) error {
+func (s *Service) SetLibraryOrder(ctx context.Context, libraryID int, hookType string, entries []models.LibraryPluginHookConfig) error {
 	return s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		// Upsert customization record
 		customization := &models.LibraryPluginCustomization{
@@ -396,7 +397,7 @@ func (s *Service) SetLibraryOrder(ctx context.Context, libraryID int, hookType s
 		}
 
 		// Delete existing entries
-		_, err = tx.NewDelete().Model((*models.LibraryPlugin)(nil)).
+		_, err = tx.NewDelete().Model((*models.LibraryPluginHookConfig)(nil)).
 			Where("library_id = ? AND hook_type = ?", libraryID, hookType).
 			Exec(ctx)
 		if err != nil {
@@ -422,7 +423,7 @@ func (s *Service) SetLibraryOrder(ctx context.Context, libraryID int, hookType s
 // ResetLibraryOrder removes per-library customization for a specific hook type.
 func (s *Service) ResetLibraryOrder(ctx context.Context, libraryID int, hookType string) error {
 	return s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		_, err := tx.NewDelete().Model((*models.LibraryPlugin)(nil)).
+		_, err := tx.NewDelete().Model((*models.LibraryPluginHookConfig)(nil)).
 			Where("library_id = ? AND hook_type = ?", libraryID, hookType).
 			Exec(ctx)
 		if err != nil {
@@ -438,7 +439,7 @@ func (s *Service) ResetLibraryOrder(ctx context.Context, libraryID int, hookType
 // ResetAllLibraryOrders removes all per-library plugin customizations for a library.
 func (s *Service) ResetAllLibraryOrders(ctx context.Context, libraryID int) error {
 	return s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-		_, err := tx.NewDelete().Model((*models.LibraryPlugin)(nil)).
+		_, err := tx.NewDelete().Model((*models.LibraryPluginHookConfig)(nil)).
 			Where("library_id = ?", libraryID).
 			Exec(ctx)
 		if err != nil {

--- a/pkg/plugins/service.go
+++ b/pkg/plugins/service.go
@@ -186,6 +186,9 @@ func (s *Service) SetOrder(ctx context.Context, hookType string, entries []model
 		for i := range entries {
 			entries[i].HookType = hookType
 			entries[i].Position = i
+			if entries[i].Mode == "" {
+				entries[i].Mode = models.PluginModeEnabled
+			}
 		}
 
 		if len(entries) > 0 {
@@ -409,6 +412,9 @@ func (s *Service) SetLibraryOrder(ctx context.Context, libraryID int, hookType s
 			entries[i].LibraryID = libraryID
 			entries[i].HookType = hookType
 			entries[i].Position = i
+			if entries[i].Mode == "" {
+				entries[i].Mode = models.PluginModeEnabled
+			}
 		}
 		if len(entries) > 0 {
 			_, err = tx.NewInsert().Model(&entries).Exec(ctx)

--- a/pkg/plugins/service_library_test.go
+++ b/pkg/plugins/service_library_test.go
@@ -39,7 +39,7 @@ func TestService_IsLibraryCustomized(t *testing.T) {
 	assert.False(t, customized)
 
 	// Mark as customized
-	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPlugin{})
+	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{})
 	require.NoError(t, err)
 
 	customized, err = svc.IsLibraryCustomized(ctx, library.ID, "metadataEnricher")
@@ -64,9 +64,9 @@ func TestService_GetLibraryOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	// Set library order with two plugins
-	entries := []models.LibraryPlugin{
-		{Scope: "test", PluginID: "enricher2", Enabled: true},
-		{Scope: "test", PluginID: "enricher", Enabled: false},
+	entries := []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher2", Mode: models.PluginModeEnabled},
+		{Scope: "test", PluginID: "enricher", Mode: models.PluginModeDisabled},
 	}
 	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", entries)
 	require.NoError(t, err)
@@ -76,10 +76,10 @@ func TestService_GetLibraryOrder(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, order, 2)
 	assert.Equal(t, "enricher2", order[0].PluginID)
-	assert.True(t, order[0].Enabled)
+	assert.Equal(t, models.PluginModeEnabled, order[0].Mode)
 	assert.Equal(t, 0, order[0].Position)
 	assert.Equal(t, "enricher", order[1].PluginID)
-	assert.False(t, order[1].Enabled)
+	assert.Equal(t, models.PluginModeDisabled, order[1].Mode)
 	assert.Equal(t, 1, order[1].Position)
 }
 
@@ -95,8 +95,8 @@ func TestService_ResetLibraryOrder(t *testing.T) {
 	_, err := db.NewInsert().Model(plugin).Exec(ctx)
 	require.NoError(t, err)
 
-	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPlugin{
-		{Scope: "test", PluginID: "enricher", Enabled: true},
+	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher", Mode: models.PluginModeEnabled},
 	})
 	require.NoError(t, err)
 
@@ -125,12 +125,12 @@ func TestService_ResetAllLibraryOrders(t *testing.T) {
 	_, err := db.NewInsert().Model(plugin).Exec(ctx)
 	require.NoError(t, err)
 
-	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPlugin{
-		{Scope: "test", PluginID: "enricher", Enabled: true},
+	err = svc.SetLibraryOrder(ctx, library.ID, "metadataEnricher", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher", Mode: models.PluginModeEnabled},
 	})
 	require.NoError(t, err)
-	err = svc.SetLibraryOrder(ctx, library.ID, "fileParser", []models.LibraryPlugin{
-		{Scope: "test", PluginID: "enricher", Enabled: true},
+	err = svc.SetLibraryOrder(ctx, library.ID, "fileParser", []models.LibraryPluginHookConfig{
+		{Scope: "test", PluginID: "enricher", Mode: models.PluginModeEnabled},
 	})
 	require.NoError(t, err)
 

--- a/pkg/plugins/service_test.go
+++ b/pkg/plugins/service_test.go
@@ -270,7 +270,7 @@ func TestService_GetOrder_SetOrder(t *testing.T) {
 	assert.Empty(t, orders)
 
 	// Set order
-	entries := []models.PluginOrder{
+	entries := []models.PluginHookConfig{
 		{Scope: "community", PluginID: "plugin-b"},
 		{Scope: "community", PluginID: "plugin-a"},
 		{Scope: "shisho", PluginID: "plugin-c"},
@@ -290,7 +290,7 @@ func TestService_GetOrder_SetOrder(t *testing.T) {
 	assert.Equal(t, 2, orders[2].Position)
 
 	// Reorder by setting a new order
-	newEntries := []models.PluginOrder{
+	newEntries := []models.PluginHookConfig{
 		{Scope: "shisho", PluginID: "plugin-c"},
 		{Scope: "community", PluginID: "plugin-a"},
 	}
@@ -321,6 +321,7 @@ func TestService_AppendToOrder(t *testing.T) {
 	require.Len(t, orders, 1)
 	assert.Equal(t, "plugin-a", orders[0].PluginID)
 	assert.Equal(t, 0, orders[0].Position)
+	assert.Equal(t, models.PluginModeEnabled, orders[0].Mode)
 
 	// Append second
 	err = svc.AppendToOrder(ctx, models.PluginHookOutputGenerator, "community", "plugin-b")
@@ -331,8 +332,10 @@ func TestService_AppendToOrder(t *testing.T) {
 	require.Len(t, orders, 2)
 	assert.Equal(t, "plugin-a", orders[0].PluginID)
 	assert.Equal(t, 0, orders[0].Position)
+	assert.Equal(t, models.PluginModeEnabled, orders[0].Mode)
 	assert.Equal(t, "plugin-b", orders[1].PluginID)
 	assert.Equal(t, 1, orders[1].Position)
+	assert.Equal(t, models.PluginModeEnabled, orders[1].Mode)
 }
 
 func TestService_ListRepositories(t *testing.T) {
@@ -709,4 +712,27 @@ func TestService_GetEffectiveFieldSettings_EmptyDeclaredFields(t *testing.T) {
 	effective, err = svc.GetEffectiveFieldSettings(ctx, library.ID, "community", "test-plugin", []string{})
 	require.NoError(t, err)
 	assert.Empty(t, effective)
+}
+
+func TestService_SetOrder_WithMode(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	insertTestPlugin(t, db, "community", "plugin-a")
+	insertTestPlugin(t, db, "community", "plugin-b")
+
+	entries := []models.PluginHookConfig{
+		{Scope: "community", PluginID: "plugin-a", Mode: models.PluginModeEnabled},
+		{Scope: "community", PluginID: "plugin-b", Mode: models.PluginModeManualOnly},
+	}
+	err := svc.SetOrder(ctx, models.PluginHookMetadataEnricher, entries)
+	require.NoError(t, err)
+
+	orders, err := svc.GetOrder(ctx, models.PluginHookMetadataEnricher)
+	require.NoError(t, err)
+	require.Len(t, orders, 2)
+	assert.Equal(t, models.PluginModeEnabled, orders[0].Mode)
+	assert.Equal(t, models.PluginModeManualOnly, orders[1].Mode)
 }

--- a/website/docs/plugins/overview.md
+++ b/website/docs/plugins/overview.md
@@ -40,15 +40,25 @@ Many plugins have configuration options, such as API keys for external services.
 3. Fill in the required configuration fields
 4. Save
 
-### Execution Order
+### Execution Order and Plugin Modes
 
-When multiple plugins of the same type are installed (e.g., two metadata enrichers), you can control the order they run in. Go to **Admin > Plugins** and drag plugins to reorder them within each hook type.
+When multiple plugins of the same type are installed (e.g., two metadata enrichers), you can control the order they run in and set their mode. Go to **Admin > Plugins** and use the **Order** tab to drag plugins to reorder them within each hook type.
+
+Each plugin can be set to one of three modes:
+
+| Mode | Automated Scans | Manual Identification | Use Case |
+|------|----------------|----------------------|----------|
+| **Enabled** | Runs automatically | Available | Default — plugin participates fully |
+| **Manual Only** | Skipped | Available | Rate-limited APIs, pay-per-use enrichers |
+| **Disabled** | Skipped | Unavailable | Temporarily turn off without uninstalling |
+
+**Manual Only** mode is only available for metadata enrichers. It lets you keep a plugin available for on-demand use (e.g., clicking "Identify" on a specific book) without having it run on every file during a library scan.
 
 ### Per-Library Settings
 
 Plugins can be customized on a per-library basis. In the library settings, you can:
 
-- **Enable or disable** specific plugins for that library
+- **Set the mode** for specific plugins in that library (enabled, manual only, or disabled)
 - **Reorder** plugin execution for that library
 - **Toggle individual fields** for metadata enrichers (e.g., allow a plugin to set genres but not the description)
 


### PR DESCRIPTION
## Summary
- Replaces the binary enabled/disabled toggle on plugin order with a three-state mode: **Enabled** (auto-scan + manual), **Manual Only** (manual identification only), and **Disabled** (completely unavailable)
- Applies at both global (Settings → Plugins → Order) and per-library (Library Settings → Plugin Order) levels
- Manual identification now respects per-library plugin settings (previously always used global order with `libraryID=0`)
- Renames `plugin_order` → `plugin_hook_config` and `library_plugins` → `library_plugin_hook_config` tables

## Test plan
- Verify the mode dropdown appears in both global plugin order (Admin → Plugins → Order tab) and per-library plugin order (Library Settings → Plugin Order tab)
- For metadata enricher hook type, verify three options appear (Enabled / Manual Only / Disabled); for other hook types, only Enabled / Disabled
- Set a plugin to "Manual Only" globally, run a scan — verify the plugin is skipped during auto-enrichment
- With a plugin set to "Manual Only", open a book's identify dialog — verify the plugin appears and can be used for manual search
- Set a plugin to "Disabled" at the library level, verify it's unavailable for both auto-scan and manual identification in that library
- Verify per-library settings override global settings
- Verify "Reset to Default" restores the global mode for a library