### PR TITLE
[Fix] Restore PDF cover_page from sidecar on rescan

### DIFF
--- a/internal/testgen/pdf.go
+++ b/internal/testgen/pdf.go
@@ -1,0 +1,89 @@
+package testgen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// PDFOptions configures the generated PDF file.
+type PDFOptions struct {
+	PageCount int // defaults to 3
+}
+
+// GeneratePDF writes a minimal valid PDF with the given page count to the
+// specified directory. The resulting file is parseable by pdfcpu and
+// renderable by go-pdfium, so it can be used in scanner and cover-page tests.
+func GeneratePDF(t *testing.T, dir, filename string, opts PDFOptions) string {
+	t.Helper()
+	pageCount := opts.PageCount
+	if pageCount <= 0 {
+		pageCount = 3
+	}
+
+	path := filepath.Join(dir, filename)
+	if err := writeMinimalPDF(path, pageCount); err != nil {
+		t.Fatalf("failed to generate pdf %s: %v", path, err)
+	}
+	return path
+}
+
+// writeMinimalPDF constructs a minimal PDF (header, catalog, pages, xref,
+// trailer) with the given number of empty pages. Mirrors the fixture helper
+// used in pkg/pdf tests.
+func writeMinimalPDF(outPath string, pageCount int) error {
+	var b strings.Builder
+	var offsets []int
+	objNum := 1
+
+	b.WriteString("%PDF-1.4\n")
+
+	// Object 1: Catalog
+	catalogObj := objNum
+	objNum++
+	offsets = append(offsets, b.Len())
+	b.WriteString(fmt.Sprintf("%d 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n", catalogObj))
+
+	// Object 2: Pages (root page tree node)
+	pagesObj := objNum
+	objNum++
+	offsets = append(offsets, b.Len())
+
+	firstPageObj := objNum
+	kidsParts := make([]string, pageCount)
+	for i := 0; i < pageCount; i++ {
+		kidsParts[i] = fmt.Sprintf("%d 0 R", firstPageObj+i)
+	}
+	kidsArr := strings.Join(kidsParts, " ")
+
+	b.WriteString(fmt.Sprintf("%d 0 obj\n<< /Type /Pages /Kids [%s] /Count %d /MediaBox [0 0 612 792] >>\nendobj\n",
+		pagesObj, kidsArr, pageCount))
+
+	// Page objects
+	for i := 0; i < pageCount; i++ {
+		offsets = append(offsets, b.Len())
+		b.WriteString(fmt.Sprintf("%d 0 obj\n<< /Type /Page /Parent %d 0 R >>\nendobj\n",
+			objNum, pagesObj))
+		objNum++
+	}
+
+	// Xref table
+	xrefOffset := b.Len()
+	b.WriteString("xref\n")
+	b.WriteString(fmt.Sprintf("0 %d\n", objNum))
+	b.WriteString("0000000000 65535 f \n")
+	for _, off := range offsets {
+		b.WriteString(fmt.Sprintf("%010d 00000 n \n", off))
+	}
+
+	// Trailer
+	b.WriteString("trailer\n")
+	b.WriteString(fmt.Sprintf("<< /Size %d /Root %d 0 R >>\n", objNum, catalogObj))
+	b.WriteString("startxref\n")
+	b.WriteString(fmt.Sprintf("%d\n", xrefOffset))
+	b.WriteString("%%EOF\n")
+
+	return os.WriteFile(outPath, []byte(b.String()), 0600)
+}

