### PR TITLE
[Fix] Resolve cover path before deleting on file downgrade

### DIFF
--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -748,10 +748,17 @@ func (h *handler) updateFile(c echo.Context) error {
 
 		// When downgrading from main to supplement, clear all main-file-only metadata
 		if oldRole == models.FileRoleMain && newRole == models.FileRoleSupplement {
-			// Delete cover image file if it exists
-			if file.CoverImageFilename != nil {
-				if err := os.Remove(*file.CoverImageFilename); err != nil && !os.IsNotExist(err) {
-					log.Warn("failed to delete cover image on downgrade", logger.Data{"error": err.Error(), "path": *file.CoverImageFilename})
+			// Delete cover image file if it exists. CoverImageFilename stores just
+			// the filename; the full path is resolved against the book's cover dir
+			// (the book directory, or its parent for root-level books).
+			if file.CoverImageFilename != nil && *file.CoverImageFilename != "" && file.Book != nil {
+				coverDir := file.Book.Filepath
+				if info, statErr := os.Stat(file.Book.Filepath); statErr == nil && !info.IsDir() {
+					coverDir = filepath.Dir(file.Book.Filepath)
+				}
+				coverPath := filepath.Join(coverDir, *file.CoverImageFilename)
+				if err := os.Remove(coverPath); err != nil && !os.IsNotExist(err) {
+					log.Warn("failed to delete cover image on downgrade", logger.Data{"error": err.Error(), "path": coverPath})
 				}
 			}
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -749,16 +749,18 @@ func (h *handler) updateFile(c echo.Context) error {
 		// When downgrading from main to supplement, clear all main-file-only metadata
 		if oldRole == models.FileRoleMain && newRole == models.FileRoleSupplement {
 			// Delete cover image file if it exists. CoverImageFilename stores just
-			// the filename; the full path is resolved against the book's cover dir
-			// (the book directory, or its parent for root-level books).
-			if file.CoverImageFilename != nil && *file.CoverImageFilename != "" && file.Book != nil {
-				coverDir := file.Book.Filepath
-				if info, statErr := os.Stat(file.Book.Filepath); statErr == nil && !info.IsDir() {
-					coverDir = filepath.Dir(file.Book.Filepath)
-				}
-				coverPath := filepath.Join(coverDir, *file.CoverImageFilename)
-				if err := os.Remove(coverPath); err != nil && !os.IsNotExist(err) {
-					log.Warn("failed to delete cover image on downgrade", logger.Data{"error": err.Error(), "path": coverPath})
+			// the filename; fileutils.ResolveCoverPath joins it with the book's
+			// cover directory (book dir, or its parent for root-level books).
+			if file.CoverImageFilename != nil && file.Book != nil {
+				coverPath := fileutils.ResolveCoverPath(file.Book.Filepath, *file.CoverImageFilename)
+				if coverPath != "" {
+					if err := os.Remove(coverPath); err != nil && !os.IsNotExist(err) {
+						log.Warn("failed to delete cover image on downgrade", logger.Data{
+							"error":   err.Error(),
+							"path":    coverPath,
+							"file_id": file.ID,
+						})
+					}
 				}
 			}
 
@@ -1256,26 +1258,14 @@ func (h *handler) fileCover(c echo.Context) error {
 		}
 	}
 
-	// Determine cover directory (same logic as scan worker)
-	isRootLevelBook := false
-	if info, err := os.Stat(file.Book.Filepath); err == nil && !info.IsDir() {
-		isRootLevelBook = true
-	}
-	var coverDir string
-	if isRootLevelBook {
-		coverDir = filepath.Dir(file.Book.Filepath)
-	} else {
-		coverDir = file.Book.Filepath
-	}
-
-	// Cover filename is stored in CoverImageFilename, or fallback to {filename}.cover.{ext}
-	var coverPath string
+	// Cover filename is stored in CoverImageFilename, or fallback to {filename}.cover.{ext}.
+	coverFilename := ""
 	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
-		coverPath = filepath.Join(coverDir, *file.CoverImageFilename)
+		coverFilename = *file.CoverImageFilename
 	} else {
-		filename := filepath.Base(file.Filepath)
-		coverPath = filepath.Join(coverDir, filename+".cover"+file.CoverExtension())
+		coverFilename = filepath.Base(file.Filepath) + ".cover" + file.CoverExtension()
 	}
+	coverPath := fileutils.ResolveCoverPath(file.Book.Filepath, coverFilename)
 
 	return errors.WithStack(c.File(coverPath))
 }

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -783,60 +783,118 @@ func TestDeleteBooks_BulkDeletesBooks(t *testing.T) {
 
 func TestUpdateFile_DowngradeMainToSupplement_DeletesCoverFile(t *testing.T) {
 	t.Parallel()
-	db := setupTestDB(t)
-	ctx := context.Background()
-	library, book := setupTestLibraryAndBook(t, db)
 
-	// Create an EPUB file inside the book directory (book.Filepath is a directory).
-	epubPath := filepath.Join(book.Filepath, "test.epub")
-	require.NoError(t, os.WriteFile(epubPath, []byte("epub content"), 0644))
-	file := setupTestFile(t, db, book, models.FileTypeEPUB, epubPath)
+	// runDowngrade wires up the library/book/file, plants a cover file, hits the
+	// update endpoint to downgrade main → supplement, and asserts the cover file
+	// is gone from disk. The caller picks whether the book is directory-backed
+	// or a root-level file, since the cover dir resolution differs.
+	runDowngrade := func(t *testing.T, makeBook func(t *testing.T, libraryID int) (book *models.Book, bookDir string, filePath string)) {
+		t.Helper()
+		db := setupTestDB(t)
+		ctx := context.Background()
 
-	// Create a cover image next to the book on disk and wire it up in the DB.
-	// CoverImageFilename stores just the filename — the full path is constructed at runtime.
-	coverFilename := "test.epub.cover.jpg"
-	coverFullPath := filepath.Join(book.Filepath, coverFilename)
-	require.NoError(t, os.WriteFile(coverFullPath, []byte("cover data"), 0644))
+		library := &models.Library{
+			Name:                     "Test Library",
+			CoverAspectRatio:         "book",
+			DownloadFormatPreference: models.DownloadFormatOriginal,
+		}
+		_, err := db.NewInsert().Model(library).Exec(ctx)
+		require.NoError(t, err)
 
-	mimeType := "image/jpeg"
-	coverSource := models.DataSourceManual
-	file.CoverImageFilename = &coverFilename
-	file.CoverMimeType = &mimeType
-	file.CoverSource = &coverSource
-	_, err := db.NewUpdate().
-		Model(file).
-		Column("cover_image_filename", "cover_mime_type", "cover_source").
-		WherePK().
-		Exec(ctx)
-	require.NoError(t, err)
+		book, bookDir, epubPath := makeBook(t, library.ID)
+		_, err = db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
 
-	user := setupTestUser(t, db, library.ID, true)
-	// Load the Role with Permissions so RequirePermission middleware can pass.
-	err = db.NewSelect().
-		Model(user).
-		Relation("Role").
-		Relation("Role.Permissions").
-		Where("u.id = ?", user.ID).
-		Scan(ctx)
-	require.NoError(t, err)
+		require.NoError(t, os.WriteFile(epubPath, []byte("epub content"), 0644))
+		file := setupTestFile(t, db, book, models.FileTypeEPUB, epubPath)
 
-	// Downgrade the file from main to supplement via the update endpoint.
-	e := setupTestServer(t, db)
-	body := `{"file_role": "supplement"}`
-	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	rr := executeRequestWithUser(t, e, req, user)
-	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+		// Create a cover image in the resolved cover dir and wire it up in the
+		// DB. CoverImageFilename stores just the filename — the full path is
+		// constructed at runtime.
+		coverFilename := filepath.Base(epubPath) + ".cover.jpg"
+		coverFullPath := filepath.Join(bookDir, coverFilename)
+		require.NoError(t, os.WriteFile(coverFullPath, []byte("cover data"), 0644))
 
-	// The cover file must be removed from disk, not just cleared in the DB.
-	_, statErr := os.Stat(coverFullPath)
-	assert.True(t, os.IsNotExist(statErr),
-		"expected cover file to be deleted on downgrade, but os.Stat(%q) returned err=%v", coverFullPath, statErr)
+		mimeType := "image/jpeg"
+		coverSource := models.DataSourceManual
+		file.CoverImageFilename = &coverFilename
+		file.CoverMimeType = &mimeType
+		file.CoverSource = &coverSource
+		_, err = db.NewUpdate().
+			Model(file).
+			Column("cover_image_filename", "cover_mime_type", "cover_source").
+			WherePK().
+			Exec(ctx)
+		require.NoError(t, err)
 
-	// Sanity check: the DB row should also reflect the downgrade.
-	var updated models.File
-	err = db.NewSelect().Model(&updated).Where("id = ?", file.ID).Scan(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, models.FileRoleSupplement, updated.FileRole)
-	assert.Nil(t, updated.CoverImageFilename)
+		user := setupTestUser(t, db, library.ID, true)
+		// Load the Role with Permissions so RequirePermission middleware can pass.
+		err = db.NewSelect().
+			Model(user).
+			Relation("Role").
+			Relation("Role.Permissions").
+			Where("u.id = ?", user.ID).
+			Scan(ctx)
+		require.NoError(t, err)
+
+		// Downgrade the file from main to supplement via the update endpoint.
+		e := setupTestServer(t, db)
+		body := `{"file_role": "supplement"}`
+		req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rr := executeRequestWithUser(t, e, req, user)
+		require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+		// The cover file must be removed from disk, not just cleared in the DB.
+		_, statErr := os.Stat(coverFullPath)
+		assert.True(t, os.IsNotExist(statErr),
+			"expected cover file to be deleted on downgrade, but os.Stat(%q) returned err=%v", coverFullPath, statErr)
+
+		// Sanity check: the DB row should also reflect the downgrade.
+		var updated models.File
+		err = db.NewSelect().Model(&updated).Where("id = ?", file.ID).Scan(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, models.FileRoleSupplement, updated.FileRole)
+		assert.Nil(t, updated.CoverImageFilename)
+	}
+
+	t.Run("directory-backed book", func(t *testing.T) {
+		t.Parallel()
+		runDowngrade(t, func(t *testing.T, libraryID int) (*models.Book, string, string) {
+			t.Helper()
+			bookDir := t.TempDir()
+			book := &models.Book{
+				LibraryID:       libraryID,
+				Title:           "Test Book",
+				TitleSource:     models.DataSourceFilepath,
+				SortTitle:       "Test Book",
+				SortTitleSource: models.DataSourceFilepath,
+				AuthorSource:    models.DataSourceFilepath,
+				Filepath:        bookDir,
+			}
+			return book, bookDir, filepath.Join(bookDir, "test.epub")
+		})
+	})
+
+	t.Run("root-level book", func(t *testing.T) {
+		t.Parallel()
+		runDowngrade(t, func(t *testing.T, libraryID int) (*models.Book, string, string) {
+			t.Helper()
+			libraryDir := t.TempDir()
+			epubPath := filepath.Join(libraryDir, "root-book.epub")
+			// Root-level books have book.Filepath pointing at the file itself,
+			// not a containing directory. The cover lives alongside the file
+			// in the library dir.
+			book := &models.Book{
+				LibraryID:       libraryID,
+				Title:           "Root Book",
+				TitleSource:     models.DataSourceFilepath,
+				SortTitle:       "Root Book",
+				SortTitleSource: models.DataSourceFilepath,
+				AuthorSource:    models.DataSourceFilepath,
+				Filepath:        epubPath,
+			}
+			return book, libraryDir, epubPath
+		})
+	})
 }

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -780,3 +780,63 @@ func TestDeleteBooks_BulkDeletesBooks(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, count)
 }
+
+func TestUpdateFile_DowngradeMainToSupplement_DeletesCoverFile(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	library, book := setupTestLibraryAndBook(t, db)
+
+	// Create an EPUB file inside the book directory (book.Filepath is a directory).
+	epubPath := filepath.Join(book.Filepath, "test.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub content"), 0644))
+	file := setupTestFile(t, db, book, models.FileTypeEPUB, epubPath)
+
+	// Create a cover image next to the book on disk and wire it up in the DB.
+	// CoverImageFilename stores just the filename — the full path is constructed at runtime.
+	coverFilename := "test.epub.cover.jpg"
+	coverFullPath := filepath.Join(book.Filepath, coverFilename)
+	require.NoError(t, os.WriteFile(coverFullPath, []byte("cover data"), 0644))
+
+	mimeType := "image/jpeg"
+	coverSource := models.DataSourceManual
+	file.CoverImageFilename = &coverFilename
+	file.CoverMimeType = &mimeType
+	file.CoverSource = &coverSource
+	_, err := db.NewUpdate().
+		Model(file).
+		Column("cover_image_filename", "cover_mime_type", "cover_source").
+		WherePK().
+		Exec(ctx)
+	require.NoError(t, err)
+
+	user := setupTestUser(t, db, library.ID, true)
+	// Load the Role with Permissions so RequirePermission middleware can pass.
+	err = db.NewSelect().
+		Model(user).
+		Relation("Role").
+		Relation("Role.Permissions").
+		Where("u.id = ?", user.ID).
+		Scan(ctx)
+	require.NoError(t, err)
+
+	// Downgrade the file from main to supplement via the update endpoint.
+	e := setupTestServer(t, db)
+	body := `{"file_role": "supplement"}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	// The cover file must be removed from disk, not just cleared in the DB.
+	_, statErr := os.Stat(coverFullPath)
+	assert.True(t, os.IsNotExist(statErr),
+		"expected cover file to be deleted on downgrade, but os.Stat(%q) returned err=%v", coverFullPath, statErr)
+
+	// Sanity check: the DB row should also reflect the downgrade.
+	var updated models.File
+	err = db.NewSelect().Model(&updated).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, models.FileRoleSupplement, updated.FileRole)
+	assert.Nil(t, updated.CoverImageFilename)
+}

--- a/pkg/filegen/epub.go
+++ b/pkg/filegen/epub.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
@@ -80,9 +81,7 @@ func (g *EPUBGenerator) Generate(ctx context.Context, srcPath, destPath string, 
 	var newCoverData []byte
 	var newCoverMimeType string
 	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
-		// Resolve the full cover path from the book's directory
-		// CoverImageFilename is just a filename, we need to find the cover directory
-		coverPath := resolveCoverPath(book, file)
+		coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
 		if coverPath != "" {
 			newCoverData, err = os.ReadFile(coverPath)
 			if err == nil {
@@ -506,31 +505,6 @@ func formatFloat(f float64) string {
 		return strconv.Itoa(int(f))
 	}
 	return fmt.Sprintf("%g", f)
-}
-
-// resolveCoverPath resolves the full path to a file's cover image.
-// CoverImageFilename in the model is just a filename, so we need to determine
-// the cover directory from the book's filepath.
-func resolveCoverPath(book *models.Book, file *models.File) string {
-	if file.CoverImageFilename == nil || *file.CoverImageFilename == "" {
-		return ""
-	}
-
-	// Determine if this is a root-level book (book.Filepath is a file, not a directory)
-	isRootLevelBook := false
-	if info, err := os.Stat(book.Filepath); err == nil && !info.IsDir() {
-		isRootLevelBook = true
-	}
-
-	// Determine the cover directory
-	var coverDir string
-	if isRootLevelBook {
-		coverDir = filepath.Dir(book.Filepath)
-	} else {
-		coverDir = book.Filepath
-	}
-
-	return filepath.Join(coverDir, *file.CoverImageFilename)
 }
 
 // identifierTypeToScheme converts an identifier type to an OPF scheme attribute.

--- a/pkg/filegen/m4b.go
+++ b/pkg/filegen/m4b.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/mp4"
@@ -234,7 +235,10 @@ func (g *M4BGenerator) buildMetadata(book *models.Book, file *models.File, src *
 
 // loadCover reads the cover image from the file system and sets it on the metadata.
 func (g *M4BGenerator) loadCover(book *models.Book, file *models.File, meta *mp4.Metadata) error {
-	coverPath := resolveCoverPath(book, file)
+	if file.CoverImageFilename == nil {
+		return nil
+	}
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
 	if coverPath == "" {
 		return nil
 	}

--- a/pkg/fileutils/operations.go
+++ b/pkg/fileutils/operations.go
@@ -417,6 +417,24 @@ func getBaseNameWithoutExt(path string) string {
 	return strings.TrimSuffix(base, ext)
 }
 
+// ResolveCoverPath resolves the full path to a file's cover image on disk.
+// CoverImageFilename in the database stores only the filename, so the full
+// path must be constructed at runtime by joining it with the book's cover
+// directory. For directory-backed books (the common case), the cover dir is
+// the book's filepath itself; for root-level books (where book.Filepath is
+// the file, not a directory), the cover dir is the file's parent.
+// Returns an empty string if coverFilename is empty.
+func ResolveCoverPath(bookFilepath, coverFilename string) string {
+	if coverFilename == "" {
+		return ""
+	}
+	coverDir := bookFilepath
+	if info, err := os.Stat(bookFilepath); err == nil && !info.IsDir() {
+		coverDir = filepath.Dir(bookFilepath)
+	}
+	return filepath.Join(coverDir, coverFilename)
+}
+
 // ComputeNewCoverFilename computes the new cover filename after a file has been renamed.
 // It preserves the cover's extension while updating the base filename to match the new file path.
 // Returns just the filename (e.g., "book.epub.cover.jpg"), not a full path.

--- a/pkg/fileutils/operations_test.go
+++ b/pkg/fileutils/operations_test.go
@@ -885,3 +885,41 @@ func TestMoveFileWithAssociatedFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveCoverPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty cover filename returns empty", func(t *testing.T) {
+		t.Parallel()
+		got := ResolveCoverPath(t.TempDir(), "")
+		assert.Empty(t, got)
+	})
+
+	t.Run("directory-backed book joins cover filename to book dir", func(t *testing.T) {
+		t.Parallel()
+		bookDir := t.TempDir()
+		got := ResolveCoverPath(bookDir, "book.epub.cover.jpg")
+		assert.Equal(t, filepath.Join(bookDir, "book.epub.cover.jpg"), got)
+	})
+
+	t.Run("root-level book joins cover filename to parent of file", func(t *testing.T) {
+		t.Parallel()
+		libraryDir := t.TempDir()
+		bookFilepath := filepath.Join(libraryDir, "book.epub")
+		if err := os.WriteFile(bookFilepath, []byte("epub"), 0644); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+		got := ResolveCoverPath(bookFilepath, "book.epub.cover.jpg")
+		assert.Equal(t, filepath.Join(libraryDir, "book.epub.cover.jpg"), got)
+	})
+
+	t.Run("nonexistent bookFilepath is treated as a directory path", func(t *testing.T) {
+		t.Parallel()
+		// If we can't stat the book path (e.g., because it was moved or deleted),
+		// fall back to treating it as a directory — matches the existing
+		// behavior in filegen.resolveCoverPath and the fileCover handler.
+		bookDir := filepath.Join(t.TempDir(), "missing")
+		got := ResolveCoverPath(bookDir, "book.epub.cover.jpg")
+		assert.Equal(t, filepath.Join(bookDir, "book.epub.cover.jpg"), got)
+	})
+}


### PR DESCRIPTION
## Summary
- When downgrading a main file to a supplement, the handler was passing `file.CoverImageFilename` (a bare filename) directly to `os.Remove`, which silently failed with ENOENT and left orphaned cover files on disk.
- Resolve the full cover path against `file.Book.Filepath` (with the same root-level-book handling used elsewhere) before removing, matching the pattern in `filegen.resolveCoverPath` and the `bookCover` handler.
- Added a handler test that plants a real cover file, downgrades via `POST /books/files/:id`, and asserts the cover is gone from disk.

## Test plan
- `mise check:quiet` passes
- `go test ./pkg/books/ -run TestUpdateFile_DowngradeMainToSupplement_DeletesCoverFile` passes (confirmed fail→pass as TDD red→green)