### PR TITLE
[Fix] Improve identify workflow for audiobooks and multi-file books

### DIFF
--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -478,7 +478,7 @@ export function BookEditDialog({
 
   return (
     <FormDialog hasChanges={hasChanges} onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle>Edit Book</DialogTitle>
           <DialogDescription>

--- a/app/components/library/DeleteConfirmationDialog.tsx
+++ b/app/components/library/DeleteConfirmationDialog.tsx
@@ -157,7 +157,7 @@ export function DeleteConfirmationDialog({
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto overflow-x-hidden">
+      <DialogContent className="max-w-md overflow-x-hidden">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-destructive shrink-0" />

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -573,7 +573,7 @@ export function FileEditDialog({
 
   return (
     <FormDialog hasChanges={hasChanges} onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto overflow-x-hidden">
+      <DialogContent className="max-w-xl overflow-x-hidden">
         <DialogHeader>
           <DialogTitle>Edit File</DialogTitle>
           <DialogDescription>

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -60,12 +60,18 @@ export function IdentifyBookDialog({
   const hasEnricherPlugins = (enricherPlugins?.length ?? 0) > 0;
   const inputRef = useRef<HTMLInputElement>(null);
   const hasSearchedRef = useRef(false);
+  const queryUserTouched = useRef(false);
 
   const mainFiles = useMemo(
     () => book.files?.filter((f) => f.file_role === "main") ?? [],
     [book.files],
   );
   const hasMultipleFiles = mainFiles.length > 1;
+
+  const selectedFile = selectedFileId
+    ? mainFiles.find((f) => f.id === selectedFileId)
+    : mainFiles[0];
+  const isAudiobook = selectedFile?.file_type === "m4b";
 
   // Pre-fill query and auto-search when dialog opens
   useEffect(() => {
@@ -75,22 +81,17 @@ export function IdentifyBookDialog({
       // Pre-fill author from first author
       const firstAuthor = book.authors?.[0]?.person?.name ?? "";
       setAuthor(firstAuthor);
-      // Pre-fill identifiers from all files (deduplicated)
-      const allIds: Array<{ type: string; value: string }> = [];
-      const seen = new Set<string>();
-      for (const file of book.files ?? []) {
-        for (const id of file.identifiers ?? []) {
-          const key = `${id.type}:${id.value}`;
-          if (!seen.has(key)) {
-            seen.add(key);
-            allIds.push({ type: id.type, value: id.value });
-          }
-        }
-      }
-      setIdentifiers(allIds);
+      // Pre-fill identifiers from the initially selected file
+      const initialFile = mainFiles[0];
+      const fileIds = (initialFile?.identifiers ?? []).map((id) => ({
+        type: id.type,
+        value: id.value,
+      }));
+      setIdentifiers(fileIds);
       setSelectedResult(null);
       setSelectedFileId(mainFiles.length > 1 ? mainFiles[0].id : undefined);
       hasSearchedRef.current = false;
+      queryUserTouched.current = false;
     }
   }, [open, book.title, book.authors, book.files, mainFiles]);
 
@@ -101,6 +102,7 @@ export function IdentifyBookDialog({
       searchMutation.mutate({
         query,
         bookId: book.id,
+        fileId: selectedFileId,
         author: author || undefined,
         identifiers: identifiers.length > 0 ? identifiers : undefined,
       });
@@ -114,6 +116,7 @@ export function IdentifyBookDialog({
     searchMutation.mutate({
       query: query.trim(),
       bookId: book.id,
+      fileId: selectedFileId,
       author: author.trim() || undefined,
       identifiers: identifiers.length > 0 ? identifiers : undefined,
     });
@@ -165,7 +168,7 @@ export function IdentifyBookDialog({
       onOpenChange={onOpenChange}
       open={open}
     >
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto overflow-x-hidden [&>*]:min-w-0">
+      <DialogContent className="max-w-2xl overflow-x-hidden [&>*]:min-w-0">
         <DialogHeader className="pr-8">
           <DialogTitle>Identify Book</DialogTitle>
           <DialogDescription>
@@ -195,7 +198,27 @@ export function IdentifyBookDialog({
                       : "border-border",
                   )}
                   key={file.id}
-                  onClick={() => setSelectedFileId(file.id)}
+                  onClick={() => {
+                    setSelectedFileId(file.id);
+                    // Update identifiers to the selected file's identifiers
+                    const fileIds = (file.identifiers ?? []).map((id) => ({
+                      type: id.type,
+                      value: id.value,
+                    }));
+                    setIdentifiers(fileIds);
+                    if (!queryUserTouched.current) {
+                      const fileTitle = file.name || getFilename(file.filepath);
+                      setQuery(fileTitle);
+                      setSelectedResult(null);
+                      searchMutation.mutate({
+                        query: fileTitle,
+                        bookId: book.id,
+                        fileId: file.id,
+                        author: author.trim() || undefined,
+                        identifiers: fileIds.length > 0 ? fileIds : undefined,
+                      });
+                    }
+                  }}
                   type="button"
                 >
                   <div className="flex items-center gap-2">
@@ -239,7 +262,10 @@ export function IdentifyBookDialog({
             <div className="flex gap-2">
               <Input
                 className="flex-1"
-                onChange={(e) => setQuery(e.target.value)}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  queryUserTouched.current = true;
+                }}
                 onKeyDown={handleKeyDown}
                 placeholder="Search by title, author, ISBN..."
                 ref={inputRef}
@@ -346,11 +372,19 @@ export function IdentifyBookDialog({
                         {result.cover_url ? (
                           <img
                             alt=""
-                            className="w-16 h-24 object-cover rounded shrink-0 bg-muted"
+                            className={cn(
+                              "w-16 object-cover rounded shrink-0 bg-muted",
+                              isAudiobook ? "h-16" : "h-24",
+                            )}
                             src={result.cover_url}
                           />
                         ) : (
-                          <div className="w-16 h-24 rounded shrink-0 bg-muted flex items-center justify-center text-muted-foreground text-xs">
+                          <div
+                            className={cn(
+                              "w-16 rounded shrink-0 bg-muted flex items-center justify-center text-muted-foreground text-xs",
+                              isAudiobook ? "h-16" : "h-24",
+                            )}
+                          >
                             No cover
                           </div>
                         )}

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -73,42 +73,41 @@ export function IdentifyBookDialog({
     : mainFiles[0];
   const isAudiobook = selectedFile?.file_type === "m4b";
 
-  // Pre-fill query and auto-search when dialog opens
+  // Pre-fill form and auto-search when dialog opens
   useEffect(() => {
     if (open) {
       setStep("search");
-      setQuery(book.title);
-      // Pre-fill author from first author
-      const firstAuthor = book.authors?.[0]?.person?.name ?? "";
-      setAuthor(firstAuthor);
-      // Pre-fill identifiers from the initially selected file
+      setSelectedResult(null);
+      hasSearchedRef.current = false;
+      queryUserTouched.current = false;
+
+      const initialQuery = book.title;
+      const initialAuthor = book.authors?.[0]?.person?.name ?? "";
+      const initialFileId = mainFiles.length > 1 ? mainFiles[0].id : undefined;
       const initialFile = mainFiles[0];
-      const fileIds = (initialFile?.identifiers ?? []).map((id) => ({
+      const initialIds = (initialFile?.identifiers ?? []).map((id) => ({
         type: id.type,
         value: id.value,
       }));
-      setIdentifiers(fileIds);
-      setSelectedResult(null);
-      setSelectedFileId(mainFiles.length > 1 ? mainFiles[0].id : undefined);
-      hasSearchedRef.current = false;
-      queryUserTouched.current = false;
-    }
-  }, [open, book.title, book.authors, book.files, mainFiles]);
 
-  // Auto-search after query is set from dialog open
-  useEffect(() => {
-    if (open && query && !hasSearchedRef.current) {
-      hasSearchedRef.current = true;
-      searchMutation.mutate({
-        query,
-        bookId: book.id,
-        fileId: selectedFileId,
-        author: author || undefined,
-        identifiers: identifiers.length > 0 ? identifiers : undefined,
-      });
+      setQuery(initialQuery);
+      setAuthor(initialAuthor);
+      setIdentifiers(initialIds);
+      setSelectedFileId(initialFileId);
+
+      if (initialQuery) {
+        hasSearchedRef.current = true;
+        searchMutation.mutate({
+          query: initialQuery,
+          bookId: book.id,
+          fileId: initialFileId,
+          author: initialAuthor || undefined,
+          identifiers: initialIds.length > 0 ? initialIds : undefined,
+        });
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, query]);
+  }, [open, book.title, book.authors, book.files, mainFiles]);
 
   const handleSearch = () => {
     if (!query.trim()) return;
@@ -210,6 +209,7 @@ export function IdentifyBookDialog({
                       const fileTitle = file.name || getFilename(file.filepath);
                       setQuery(fileTitle);
                       setSelectedResult(null);
+                      searchMutation.reset();
                       searchMutation.mutate({
                         query: fileTitle,
                         bookId: book.id,

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -495,6 +495,7 @@ export function IdentifyReviewForm({
   // Cover state — page-based formats (CBZ, PDF) derive covers from page
   // content and shouldn't be overwritten by plugin images.
   const coverEditable = !isPageBasedFileType(file?.file_type);
+  const isAudiobook = file?.file_type === "m4b";
   const newCoverUrl = result.cover_url;
   const currentCoverUrl = file?.cover_image_filename
     ? `/api/books/files/${file.id}/cover?t=${new Date(file.updated_at).getTime()}`
@@ -667,7 +668,10 @@ export function IdentifyReviewForm({
               >
                 <img
                   alt="Current cover"
-                  className="w-24 h-36 object-cover bg-muted"
+                  className={cn(
+                    "w-24 object-cover bg-muted",
+                    isAudiobook ? "h-24" : "h-36",
+                  )}
                   src={currentCoverUrl}
                 />
                 <span className="absolute bottom-0 inset-x-0 bg-black/60 text-white text-[0.6rem] text-center py-0.5">
@@ -693,7 +697,10 @@ export function IdentifyReviewForm({
             >
               <img
                 alt="New cover"
-                className="w-24 h-36 object-cover bg-muted"
+                className={cn(
+                  "w-24 object-cover bg-muted",
+                  isAudiobook ? "h-24" : "h-36",
+                )}
                 src={newCoverUrl}
               />
               <span className="absolute bottom-0 inset-x-0 bg-black/60 text-white text-[0.6rem] text-center py-0.5">

--- a/app/components/library/MergeBooksDialog.tsx
+++ b/app/components/library/MergeBooksDialog.tsx
@@ -128,7 +128,7 @@ export function MergeBooksDialog({
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <GitMerge className="h-5 w-5" />

--- a/app/components/ui/dialog.tsx
+++ b/app/components/ui/dialog.tsx
@@ -93,7 +93,7 @@ const DialogContent = React.forwardRef<
             ? // Mobile: slide up from bottom, desktop: centered modal
               "inset-x-0 bottom-0 rounded-t-lg max-h-[90vh] overflow-y-auto data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:inset-auto sm:left-[50%] sm:top-[50%] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg sm:max-w-lg sm:max-h-[85vh] sm:data-[state=closed]:slide-out-to-left-1/2 sm:data-[state=closed]:slide-out-to-top-[48%] sm:data-[state=open]:slide-in-from-left-1/2 sm:data-[state=open]:slide-in-from-top-[48%] sm:data-[state=closed]:zoom-out-95 sm:data-[state=open]:zoom-in-95"
             : // Default: centered modal
-              "left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] max-w-lg data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+              "left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%] max-w-lg max-h-[90vh] overflow-y-auto data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
           className,
         )}
         {...props}

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -575,14 +575,16 @@ export const usePluginSearch = () => {
     {
       query: string;
       bookId: number;
+      fileId?: number;
       author?: string;
       identifiers?: Array<{ type: string; value: string }>;
     }
   >({
-    mutationFn: ({ query, bookId, author, identifiers }) => {
+    mutationFn: ({ query, bookId, fileId, author, identifiers }) => {
       return API.request<PluginSearchResponse>("POST", "/plugins/search", {
         query,
         book_id: bookId,
+        file_id: fileId,
         author: author || undefined,
         identifiers: identifiers?.length ? identifiers : undefined,
       });

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -144,6 +144,7 @@ type setOrderPayload struct {
 type searchPayload struct {
 	Query       string                       `json:"query" validate:"required"`
 	BookID      int                          `json:"book_id" validate:"required"`
+	FileID      *int                         `json:"file_id"`
 	Author      string                       `json:"author"`
 	Identifiers []mediafile.ParsedIdentifier `json:"identifiers"`
 }
@@ -1405,9 +1406,26 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		searchCtx["identifiers"] = ids
 	}
 
-	// Add file hints from the book's first file (non-modifiable context)
-	if len(book.Files) > 0 {
-		f := book.Files[0]
+	// Select the target file — use the explicitly requested file if provided,
+	// otherwise fall back to the first file on the book.
+	var targetFile *models.File
+	if payload.FileID != nil {
+		for _, f := range book.Files {
+			if f.ID == *payload.FileID {
+				targetFile = f
+				break
+			}
+		}
+	}
+	if targetFile == nil && len(book.Files) > 0 {
+		targetFile = book.Files[0]
+	}
+
+	// Add file hints from the target file (non-modifiable context)
+	var fileType string
+	if targetFile != nil {
+		f := targetFile
+		fileType = f.FileType
 		fileCtx := map[string]interface{}{
 			"fileType": f.FileType,
 		}
@@ -1423,6 +1441,24 @@ func (h *handler) searchMetadata(c echo.Context) error {
 
 	var allResults []EnrichSearchResult
 	for _, rt := range runtimes {
+		// Skip plugins that don't handle this file type
+		if fileType != "" {
+			enricherCap := rt.Manifest().Capabilities.MetadataEnricher
+			if enricherCap == nil {
+				continue
+			}
+			handles := false
+			for _, ft := range enricherCap.FileTypes {
+				if ft == fileType {
+					handles = true
+					break
+				}
+			}
+			if !handles {
+				continue
+			}
+		}
+
 		resp, sErr := h.manager.RunMetadataSearch(ctx, rt, searchCtx)
 		if sErr != nil {
 			continue // Skip failed plugins


### PR DESCRIPTION
## Summary
- Use square cover image aspect ratios for audiobooks in the identify search results and review form, matching the rest of the app
- Filter enricher plugins by file type during manual identification (was already done during auto scans but missing from the identify dialog), and send the selected file ID so switching files uses the correct file type
- Re-search automatically when switching between files in multi-file books, updating query text and identifiers to match the selected file
- Add `max-h-[90vh] overflow-y-auto` to the base `DialogContent` component so all dialogs scroll on short viewports, removing redundant per-dialog overrides

## Test plan
- Open identify dialog for an audiobook — cover images in search results and review form should be square (1:1), not tall (2:3)
- Open identify dialog for a book with both EPUB and M4B files — switching to the M4B file should trigger a new search with audiobook-specific plugins (e.g., Audible enricher)
- Verify the plugin config dialog scrolls when the viewport is short
- Verify other dialogs (BookEdit, FileEdit, DeleteConfirmation, MergeBooks) still scroll correctly