### PR TITLE
[Fix] Add language and abridged to plugin SDK MetadataField union

### DIFF
--- a/packages/plugin-sdk/manifest.d.ts
+++ b/packages/plugin-sdk/manifest.d.ts
@@ -45,7 +45,9 @@ export type MetadataField =
   | "url"
   | "releaseDate"
   | "cover"
-  | "identifiers";
+  | "identifiers"
+  | "language"
+  | "abridged";
 
 /** Metadata enricher capability declaration. */
 export interface MetadataEnricherCap {


### PR DESCRIPTION
## Summary
- Add `"language"` and `"abridged"` to the `MetadataField` string union in `packages/plugin-sdk/manifest.d.ts` to match the backend's `ValidMetadataFields` in `pkg/plugins/manifest.go`
- Fixes SDK drift from #64 — `metadata.d.ts` already exposed both fields on `ParsedMetadata`, but `manifest.d.ts` was missed, so TypeScript plugin authors declaring these in `metadataEnricher.fields` would hit a false type error

## Test plan
- `pnpm lint:types` passes
- `mise check:quiet` passes
- Union now matches `ValidMetadataFields` in `pkg/plugins/manifest.go`