--- a/pkg/pdf/cover.go
+++ b/pkg/pdf/cover.go
@@ -131,6 +131,12 @@ func PdfiumInstance(timeout time.Duration) (pdfium.Pdfium, error) {
 
 // renderPageCover renders page 1 of a PDF to JPEG using go-pdfium WASM.
 func renderPageCover(path string) ([]byte, string, error) {
+	return RenderPageJPEG(path, 0, 150, 85)
+}
+
+// RenderPageJPEG renders a single page of a PDF to JPEG using the shared
+// pdfium WASM pool. pageIdx is 0-indexed.
+func RenderPageJPEG(path string, pageIdx int, dpi int, quality int) ([]byte, string, error) {
 	instance, err := PdfiumInstance(30 * time.Second)
 	if err != nil {
 		return nil, "", err
@@ -150,11 +156,11 @@ func renderPageCover(path string) ([]byte, string, error) {
 	}()
 
 	render, err := instance.RenderPageInDPI(&requests.RenderPageInDPI{
-		DPI: 150,
+		DPI: dpi,
 		Page: requests.Page{
 			ByIndex: &requests.PageByIndex{
 				Document: doc.Document,
-				Index:    0,
+				Index:    pageIdx,
 			},
 		},
 	})
@@ -163,9 +169,8 @@ func renderPageCover(path string) ([]byte, string, error) {
 	}
 	defer render.Cleanup()
 
-	// Encode the rendered RGBA image to JPEG.
 	var buf bytes.Buffer
-	if err := jpeg.Encode(&buf, render.Result.Image, &jpeg.Options{Quality: 85}); err != nil {
+	if err := jpeg.Encode(&buf, render.Result.Image, &jpeg.Options{Quality: quality}); err != nil {
 		return nil, "", err
 	}
 

--- a/pkg/pdf/cover.go
+++ b/pkg/pdf/cover.go
@@ -13,6 +13,7 @@ import (
 	"github.com/klippa-app/go-pdfium/webassembly"
 	"github.com/pdfcpu/pdfcpu/pkg/api"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
+	"github.com/pkg/errors"
 )
 
 // pdfiumPool is lazily initialized on first use via pdfiumOnce.
@@ -137,6 +138,10 @@ func renderPageCover(path string) ([]byte, string, error) {
 // RenderPageJPEG renders a single page of a PDF to JPEG using the shared
 // pdfium WASM pool. pageIdx is 0-indexed.
 func RenderPageJPEG(path string, pageIdx int, dpi int, quality int) ([]byte, string, error) {
+	if pageIdx < 0 {
+		return nil, "", errors.Errorf("page %d out of range", pageIdx)
+	}
+
 	instance, err := PdfiumInstance(30 * time.Second)
 	if err != nil {
 		return nil, "", err
@@ -154,6 +159,16 @@ func RenderPageJPEG(path string, pageIdx int, dpi int, quality int) ([]byte, str
 			Document: doc.Document,
 		})
 	}()
+
+	pageCountResp, err := instance.FPDF_GetPageCount(&requests.FPDF_GetPageCount{
+		Document: doc.Document,
+	})
+	if err != nil {
+		return nil, "", errors.Wrap(err, "failed to get page count")
+	}
+	if pageIdx >= pageCountResp.PageCount {
+		return nil, "", errors.Errorf("page %d out of range (0-%d)", pageIdx, pageCountResp.PageCount-1)
+	}
 
 	render, err := instance.RenderPageInDPI(&requests.RenderPageInDPI{
 		DPI: dpi,

--- a/pkg/sidecar/types.go
+++ b/pkg/sidecar/types.go
@@ -30,7 +30,7 @@ type FileSidecar struct {
 	Identifiers []IdentifierMetadata `json:"identifiers,omitempty"`
 	Name        *string              `json:"name,omitempty"`
 	Chapters    []ChapterMetadata    `json:"chapters,omitempty"`
-	CoverPage   *int                 `json:"cover_page,omitempty"` // 0-indexed page number for CBZ cover
+	CoverPage   *int                 `json:"cover_page,omitempty"` // 0-indexed page number for page-based formats (CBZ, PDF)
 	Language    *string              `json:"language,omitempty"`
 	Abridged    *bool                `json:"abridged,omitempty"`
 }

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -1887,9 +1887,9 @@ func (w *Worker) scanFileCore(
 		}
 	}
 
-	// Update cover page (from sidecar) for CBZ files
-	// This restores user-selected cover page from sidecar after library rescans
-	if fileSidecarData != nil && fileSidecarData.CoverPage != nil && file.FileType == models.FileTypeCBZ {
+	// Update cover page (from sidecar) for page-based formats (CBZ, PDF).
+	// This restores user-selected cover page from sidecar after library rescans.
+	if fileSidecarData != nil && fileSidecarData.CoverPage != nil && models.IsPageBasedFileType(file.FileType) {
 		existingCoverSource := ""
 		if file.CoverSource != nil {
 			existingCoverSource = *file.CoverSource
@@ -1925,8 +1925,14 @@ func (w *Worker) scanFileCore(
 			filename := filepath.Base(file.Filepath)
 			coverBaseName := filename + ".cover"
 
-			// Extract the cover page from CBZ
-			coverFilename, coverMimeType, err := extractCBZPageCover(file.Filepath, coverDir, coverBaseName, *fileSidecarData.CoverPage)
+			// Extract the cover page from the source file.
+			var coverFilename, coverMimeType string
+			switch file.FileType {
+			case models.FileTypePDF:
+				coverFilename, coverMimeType, err = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, *fileSidecarData.CoverPage)
+			default:
+				coverFilename, coverMimeType, err = extractCBZPageCover(file.Filepath, coverDir, coverBaseName, *fileSidecarData.CoverPage)
+			}
 			if err != nil {
 				logWarn("failed to extract cover page from sidecar", logger.Data{
 					"error":      err.Error(),
@@ -3535,6 +3541,32 @@ func extractCBZPageCover(cbzPath string, coverDir string, coverBaseName string, 
 	}
 
 	return coverBaseName + ext, mimeType, nil
+}
+
+// extractPDFPageCover renders a specific page from a PDF file via pdfium and
+// saves it as the cover image. Returns the cover filename (relative to
+// coverDir), mime type, and any error. pageNum is 0-indexed.
+func extractPDFPageCover(pdfPath string, coverDir string, coverBaseName string, pageNum int) (string, string, error) {
+	data, mimeType, err := pdf.RenderPageJPEG(pdfPath, pageNum, 150, 85)
+	if err != nil {
+		return "", "", errors.Wrap(err, "failed to render pdf page")
+	}
+
+	// Delete any existing cover with this base name (regardless of extension).
+	for _, existingExt := range fileutils.CoverImageExtensions {
+		existingPath := filepath.Join(coverDir, coverBaseName+existingExt)
+		if _, statErr := os.Stat(existingPath); statErr == nil {
+			_ = os.Remove(existingPath)
+		}
+	}
+
+	coverFilename := coverBaseName + ".jpg"
+	coverFilePath := filepath.Join(coverDir, coverFilename)
+	if err := os.WriteFile(coverFilePath, data, 0644); err != nil { //nolint:gosec // Cover files need to be readable by the HTTP server
+		return "", "", errors.WithStack(err)
+	}
+
+	return coverFilename, mimeType, nil
 }
 
 // getConfidenceThresholdFromCache returns the effective confidence threshold

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -1930,8 +1930,10 @@ func (w *Worker) scanFileCore(
 			switch file.FileType {
 			case models.FileTypePDF:
 				coverFilename, coverMimeType, err = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, *fileSidecarData.CoverPage)
-			default:
+			case models.FileTypeCBZ:
 				coverFilename, coverMimeType, err = extractCBZPageCover(file.Filepath, coverDir, coverBaseName, *fileSidecarData.CoverPage)
+			default:
+				err = errors.Errorf("unsupported page-based file type for cover extraction: %s", file.FileType)
 			}
 			if err != nil {
 				logWarn("failed to extract cover page from sidecar", logger.Data{

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -4199,6 +4199,9 @@ func TestScanFileCore_PDFCoverPageRestoredFromSidecar(t *testing.T) {
 	require.NotNil(t, updatedFile.CoverSource)
 	assert.Equal(t, models.DataSourceSidecar, *updatedFile.CoverSource)
 
+	require.NotNil(t, updatedFile.CoverMimeType)
+	assert.Equal(t, "image/jpeg", *updatedFile.CoverMimeType)
+
 	// The cover image should have been extracted and saved to disk.
 	require.NotNil(t, updatedFile.CoverImageFilename)
 	coverPath := filepath.Join(bookDir, *updatedFile.CoverImageFilename)

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -4132,3 +4132,76 @@ func TestScanFileCore_Chapters_EmptyChapters_Skipped(t *testing.T) {
 	require.Len(t, chapters, 1)
 	assert.Equal(t, "Existing Chapter", chapters[0].Title)
 }
+
+// TestScanFileCore_PDFCoverPageRestoredFromSidecar is a regression test for a
+// bug where the sidecar `cover_page` restore path was gated on file type ==
+// CBZ, silently dropping user-selected PDF cover pages on rescan. The sidecar
+// should be the source of truth for both CBZ and PDF.
+func TestScanFileCore_PDFCoverPageRestoredFromSidecar(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "Test PDF Book")
+
+	// Create a real PDF on disk so cover page rendering can succeed.
+	pdfPath := testgen.GeneratePDF(t, bookDir, "book.pdf", testgen.PDFOptions{PageCount: 5})
+
+	// Create book and file records simulating a prior scan where CoverPage
+	// started at 0 (the default from pdf.Parse).
+	book := &models.Book{
+		LibraryID:    1,
+		Filepath:     bookDir,
+		Title:        "Test PDF Book",
+		TitleSource:  models.DataSourceFilepath,
+		SortTitle:    "Test PDF Book",
+		AuthorSource: models.DataSourceFilepath,
+	}
+	require.NoError(t, tc.bookService.CreateBook(tc.ctx, book))
+
+	zero := 0
+	filepathSource := models.DataSourceFilepath
+	file := &models.File{
+		LibraryID:     1,
+		BookID:        book.ID,
+		Filepath:      pdfPath,
+		FileType:      models.FileTypePDF,
+		FilesizeBytes: 1000,
+		CoverPage:     &zero,
+		CoverSource:   &filepathSource,
+	}
+	require.NoError(t, tc.bookService.CreateFile(tc.ctx, file))
+
+	// Write a sidecar with a user-selected cover page (2) that differs from
+	// the default (0). On rescan, the scanner should honor this.
+	sidecarPath := pdfPath + ".metadata.json"
+	sidecarContent := `{"version":1,"cover_page":2}`
+	require.NoError(t, os.WriteFile(sidecarPath, []byte(sidecarContent), 0644))
+
+	// Fresh metadata from a re-parse: pdf.Parse always returns CoverPage=0.
+	reparsedCoverPage := 0
+	metadata := &mediafile.ParsedMetadata{
+		DataSource: models.DataSourcePDFMetadata,
+		CoverPage:  &reparsedCoverPage,
+	}
+
+	_, err := tc.worker.scanFileCore(tc.ctx, file, book, metadata, false, true, nil, nil)
+	require.NoError(t, err)
+
+	updatedFile, err := tc.bookService.RetrieveFile(tc.ctx, books.RetrieveFileOptions{ID: &file.ID})
+	require.NoError(t, err)
+
+	require.NotNil(t, updatedFile.CoverPage)
+	assert.Equal(t, 2, *updatedFile.CoverPage, "PDF cover_page should be restored from sidecar")
+
+	require.NotNil(t, updatedFile.CoverSource)
+	assert.Equal(t, models.DataSourceSidecar, *updatedFile.CoverSource)
+
+	// The cover image should have been extracted and saved to disk.
+	require.NotNil(t, updatedFile.CoverImageFilename)
+	coverPath := filepath.Join(bookDir, *updatedFile.CoverImageFilename)
+	_, statErr := os.Stat(coverPath)
+	assert.NoError(t, statErr, "extracted cover image should exist on disk at %s", coverPath)
+}


### PR DESCRIPTION
## Summary
- The sidecar `cover_page` restore path in `scan_unified.go` was gated on `FileType == CBZ`, so PDF files with a user-selected cover page silently reverted to page 0 on rescan.
- Extend the gate to all page-based formats via `models.IsPageBasedFileType` and dispatch extraction: CBZ continues to use the zip-based path; PDF now renders the target page via pdfium.
- Adds exported `pdf.RenderPageJPEG` helper (reused by the existing `renderPageCover`), a `testgen.GeneratePDF` helper for scan tests, and regression test `TestScanFileCore_PDFCoverPageRestoredFromSidecar`.

## Test plan
- `mise check:quiet` passes (Go tests, Go lint, JS tests, JS lint).
- New regression test fails on master and passes after the fix.
- Manual: set a non-zero PDF cover page via the API, trigger a rescan, and verify `file.cover_page` is preserved and the cover image on disk matches the selected page.