### PR TITLE
[Fix] Surface plugin install errors in the UI

### DIFF
--- a/app/components/pages/AdminPlugins.tsx
+++ b/app/components/pages/AdminPlugins.tsx
@@ -364,7 +364,12 @@ const BrowseTab = () => {
         name: installTarget.name,
         version: compatibleVersion.version,
       },
-      { onSuccess: () => setInstallTarget(null) },
+      {
+        onSuccess: () => setInstallTarget(null),
+        onError: (err) => {
+          toast.error(`Failed to install plugin: ${err.message}`);
+        },
+      },
     );
   };
 

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -196,7 +196,8 @@ func (h *handler) install(c echo.Context) error {
 		// Install from provided download URL
 		manifest, err := h.installer.InstallPlugin(ctx, payload.Scope, payload.ID, payload.DownloadURL, payload.SHA256)
 		if err != nil {
-			return errcodes.BadRequest(err.Error())
+			logger.FromContext(ctx).Warn("plugin install failed", logger.Data{"url": payload.DownloadURL, "error": err.Error()})
+			return errcodes.ValidationError(err.Error())
 		}
 
 		plugin = &models.Plugin{
@@ -225,7 +226,8 @@ func (h *handler) install(c echo.Context) error {
 
 		manifest, err := h.installer.InstallPlugin(ctx, payload.Scope, payload.ID, downloadURL, sha256Hash)
 		if err != nil {
-			return errcodes.BadRequest(err.Error())
+			logger.FromContext(ctx).Warn("plugin install failed", logger.Data{"url": downloadURL, "error": err.Error()})
+			return errcodes.ValidationError(err.Error())
 		}
 
 		// Download plugin icon (non-fatal)

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -196,7 +196,7 @@ func (h *handler) install(c echo.Context) error {
 		// Install from provided download URL
 		manifest, err := h.installer.InstallPlugin(ctx, payload.Scope, payload.ID, payload.DownloadURL, payload.SHA256)
 		if err != nil {
-			return errors.WithStack(err)
+			return errcodes.BadRequest(err.Error())
 		}
 
 		plugin = &models.Plugin{
@@ -225,7 +225,7 @@ func (h *handler) install(c echo.Context) error {
 
 		manifest, err := h.installer.InstallPlugin(ctx, payload.Scope, payload.ID, downloadURL, sha256Hash)
 		if err != nil {
-			return errors.WithStack(err)
+			return errcodes.BadRequest(err.Error())
 		}
 
 		// Download plugin icon (non-fatal)

--- a/pkg/plugins/installer.go
+++ b/pkg/plugins/installer.go
@@ -169,7 +169,7 @@ func (inst *Installer) downloadToTemp(ctx context.Context, url string) (string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("failed to download plugin: HTTP %d from %s", resp.StatusCode, url)
+		return "", errors.Errorf("failed to download plugin: HTTP %d", resp.StatusCode)
 	}
 
 	tmpFile, err := os.CreateTemp("", "plugin-download-*.zip")

--- a/pkg/plugins/installer.go
+++ b/pkg/plugins/installer.go
@@ -169,7 +169,7 @@ func (inst *Installer) downloadToTemp(ctx context.Context, url string) (string, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("failed to download plugin: HTTP %d", resp.StatusCode)
+		return "", errors.Errorf("failed to download plugin: HTTP %d from %s", resp.StatusCode, url)
 	}
 
 	tmpFile, err := os.CreateTemp("", "plugin-download-*.zip")


### PR DESCRIPTION
## Summary
- Plugin installation failures (e.g., HTTP 404 from a bad download URL) now show the actual error message in a toast instead of being silently swallowed
- Backend returns `errcodes.BadRequest` instead of a generic 500 so the error message reaches the client
- Download error messages now include the URL for easier debugging
- Install dialog stays open on error so the user can retry or dismiss

## Test plan
- Configure a plugin repository with an invalid download URL and attempt to install — verify the toast shows the actual error (e.g., "failed to download plugin: HTTP 404 from https://...")
- Verify the capabilities warning dialog stays open after the error
- Verify successful installs still work and close the dialog