### PR TITLE
[CI] Remove Docker ecosystem from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-- package-ecosystem: "github-actions"
+  - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,20 +20,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "saturday"
-    groups:
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-  - package-ecosystem: "github-actions"
+- package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,14 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Remove Docker ecosystem from Dependabot config entirely
- Docker image versions (Go, Node, Caddy) must stay in sync with mise.toml, so they should be updated manually

## Test plan
- Verify Dependabot no longer opens PRs for Docker image updates
- Confirm gomod, npm, and github-actions ecosystems are unaffected