### PR TITLE
[Docs] Add metadata-field skill for cross-stack field changes

### DIFF
--- a/.claude/skills/metadata-field/SKILL.md
+++ b/.claude/skills/metadata-field/SKILL.md
@@ -57,6 +57,7 @@ git grep -l 'Publisher\|publisher' pkg/filegen/  # File generators
 git grep -l 'Publisher' pkg/kepub/            # KePub CBZ path
 git grep -l 'Publisher' pkg/opds/             # OPDS feed
 git grep -l 'Publisher' pkg/kobo/             # Kobo sync
+git grep -l 'Publisher\|publisher' pkg/ereader/  # eReader server-rendered UI (metaParts builder in handlers.go)
 
 # 3. Plugin bridge — there are THREE parallel JS→Go parsers plus several
 # merge/filter/persist functions. All must be updated in lockstep.
@@ -99,6 +100,18 @@ Save the union of everything these commands return. That's your implementation s
 
 Produce a written plan that maps each discovered file to a specific change. Group by layer:
 
+**Naming conventions to watch for.** A new field touches code that uses several different casing conventions for the same logical name. Pick the canonical names up front and stay consistent — getting one wrong tends to cause silent bugs that don't show up until runtime:
+
+- **Go struct fields** are `PascalCase` (e.g., `EditionNote`)
+- **Database columns** are `snake_case` (e.g., `edition_note`, `edition_note_source`)
+- **JSON tags on the model and API** are `snake_case` (e.g., `json:"edition_note"`)
+- **`mediafile.ParsedMetadata.FieldDataSources` map keys are `camelCase`** (e.g., `"editionNote"`, NOT `"edition_note"`). This is because the same map is used for both Go-side bookkeeping and JS-side plugin field declarations, and the plugin SDK uses camelCase. Look at how `"releaseDate"` is keyed in this map for the canonical example.
+- **Plugin SDK TypeScript types** are `camelCase` (e.g., `editionNote?: string`)
+- **Plugin manifest `MetadataField` enum values** are `camelCase` (must match the SDK and `ValidMetadataFields`)
+- **`pkg/plugins/manifest.go` `ValidMetadataFields` strings are `camelCase`** to match the SDK
+
+The only places that use `snake_case` for the field name are the database column, the Go `json` tag on the model, and the API payload. Everywhere else (Go struct fields, FieldDataSources keys, plugin SDK types, manifest validation) is camelCase or PascalCase. When in doubt, grep for how an existing similar field is keyed in each location.
+
 **Data model**
 - Migration: `ALTER TABLE` + partial index if the field will be filtered/searched
 - Go model: field + `_source` tracking field
@@ -133,11 +146,13 @@ Produce a written plan that maps each discovered file to a specific change. Grou
 - `pkg/plugins/hooks.go` `parseSearchResponse` (metadataEnricher hook path)
 - `pkg/plugins/handler.go` `convertFieldsToMetadata` (identify apply path)
 - `pkg/plugins/handler.go` `persistMetadata` — the apply actually writes the field
-- `packages/plugin-sdk/metadata.d.ts` — TypeScript types
+- `packages/plugin-sdk/metadata.d.ts` — `ParsedMetadata` interface (the runtime data shape)
+- `packages/plugin-sdk/manifest.d.ts` — the `MetadataField` string union (the manifest validation type, separate from `ParsedMetadata`). It's easy to update one and forget the other; both must list the new field.
 
 **Other consumers**
 - OPDS entry population in `pkg/opds/service.go`
-- Kobo sync in `pkg/kobo/handlers.go`
+- Kobo sync in `pkg/kobo/handlers.go` (currently hardcodes some fields — check if your field needs special handling)
+- eReader server-rendered UI in `pkg/ereader/handlers.go` — look for the `metaParts` builder that emits page count, duration, etc. inline on file rows. New file-level display fields usually want a row here.
 - Any other format-adjacent subsystem
 
 **Frontend**

