### PR TITLE
[Fix] Fix flaky check:quiet when subshell is killed before writing exit code

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -122,12 +122,14 @@ depends = ["tygo"]
 run = '''
 tmpdir=$(mktemp -d)
 for step in lint test test:js lint:js; do
+  echo 1 >"$tmpdir/$step.rc"
+  touch "$tmpdir/$step.out"
   ( mise "$step" >"$tmpdir/$step.out" 2>&1; echo $? >"$tmpdir/$step.rc" ) &
 done
 wait
 failed=0
 for step in lint test test:js lint:js; do
-  rc=$(cat "$tmpdir/$step.rc")
+  rc=$(cat "$tmpdir/$step.rc" 2>/dev/null || echo 1)
   if [ "$rc" -eq 0 ]; then
     printf '  \033[32mPASS\033[0m  %s\n' "$step"
   else

--- a/.mise.toml
+++ b/.mise.toml
@@ -121,6 +121,7 @@ description = "Run all checks, suppress output on success"
 depends = ["tygo"]
 run = '''
 tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
 for step in lint test test:js lint:js; do
   echo 1 >"$tmpdir/$step.rc"
   touch "$tmpdir/$step.out"
@@ -138,7 +139,6 @@ for step in lint test test:js lint:js; do
     failed=1
   fi
 done
-rm -rf "$tmpdir"
 if [ "$failed" -eq 1 ]; then
   printf '\n\033[31mcheck:quiet FAILED\033[0m\n'; exit 1
 else


### PR DESCRIPTION
## Summary
- Pre-initialize `.rc` files to `1` (failure) and `touch` `.out` files before spawning background jobs, so they always exist even if a subshell is killed by a signal before writing its exit code
- Add defensive fallback on `cat` (`|| echo 1`) as belt-and-suspenders

## Test plan
- Run `mise check:quiet` multiple times and confirm it no longer fails with `cat: .../test:js.rc: No such file or directory`
- Verify that failing steps still report FAIL correctly (the pre-initialized `1` ensures killed subshells default to failure)
- Verify that passing steps still report PASS (the subshell overwrites the `1` with `0` on success)