--- a/.claude/skills/metadata-field/SKILL.md
+++ b/.claude/skills/metadata-field/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: metadata-field
+description: Use when adding, removing, or significantly modifying a metadata field on books or files (e.g., adding a new field like "language" to the File model). Enumerates the cross-stack touchpoints, enforces a discovery-based workflow that uses the codebase itself as the checklist, and includes a verification phase that catches parallel code paths that would otherwise be missed.
+---
+
+# Adding or Changing a Metadata Field
+
+## Why this skill exists
+
+Adding a metadata field to books or files in Shisho touches ~20-25 files across the stack. There are multiple parallel code paths that silently drop fields if you miss them (three separate JS→Go parsers, two merge functions, a filter function, file generators for four formats, the M4B freeform atom writer, the identify apply handler, OPDS feeds, Kobo sync, the frontend edit dialog, the gallery filter, the identify review form, and the plugin config labels — plus docs and tests for each).
+
+A static checklist decays: code gets added, names drift, new touchpoints appear. This skill does NOT use a hardcoded list. It uses the **current state of the codebase** as the checklist by discovering touchpoints dynamically through grep.
+
+## When to invoke
+
+- Adding a new field to `models.File` or `models.Book`
+- Adding a new field that flows through the scanner → sidecar → download pipeline
+- Adding a field that plugins should be able to set
+- Significantly modifying an existing field's data flow (e.g., changing nullability, adding plugin support)
+
+Do NOT invoke for: adding a purely ephemeral UI state field, a handler-internal helper, or a field that lives entirely within one subsystem (e.g., a scan job internal field).
+
+## The four phases
+
+Work through these in order. Do not skip ahead — Phase 1 discovery informs Phase 2 planning, and Phase 4 verification is the killer step that catches missed parallel paths.
+
+### Phase 1 — Discovery
+
+**Pick a proxy field.** Choose an existing field that's as similar as possible to the one you're adding. This is the most important decision in the skill — a good proxy gives you a comprehensive checklist automatically; a bad proxy misses touchpoints.
+
+Proxy selection guide:
+- **New nullable string on files** (e.g., language, description) → use `publisher` or `url`
+- **New nullable boolean on files** → use something nullable like a future feature. If none exists, use a nullable scalar like `release_date` and manually add the bool-specific branches
+- **New date on files** → use `release_date`
+- **New relation (many-to-many or belongs-to)** → use `publisher` (belongs-to) or `narrators` (has-many)
+- **New book-level field** → use `subtitle` or `description`
+- **New audiobook-specific field** → use `audiobook_codec` or similar
+
+**Run discovery greps.** Replace `PROXY` with your chosen proxy field name (both the Go `PascalCase` and the JSON `snake_case` form). Paste the output into your notes — you'll need it for Phase 2.
+
+```bash
+# 1. Find every Go file that references the proxy field. This is the master
+# list of backend touchpoints. Anywhere the proxy appears, the new field
+# probably needs to appear too.
+git grep -il 'Publisher\|publisher' pkg/
+
+# 2. Narrow by layer:
+git grep -l 'publisher' pkg/mediafile/        # ParsedMetadata struct
+git grep -l 'Publisher' pkg/models/           # File/Book model
+git grep -l 'Publisher\|publisher' pkg/migrations/
+git grep -l 'Publisher' pkg/sidecar/          # Sidecar types + conversion
+git grep -l 'Publisher' pkg/downloadcache/    # Fingerprint
+git grep -l 'Publisher\|publisher' pkg/worker/ # Scanner (multiple merge/filter funcs)
+git grep -l 'Publisher\|publisher' pkg/books/ # Edit API + validators + handlers
+git grep -l 'Publisher' pkg/epub/ pkg/cbz/ pkg/mp4/ pkg/pdf/  # Parsers
+git grep -l 'Publisher\|publisher' pkg/filegen/  # File generators
+git grep -l 'Publisher' pkg/kepub/            # KePub CBZ path
+git grep -l 'Publisher' pkg/opds/             # OPDS feed
+git grep -l 'Publisher' pkg/kobo/             # Kobo sync
+
+# 3. Plugin bridge — there are THREE parallel JS→Go parsers plus several
+# merge/filter/persist functions. All must be updated in lockstep.
+git grep -l 'Publisher\|publisher' pkg/plugins/
+git grep -n 'parseSearchResponse\|parseParsedMetadata\|convertFieldsToMetadata' pkg/plugins/hooks.go pkg/plugins/handler.go
+git grep -n 'persistMetadata\|mergeEnrichedMetadata\|filterMetadataFields' pkg/worker/scan_unified.go pkg/plugins/handler.go
+
+# 4. Frontend touchpoints.
+git grep -il 'publisher' app/
+git grep -l 'publisher' app/components/library/FileEditDialog.tsx
+git grep -l 'publisher' app/components/library/IdentifyReviewForm.tsx
+git grep -l 'publisher' app/components/files/FileDetailsTab.tsx
+git grep -l 'publisher' app/components/pages/BookDetail.tsx
+git grep -l 'publisher' app/components/pages/Home.tsx  # gallery filter
+git grep -l 'publisher' app/utils/format.ts            # METADATA_FIELD_LABELS
+git grep -l 'publisher' app/hooks/queries/             # query types
+git grep -l 'publisher' app/types/                     # TypeScript types (tygo-generated + custom)
+
+# 5. Plugin SDK + manifest validation.
+git grep -l 'publisher' packages/plugin-sdk/
+git grep -n 'ValidMetadataFields' pkg/plugins/manifest.go
+
+# 6. Documentation.
+git grep -l 'publisher' website/docs/
+git grep -l 'publisher' pkg/*/CLAUDE.md
+
+# 7. Find every ParsedMetadata constructor (any place that builds the struct
+# from scratch is a place that might need your new field set).
+git grep -n 'ParsedMetadata{' pkg/
+
+# 8. Find every File / Entity constructor pattern in tests.
+git grep -l 'models\.File{' pkg/ --include='*_test.go'
+```
+
+Save the union of everything these commands return. That's your implementation surface area. If it surprises you, investigate before continuing — there may be recently-added touchpoints not covered by the proxy.
+
+**Check for the M4B Freeform write-back trap.** If your field lives in `mp4.Metadata.Freeform` (e.g., `com.shisho:*` or `com.pilabor.tone:*` atoms), verify that `pkg/mp4/writer.go` `buildIlst` actually iterates the Freeform map. Historically the writer dropped freeform atoms silently.
+
+### Phase 2 — Planning
+
+Produce a written plan that maps each discovered file to a specific change. Group by layer:
+
+**Data model**
+- Migration: `ALTER TABLE` + partial index if the field will be filtered/searched
+- Go model: field + `_source` tracking field
+- Run `mise tygo` to regenerate TypeScript types
+
+**Parsing & extraction**
+- `pkg/mediafile/mediafile.go` — add to `ParsedMetadata`
+- Per-format parsers (EPUB, CBZ, M4B, PDF) — extract where applicable
+- Normalization helpers if needed (e.g., `NormalizeLanguage`)
+
+**Persistence & round-trip**
+- Sidecar types + conversion
+- Download fingerprint struct + computation
+- File generators — EVERY format, plus KePub CBZ path
+- Write round-trip tests FIRST (Red), then implement generators (Green)
+
+**Scanner**
+- `scanFileCore` in `pkg/worker/scan_unified.go` — metadata AND sidecar source priority handling
+- `mergeEnrichedMetadata` — copy field from enricher results
+- `filterMetadataFields` — declared/enabled toggle handling
+- `runMetadataEnrichers` path if there are other consumers
+
+**Edit API**
+- Validator struct (`UpdateFilePayload` or similar)
+- Handler update logic
+- Supplement downgrade clearing (preserve or clear?)
+- Validation normalization
+
+**Plugin bridge (the easy-to-miss trio)**
+- `pkg/plugins/manifest.go` `ValidMetadataFields`
+- `pkg/plugins/hooks.go` `parseParsedMetadata` (fileParser hook path)
+- `pkg/plugins/hooks.go` `parseSearchResponse` (metadataEnricher hook path)
+- `pkg/plugins/handler.go` `convertFieldsToMetadata` (identify apply path)
+- `pkg/plugins/handler.go` `persistMetadata` — the apply actually writes the field
+- `packages/plugin-sdk/metadata.d.ts` — TypeScript types
+
+**Other consumers**
+- OPDS entry population in `pkg/opds/service.go`
+- Kobo sync in `pkg/kobo/handlers.go`
+- Any other format-adjacent subsystem
+
+**Frontend**
+- `FileEditDialog` — state, initial values, hasChanges, save payload, UI
+- `BookDetail` expandable metadata
+- `FileDetailsTab`
+- `Home` gallery filter (if applicable)
+- `IdentifyReviewForm` — defaults, state, hasChanges, submit, UI, plus
+  `PluginSearchResult` type
+- `METADATA_FIELD_LABELS` in `app/utils/format.ts` for the plugin config toggles
+- Query hooks if new endpoints are added
+- Curated lookup tables (e.g., languages) if applicable
+
+**Docs**
+- `website/docs/metadata.md`
+- `website/docs/sidecar-files.md`
+- `website/docs/supported-formats.md`
+- `website/docs/plugins/development.md`
+- Relevant `pkg/*/CLAUDE.md` files
+
+**Tests**
+- Parser extraction tests per format
+- Round-trip test for each file generator
+- Sidecar round-trip test
+- Scanner merge/filter tests
+- Plugin bridge parser tests (all three)
+- Edit API handler test (including downgrade)
+- Frontend unit tests where applicable
+
+### Phase 3 — Implementation order
+
+Work in this order to minimize rework:
+
+1. **Migration + model + `mise tygo`** — everything downstream needs the type
+2. **`ParsedMetadata` field** — parsers and plugins both depend on it
+3. **Parser extraction per format** — write extraction tests alongside
+4. **Round-trip test for file generators (RED)** — write the test that asserts the field survives write → read. This should fail.
+5. **File generators (GREEN)** — implement write-back until the round-trip test passes
+6. **Sidecar + fingerprint** — simple additive changes
+7. **Scanner integration** — metadata + sidecar source priority
+8. **Edit API** — payload, handler, downgrade
+9. **Plugin bridge** — all three JS→Go parsers + manifest validation + filter/merge/persist
+10. **Other backend consumers** — OPDS, Kobo, etc.
+11. **Frontend edit + display**
+12. **Frontend identify review form + plugin config labels**
+13. **Docs + CLAUDE.md**
+14. **`mise check:quiet`** to verify
+
+### Phase 4 — Verification (the killer step)
+
+Before opening a PR, run these greps to find parallel code paths that reference your proxy field but NOT the new field. Any hit is a potential miss.
+
+```bash
+# For every file that mentions the proxy field, check whether it also
+# mentions the new field. Anything that doesn't is a potential miss —
+# investigate each one.
+for f in $(git grep -il 'publisher' pkg/ app/); do
+  if ! grep -qi 'NEW_FIELD' "$f"; then
+    echo "MAYBE MISSING: $f"
+  fi
+done
+
+# Extra safety nets:
+# 1. Every ParsedMetadata constructor should set the new field (or
+# intentionally leave it nil with a comment).
+git grep -n 'ParsedMetadata{' pkg/
+
+# 2. Every plugin test fixture JS that returns metadata should be
+# updated if your field is returnable by plugins.
+git grep -l 'return {' pkg/plugins/testdata/
+
+# 3. Verify tests actually assert the new field end-to-end, not just
+# compile. Run:
+mise test
+mise test:js
+mise check:quiet
+```
+
+Investigate every "MAYBE MISSING" hit. Most will be false positives (test helpers, unrelated code). The ones that aren't are exactly the class of bug that takes multiple review rounds to catch.
+
+## Red flags during the work
+
+If any of these occur, stop and reassess:
+
+- **You find a function that builds `ParsedMetadata` that you didn't know about.** There may be more parallel paths — re-run Phase 1 discovery.
+- **You find that the proxy field is handled inconsistently in two places.** That's a pre-existing bug your new field is about to inherit. File a Notion task.
+- **Your round-trip test passes trivially without reading the write path.** The test isn't actually exercising the round-trip — fix it.
+- **You're tempted to skip the Phase 4 verification greps because "it works locally".** That's exactly how the bugs that required 9 review rounds on the language/abridged PR got through. Do the greps.
+
+## Why this skill doesn't have a hardcoded checklist
+
+A hardcoded checklist decays: it goes out of date as the codebase grows. Every time a new parallel code path is added (e.g., a third JS→Go parser, or a new frontend display component), a static checklist gets stale and misses touchpoints. The discovery-based approach self-corrects because it reads the current codebase state every time it runs. Trust the grep, not a historical list.
+
+If you find that this skill is consistently missing a category, add a new grep to Phase 1, not a new bullet to Phase 2.

--- a/.claude/skills/metadata-field/SKILL.md
+++ b/.claude/skills/metadata-field/SKILL.md
@@ -28,61 +28,72 @@ Work through these in order. Do not skip ahead — Phase 1 discovery informs Pha
 
 **Pick a proxy field.** Choose an existing field that's as similar as possible to the one you're adding. This is the most important decision in the skill — a good proxy gives you a comprehensive checklist automatically; a bad proxy misses touchpoints.
 
+**`language` is the best general-purpose proxy.** It's the most recent nullable file-level field and it touches the broadest surface area: every parser, every generator, sidecar, fingerprint, scanner (metadata + sidecar + merge + filter paths), edit API with supplement-downgrade clearing, plugin bridge (both JS→Go parsers + both identify-apply functions + the manifest validation list), plugin SDK (both `metadata.d.ts` and `manifest.d.ts`), eReader UI, OPDS, AND it's a gallery filter facet in `Home.tsx`. Most other proxies miss at least one of these. Default to `language` unless you have a specific reason to pick something else.
+
 Proxy selection guide:
-- **New nullable string on files** (e.g., language, description) → use `publisher` or `url`
-- **New nullable boolean on files** → use something nullable like a future feature. If none exists, use a nullable scalar like `release_date` and manually add the bool-specific branches
+- **New nullable string on files** (e.g., description, edition_note) → use `language` (best coverage). For fields that won't be filterable, `publisher` is also fine but **does not appear in the gallery filter** in `Home.tsx` — only `language`, `genres`, `tags`, and `fileTypes` do, so a `publisher`-only sweep will miss `Home.tsx` entirely. If your field could ever be a filter facet, use `language`.
+- **New nullable boolean on files** → use `abridged` (added with language, similar shape, plugin-settable, has source tracking)
+- **New nullable integer on files** → cross-check `abridged` (for plugin/source/scanner coverage) AND `page_count` (for the integer comparison patterns and `goja.ToInteger()`). Note that `page_count` is NOT plugin-settable today, so don't trust its plugin-bridge coverage.
 - **New date on files** → use `release_date`
 - **New relation (many-to-many or belongs-to)** → use `publisher` (belongs-to) or `narrators` (has-many)
 - **New book-level field** → use `subtitle` or `description`
 - **New audiobook-specific field** → use `audiobook_codec` or similar
 
-**Run discovery greps.** Replace `PROXY` with your chosen proxy field name (both the Go `PascalCase` and the JSON `snake_case` form). Paste the output into your notes — you'll need it for Phase 2.
+**When in doubt, cross-check with two proxies.** If your field has an unusual shape (e.g., a nullable bool that's also filterable), pick the closest structural match AND `language`, then take the union of both discovery passes. The cost is a few extra greps; the benefit is catching paths a single proxy misses.
+
+**Run discovery greps.** The examples below use `language` (the recommended default proxy). Replace it with your chosen proxy if different — use both the Go `PascalCase` form (`Language`) and the JSON `snake_case` form (`language`) since they appear in different files. The grep is case-insensitive (`-i`) so you don't need to enumerate variants by hand.
 
 ```bash
 # 1. Find every Go file that references the proxy field. This is the master
 # list of backend touchpoints. Anywhere the proxy appears, the new field
 # probably needs to appear too.
-git grep -il 'Publisher\|publisher' pkg/
+git grep -il 'language' pkg/
 
 # 2. Narrow by layer:
-git grep -l 'publisher' pkg/mediafile/        # ParsedMetadata struct
-git grep -l 'Publisher' pkg/models/           # File/Book model
-git grep -l 'Publisher\|publisher' pkg/migrations/
-git grep -l 'Publisher' pkg/sidecar/          # Sidecar types + conversion
-git grep -l 'Publisher' pkg/downloadcache/    # Fingerprint
-git grep -l 'Publisher\|publisher' pkg/worker/ # Scanner (multiple merge/filter funcs)
-git grep -l 'Publisher\|publisher' pkg/books/ # Edit API + validators + handlers
-git grep -l 'Publisher' pkg/epub/ pkg/cbz/ pkg/mp4/ pkg/pdf/  # Parsers
-git grep -l 'Publisher\|publisher' pkg/filegen/  # File generators
-git grep -l 'Publisher' pkg/kepub/            # KePub CBZ path
-git grep -l 'Publisher' pkg/opds/             # OPDS feed
-git grep -l 'Publisher' pkg/kobo/             # Kobo sync
-git grep -l 'Publisher\|publisher' pkg/ereader/  # eReader server-rendered UI (metaParts builder in handlers.go)
+git grep -il 'language' pkg/mediafile/        # ParsedMetadata struct
+git grep -il 'language' pkg/models/           # File/Book model
+git grep -il 'language' pkg/migrations/
+git grep -il 'language' pkg/sidecar/          # Sidecar types + conversion
+git grep -il 'language' pkg/downloadcache/    # Fingerprint
+git grep -il 'language' pkg/worker/           # Scanner (multiple merge/filter funcs)
+git grep -il 'language' pkg/books/            # Edit API + validators + handlers
+git grep -il 'language' pkg/epub/ pkg/cbz/ pkg/mp4/ pkg/pdf/  # Parsers
+git grep -il 'language' pkg/filegen/          # File generators
+git grep -il 'language' pkg/kepub/            # KePub CBZ path
+git grep -il 'language' pkg/opds/             # OPDS feed
+git grep -il 'language' pkg/kobo/             # Kobo sync
+git grep -il 'language' pkg/ereader/          # eReader server-rendered UI (metaParts builder in handlers.go)
 
 # 3. Plugin bridge — there are THREE parallel JS→Go parsers plus several
 # merge/filter/persist functions. All must be updated in lockstep.
-git grep -l 'Publisher\|publisher' pkg/plugins/
+git grep -il 'language' pkg/plugins/
 git grep -n 'parseSearchResponse\|parseParsedMetadata\|convertFieldsToMetadata' pkg/plugins/hooks.go pkg/plugins/handler.go
 git grep -n 'persistMetadata\|mergeEnrichedMetadata\|filterMetadataFields' pkg/worker/scan_unified.go pkg/plugins/handler.go
 
-# 4. Frontend touchpoints.
-git grep -il 'publisher' app/
-git grep -l 'publisher' app/components/library/FileEditDialog.tsx
-git grep -l 'publisher' app/components/library/IdentifyReviewForm.tsx
-git grep -l 'publisher' app/components/files/FileDetailsTab.tsx
-git grep -l 'publisher' app/components/pages/BookDetail.tsx
-git grep -l 'publisher' app/components/pages/Home.tsx  # gallery filter
-git grep -l 'publisher' app/utils/format.ts            # METADATA_FIELD_LABELS
-git grep -l 'publisher' app/hooks/queries/             # query types
-git grep -l 'publisher' app/types/                     # TypeScript types (tygo-generated + custom)
+# 4. Frontend touchpoints. NB: Home.tsx is the gallery filter — only shows
+# 'language', 'genres', 'tags', and 'fileTypes' as facets today, so a
+# `publisher` proxy will MISS it entirely. This is why language is the
+# recommended default proxy.
+git grep -il 'language' app/
+git grep -l 'language' app/components/library/FileEditDialog.tsx
+git grep -l 'language' app/components/library/IdentifyReviewForm.tsx
+git grep -l 'language' app/components/files/FileDetailsTab.tsx
+git grep -l 'language' app/components/pages/BookDetail.tsx
+git grep -l 'language' app/components/pages/Home.tsx  # gallery filter
+git grep -l 'language' app/utils/format.ts            # METADATA_FIELD_LABELS
+git grep -l 'language' app/hooks/queries/             # query types
+git grep -l 'language' app/types/                     # TypeScript types (tygo-generated + custom)
 
-# 5. Plugin SDK + manifest validation.
-git grep -l 'publisher' packages/plugin-sdk/
+# 5. Plugin SDK + manifest validation. Both metadata.d.ts AND manifest.d.ts
+# must be updated — they live in the same package but cover different
+# concerns (runtime data shape vs. manifest enum validation).
+git grep -il 'language' packages/plugin-sdk/
 git grep -n 'ValidMetadataFields' pkg/plugins/manifest.go
 
-# 6. Documentation.
-git grep -l 'publisher' website/docs/
-git grep -l 'publisher' pkg/*/CLAUDE.md
+# 6. Documentation. Update website/docs/ but NOT website/versioned_docs/
+# (those are historical snapshots — never backport current behavior).
+git grep -il 'language' website/docs/
+git grep -l 'language' pkg/*/CLAUDE.md
 
 # 7. Find every ParsedMetadata constructor (any place that builds the struct
 # from scratch is a place that might need your new field set).
@@ -92,7 +103,7 @@ git grep -n 'ParsedMetadata{' pkg/
 git grep -l 'models\.File{' pkg/ --include='*_test.go'
 ```
 
-Save the union of everything these commands return. That's your implementation surface area. If it surprises you, investigate before continuing — there may be recently-added touchpoints not covered by the proxy.
+Save the union of everything these commands return as a deduplicated flat list of absolute paths. That's your implementation surface area. As a sanity check: if the union is fewer than ~10 entries you probably picked too narrow a proxy; if it's more than ~50 your grep is probably too broad. For a good proxy like `language`, expect roughly 25-40 entries. If the result surprises you, investigate before continuing — there may be recently-added touchpoints not covered by the proxy.
 
 **Check for the M4B Freeform write-back trap.** If your field lives in `mp4.Metadata.Freeform` (e.g., `com.shisho:*` or `com.pilabor.tone:*` atoms), verify that `pkg/mp4/writer.go` `buildIlst` actually iterates the Freeform map. Historically the writer dropped freeform atoms silently.
 
@@ -140,12 +151,12 @@ The only places that use `snake_case` for the field name are the database column
 - Supplement downgrade clearing (preserve or clear?)
 - Validation normalization
 
-**Plugin bridge (the easy-to-miss trio)**
-- `pkg/plugins/manifest.go` `ValidMetadataFields`
-- `pkg/plugins/hooks.go` `parseParsedMetadata` (fileParser hook path)
-- `pkg/plugins/hooks.go` `parseSearchResponse` (metadataEnricher hook path)
-- `pkg/plugins/handler.go` `convertFieldsToMetadata` (identify apply path)
-- `pkg/plugins/handler.go` `persistMetadata` — the apply actually writes the field
+**Plugin bridge (multiple parallel paths — easy to miss)**
+- `pkg/plugins/manifest.go` `ValidMetadataFields` — backend validation list
+- `pkg/plugins/hooks.go` `parseParsedMetadata` (fileParser hook path) — JS→Go #1
+- `pkg/plugins/hooks.go` `parseSearchResponse` (metadataEnricher hook path) — JS→Go #2
+- `pkg/plugins/handler.go` `convertFieldsToMetadata` (identify apply path) — JS→Go #3
+- `pkg/plugins/handler.go` `persistMetadata` — the apply path that actually writes the field to the file model
 - `packages/plugin-sdk/metadata.d.ts` — `ParsedMetadata` interface (the runtime data shape)
 - `packages/plugin-sdk/manifest.d.ts` — the `MetadataField` string union (the manifest validation type, separate from `ParsedMetadata`). It's easy to update one and forget the other; both must list the new field.
 
@@ -172,6 +183,7 @@ The only places that use `snake_case` for the field name are the database column
 - `website/docs/supported-formats.md`
 - `website/docs/plugins/development.md`
 - Relevant `pkg/*/CLAUDE.md` files
+- **Do NOT update `website/versioned_docs/`** — those are historical snapshots that document past behavior. Backporting current behavior into them is wrong.
 
 **Tests**
 - Parser extraction tests per format

--- a/.claude/skills/metadata-field/evals/evals.json
+++ b/.claude/skills/metadata-field/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "metadata-field",
+  "evals": [
+    {
+      "id": 1,
+      "name": "edition-note-string-field",
+      "prompt": "I want to add a new `edition_note` field to files in this Shisho codebase. It's a nullable string for things like 'First Edition', 'Annotated Edition', 'Director's Cut'. It should be editable in the file edit dialog, displayable on the book detail and file detail views, settable by plugins (both file parsers and metadata enrichers), persisted in sidecars, and survive a download round-trip for EPUB and CBZ. Please give me a comprehensive plan of every file I'd need to touch and in what order. Don't actually write the implementation — just the plan. Include any non-obvious touchpoints.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "word-count-int-field",
+      "prompt": "Help me add a `word_count` integer field to files for ebook word counts. EPUB and PDF parsers should extract it (PDF can estimate from text extraction). It should be displayed on the file details page and queryable via the API. Plugins should be able to set it via the metadata enricher. Walk me through every file I'd need to update across the backend, frontend, plugin system, and docs.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "remove-chapter-source-field",
+      "prompt": "I want to remove the `chapter_source` field from the files table. It's no longer used. Help me find every place that references it so I can safely delete it without leaving dangling references or broken queries. Don't make the changes yet — just enumerate every file I'd need to touch and what change each one needs.",
+      "files": []
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **When dispatching subagents (for implementation, code review, spec review, or any other task), always include this instruction in the prompt:**
 
-> Check the project's root CLAUDE.md and any relevant subdirectory CLAUDE.md files for rules that apply to your work. These contain critical project conventions, gotchas, and requirements (e.g., docs update requirements, testing conventions, naming rules, metadata sync checklists). Violations of these rules are review failures.
+> Check the project's root CLAUDE.md and any relevant subdirectory CLAUDE.md files for rules that apply to your work. These contain critical project conventions, gotchas, and requirements (e.g., docs update requirements, testing conventions, naming rules). Violations of these rules are review failures.
 
 Subdirectory CLAUDE.md files are loaded automatically when working on files in that directory, but cross-cutting rules (like "update website docs when changing user-facing behavior") live in this root file and are easy to overlook if not explicitly checked.
 
@@ -27,7 +27,7 @@ Project-specific conventions are documented in `CLAUDE.md` files within each sub
 
 | Location | Covers |
 |----------|--------|
-| `pkg/CLAUDE.md` | Go backend: Echo handlers, Bun ORM, workers, metadata sync checklist |
+| `pkg/CLAUDE.md` | Go backend: Echo handlers, Bun ORM, workers |
 | `app/CLAUDE.md` | React frontend: Tanstack Query, components, UI patterns |
 | `pkg/plugins/CLAUDE.md` | Plugin system: Goja runtime, hooks, host APIs, manifests |
 | `pkg/epub/CLAUDE.md` | EPUB format: OPF, Dublin Core, parsing/generation |
@@ -48,6 +48,7 @@ These workflow-based skills (in `.claude/skills/`) are invoked on demand:
 |-------|-------------|
 | `favicon` | Creating or updating favicon, app icons, PWA icons |
 | `splash` | Creating or updating the README splash image |
+| `metadata-field` | Adding, removing, or significantly modifying a metadata field on books or files |
 
 ## Critical Gotchas
 

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -358,32 +358,11 @@ for _, f := range book.Files {
 }
 ```
 
-## Metadata Sync Checklist
+## Adding or Modifying Metadata Fields
 
-When adding or modifying book/file metadata fields, ensure these files are updated:
+**Invoke the `metadata-field` skill when adding or significantly modifying a metadata field on books or files.** The skill walks you through discovery (finding existing touchpoints via grep, not a static list), planning, implementation order, and — most importantly — a verification phase that catches parallel code paths that would otherwise be missed.
 
-1. **Sidecar types** (`pkg/sidecar/types.go`) - Add field to `BookSidecar` or `FileSidecar` struct
-2. **Sidecar conversion** (`pkg/sidecar/sidecar.go`) - Update `BookSidecarFromModel()` or `FileSidecarFromModel()`
-3. **Download fingerprint** (`pkg/downloadcache/fingerprint.go`) - Add field to `Fingerprint` struct and `ComputeFingerprint()` so cache invalidates when metadata changes
-4. **Download filename** (`pkg/downloadcache/filename.go`) - If the field affects display names (like `file.Name`), update `FormatDownloadFilename()` and `FormatKepubDownloadFilename()` to use it
-5. **File parsers** - Update to extract the new field:
-   - EPUB: `pkg/epub/opf.go`
-   - CBZ: `pkg/cbz/cbz.go`
-   - M4B: `pkg/mp4/metadata.go`
-   - PDF: `pkg/pdf/pdf.go`
-6. **File generators** - Update to write the field back:
-   - EPUB: `pkg/filegen/epub.go`
-   - CBZ: `pkg/filegen/cbz.go`
-   - M4B: `pkg/filegen/m4b.go`
-   - PDF: `pkg/filegen/pdf.go`
-   - KePub: `pkg/kepub/cbz.go` (for CBZ-to-KePub conversion)
-7. **Scanner** (`pkg/worker/scan.go`) - Handle the new field during scanning
-8. **ParsedMetadata** (`pkg/mediafile/mediafile.go`) - Add field if it's parsed from files
-9. **API relations** (`pkg/books/service.go`) - If adding a relation to File (like Publisher, Imprint), add `.Relation("Files.NewRelation")` to all book query methods: `RetrieveBook`, `RetrieveBookByFilePath`, and `listBooksWithTotal`
-10. **File retrieval** (`pkg/books/service.go`) - If the new field is a File relation used by sidecar or fingerprint, add it to `RetrieveFileWithRelations()` and consider adding to `RetrieveFile()` if lightweight
-11. **File reorganization** (`pkg/books/handlers.go`) - If the field affects file organization (like `Name`), trigger reorganization when the field changes via the edit endpoint
-12. **Organization options** (`pkg/books/service.go`, `pkg/books/handlers.go`) - If the field should be used for file organization, update all places that build `fileutils.OrganizedNameOptions` to use the new file-level field
-13. **UI display** (`app/components/pages/BookDetail.tsx`) - Display the new field in the book detail view
+Do not rely on a static checklist here: the codebase has accumulated multiple parallel code paths (three separate JS→Go parsers in the plugin bridge, several merge/filter/persist functions in the scanner, per-format file generators, OPDS, Kobo sync, frontend edit/display/filter/identify-review paths) and a hand-maintained list drifts out of date. The skill uses grep against an existing similar field as the authoritative source of truth.
 
 ## File-Level vs Book-Level Fields
 


### PR DESCRIPTION
## Summary
- Adds a new `metadata-field` skill at `.claude/skills/metadata-field/SKILL.md` that uses a discovery-based workflow (grep against an existing similar field) to enumerate the cross-stack touchpoints when adding, removing, or modifying a metadata field on books or files. Includes a verification phase that catches parallel code paths that would otherwise be missed.
- Removes the static "Metadata Sync Checklist" from `pkg/CLAUDE.md` (was incomplete and decayed) and replaces it with a one-line pointer to the skill. Updates the root `CLAUDE.md` skills table.
- Tested across two iterations of three realistic prompts (add string field, add integer field, remove field) with quantitative assertions covering the parallel-path traps that took 9 review rounds to find in the language/abridged PR. With-skill runs hit 100% pass rate (vs ~84% baseline). Test prompts saved to `evals/evals.json`.

## Test plan
- Read the new SKILL.md to verify the four-phase workflow (Discovery, Planning, Implementation, Verification) is clear
- Verify `pkg/CLAUDE.md` no longer contains the static Metadata Sync Checklist and instead points to the skill
- Verify the root `CLAUDE.md` Utility Skills table includes the new `metadata-field` skill
- Optionally invoke the skill against a hypothetical new field (e.g., "add an edition_note field") and confirm it walks through discovery → planning → verification phases
- Sanity-check the workspace directory (`.claude/skills/metadata-field-workspace/`) is gitignored / not committed