### PR TITLE
[Feature] Write edited PDF chapters back as bookmarks on download

### DIFF
--- a/app/components/files/ChapterRow.test.tsx
+++ b/app/components/files/ChapterRow.test.tsx
@@ -271,8 +271,12 @@ describe("ChapterRow - M4B Playback", () => {
     });
   });
 
-  describe("edit mode timestamp buttons trigger reorder", () => {
-    it("calls onBlur after clicking decrement timestamp button", async () => {
+  describe("edit mode timestamp buttons commit but do not reorder", () => {
+    // Button clicks intentionally do NOT fire onBlur so rapid clicking can't
+    // swap the chapter row under the user's cursor. onBlur reorder is
+    // reserved for explicit commit actions (input blur, page picker).
+
+    it("commits but does not reorder after clicking decrement timestamp button", async () => {
       const user = userEvent.setup();
       const onBlur = vi.fn();
       const onStartTimestampChange = vi.fn();
@@ -305,10 +309,10 @@ describe("ChapterRow - M4B Playback", () => {
       await user.click(minusButton);
 
       expect(onStartTimestampChange).toHaveBeenCalledWith(59000);
-      expect(onBlur).toHaveBeenCalled();
+      expect(onBlur).not.toHaveBeenCalled();
     });
 
-    it("calls onBlur after clicking increment timestamp button", async () => {
+    it("commits but does not reorder after clicking increment timestamp button", async () => {
       const user = userEvent.setup();
       const onBlur = vi.fn();
       const onStartTimestampChange = vi.fn();
@@ -341,7 +345,7 @@ describe("ChapterRow - M4B Playback", () => {
       await user.click(plusButton);
 
       expect(onStartTimestampChange).toHaveBeenCalledWith(61000);
-      expect(onBlur).toHaveBeenCalled();
+      expect(onBlur).not.toHaveBeenCalled();
     });
   });
 });
@@ -407,8 +411,12 @@ describe("ChapterRow - CBZ", () => {
     expect(screen.getByText("Chapter 1")).toBeInTheDocument();
   });
 
-  describe("edit mode page arrows trigger reorder", () => {
-    it("calls onBlur after clicking decrement page button", async () => {
+  describe("edit mode page arrows commit but do not reorder", () => {
+    // Button clicks intentionally do NOT fire onBlur so rapid clicking can't
+    // swap the chapter row under the user's cursor. onBlur reorder is
+    // reserved for explicit commit actions (input blur, page picker).
+
+    it("commits but does not reorder after clicking decrement page button", async () => {
       const user = userEvent.setup();
       const onBlur = vi.fn();
       const onStartPageChange = vi.fn();
@@ -437,10 +445,10 @@ describe("ChapterRow - CBZ", () => {
       await user.click(prevButton);
 
       expect(onStartPageChange).toHaveBeenCalledWith(4);
-      expect(onBlur).toHaveBeenCalled();
+      expect(onBlur).not.toHaveBeenCalled();
     });
 
-    it("calls onBlur after clicking increment page button", async () => {
+    it("commits but does not reorder after clicking increment page button", async () => {
       const user = userEvent.setup();
       const onBlur = vi.fn();
       const onStartPageChange = vi.fn();
@@ -469,7 +477,7 @@ describe("ChapterRow - CBZ", () => {
       await user.click(nextButton);
 
       expect(onStartPageChange).toHaveBeenCalledWith(6);
-      expect(onBlur).toHaveBeenCalled();
+      expect(onBlur).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/files/ChapterRow.tsx
+++ b/app/components/files/ChapterRow.tsx
@@ -257,21 +257,24 @@ const ChapterRow = (props: ChapterRowProps) => {
   };
 
   // Page handler: Decrement page
+  // Does NOT call props.onBlur — rapid clicking +/- must not trigger the
+  // parent's reorder, otherwise the DOM element at the user's click position
+  // can get swapped for a different chapter mid-click and the next click
+  // silently updates the wrong chapter. The parent's reorder still fires
+  // from the real input blur handler and from PagePicker selection below.
   const handleDecrementPage = () => {
     const newPage = Math.max(0, currentPage - 1);
     setLocalPageValue(String(newPage + 1)); // Display is 1-indexed
     setHasPageError(false);
     props.onStartPageChange?.(newPage);
-    props.onBlur?.();
   };
 
-  // Page handler: Increment page
+  // Page handler: Increment page (see handleDecrementPage for onBlur rationale)
   const handleIncrementPage = () => {
     const newPage = Math.min(pageCount - 1, currentPage + 1);
     setLocalPageValue(String(newPage + 1)); // Display is 1-indexed
     setHasPageError(false);
     props.onStartPageChange?.(newPage);
-    props.onBlur?.();
   };
 
   // Page handler: Page selection from picker (receives 0-indexed page)
@@ -316,23 +319,23 @@ const ChapterRow = (props: ChapterRowProps) => {
   };
 
   // M4B handler: Decrement timestamp by 1 second
+  // Does NOT call props.onBlur (see handleDecrementPage for rationale).
   const handleDecrementTimestamp = () => {
     const newMs = Math.max(0, currentTimestampMs - 1000);
     setLocalTimestampValue(formatTimestampMs(newMs));
     setHasTimestampError(false);
     props.onValidationChange?.(chapter.id, false);
     props.onStartTimestampChange?.(newMs);
-    props.onBlur?.();
   };
 
   // M4B handler: Increment timestamp by 1 second
+  // Does NOT call props.onBlur (see handleDecrementPage for rationale).
   const handleIncrementTimestamp = () => {
     const newMs = Math.min(maxDurationMs, currentTimestampMs + 1000);
     setLocalTimestampValue(formatTimestampMs(newMs));
     setHasTimestampError(false);
     props.onValidationChange?.(chapter.id, false);
     props.onStartTimestampChange?.(newMs);
-    props.onBlur?.();
   };
 
   // EPUB edit mode

--- a/app/components/files/FileChaptersTab.test.tsx
+++ b/app/components/files/FileChaptersTab.test.tsx
@@ -707,4 +707,44 @@ describe("FileChaptersTab - PDF chapter page increment regression", () => {
     expect(pageInputs[0].value).toBe("8");
     expect(pageInputs[1].value).toBe("6");
   });
+
+  it("typing a new page number and blurring reorders the chapters", async () => {
+    // The companion behavior: typing a page number into an input and tabbing
+    // out is an explicit "commit" gesture, so the parent does reorder on
+    // blur. Only button clicks intentionally skip the reorder.
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <FileChaptersTab
+        file={mockPdfFile}
+        isEditing={true}
+        onEditingChange={vi.fn()}
+      />,
+    );
+
+    await screen.findByDisplayValue("Alpha");
+
+    const pageInputs = screen.getAllByRole("spinbutton") as HTMLInputElement[];
+    expect(pageInputs[0].value).toBe("1"); // Alpha at display 1 (0-indexed 0)
+    expect(pageInputs[1].value).toBe("6"); // Bravo at display 6 (0-indexed 5)
+
+    // Retarget Alpha to page 10 (display 10 → 0-indexed 9).
+    await user.clear(pageInputs[0]);
+    await user.type(pageInputs[0], "10");
+    await user.tab(); // Blur the input → parent sorts by start_page.
+
+    // After reorder, Bravo (page 5) should be first and Alpha (page 9)
+    // should be second. The title inputs and the page inputs both move.
+    const titleInputsAfter = screen.getAllByPlaceholderText(
+      "Chapter title",
+    ) as HTMLInputElement[];
+    expect(titleInputsAfter[0].value).toBe("Bravo");
+    expect(titleInputsAfter[1].value).toBe("Alpha");
+
+    const pageInputsAfter = screen.getAllByRole(
+      "spinbutton",
+    ) as HTMLInputElement[];
+    expect(pageInputsAfter[0].value).toBe("6");
+    expect(pageInputsAfter[1].value).toBe("10");
+  });
 });

--- a/app/components/files/FileChaptersTab.test.tsx
+++ b/app/components/files/FileChaptersTab.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useFileChapters } from "@/hooks/queries/chapters";
-import { FileTypeM4B, type Chapter, type File } from "@/types";
+import { FileTypeM4B, FileTypePDF, type Chapter, type File } from "@/types";
 
 // Mock the API hooks
 vi.mock("@/hooks/queries/chapters", () => ({
@@ -620,18 +620,18 @@ describe("FileChaptersTab - Edit mode play after timestamp change", () => {
   });
 });
 
-describe("FileChaptersTab - Timestamp reorder stops playback", () => {
-  const mockM4bFile: File = {
+describe("FileChaptersTab - PDF chapter page increment regression", () => {
+  const mockPdfFile: File = {
     id: 1,
     created_at: "2024-01-01T00:00:00Z",
     updated_at: "2024-01-01T00:00:00Z",
     book_id: 1,
     library_id: 1,
-    file_type: FileTypeM4B,
+    file_type: FileTypePDF,
     file_role: "main",
-    filepath: "/test/book.m4b",
+    filepath: "/test/book.pdf",
     filesize_bytes: 1000000,
-    audiobook_duration_seconds: 3600,
+    page_count: 100,
   };
 
   const mockChapters: Chapter[] = [
@@ -640,9 +640,9 @@ describe("FileChaptersTab - Timestamp reorder stops playback", () => {
       created_at: "2024-01-01T00:00:00Z",
       updated_at: "2024-01-01T00:00:00Z",
       file_id: 1,
-      title: "Chapter 1",
+      title: "Alpha",
       sort_order: 0,
-      start_timestamp_ms: 0,
+      start_page: 0,
       children: [],
     },
     {
@@ -650,9 +650,9 @@ describe("FileChaptersTab - Timestamp reorder stops playback", () => {
       created_at: "2024-01-01T00:00:00Z",
       updated_at: "2024-01-01T00:00:00Z",
       file_id: 1,
-      title: "Chapter 2",
+      title: "Bravo",
       sort_order: 1,
-      start_timestamp_ms: 60000,
+      start_page: 5,
       children: [],
     },
   ];
@@ -666,50 +666,45 @@ describe("FileChaptersTab - Timestamp reorder stops playback", () => {
     } as ReturnType<typeof useFileChapters>);
   });
 
-  it("stops playback when timestamp input loses focus (triggers reorder)", async () => {
+  it("clicking next-page on the first chapter past the second's page does not mutate the second chapter", async () => {
+    // Regression: live sort-on-blur combined with index-based React keys
+    // meant that once the first chapter's page crossed the second's, the DOM
+    // element at screen position 0 got reused for the (now-first) second
+    // chapter, and the user's next click on that position silently
+    // incremented the wrong chapter.
     const user = userEvent.setup();
 
     renderWithProviders(
       <FileChaptersTab
-        file={mockM4bFile}
+        file={mockPdfFile}
         isEditing={true}
         onEditingChange={vi.fn()}
       />,
     );
 
-    // Find play buttons in edit mode - they're part of the timestamp controls
-    // In edit mode, there are multiple buttons per row (play, -, +, delete)
-    const allButtons = screen.getAllByRole("button");
+    // Wait for edit mode to initialize from the mocked chapters.
+    await screen.findByDisplayValue("Alpha");
 
-    // Find a play button by looking for one that doesn't have specific text
-    // Play buttons are the ones without visible text content
-    const playButtons = allButtons.filter((btn) => {
-      const svg = btn.querySelector("svg");
-      return svg?.classList.contains("lucide-play");
-    });
+    // Find the "Next page" buttons — one per chapter row.
+    const nextButtons = screen.getAllByRole("button", { name: /next page/i });
+    expect(nextButtons.length).toBe(2);
 
-    if (playButtons.length > 0) {
-      // Play the first chapter
-      await user.click(playButtons[0]);
-      expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled();
-
-      // Find timestamp inputs
-      const timestampInputs = screen.getAllByRole("textbox");
-      const chapterTimestampInputs = timestampInputs.filter((input) =>
-        (input as HTMLInputElement).value.includes(":"),
-      );
-
-      if (chapterTimestampInputs.length > 0) {
-        // Change timestamp and blur to trigger reorder
-        await user.clear(chapterTimestampInputs[0]);
-        await user.type(chapterTimestampInputs[0], "00:02:00.000");
-        await user.tab(); // Blur the input
-
-        // Playback should be stopped due to reorder
-        await waitFor(() => {
-          expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalled();
-        });
-      }
+    // Click Alpha's + button 7 times. This would push Alpha from page 0 to
+    // page 7, crossing Bravo's page 5.
+    for (let i = 0; i < 7; i++) {
+      await user.click(nextButtons[0]);
     }
+
+    // The first row should still be Alpha with its page advanced to 8
+    // (0-indexed 7 + 1 for display). Bravo should be untouched at display 6.
+    const titleInputs = screen.getAllByPlaceholderText(
+      "Chapter title",
+    ) as HTMLInputElement[];
+    expect(titleInputs[0].value).toBe("Alpha");
+    expect(titleInputs[1].value).toBe("Bravo");
+
+    const pageInputs = screen.getAllByRole("spinbutton") as HTMLInputElement[];
+    expect(pageInputs[0].value).toBe("8");
+    expect(pageInputs[1].value).toBe("6");
   });
 });

--- a/app/components/files/FileChaptersTab.tsx
+++ b/app/components/files/FileChaptersTab.tsx
@@ -51,14 +51,50 @@ interface FileChaptersTabProps {
 }
 
 /**
+ * Chapter shape used inside edit mode. The `_editKey` is a stable client-side
+ * identifier assigned when a chapter enters edit state (either by loading from
+ * the server or by being added via an Add Chapter button). Using `_editKey` as
+ * the React `key` prevents index-based reconciliation bugs where editing one
+ * chapter could silently mutate a sibling after a reorder.
+ *
+ * `_editKey` is stripped before submitting to the server via `stripEditKeys`.
+ */
+interface EditedChapter extends ChapterInput {
+  _editKey: string;
+  children: EditedChapter[];
+}
+
+// Module-level counter for generating unique edit keys. Keys only need to be
+// unique within a single edit session, so a monotonic counter is sufficient.
+let editKeyCounter = 0;
+const nextEditKey = () => `ek-${++editKeyCounter}`;
+
+const toEditedChapters = (chapters: ChapterInput[]): EditedChapter[] =>
+  chapters.map((c) => ({
+    ...c,
+    _editKey: nextEditKey(),
+    children: toEditedChapters(c.children ?? []),
+  }));
+
+const stripEditKeys = (chapters: EditedChapter[]): ChapterInput[] =>
+  chapters.map((chapter) => ({
+    title: chapter.title,
+    start_page: chapter.start_page,
+    start_timestamp_ms: chapter.start_timestamp_ms,
+    href: chapter.href,
+    children: stripEditKeys(chapter.children),
+  }));
+
+/**
  * Creates a new chapter with appropriate defaults based on file type.
  * - CBZ/PDF: start_page defaults to 0
  * - M4B: start_timestamp_ms defaults to 0
  */
-const createNewChapter = (fileType: string): ChapterInput => {
-  const chapter: ChapterInput = {
+const createNewChapter = (fileType: string): EditedChapter => {
+  const chapter: EditedChapter = {
     title: "",
     children: [],
+    _editKey: nextEditKey(),
   };
 
   if (fileType === FileTypeCBZ || fileType === FileTypePDF) {
@@ -77,7 +113,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     const updateChaptersMutation = useUpdateFileChapters(file.id);
 
     // State for edited chapters (used in edit mode)
-    const [editedChapters, setEditedChapters] = useState<ChapterInput[]>([]);
+    const [editedChapters, setEditedChapters] = useState<EditedChapter[]>([]);
 
     // Track validation errors by chapter index (for M4B timestamp validation)
     const [validationErrors, setValidationErrors] = useState<
@@ -88,7 +124,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     const editInitializedRef = useRef(false);
 
     // Store initial chapters for change detection
-    const [initialChapters, setInitialChapters] = useState<ChapterInput[]>([]);
+    const [initialChapters, setInitialChapters] = useState<EditedChapter[]>([]);
 
     // M4B audio playback state
     const audioRef = useRef<HTMLAudioElement>(null);
@@ -105,7 +141,9 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     // Initialize editedChapters when entering edit mode
     useEffect(() => {
       if (isEditing && !editInitializedRef.current && chapters.length > 0) {
-        const chaptersAsInput = chaptersToInputArray(chapters);
+        const chaptersAsInput = toEditedChapters(
+          chaptersToInputArray(chapters),
+        );
         setEditedChapters(chaptersAsInput);
         setInitialChapters(chaptersAsInput);
         editInitializedRef.current = true;
@@ -303,13 +341,16 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
      * Adds a new chapter at page 0 and enters edit mode.
      */
     const handleAddChapterAtPageZero = () => {
-      const newChapter: ChapterInput = {
+      const newChapter: EditedChapter = {
         title: "",
         start_page: 0,
         children: [],
+        _editKey: nextEditKey(),
       };
       // Prepend the new chapter to existing chapters
-      const existingChaptersAsInputs = chaptersToInputArray(chapters);
+      const existingChaptersAsInputs = toEditedChapters(
+        chaptersToInputArray(chapters),
+      );
       setEditedChapters([newChapter, ...existingChaptersAsInputs]);
       setInitialChapters(existingChaptersAsInputs); // Initial is the existing chapters
       editInitializedRef.current = true;
@@ -319,11 +360,14 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     /**
      * Handles saving edited chapters. Normalizes chapter order (page-based
      * sorted by start_page, M4B sorted by start_timestamp_ms) before the
-     * mutation fires so out-of-order edits can't land in the DB even when
-     * the user saves without triggering an input blur.
+     * mutation fires so out-of-order edits can't land in the DB, then strips
+     * client-only `_editKey` fields before sending to the server.
      */
     const handleSave = () => {
-      const normalized = normalizeChapterOrder(editedChapters, file.file_type);
+      const normalized = normalizeChapterOrder(
+        stripEditKeys(editedChapters),
+        file.file_type,
+      );
       updateChaptersMutation.mutate(
         { chapters: normalized },
         {
@@ -379,15 +423,11 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
       onActionStateChange,
     ]);
 
-    /**
-     * Handles blur on page input - reorders chapters by start_page.
-     * The array position determines chapter order (API derives sort_order from array index).
-     */
-    const handleBlurReorder = () => {
-      setEditedChapters((prev) =>
-        [...prev].sort((a, b) => (a.start_page ?? 0) - (b.start_page ?? 0)),
-      );
-    };
+    // Note: chapters are intentionally NOT reordered during edit. Live
+    // sort-on-blur combined with React's stable keys caused a subtle bug
+    // where clicking a page +/- button could mutate a sibling chapter
+    // after the reorder swapped positions. Order normalization now happens
+    // only once, in `handleSave`, via `normalizeChapterOrder`.
 
     /**
      * Handles adding a new chapter for page-based files.
@@ -400,28 +440,15 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
       const startPage = lastChapter ? (lastChapter.start_page ?? 0) + 1 : 0;
       const title = lastChapter ? getNextChapterTitle(lastChapter.title) : "";
 
-      const newChapter: ChapterInput = {
+      const newChapter: EditedChapter = {
         title,
         start_page: startPage,
         children: [],
+        _editKey: nextEditKey(),
       };
 
       setEditedChapters((prev) => [...prev, newChapter]);
     };
-
-    /**
-     * Handles blur on timestamp input - reorders chapters by start_timestamp_ms.
-     * The array position determines chapter order (API derives sort_order from array index).
-     * Stops any current playback since reordering invalidates the playing index.
-     */
-    const handleTimestampBlurReorder = useCallback(() => {
-      handleAudioStop();
-      setEditedChapters((prev) =>
-        [...prev].sort(
-          (a, b) => (a.start_timestamp_ms ?? 0) - (b.start_timestamp_ms ?? 0),
-        ),
-      );
-    }, [handleAudioStop]);
 
     /**
      * Handles adding a new chapter for M4B files.
@@ -436,10 +463,11 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
         : 0;
       const title = lastChapter ? getNextChapterTitle(lastChapter.title) : "";
 
-      const newChapter: ChapterInput = {
+      const newChapter: EditedChapter = {
         title,
         start_timestamp_ms: startTimestampMs,
         children: [],
+        _editKey: nextEditKey(),
       };
 
       setEditedChapters((prev) => [...prev, newChapter]);
@@ -450,10 +478,10 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
      * For EPUB, chapters can be nested, so we need to handle the path.
      */
     const updateChapterTitle = (
-      chapters: ChapterInput[],
+      chapters: EditedChapter[],
       index: number,
       title: string,
-    ): ChapterInput[] => {
+    ): EditedChapter[] => {
       return chapters.map((chapter, i) => {
         if (i === index) {
           return { ...chapter, title };
@@ -466,10 +494,10 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
      * Updates a chapter's start_page at a specific index.
      */
     const updateChapterStartPage = (
-      chapters: ChapterInput[],
+      chapters: EditedChapter[],
       index: number,
       startPage: number,
-    ): ChapterInput[] => {
+    ): EditedChapter[] => {
       return chapters.map((chapter, i) => {
         if (i === index) {
           return { ...chapter, start_page: startPage };
@@ -482,10 +510,10 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
      * Updates a chapter's start_timestamp_ms at a specific index.
      */
     const updateChapterStartTimestamp = (
-      chapters: ChapterInput[],
+      chapters: EditedChapter[],
       index: number,
       startTimestampMs: number,
-    ): ChapterInput[] => {
+    ): EditedChapter[] => {
       return chapters.map((chapter, i) => {
         if (i === index) {
           return { ...chapter, start_timestamp_ms: startTimestampMs };
@@ -499,9 +527,9 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
      * For EPUB chapters with children, this also removes all descendants.
      */
     const deleteChapter = (
-      chapters: ChapterInput[],
+      chapters: EditedChapter[],
       index: number,
-    ): ChapterInput[] => {
+    ): EditedChapter[] => {
       return chapters.filter((_, i) => i !== index);
     };
 
@@ -509,11 +537,11 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
      * Updates a child chapter's title within a parent chapter.
      */
     const updateChildTitle = (
-      chapters: ChapterInput[],
+      chapters: EditedChapter[],
       parentIndex: number,
       childIndex: number,
       title: string,
-    ): ChapterInput[] => {
+    ): EditedChapter[] => {
       return chapters.map((chapter, i) => {
         if (i === parentIndex) {
           return {
@@ -533,10 +561,10 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
      * Deletes a child chapter from a parent chapter.
      */
     const deleteChildChapter = (
-      chapters: ChapterInput[],
+      chapters: EditedChapter[],
       parentIndex: number,
       childIndex: number,
-    ): ChapterInput[] => {
+    ): EditedChapter[] => {
       return chapters.map((chapter, i) => {
         if (i === parentIndex) {
           return {
@@ -612,21 +640,14 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
 
             {editedChapters.map((chapter, index) => (
               <ChapterRow
-                chapter={chapter as Chapter}
+                chapter={chapter as unknown as Chapter}
                 chapterIndex={isM4b ? index : undefined}
                 depth={0}
                 fileId={file.id}
                 fileType={file.file_type}
                 isEditing={true}
-                key={`edit-${index}`}
+                key={chapter._editKey}
                 maxDurationMs={isM4b ? maxDurationMs : undefined}
-                onBlur={
-                  isPageBased
-                    ? handleBlurReorder
-                    : isM4b
-                      ? handleTimestampBlurReorder
-                      : undefined
-                }
                 onDelete={() =>
                   setEditedChapters((prev) => deleteChapter(prev, index))
                 }
@@ -715,9 +736,6 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     const hasUncoveredPages =
       firstChapterStartPage != null && firstChapterStartPage > 0;
 
-    // Determine which chapters to display
-    const displayChapters = isEditing ? editedChapters : chapters;
-
     // Edit mode rendering
     if (isEditing) {
       const isEpub = file.file_type === FileTypeEPUB;
@@ -742,23 +760,16 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
             <audio ref={audioRef} src={`/api/books/files/${file.id}/stream`} />
           )}
 
-          {displayChapters.map((chapter, index) => (
+          {editedChapters.map((chapter, index) => (
             <ChapterRow
-              chapter={chapter as Chapter}
+              chapter={chapter as unknown as Chapter}
               chapterIndex={isM4b ? index : undefined}
               depth={0}
               fileId={file.id}
               fileType={file.file_type}
               isEditing={true}
-              key={`edit-${index}`}
+              key={chapter._editKey}
               maxDurationMs={isM4b ? maxDurationMs : undefined}
-              onBlur={
-                isPageBased
-                  ? handleBlurReorder
-                  : isM4b
-                    ? handleTimestampBlurReorder
-                    : undefined
-              }
               onChildDelete={
                 isEpub ? createChildDeleteCallback(index) : undefined
               }

--- a/app/components/files/FileChaptersTab.tsx
+++ b/app/components/files/FileChaptersTab.tsx
@@ -423,11 +423,34 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
       onActionStateChange,
     ]);
 
-    // Note: chapters are intentionally NOT reordered during edit. Live
-    // sort-on-blur combined with React's stable keys caused a subtle bug
-    // where clicking a page +/- button could mutate a sibling chapter
-    // after the reorder swapped positions. Order normalization now happens
-    // only once, in `handleSave`, via `normalizeChapterOrder`.
+    /**
+     * Reorders edited chapters by start_page. Fired from ChapterRow's `onBlur`
+     * only on "commit" actions — the page input's real onBlur, and picker
+     * selection. The +/- buttons intentionally do NOT trigger this, so rapid
+     * button clicks don't swap chapter positions mid-stream (which made the
+     * next click land on a different chapter — see the regression test).
+     */
+    const handleBlurReorder = useCallback(() => {
+      setEditedChapters((prev) => {
+        const sorted = [...prev].sort(
+          (a, b) => (a.start_page ?? 0) - (b.start_page ?? 0),
+        );
+        return sorted;
+      });
+    }, []);
+
+    /**
+     * Reorders edited chapters by start_timestamp_ms on M4B timestamp commit.
+     * Also stops playback since reordering invalidates playingChapterIndex.
+     */
+    const handleTimestampBlurReorder = useCallback(() => {
+      handleAudioStop();
+      setEditedChapters((prev) =>
+        [...prev].sort(
+          (a, b) => (a.start_timestamp_ms ?? 0) - (b.start_timestamp_ms ?? 0),
+        ),
+      );
+    }, [handleAudioStop]);
 
     /**
      * Handles adding a new chapter for page-based files.
@@ -648,6 +671,13 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
                 isEditing={true}
                 key={chapter._editKey}
                 maxDurationMs={isM4b ? maxDurationMs : undefined}
+                onBlur={
+                  isPageBased
+                    ? handleBlurReorder
+                    : isM4b
+                      ? handleTimestampBlurReorder
+                      : undefined
+                }
                 onDelete={() =>
                   setEditedChapters((prev) => deleteChapter(prev, index))
                 }
@@ -770,6 +800,13 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
               isEditing={true}
               key={chapter._editKey}
               maxDurationMs={isM4b ? maxDurationMs : undefined}
+              onBlur={
+                isPageBased
+                  ? handleBlurReorder
+                  : isM4b
+                    ? handleTimestampBlurReorder
+                    : undefined
+              }
               onChildDelete={
                 isEpub ? createChildDeleteCallback(index) : undefined
               }

--- a/app/components/files/FileChaptersTab.tsx
+++ b/app/components/files/FileChaptersTab.tsx
@@ -14,6 +14,7 @@ import ChapterRow from "@/components/files/ChapterRow";
 import {
   chaptersToInputArray,
   getNextChapterTitle,
+  normalizeChapterOrder,
 } from "@/components/files/chapterUtils";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { Button } from "@/components/ui/button";
@@ -316,11 +317,15 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     };
 
     /**
-     * Handles saving edited chapters.
+     * Handles saving edited chapters. Normalizes chapter order (page-based
+     * sorted by start_page, M4B sorted by start_timestamp_ms) before the
+     * mutation fires so out-of-order edits can't land in the DB even when
+     * the user saves without triggering an input blur.
      */
     const handleSave = () => {
+      const normalized = normalizeChapterOrder(editedChapters, file.file_type);
       updateChaptersMutation.mutate(
-        { chapters: editedChapters },
+        { chapters: normalized },
         {
           onSuccess: () => {
             toast.success("Chapters saved");

--- a/app/components/files/FileChaptersTab.tsx
+++ b/app/components/files/FileChaptersTab.tsx
@@ -76,14 +76,20 @@ const toEditedChapters = (chapters: ChapterInput[]): EditedChapter[] =>
     children: toEditedChapters(c.children ?? []),
   }));
 
+// Destructure-based strip so any future ChapterInput field flows through
+// automatically — only _editKey is removed, everything else rides in ...rest.
+// children is named explicitly because EditedChapter.children is EditedChapter[]
+// while ChapterInput.children is ChapterInput[], so the child list needs its
+// own recursive strip to produce a ChapterInput-compatible shape.
 const stripEditKeys = (chapters: EditedChapter[]): ChapterInput[] =>
-  chapters.map((chapter) => ({
-    title: chapter.title,
-    start_page: chapter.start_page,
-    start_timestamp_ms: chapter.start_timestamp_ms,
-    href: chapter.href,
-    children: stripEditKeys(chapter.children),
-  }));
+  chapters.map((chapter) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { _editKey, children, ...rest } = chapter;
+    return {
+      ...rest,
+      children: stripEditKeys(children),
+    };
+  });
 
 /**
  * Creates a new chapter with appropriate defaults based on file type.
@@ -569,11 +575,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
         if (i === parentIndex) {
           return {
             ...chapter,
-            children: updateChapterTitle(
-              chapter.children ?? [],
-              childIndex,
-              title,
-            ),
+            children: updateChapterTitle(chapter.children, childIndex, title),
           };
         }
         return chapter;
@@ -592,7 +594,7 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
         if (i === parentIndex) {
           return {
             ...chapter,
-            children: deleteChapter(chapter.children ?? [], childIndex),
+            children: deleteChapter(chapter.children, childIndex),
           };
         }
         return chapter;

--- a/app/components/files/chapterUtils.test.ts
+++ b/app/components/files/chapterUtils.test.ts
@@ -1,9 +1,18 @@
 import {
   formatTimestampMs,
   getNextChapterTitle,
+  normalizeChapterOrder,
   parseTimestampMs,
 } from "./chapterUtils";
 import { describe, expect, it } from "vitest";
+
+import {
+  FileTypeCBZ,
+  FileTypeEPUB,
+  FileTypeM4B,
+  FileTypePDF,
+  type ChapterInput,
+} from "@/types";
 
 describe("getNextChapterTitle", () => {
   it('detects "Chapter N" pattern', () => {
@@ -143,5 +152,96 @@ describe("parseTimestampMs", () => {
       const parsed = parseTimestampMs(formatted);
       expect(parsed).toBe(ms);
     }
+  });
+});
+
+describe("normalizeChapterOrder", () => {
+  const makePageChapter = (
+    title: string,
+    start_page: number,
+  ): ChapterInput => ({
+    title,
+    start_page,
+    children: [],
+  });
+
+  const makeTimestampChapter = (
+    title: string,
+    start_timestamp_ms: number,
+  ): ChapterInput => ({
+    title,
+    start_timestamp_ms,
+    children: [],
+  });
+
+  it("sorts CBZ chapters by start_page", () => {
+    const input = [
+      makePageChapter("C", 10),
+      makePageChapter("A", 0),
+      makePageChapter("B", 5),
+    ];
+    const result = normalizeChapterOrder(input, FileTypeCBZ);
+    expect(result.map((c) => c.title)).toEqual(["A", "B", "C"]);
+  });
+
+  it("sorts PDF chapters by start_page", () => {
+    const input = [
+      makePageChapter("C", 10),
+      makePageChapter("A", 0),
+      makePageChapter("B", 5),
+    ];
+    const result = normalizeChapterOrder(input, FileTypePDF);
+    expect(result.map((c) => c.title)).toEqual(["A", "B", "C"]);
+  });
+
+  it("sorts M4B chapters by start_timestamp_ms", () => {
+    const input = [
+      makeTimestampChapter("C", 7000),
+      makeTimestampChapter("A", 0),
+      makeTimestampChapter("B", 3000),
+    ];
+    const result = normalizeChapterOrder(input, FileTypeM4B);
+    expect(result.map((c) => c.title)).toEqual(["A", "B", "C"]);
+  });
+
+  it("treats missing start_page as 0 for page-based files", () => {
+    const input: ChapterInput[] = [
+      { title: "at page 5", start_page: 5, children: [] },
+      { title: "no page", children: [] },
+    ];
+    const result = normalizeChapterOrder(input, FileTypeCBZ);
+    expect(result.map((c) => c.title)).toEqual(["no page", "at page 5"]);
+  });
+
+  it("treats missing start_timestamp_ms as 0 for M4B", () => {
+    const input: ChapterInput[] = [
+      { title: "at 5s", start_timestamp_ms: 5000, children: [] },
+      { title: "no timestamp", children: [] },
+    ];
+    const result = normalizeChapterOrder(input, FileTypeM4B);
+    expect(result.map((c) => c.title)).toEqual(["no timestamp", "at 5s"]);
+  });
+
+  it("leaves EPUB chapters in their original order", () => {
+    const input: ChapterInput[] = [
+      { title: "Z", href: "z.xhtml", children: [] },
+      { title: "A", href: "a.xhtml", children: [] },
+      { title: "M", href: "m.xhtml", children: [] },
+    ];
+    const result = normalizeChapterOrder(input, FileTypeEPUB);
+    expect(result.map((c) => c.title)).toEqual(["Z", "A", "M"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [makePageChapter("B", 5), makePageChapter("A", 0)];
+    const snapshot = input.map((c) => c.title);
+    normalizeChapterOrder(input, FileTypeCBZ);
+    expect(input.map((c) => c.title)).toEqual(snapshot);
+  });
+
+  it("returns an empty array unchanged", () => {
+    expect(normalizeChapterOrder([], FileTypeCBZ)).toEqual([]);
+    expect(normalizeChapterOrder([], FileTypeM4B)).toEqual([]);
+    expect(normalizeChapterOrder([], FileTypeEPUB)).toEqual([]);
   });
 });

--- a/app/components/files/chapterUtils.ts
+++ b/app/components/files/chapterUtils.ts
@@ -1,4 +1,10 @@
-import type { Chapter, ChapterInput } from "@/types";
+import {
+  FileTypeCBZ,
+  FileTypeM4B,
+  FileTypePDF,
+  type Chapter,
+  type ChapterInput,
+} from "@/types";
 import { formatTimestamp } from "@/utils/format";
 
 /**
@@ -134,6 +140,40 @@ export const chaptersToInputArray = (chapters: Chapter[]): ChapterInput[] => {
       ? chaptersToInputArray(chapter.children.filter(Boolean) as Chapter[])
       : [],
   }));
+};
+
+/**
+ * Normalizes chapter order before saving so that downstream consumers (the
+ * API, file generators, readers) receive chapters in their natural order.
+ *
+ * - CBZ/PDF: top-level chapters sorted ascending by `start_page`. Chapters
+ *   without a page fall to 0. Children are left alone — the current UI
+ *   doesn't produce nested chapters for page-based formats.
+ * - M4B: top-level chapters sorted ascending by `start_timestamp_ms`.
+ *   Chapters without a timestamp fall to 0.
+ * - EPUB (or any other type): returned as-is. EPUB ordering is user-intent
+ *   driven (spine/nav hierarchy) and has no natural numeric order.
+ *
+ * Normalizing on save is defense-in-depth: `handleBlurReorder` already
+ * re-sorts on input blur, but programmatic saves, keyboard shortcuts, and
+ * saves triggered without an intervening blur would otherwise submit the
+ * array in its unsorted edit-time order.
+ */
+export const normalizeChapterOrder = (
+  chapters: ChapterInput[],
+  fileType: string,
+): ChapterInput[] => {
+  if (fileType === FileTypeCBZ || fileType === FileTypePDF) {
+    return [...chapters].sort(
+      (a, b) => (a.start_page ?? 0) - (b.start_page ?? 0),
+    );
+  }
+  if (fileType === FileTypeM4B) {
+    return [...chapters].sort(
+      (a, b) => (a.start_timestamp_ms ?? 0) - (b.start_timestamp_ms ?? 0),
+    );
+  }
+  return chapters;
 };
 
 /**

--- a/pkg/downloadcache/fingerprint.go
+++ b/pkg/downloadcache/fingerprint.go
@@ -86,20 +86,71 @@ type FingerprintCover struct {
 	ModTime  time.Time `json:"mod_time"`
 }
 
-// convertChaptersToFingerprint recursively converts model chapters to fingerprint format.
-func convertChaptersToFingerprint(chapters []*models.Chapter) []FingerprintChapter {
+// chapterNaturalLess returns a less function for sorting chapters by their
+// natural position field, matching how pkg/filegen writes chapters on download:
+// CBZ/PDF by StartPage, M4B by StartTimestampMs, everything else by SortOrder.
+// Ties break on SortOrder so the result is stable.
+func chapterNaturalLess(chapters []*models.Chapter, fileType string) func(i, j int) bool {
+	switch fileType {
+	case models.FileTypeCBZ, models.FileTypePDF:
+		return func(i, j int) bool {
+			ai := 0
+			if chapters[i].StartPage != nil {
+				ai = *chapters[i].StartPage
+			}
+			aj := 0
+			if chapters[j].StartPage != nil {
+				aj = *chapters[j].StartPage
+			}
+			if ai != aj {
+				return ai < aj
+			}
+			return chapters[i].SortOrder < chapters[j].SortOrder
+		}
+	case models.FileTypeM4B:
+		return func(i, j int) bool {
+			var ai int64
+			if chapters[i].StartTimestampMs != nil {
+				ai = *chapters[i].StartTimestampMs
+			}
+			var aj int64
+			if chapters[j].StartTimestampMs != nil {
+				aj = *chapters[j].StartTimestampMs
+			}
+			if ai != aj {
+				return ai < aj
+			}
+			return chapters[i].SortOrder < chapters[j].SortOrder
+		}
+	default:
+		return func(i, j int) bool {
+			return chapters[i].SortOrder < chapters[j].SortOrder
+		}
+	}
+}
+
+// convertChaptersToFingerprint recursively converts model chapters to fingerprint
+// format, sorting by the natural position field for the given file type so the
+// fingerprint reflects the same order the file generator will emit. The
+// FingerprintChapter.SortOrder field is re-derived from the sorted index so it
+// matches the array position regardless of drift in the DB's sort_order column.
+func convertChaptersToFingerprint(chapters []*models.Chapter, fileType string) []FingerprintChapter {
 	if len(chapters) == 0 {
 		return []FingerprintChapter{}
 	}
-	result := make([]FingerprintChapter, len(chapters))
-	for i, ch := range chapters {
+	sorted := make([]*models.Chapter, len(chapters))
+	copy(sorted, chapters)
+	sort.SliceStable(sorted, chapterNaturalLess(sorted, fileType))
+
+	result := make([]FingerprintChapter, len(sorted))
+	for i, ch := range sorted {
 		result[i] = FingerprintChapter{
 			Title:            ch.Title,
-			SortOrder:        ch.SortOrder,
+			SortOrder:        i, // re-derive from sorted position for stability
 			StartPage:        ch.StartPage,
 			StartTimestampMs: ch.StartTimestampMs,
 			Href:             ch.Href,
-			Children:         convertChaptersToFingerprint(ch.Children),
+			Children:         convertChaptersToFingerprint(ch.Children, fileType),
 		}
 	}
 	return result
@@ -251,14 +302,14 @@ func ComputeFingerprint(book *models.Book, file *models.File) (*Fingerprint, err
 		fp.CoverPage = file.CoverPage
 	}
 
-	// Add chapters (sorted by SortOrder for consistent fingerprinting)
+	// Add chapters, sorted by natural position so the fingerprint matches
+	// the order the file generator will emit on download.
+	fileType := ""
+	if file != nil {
+		fileType = file.FileType
+	}
 	if file != nil && len(file.Chapters) > 0 {
-		chapters := make([]*models.Chapter, len(file.Chapters))
-		copy(chapters, file.Chapters)
-		sort.Slice(chapters, func(i, j int) bool {
-			return chapters[i].SortOrder < chapters[j].SortOrder
-		})
-		fp.Chapters = convertChaptersToFingerprint(chapters)
+		fp.Chapters = convertChaptersToFingerprint(file.Chapters, fileType)
 	} else {
 		fp.Chapters = []FingerprintChapter{}
 	}

--- a/pkg/downloadcache/fingerprint_test.go
+++ b/pkg/downloadcache/fingerprint_test.go
@@ -853,6 +853,146 @@ func TestComputeFingerprint_NestedChaptersAreIncluded(t *testing.T) {
 	assert.Equal(t, 0, fp.Chapters[1].Children[0].SortOrder)
 }
 
+func TestComputeFingerprint_ChapterOrderStableAgainstSortOrderDrift(t *testing.T) {
+	t.Parallel()
+
+	// Regression: the fingerprint used to sort chapters by SortOrder. After
+	// the file generators started sorting by natural position (StartPage /
+	// StartTimestampMs), the fingerprint must also sort by natural position
+	// so that two DB states representing the same produced file hash to the
+	// same fingerprint.
+
+	book := &models.Book{Title: "Book"}
+
+	t.Run("PDF: sort_order drift does not change the fingerprint", func(t *testing.T) {
+		t.Parallel()
+		startPage0 := 0
+		startPage3 := 3
+		startPage7 := 7
+
+		// "Normalized" state: SortOrder matches StartPage order.
+		normalized := &models.File{
+			FileType: models.FileTypePDF,
+			Chapters: []*models.Chapter{
+				{Title: "A", SortOrder: 0, StartPage: &startPage0},
+				{Title: "B", SortOrder: 1, StartPage: &startPage3},
+				{Title: "C", SortOrder: 2, StartPage: &startPage7},
+			},
+		}
+
+		// "Drifted" state: same chapters, same pages, but SortOrder is
+		// reversed. The file generator produces the same output for both.
+		drifted := &models.File{
+			FileType: models.FileTypePDF,
+			Chapters: []*models.Chapter{
+				{Title: "C", SortOrder: 0, StartPage: &startPage7},
+				{Title: "B", SortOrder: 1, StartPage: &startPage3},
+				{Title: "A", SortOrder: 2, StartPage: &startPage0},
+			},
+		}
+
+		fpNorm, err := ComputeFingerprint(book, normalized)
+		require.NoError(t, err)
+		fpDrift, err := ComputeFingerprint(book, drifted)
+		require.NoError(t, err)
+
+		hNorm, err := fpNorm.Hash()
+		require.NoError(t, err)
+		hDrift, err := fpDrift.Hash()
+		require.NoError(t, err)
+		assert.Equal(t, hNorm, hDrift, "PDF fingerprint must be stable against SortOrder drift")
+
+		// Also pin the expected output order explicitly.
+		require.Len(t, fpDrift.Chapters, 3)
+		assert.Equal(t, "A", fpDrift.Chapters[0].Title)
+		assert.Equal(t, 0, fpDrift.Chapters[0].SortOrder)
+		assert.Equal(t, "B", fpDrift.Chapters[1].Title)
+		assert.Equal(t, 1, fpDrift.Chapters[1].SortOrder)
+		assert.Equal(t, "C", fpDrift.Chapters[2].Title)
+		assert.Equal(t, 2, fpDrift.Chapters[2].SortOrder)
+	})
+
+	t.Run("M4B: sort_order drift does not change the fingerprint", func(t *testing.T) {
+		t.Parallel()
+		normalized := &models.File{
+			FileType: models.FileTypeM4B,
+			Chapters: []*models.Chapter{
+				{Title: "A", SortOrder: 0, StartTimestampMs: int64Ptr(0)},
+				{Title: "B", SortOrder: 1, StartTimestampMs: int64Ptr(3000)},
+				{Title: "C", SortOrder: 2, StartTimestampMs: int64Ptr(7000)},
+			},
+		}
+		drifted := &models.File{
+			FileType: models.FileTypeM4B,
+			Chapters: []*models.Chapter{
+				{Title: "C", SortOrder: 0, StartTimestampMs: int64Ptr(7000)},
+				{Title: "A", SortOrder: 1, StartTimestampMs: int64Ptr(0)},
+				{Title: "B", SortOrder: 2, StartTimestampMs: int64Ptr(3000)},
+			},
+		}
+
+		fpNorm, _ := ComputeFingerprint(book, normalized)
+		fpDrift, _ := ComputeFingerprint(book, drifted)
+		hNorm, _ := fpNorm.Hash()
+		hDrift, _ := fpDrift.Hash()
+		assert.Equal(t, hNorm, hDrift, "M4B fingerprint must be stable against SortOrder drift")
+	})
+
+	t.Run("CBZ: sort_order drift does not change the fingerprint", func(t *testing.T) {
+		t.Parallel()
+		startPage0 := 0
+		startPage3 := 3
+		normalized := &models.File{
+			FileType: models.FileTypeCBZ,
+			Chapters: []*models.Chapter{
+				{Title: "A", SortOrder: 0, StartPage: &startPage0},
+				{Title: "B", SortOrder: 1, StartPage: &startPage3},
+			},
+		}
+		drifted := &models.File{
+			FileType: models.FileTypeCBZ,
+			Chapters: []*models.Chapter{
+				{Title: "B", SortOrder: 0, StartPage: &startPage3},
+				{Title: "A", SortOrder: 1, StartPage: &startPage0},
+			},
+		}
+
+		fpNorm, _ := ComputeFingerprint(book, normalized)
+		fpDrift, _ := ComputeFingerprint(book, drifted)
+		hNorm, _ := fpNorm.Hash()
+		hDrift, _ := fpDrift.Hash()
+		assert.Equal(t, hNorm, hDrift, "CBZ fingerprint must be stable against SortOrder drift")
+	})
+
+	t.Run("EPUB: still sorts by SortOrder (no natural position field)", func(t *testing.T) {
+		t.Parallel()
+		// EPUB chapters use href; there's no natural numeric order, so
+		// SortOrder remains the source of truth — different SortOrder
+		// values do produce different fingerprints.
+		a := "a.xhtml"
+		b := "b.xhtml"
+		state1 := &models.File{
+			FileType: models.FileTypeEPUB,
+			Chapters: []*models.Chapter{
+				{Title: "A", SortOrder: 0, Href: &a},
+				{Title: "B", SortOrder: 1, Href: &b},
+			},
+		}
+		state2 := &models.File{
+			FileType: models.FileTypeEPUB,
+			Chapters: []*models.Chapter{
+				{Title: "B", SortOrder: 0, Href: &b},
+				{Title: "A", SortOrder: 1, Href: &a},
+			},
+		}
+		fp1, _ := ComputeFingerprint(book, state1)
+		fp2, _ := ComputeFingerprint(book, state2)
+		h1, _ := fp1.Hash()
+		h2, _ := fp2.Hash()
+		assert.NotEqual(t, h1, h2, "EPUB fingerprint must reflect SortOrder changes")
+	})
+}
+
 func strPtr(s string) *string {
 	return &s
 }

--- a/pkg/downloadcache/fingerprint_test.go
+++ b/pkg/downloadcache/fingerprint_test.go
@@ -232,9 +232,10 @@ func TestComputeFingerprint(t *testing.T) {
 		assert.Empty(t, fp.Tags)
 	})
 
-	t.Run("chapters sorted by sort_order for consistent fingerprinting", func(t *testing.T) {
+	t.Run("M4B chapters sorted by StartTimestampMs for consistent fingerprinting", func(t *testing.T) {
 		book := &models.Book{Title: "Book with Chapters"}
 		file := &models.File{
+			FileType: models.FileTypeM4B,
 			Chapters: []*models.Chapter{
 				{Title: "Third Chapter", SortOrder: 2, StartTimestampMs: int64Ptr(120000)},
 				{Title: "First Chapter", SortOrder: 0, StartTimestampMs: int64Ptr(0)},
@@ -245,7 +246,9 @@ func TestComputeFingerprint(t *testing.T) {
 		fp, err := ComputeFingerprint(book, file)
 		require.NoError(t, err)
 
-		// Chapters should be sorted by SortOrder (0, 1, 2)
+		// Chapters should be sorted by StartTimestampMs, matching the order
+		// the file generator will emit. SortOrder is re-derived from the
+		// sorted position so the fingerprint is stable against DB drift.
 		require.Len(t, fp.Chapters, 3)
 		assert.Equal(t, "First Chapter", fp.Chapters[0].Title)
 		assert.Equal(t, 0, fp.Chapters[0].SortOrder)
@@ -713,7 +716,11 @@ func TestComputeFingerprint_ChaptersWithNilOptionalFieldsFingerprintCorrectly(t 
 	book := &models.Book{
 		Title: "Test Book with Minimal Chapters",
 	}
+	// FileType: EPUB so chapters sort by SortOrder (EPUB has no natural
+	// position field). This pins the input array order in the fingerprint
+	// output regardless of which nil optional fields are set.
 	file := &models.File{
+		FileType: models.FileTypeEPUB,
 		Chapters: []*models.Chapter{
 			{
 				Title:            "Chapter with all nil optional fields",
@@ -764,8 +771,11 @@ func TestComputeFingerprint_NestedChaptersAreIncluded(t *testing.T) {
 	book := &models.Book{
 		Title: "Test Book with Nested Chapters",
 	}
-	// Create a parent chapter with nested children
+	// Create a parent chapter with nested children. FileType: M4B so the
+	// sort uses StartTimestampMs; the fixture data is already in timestamp
+	// order, so sorted output matches the input array.
 	file := &models.File{
+		FileType: models.FileTypeM4B,
 		Chapters: []*models.Chapter{
 			{
 				Title:            "Part 1",

--- a/pkg/filegen/kepub_cbz.go
+++ b/pkg/filegen/kepub_cbz.go
@@ -113,14 +113,28 @@ func buildCBZMetadata(book *models.Book, file *models.File) *kepub.CBZMetadata {
 
 // convertModelChaptersToCBZ converts model chapters to CBZ chapters.
 // Only top-level chapters are included (children are flattened/ignored).
-// Chapters are sorted by SortOrder.
+//
+// Sorts by StartPage so the generated KePub's chapter navigation is in page
+// order even if the DB's SortOrder disagrees. Ties break on SortOrder for
+// stability. Chapters with nil StartPage are treated as page 0.
 func convertModelChaptersToCBZ(chapters []*models.Chapter) []kepub.CBZChapter {
 	// Copy to avoid modifying the original slice
 	sorted := make([]*models.Chapter, len(chapters))
 	copy(sorted, chapters)
 
-	// Sort by SortOrder
-	sort.Slice(sorted, func(i, j int) bool {
+	// Sort by StartPage (nil == 0), fall back to SortOrder for ties.
+	sort.SliceStable(sorted, func(i, j int) bool {
+		ai := 0
+		if sorted[i].StartPage != nil {
+			ai = *sorted[i].StartPage
+		}
+		aj := 0
+		if sorted[j].StartPage != nil {
+			aj = *sorted[j].StartPage
+		}
+		if ai != aj {
+			return ai < aj
+		}
 		return sorted[i].SortOrder < sorted[j].SortOrder
 	})
 

--- a/pkg/filegen/kepub_cbz_test.go
+++ b/pkg/filegen/kepub_cbz_test.go
@@ -263,7 +263,7 @@ func TestBuildCBZMetadata_Chapters(t *testing.T) {
 		assert.Equal(t, 0, metadata.Chapters[0].StartPage) // Defaults to 0
 	})
 
-	t.Run("sorts chapters by SortOrder", func(t *testing.T) {
+	t.Run("sorts chapters by StartPage", func(t *testing.T) {
 		startPage0 := 0
 		startPage5 := 5
 		startPage10 := 10
@@ -272,6 +272,8 @@ func TestBuildCBZMetadata_Chapters(t *testing.T) {
 		}
 		file := &models.File{
 			Chapters: []*models.Chapter{
+				// Provided in SortOrder ascending but StartPage ascending too,
+				// so both orderings give the same result — this is the baseline.
 				{Title: "Chapter 3", StartPage: &startPage10, SortOrder: 2},
 				{Title: "Chapter 1", StartPage: &startPage0, SortOrder: 0},
 				{Title: "Chapter 2", StartPage: &startPage5, SortOrder: 1},
@@ -285,6 +287,34 @@ func TestBuildCBZMetadata_Chapters(t *testing.T) {
 		assert.Equal(t, "Chapter 1", metadata.Chapters[0].Title)
 		assert.Equal(t, "Chapter 2", metadata.Chapters[1].Title)
 		assert.Equal(t, "Chapter 3", metadata.Chapters[2].Title)
+	})
+
+	t.Run("chapter order follows StartPage when SortOrder disagrees", func(t *testing.T) {
+		// Regression: SortOrder and StartPage disagree. The generated KePub
+		// must render chapters in page order, not SortOrder order, so the
+		// reader's navigation lines up with the pages.
+		startPage0 := 0
+		startPage3 := 3
+		startPage7 := 7
+		book := &models.Book{Title: "Comic Book"}
+		file := &models.File{
+			Chapters: []*models.Chapter{
+				{Title: "at page 7", StartPage: &startPage7, SortOrder: 0},
+				{Title: "at page 0", StartPage: &startPage0, SortOrder: 1},
+				{Title: "at page 3", StartPage: &startPage3, SortOrder: 2},
+			},
+		}
+
+		metadata := buildCBZMetadata(book, file)
+
+		require.NotNil(t, metadata)
+		require.Len(t, metadata.Chapters, 3)
+		assert.Equal(t, "at page 0", metadata.Chapters[0].Title)
+		assert.Equal(t, 0, metadata.Chapters[0].StartPage)
+		assert.Equal(t, "at page 3", metadata.Chapters[1].Title)
+		assert.Equal(t, 3, metadata.Chapters[1].StartPage)
+		assert.Equal(t, "at page 7", metadata.Chapters[2].Title)
+		assert.Equal(t, 7, metadata.Chapters[2].StartPage)
 	})
 }
 

--- a/pkg/filegen/m4b.go
+++ b/pkg/filegen/m4b.go
@@ -268,15 +268,31 @@ func (g *M4BGenerator) loadCover(book *models.Book, file *models.File, meta *mp4
 // convertModelChaptersToMP4 converts database chapters to MP4 format.
 // M4B doesn't support nested chapters, so only top-level chapters are used.
 // duration is the total file duration, used to calculate the End time of the last chapter.
+//
+// Sorts by StartTimestampMs so the generated file plays chapters in temporal
+// order even if the DB's SortOrder disagrees with the timestamps (e.g. a user
+// reordered chapters in the UI without re-normalizing). Ties break on SortOrder
+// for stability.
 func convertModelChaptersToMP4(chapters []*models.Chapter, duration time.Duration) []mp4.Chapter {
 	if len(chapters) == 0 {
 		return nil
 	}
 
-	// Sort by SortOrder
+	// Sort by StartTimestampMs (nil == 0), fall back to SortOrder for ties.
 	sorted := make([]*models.Chapter, len(chapters))
 	copy(sorted, chapters)
-	sort.Slice(sorted, func(i, j int) bool {
+	sort.SliceStable(sorted, func(i, j int) bool {
+		ai := int64(0)
+		if sorted[i].StartTimestampMs != nil {
+			ai = *sorted[i].StartTimestampMs
+		}
+		aj := int64(0)
+		if sorted[j].StartTimestampMs != nil {
+			aj = *sorted[j].StartTimestampMs
+		}
+		if ai != aj {
+			return ai < aj
+		}
 		return sorted[i].SortOrder < sorted[j].SortOrder
 	})
 

--- a/pkg/filegen/m4b_test.go
+++ b/pkg/filegen/m4b_test.go
@@ -778,6 +778,48 @@ func TestM4BGenerator_Generate(t *testing.T) {
 		assert.Equal(t, "Third Chapter", meta.Chapters[2].Title, "chapter 2 should be 'Third Chapter' (SortOrder 2)")
 	})
 
+	t.Run("chapter order follows StartTimestampMs when SortOrder disagrees", func(t *testing.T) {
+		testgen.SkipIfNoFFmpeg(t)
+		dir := testgen.TempDir(t, "m4b-gen-*")
+
+		// Regression: SortOrder and timestamps disagree. The generated file
+		// must play chapters in temporal order, not SortOrder order, so the
+		// listener hears chapters lining up with the audio.
+		srcPath := testgen.GenerateM4B(t, dir, "source.m4b", testgen.M4BOptions{
+			Title:    "Test Book",
+			Duration: 10.0,
+		})
+
+		destPath := filepath.Join(dir, "dest.m4b")
+
+		ts0 := int64(0)
+		ts3 := int64(3000)
+		ts7 := int64(7000)
+		book := &models.Book{
+			Title:   "Test Book",
+			Authors: []*models.Author{{SortOrder: 0, Person: &models.Person{Name: "Author"}}},
+		}
+		file := &models.File{
+			FileType: models.FileTypeM4B,
+			Chapters: []*models.Chapter{
+				// SortOrder ascending but timestamps NOT in ascending order.
+				{Title: "plays at 7s", SortOrder: 0, StartTimestampMs: &ts7},
+				{Title: "plays at 0s", SortOrder: 1, StartTimestampMs: &ts0},
+				{Title: "plays at 3s", SortOrder: 2, StartTimestampMs: &ts3},
+			},
+		}
+
+		err := (&M4BGenerator{}).Generate(context.Background(), srcPath, destPath, book, file)
+		require.NoError(t, err)
+
+		meta, err := mp4.ParseFull(destPath)
+		require.NoError(t, err)
+		require.Len(t, meta.Chapters, 3)
+		assert.Equal(t, "plays at 0s", meta.Chapters[0].Title)
+		assert.Equal(t, "plays at 3s", meta.Chapters[1].Title)
+		assert.Equal(t, "plays at 7s", meta.Chapters[2].Title)
+	})
+
 	t.Run("chapters with missing StartTimestampMs use zero", func(t *testing.T) {
 		testgen.SkipIfNoFFmpeg(t)
 		dir := testgen.TempDir(t, "m4b-gen-*")

--- a/pkg/filegen/m4b_test.go
+++ b/pkg/filegen/m4b_test.go
@@ -730,54 +730,6 @@ func TestM4BGenerator_Generate(t *testing.T) {
 		assert.Equal(t, "Source Chapter 3", meta.Chapters[2].Title)
 	})
 
-	t.Run("chapter order in generated M4B matches SortOrder", func(t *testing.T) {
-		testgen.SkipIfNoFFmpeg(t)
-		dir := testgen.TempDir(t, "m4b-gen-*")
-
-		// Create source M4B (with no chapters in source)
-		srcPath := testgen.GenerateM4B(t, dir, "source.m4b", testgen.M4BOptions{
-			Title:    "Test Book",
-			Duration: 10.0, // 10 seconds to accommodate chapter timestamps
-		})
-
-		destPath := filepath.Join(dir, "dest.m4b")
-
-		// Create file model with chapters in WRONG sort order (2, 0, 1)
-		// The generator should sort them by SortOrder before writing
-		ts1 := int64(0)    // 0ms for chapter with SortOrder 0
-		ts2 := int64(3000) // 3000ms for chapter with SortOrder 1
-		ts3 := int64(7000) // 7000ms for chapter with SortOrder 2
-		book := &models.Book{
-			Title: "Test Book",
-			Authors: []*models.Author{
-				{SortOrder: 0, Person: &models.Person{Name: "Author"}},
-			},
-		}
-		file := &models.File{
-			FileType: models.FileTypeM4B,
-			Chapters: []*models.Chapter{
-				// Deliberately out of order: SortOrder 2, 0, 1
-				{Title: "Third Chapter", SortOrder: 2, StartTimestampMs: &ts3},
-				{Title: "First Chapter", SortOrder: 0, StartTimestampMs: &ts1},
-				{Title: "Second Chapter", SortOrder: 1, StartTimestampMs: &ts2},
-			},
-		}
-
-		gen := &M4BGenerator{}
-		err := gen.Generate(context.Background(), srcPath, destPath, book, file)
-		require.NoError(t, err)
-
-		// Parse result and verify chapters are in sorted order (0, 1, 2)
-		meta, err := mp4.ParseFull(destPath)
-		require.NoError(t, err)
-
-		// Should have 3 chapters sorted by SortOrder, not insertion order
-		require.Len(t, meta.Chapters, 3, "expected 3 chapters from file model")
-		assert.Equal(t, "First Chapter", meta.Chapters[0].Title, "chapter 0 should be 'First Chapter' (SortOrder 0)")
-		assert.Equal(t, "Second Chapter", meta.Chapters[1].Title, "chapter 1 should be 'Second Chapter' (SortOrder 1)")
-		assert.Equal(t, "Third Chapter", meta.Chapters[2].Title, "chapter 2 should be 'Third Chapter' (SortOrder 2)")
-	})
-
 	t.Run("chapter order follows StartTimestampMs when SortOrder disagrees", func(t *testing.T) {
 		testgen.SkipIfNoFFmpeg(t)
 		dir := testgen.TempDir(t, "m4b-gen-*")

--- a/pkg/filegen/pdf.go
+++ b/pkg/filegen/pdf.go
@@ -9,9 +9,14 @@ import (
 	"github.com/pdfcpu/pdfcpu/pkg/api"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
+	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/pdf"
 )
+
+// noParentPage is the sentinel passed to convertModelChaptersToPDFBookmarks at
+// the top level, meaning "no parent constraint — any non-negative page is OK".
+const noParentPage = -1
 
 // PDFGenerator generates PDF files with modified metadata.
 type PDFGenerator struct{}
@@ -44,32 +49,44 @@ func (g *PDFGenerator) Generate(ctx context.Context, srcPath, destPath string, b
 	// AddPropertiesFile reads srcPath and writes the result with updated info dict
 	// to destPath. When srcPath != destPath, pdfcpu creates destPath directly
 	// without modifying srcPath.
+	// conf is reused across the two pdfcpu entry points below; both overwrite
+	// conf.Cmd on entry so the reuse is safe.
 	conf := model.NewDefaultConfiguration()
 	conf.ValidationMode = model.ValidationRelaxed
 	if err := api.AddPropertiesFile(srcPath, destPath, properties, conf); err != nil {
 		return NewGenerationError(models.FileTypePDF, err, "failed to write PDF metadata")
 	}
 
-	// Write chapters back to the destination as a bookmark outline. Skipped when
-	// the file has no chapters in the DB — we don't touch existing bookmarks in
-	// the source PDF in that case.
+	// Write chapters back to the destination as a bookmark outline. This is
+	// best-effort: a failure here leaves the properties-only destPath in place
+	// rather than failing the whole download (matches the cover-extraction
+	// pattern in pkg/pdf/pdf.go). Skipped entirely when the DB has no chapters
+	// so we don't touch existing bookmarks in the source PDF.
 	if file != nil && len(file.Chapters) > 0 {
 		pageCount := 0
 		if file.PageCount != nil {
 			pageCount = *file.PageCount
 		}
-		bookmarks := convertModelChaptersToPDFBookmarks(file.Chapters, pageCount)
+		// pageCount == 0 means "we don't know how many pages the file has" —
+		// the converter treats that as "trust the input, no upper bound".
+		bookmarks := convertModelChaptersToPDFBookmarks(file.Chapters, pageCount, noParentPage)
 		if len(bookmarks) > 0 {
-			// AddBookmarksFile needs distinct input and output paths. Write to a
-			// sibling tmp file and rename over destPath on success.
+			// AddBookmarksFile requires distinct input and output paths. Write
+			// to a sibling tmp file and rename over destPath on success.
 			tmpPath := destPath + ".bookmarks.tmp"
 			if err := api.AddBookmarksFile(destPath, tmpPath, bookmarks, true, conf); err != nil {
 				_ = os.Remove(tmpPath)
-				return NewGenerationError(models.FileTypePDF, err, "failed to write PDF bookmarks")
-			}
-			if err := os.Rename(tmpPath, destPath); err != nil {
+				logger.FromContext(ctx).Warn("failed to write PDF bookmarks, continuing without them", logger.Data{
+					"error":    err.Error(),
+					"dest":     destPath,
+					"chapters": len(bookmarks),
+				})
+			} else if err := os.Rename(tmpPath, destPath); err != nil {
 				_ = os.Remove(tmpPath)
-				return NewGenerationError(models.FileTypePDF, err, "failed to finalize PDF with bookmarks")
+				logger.FromContext(ctx).Warn("failed to finalize PDF with bookmarks, continuing without them", logger.Data{
+					"error": err.Error(),
+					"dest":  destPath,
+				})
 			}
 		}
 	}
@@ -78,23 +95,28 @@ func (g *PDFGenerator) Generate(ctx context.Context, srcPath, destPath string, b
 }
 
 // convertModelChaptersToPDFBookmarks converts database chapter models into
-// pdfcpu bookmark entries, preserving nesting. Chapters with nil StartPage or
-// a StartPage outside [0, pageCount) are dropped. Pages are converted from the
-// 0-indexed storage format to the 1-indexed form pdfcpu expects. A pageCount
-// of 0 disables range filtering (used when the file's PageCount is unknown).
-func convertModelChaptersToPDFBookmarks(chapters []*models.Chapter, pageCount int) []pdfcpu.Bookmark {
+// pdfcpu bookmark entries, preserving nesting.
+//
+// Chapters are filtered and sorted to satisfy pdfcpu's page-order constraint
+// (siblings must be monotonically non-decreasing by page, and a child must not
+// start before its parent). Specifically:
+//   - nil StartPage, negative StartPage, and StartPage outside [0, pageCount)
+//     are dropped
+//   - children whose StartPage is less than their parent's are dropped
+//   - siblings are sorted by StartPage (ties broken by SortOrder for stability)
+//
+// Pages are converted from the 0-indexed storage format to the 1-indexed form
+// pdfcpu expects. pageCount == 0 disables the upper-bound filter (used when
+// the file's PageCount is unknown). parentPage is the parent bookmark's
+// 0-indexed StartPage, or noParentPage at the top level.
+func convertModelChaptersToPDFBookmarks(chapters []*models.Chapter, pageCount int, parentPage int) []pdfcpu.Bookmark {
 	if len(chapters) == 0 {
 		return nil
 	}
 
-	sorted := make([]*models.Chapter, len(chapters))
-	copy(sorted, chapters)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		return sorted[i].SortOrder < sorted[j].SortOrder
-	})
-
-	result := make([]pdfcpu.Bookmark, 0, len(sorted))
-	for _, ch := range sorted {
+	// First pass: filter out invalid / out-of-range / child-before-parent entries.
+	valid := make([]*models.Chapter, 0, len(chapters))
+	for _, ch := range chapters {
 		if ch.StartPage == nil {
 			continue
 		}
@@ -105,12 +127,29 @@ func convertModelChaptersToPDFBookmarks(chapters []*models.Chapter, pageCount in
 		if pageCount > 0 && page >= pageCount {
 			continue
 		}
+		if parentPage != noParentPage && page < parentPage {
+			continue
+		}
+		valid = append(valid, ch)
+	}
+
+	// Sort by StartPage; fall back to SortOrder for ties to keep output stable.
+	sort.SliceStable(valid, func(i, j int) bool {
+		if *valid[i].StartPage != *valid[j].StartPage {
+			return *valid[i].StartPage < *valid[j].StartPage
+		}
+		return valid[i].SortOrder < valid[j].SortOrder
+	})
+
+	result := make([]pdfcpu.Bookmark, 0, len(valid))
+	for _, ch := range valid {
+		page := *ch.StartPage
 		bm := pdfcpu.Bookmark{
 			Title:    ch.Title,
 			PageFrom: page + 1, // pdfcpu is 1-indexed
 		}
 		if len(ch.Children) > 0 {
-			bm.Kids = convertModelChaptersToPDFBookmarks(ch.Children, pageCount)
+			bm.Kids = convertModelChaptersToPDFBookmarks(ch.Children, pageCount, page)
 		}
 		result = append(result, bm)
 	}

--- a/pkg/filegen/pdf.go
+++ b/pkg/filegen/pdf.go
@@ -61,8 +61,9 @@ func (g *PDFGenerator) Generate(ctx context.Context, srcPath, destPath string, b
 	//
 	// This block is best-effort: if bookmark writing fails for any reason, we
 	// log a warning and keep the properties-only destPath rather than failing
-	// the whole download. This matches the cover-extraction pattern in
-	// pkg/pdf/pdf.go and ensures a metadata quirk can never block a download.
+	// the whole download. This matches the best-effort cover-extraction pattern
+	// in pkg/pdf/cover.go (invoked from pkg/pdf/pdf.go's Parse) and ensures a
+	// metadata quirk can never block a download.
 	// Skipped entirely when the DB has no chapters so we don't touch existing
 	// bookmarks in the source PDF.
 	//

--- a/pkg/filegen/pdf.go
+++ b/pkg/filegen/pdf.go
@@ -2,10 +2,12 @@ package filegen
 
 import (
 	"context"
+	"os"
 	"sort"
 	"strings"
 
 	"github.com/pdfcpu/pdfcpu/pkg/api"
+	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu"
 	"github.com/pdfcpu/pdfcpu/pkg/pdfcpu/model"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/pdf"
@@ -48,7 +50,71 @@ func (g *PDFGenerator) Generate(ctx context.Context, srcPath, destPath string, b
 		return NewGenerationError(models.FileTypePDF, err, "failed to write PDF metadata")
 	}
 
+	// Write chapters back to the destination as a bookmark outline. Skipped when
+	// the file has no chapters in the DB — we don't touch existing bookmarks in
+	// the source PDF in that case.
+	if file != nil && len(file.Chapters) > 0 {
+		pageCount := 0
+		if file.PageCount != nil {
+			pageCount = *file.PageCount
+		}
+		bookmarks := convertModelChaptersToPDFBookmarks(file.Chapters, pageCount)
+		if len(bookmarks) > 0 {
+			// AddBookmarksFile needs distinct input and output paths. Write to a
+			// sibling tmp file and rename over destPath on success.
+			tmpPath := destPath + ".bookmarks.tmp"
+			if err := api.AddBookmarksFile(destPath, tmpPath, bookmarks, true, conf); err != nil {
+				_ = os.Remove(tmpPath)
+				return NewGenerationError(models.FileTypePDF, err, "failed to write PDF bookmarks")
+			}
+			if err := os.Rename(tmpPath, destPath); err != nil {
+				_ = os.Remove(tmpPath)
+				return NewGenerationError(models.FileTypePDF, err, "failed to finalize PDF with bookmarks")
+			}
+		}
+	}
+
 	return nil
+}
+
+// convertModelChaptersToPDFBookmarks converts database chapter models into
+// pdfcpu bookmark entries, preserving nesting. Chapters with nil StartPage or
+// a StartPage outside [0, pageCount) are dropped. Pages are converted from the
+// 0-indexed storage format to the 1-indexed form pdfcpu expects. A pageCount
+// of 0 disables range filtering (used when the file's PageCount is unknown).
+func convertModelChaptersToPDFBookmarks(chapters []*models.Chapter, pageCount int) []pdfcpu.Bookmark {
+	if len(chapters) == 0 {
+		return nil
+	}
+
+	sorted := make([]*models.Chapter, len(chapters))
+	copy(sorted, chapters)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].SortOrder < sorted[j].SortOrder
+	})
+
+	result := make([]pdfcpu.Bookmark, 0, len(sorted))
+	for _, ch := range sorted {
+		if ch.StartPage == nil {
+			continue
+		}
+		page := *ch.StartPage
+		if page < 0 {
+			continue
+		}
+		if pageCount > 0 && page >= pageCount {
+			continue
+		}
+		bm := pdfcpu.Bookmark{
+			Title:    ch.Title,
+			PageFrom: page + 1, // pdfcpu is 1-indexed
+		}
+		if len(ch.Children) > 0 {
+			bm.Kids = convertModelChaptersToPDFBookmarks(ch.Children, pageCount)
+		}
+		result = append(result, bm)
+	}
+	return result
 }
 
 // buildProperties constructs the info dict map from book and file models.

--- a/pkg/filegen/pdf.go
+++ b/pkg/filegen/pdf.go
@@ -57,11 +57,21 @@ func (g *PDFGenerator) Generate(ctx context.Context, srcPath, destPath string, b
 		return NewGenerationError(models.FileTypePDF, err, "failed to write PDF metadata")
 	}
 
-	// Write chapters back to the destination as a bookmark outline. This is
-	// best-effort: a failure here leaves the properties-only destPath in place
-	// rather than failing the whole download (matches the cover-extraction
-	// pattern in pkg/pdf/pdf.go). Skipped entirely when the DB has no chapters
-	// so we don't touch existing bookmarks in the source PDF.
+	// Write chapters back to the destination as a bookmark outline.
+	//
+	// This block is best-effort: if bookmark writing fails for any reason, we
+	// log a warning and keep the properties-only destPath rather than failing
+	// the whole download. This matches the cover-extraction pattern in
+	// pkg/pdf/pdf.go and ensures a metadata quirk can never block a download.
+	// Skipped entirely when the DB has no chapters so we don't touch existing
+	// bookmarks in the source PDF.
+	//
+	// The failure branches below are not exercised by tests: after the
+	// filter+sort in convertModelChaptersToPDFBookmarks, pdfcpu has no
+	// ordering reason to reject the input, and injecting a file-system
+	// failure without a mockable seam is intrusive. They exist as
+	// defense-in-depth against future pdfcpu changes, disk-state anomalies,
+	// and cross-filesystem rename quirks — do not remove them as dead code.
 	if file != nil && len(file.Chapters) > 0 {
 		pageCount := 0
 		if file.PageCount != nil {
@@ -75,23 +85,41 @@ func (g *PDFGenerator) Generate(ctx context.Context, srcPath, destPath string, b
 			// to a sibling tmp file and rename over destPath on success.
 			tmpPath := destPath + ".bookmarks.tmp"
 			if err := api.AddBookmarksFile(destPath, tmpPath, bookmarks, true, conf); err != nil {
-				_ = os.Remove(tmpPath)
+				removeErr := os.Remove(tmpPath)
 				logger.FromContext(ctx).Warn("failed to write PDF bookmarks, continuing without them", logger.Data{
-					"error":    err.Error(),
-					"dest":     destPath,
-					"chapters": len(bookmarks),
+					"category":       "pdf_bookmark_write",
+					"error":          err.Error(),
+					"dest":           destPath,
+					"chapter_count":  len(bookmarks),
+					"tmp_remove_err": removeErrString(removeErr),
 				})
 			} else if err := os.Rename(tmpPath, destPath); err != nil {
-				_ = os.Remove(tmpPath)
+				removeErr := os.Remove(tmpPath)
 				logger.FromContext(ctx).Warn("failed to finalize PDF with bookmarks, continuing without them", logger.Data{
-					"error": err.Error(),
-					"dest":  destPath,
+					"category":       "pdf_bookmark_write",
+					"error":          err.Error(),
+					"dest":           destPath,
+					"tmp_remove_err": removeErrString(removeErr),
 				})
 			}
 		}
 	}
 
 	return nil
+}
+
+// removeErrString renders an os.Remove error for structured logging. Returns
+// "ok" when the cleanup succeeded and "not_found" for ENOENT (a tmp file that
+// was never created is the common case), so dashboards aggregating by this
+// field aren't polluted with noise.
+func removeErrString(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	if os.IsNotExist(err) {
+		return "not_found"
+	}
+	return err.Error()
 }
 
 // convertModelChaptersToPDFBookmarks converts database chapter models into
@@ -104,6 +132,17 @@ func (g *PDFGenerator) Generate(ctx context.Context, srcPath, destPath string, b
 //     are dropped
 //   - children whose StartPage is less than their parent's are dropped
 //   - siblings are sorted by StartPage (ties broken by SortOrder for stability)
+//
+// The child-before-parent filter is stricter than pdfcpu strictly requires —
+// pdfcpu only validates the first child against the parent and then walks
+// siblings — but rejecting *all* out-of-range children is simpler and avoids
+// surprising subtrees where child[0] passes the parent check but child[2]
+// would later fail sibling monotonicity after sorting.
+//
+// Chapters with invalid StartPage are dropped along with their entire subtree
+// — we do not re-parent grandchildren to a dropped parent's parent. In
+// practice, PDFs produced by the UI today are flat, so this only matters for
+// sidecar- or plugin-supplied nested chapters.
 //
 // Pages are converted from the 0-indexed storage format to the 1-indexed form
 // pdfcpu expects. pageCount == 0 disables the upper-bound filter (used when

--- a/pkg/filegen/pdf_test.go
+++ b/pkg/filegen/pdf_test.go
@@ -751,6 +751,46 @@ func TestConvertModelChaptersToPDFBookmarks(t *testing.T) {
 		require.Len(t, result[0].Kids, 1)
 		assert.Equal(t, "Good child", result[0].Kids[0].Title)
 	})
+
+	t.Run("dropping a parent with invalid StartPage drops its entire subtree", func(t *testing.T) {
+		t.Parallel()
+		// When a parent's StartPage is nil we drop the parent — and we do NOT
+		// re-parent its grandchildren to the root. This pins the documented
+		// subtree-drop behavior and prevents accidental reparenting in a
+		// future refactor.
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{Title: "Good sibling", SortOrder: 0, StartPage: &startPage0},
+			{
+				Title:     "Invalid parent (nil page)",
+				SortOrder: 1,
+				StartPage: nil,
+				Children: []*models.Chapter{
+					{Title: "Orphaned child", SortOrder: 0, StartPage: &startPage2},
+					{
+						Title:     "Orphaned child with grandchild",
+						SortOrder: 1,
+						StartPage: &startPage2,
+						Children: []*models.Chapter{
+							{Title: "Orphaned grandchild", SortOrder: 0, StartPage: &startPage5},
+						},
+					},
+				},
+			},
+			{Title: "Another good sibling", SortOrder: 2, StartPage: &startPage5},
+		}, 10, noParentPage)
+
+		require.Len(t, result, 2, "only the two valid top-level siblings should survive")
+		assert.Equal(t, "Good sibling", result[0].Title)
+		assert.Equal(t, "Another good sibling", result[1].Title)
+		// Neither orphan from the dropped subtree should appear anywhere in
+		// the output, at any depth.
+		for _, bm := range result {
+			assert.NotContains(t, bm.Title, "Orphaned")
+			for _, kid := range bm.Kids {
+				assert.NotContains(t, kid.Title, "Orphaned")
+			}
+		}
+	})
 }
 
 func TestPDFGenerator_Generate_CancelledContext(t *testing.T) {

--- a/pkg/filegen/pdf_test.go
+++ b/pkg/filegen/pdf_test.go
@@ -79,6 +79,13 @@ func writeTestPDFWithPages(t *testing.T, outPath string, pageCount int, infoEntr
 		var infoStr strings.Builder
 		infoStr.WriteString(fmt.Sprintf("%d 0 obj\n<< ", infoObj))
 		for k, v := range infoEntries {
+			// Keys in a PDF name object can't contain whitespace, delimiters,
+			// or PDF-special characters. Tests pass simple ASCII keys, so
+			// rather than implementing full name-escaping we fail loudly if
+			// someone introduces a problematic key.
+			if strings.ContainsAny(k, " \t\n\r()<>[]{}/\\%#") {
+				require.FailNowf(t, "invalid info dict key", "key %q contains PDF-special characters", k)
+			}
 			escaped := strings.ReplaceAll(v, "\\", "\\\\")
 			escaped = strings.ReplaceAll(escaped, "(", "\\(")
 			escaped = strings.ReplaceAll(escaped, ")", "\\)")

--- a/pkg/filegen/pdf_test.go
+++ b/pkg/filegen/pdf_test.go
@@ -382,26 +382,70 @@ func TestPDFGenerator_Generate_Chapters(t *testing.T) {
 	assert.Equal(t, 4, entries[2].StartPage)
 }
 
-func TestPDFGenerator_Generate_Chapters_SortOrder(t *testing.T) {
+func TestPDFGenerator_Generate_Chapters_OutOfOrder(t *testing.T) {
 	t.Parallel()
 
+	// Regression: pdfcpu rejects sibling bookmarks whose PageFrom is not
+	// monotonically non-decreasing, which made Generate fatally error for
+	// any DB state where SortOrder disagreed with StartPage order. The
+	// converter now sorts by StartPage, so this must round-trip in page
+	// order regardless of the input ordering.
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "source.pdf")
+	writeTestPDFWithPages(t, srcPath, 10, nil)
+
+	destPath := filepath.Join(tmpDir, "dest.pdf")
+
+	startPage5 := 5
+	startPage0 := 0
+	startPage2 := 2
+	book := &models.Book{Title: "Test"}
+	file := &models.File{
+		FileType: models.FileTypePDF,
+		Chapters: []*models.Chapter{
+			// Provided in SortOrder that disagrees with page order.
+			{Title: "at page 5", SortOrder: 0, StartPage: &startPage5},
+			{Title: "at page 0", SortOrder: 1, StartPage: &startPage0},
+			{Title: "at page 2", SortOrder: 2, StartPage: &startPage2},
+		},
+	}
+
+	err := (&PDFGenerator{}).Generate(context.Background(), srcPath, destPath, book, file)
+	require.NoError(t, err, "Generate must not fail when SortOrder disagrees with StartPage")
+
+	entries, err := pdf.ExtractOutline(destPath)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "at page 0", entries[0].Title)
+	assert.Equal(t, 0, entries[0].StartPage)
+	assert.Equal(t, "at page 2", entries[1].Title)
+	assert.Equal(t, 2, entries[1].StartPage)
+	assert.Equal(t, "at page 5", entries[2].Title)
+	assert.Equal(t, 5, entries[2].StartPage)
+}
+
+func TestPDFGenerator_Generate_Chapters_EmptyAndDuplicateTitles(t *testing.T) {
+	t.Parallel()
+
+	// pdfcpu must accept empty-title and duplicate-title bookmarks — it
+	// disambiguates duplicates internally. We just pin that they round-trip
+	// without errors and all three bookmarks appear in the output.
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "source.pdf")
 	writeTestPDFWithPages(t, srcPath, 5, nil)
 
 	destPath := filepath.Join(tmpDir, "dest.pdf")
 
-	// Chapters provided in the wrong order should be written in SortOrder order.
 	startPage0 := 0
-	startPage2 := 2
-	startPage4 := 4
+	startPage1 := 1
+	startPage3 := 3
 	book := &models.Book{Title: "Test"}
 	file := &models.File{
 		FileType: models.FileTypePDF,
 		Chapters: []*models.Chapter{
-			{Title: "Third", SortOrder: 2, StartPage: &startPage4},
-			{Title: "First", SortOrder: 0, StartPage: &startPage0},
-			{Title: "Second", SortOrder: 1, StartPage: &startPage2},
+			{Title: "", SortOrder: 0, StartPage: &startPage0},
+			{Title: "Chapter", SortOrder: 1, StartPage: &startPage1},
+			{Title: "Chapter", SortOrder: 2, StartPage: &startPage3},
 		},
 	}
 
@@ -410,10 +454,12 @@ func TestPDFGenerator_Generate_Chapters_SortOrder(t *testing.T) {
 
 	entries, err := pdf.ExtractOutline(destPath)
 	require.NoError(t, err)
-	require.Len(t, entries, 3)
-	assert.Equal(t, "First", entries[0].Title)
-	assert.Equal(t, "Second", entries[1].Title)
-	assert.Equal(t, "Third", entries[2].Title)
+	require.Len(t, entries, 3, "all three bookmarks must be written")
+	// The three target pages should appear in order, regardless of how pdfcpu
+	// disambiguated the duplicate/empty titles.
+	assert.Equal(t, 0, entries[0].StartPage)
+	assert.Equal(t, 1, entries[1].StartPage)
+	assert.Equal(t, 3, entries[2].StartPage)
 }
 
 func TestPDFGenerator_Generate_Chapters_Nested(t *testing.T) {
@@ -564,8 +610,8 @@ func TestConvertModelChaptersToPDFBookmarks(t *testing.T) {
 
 	t.Run("empty input returns nil", func(t *testing.T) {
 		t.Parallel()
-		assert.Nil(t, convertModelChaptersToPDFBookmarks(nil, 10))
-		assert.Nil(t, convertModelChaptersToPDFBookmarks([]*models.Chapter{}, 10))
+		assert.Nil(t, convertModelChaptersToPDFBookmarks(nil, 10, noParentPage))
+		assert.Nil(t, convertModelChaptersToPDFBookmarks([]*models.Chapter{}, 10, noParentPage))
 	})
 
 	t.Run("converts 0-indexed to 1-indexed pages", func(t *testing.T) {
@@ -573,7 +619,7 @@ func TestConvertModelChaptersToPDFBookmarks(t *testing.T) {
 		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
 			{Title: "A", SortOrder: 0, StartPage: &startPage0},
 			{Title: "B", SortOrder: 1, StartPage: &startPage2},
-		}, 10)
+		}, 10, noParentPage)
 		require.Len(t, result, 2)
 		assert.Equal(t, "A", result[0].Title)
 		assert.Equal(t, 1, result[0].PageFrom)
@@ -586,7 +632,7 @@ func TestConvertModelChaptersToPDFBookmarks(t *testing.T) {
 		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
 			{Title: "A", SortOrder: 0, StartPage: &startPage0},
 			{Title: "B", SortOrder: 1, StartPage: nil},
-		}, 10)
+		}, 10, noParentPage)
 		require.Len(t, result, 1)
 		assert.Equal(t, "A", result[0].Title)
 	})
@@ -596,7 +642,7 @@ func TestConvertModelChaptersToPDFBookmarks(t *testing.T) {
 		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
 			{Title: "Bad", SortOrder: 0, StartPage: &startPageNeg},
 			{Title: "Good", SortOrder: 1, StartPage: &startPage0},
-		}, 10)
+		}, 10, noParentPage)
 		require.Len(t, result, 1)
 		assert.Equal(t, "Good", result[0].Title)
 	})
@@ -606,16 +652,27 @@ func TestConvertModelChaptersToPDFBookmarks(t *testing.T) {
 		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
 			{Title: "In range", SortOrder: 0, StartPage: &startPage2},
 			{Title: "Out of range", SortOrder: 1, StartPage: &startPage5},
-		}, 3)
+		}, 3, noParentPage)
 		require.Len(t, result, 1)
 		assert.Equal(t, "In range", result[0].Title)
+	})
+
+	t.Run("boundary StartPage == pageCount is dropped", func(t *testing.T) {
+		t.Parallel()
+		startPage3 := 3
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{Title: "Just in", SortOrder: 0, StartPage: &startPage2},
+			{Title: "Boundary", SortOrder: 1, StartPage: &startPage3}, // pageCount is 3 → page index 3 is out
+		}, 3, noParentPage)
+		require.Len(t, result, 1)
+		assert.Equal(t, "Just in", result[0].Title)
 	})
 
 	t.Run("pageCount 0 disables upper-bound filter", func(t *testing.T) {
 		t.Parallel()
 		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
 			{Title: "A", SortOrder: 0, StartPage: &startPage5},
-		}, 0)
+		}, 0, noParentPage)
 		require.Len(t, result, 1)
 		assert.Equal(t, 6, result[0].PageFrom)
 	})
@@ -631,7 +688,7 @@ func TestConvertModelChaptersToPDFBookmarks(t *testing.T) {
 					{Title: "Child", SortOrder: 0, StartPage: &startPage2},
 				},
 			},
-		}, 10)
+		}, 10, noParentPage)
 		require.Len(t, result, 1)
 		assert.Equal(t, "Parent", result[0].Title)
 		require.Len(t, result[0].Kids, 1)
@@ -639,17 +696,53 @@ func TestConvertModelChaptersToPDFBookmarks(t *testing.T) {
 		assert.Equal(t, 3, result[0].Kids[0].PageFrom)
 	})
 
-	t.Run("sorts by SortOrder", func(t *testing.T) {
+	t.Run("sorts siblings by StartPage even when SortOrder disagrees", func(t *testing.T) {
+		t.Parallel()
+		// SortOrder says First, Second, Third but pages are 5, 0, 2 — the
+		// PDF outline must be in page order to satisfy pdfcpu's constraint.
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{Title: "page 5", SortOrder: 0, StartPage: &startPage5},
+			{Title: "page 0", SortOrder: 1, StartPage: &startPage0},
+			{Title: "page 2", SortOrder: 2, StartPage: &startPage2},
+		}, 10, noParentPage)
+		require.Len(t, result, 3)
+		assert.Equal(t, "page 0", result[0].Title)
+		assert.Equal(t, 1, result[0].PageFrom)
+		assert.Equal(t, "page 2", result[1].Title)
+		assert.Equal(t, 3, result[1].PageFrom)
+		assert.Equal(t, "page 5", result[2].Title)
+		assert.Equal(t, 6, result[2].PageFrom)
+	})
+
+	t.Run("breaks StartPage ties by SortOrder", func(t *testing.T) {
 		t.Parallel()
 		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
-			{Title: "Third", SortOrder: 2, StartPage: &startPage5},
-			{Title: "First", SortOrder: 0, StartPage: &startPage0},
-			{Title: "Second", SortOrder: 1, StartPage: &startPage2},
-		}, 10)
-		require.Len(t, result, 3)
-		assert.Equal(t, "First", result[0].Title)
-		assert.Equal(t, "Second", result[1].Title)
-		assert.Equal(t, "Third", result[2].Title)
+			{Title: "B", SortOrder: 1, StartPage: &startPage2},
+			{Title: "A", SortOrder: 0, StartPage: &startPage2},
+		}, 10, noParentPage)
+		require.Len(t, result, 2)
+		assert.Equal(t, "A", result[0].Title)
+		assert.Equal(t, "B", result[1].Title)
+	})
+
+	t.Run("drops children whose StartPage is before their parent", func(t *testing.T) {
+		t.Parallel()
+		// pdfcpu rejects a nested bookmark whose PageFrom is less than the
+		// parent's, so we drop such children.
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{
+				Title:     "Parent",
+				SortOrder: 0,
+				StartPage: &startPage2,
+				Children: []*models.Chapter{
+					{Title: "Bad child (before parent)", SortOrder: 0, StartPage: &startPage0},
+					{Title: "Good child", SortOrder: 1, StartPage: &startPage5},
+				},
+			},
+		}, 10, noParentPage)
+		require.Len(t, result, 1)
+		require.Len(t, result[0].Kids, 1)
+		assert.Equal(t, "Good child", result[0].Kids[0].Title)
 	})
 }
 

--- a/pkg/filegen/pdf_test.go
+++ b/pkg/filegen/pdf_test.go
@@ -17,14 +17,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// writeTestPDF writes a minimal valid PDF to outPath with the given info dict entries.
-// infoEntries maps info dict key names (e.g., "Title", "Author") to string values.
-// Pass nil or empty map for no info dict entries.
+// writeTestPDF writes a minimal valid single-page PDF to outPath with the given
+// info dict entries. infoEntries maps info dict key names (e.g., "Title", "Author")
+// to string values. Pass nil or empty map for no info dict entries.
 func writeTestPDF(t *testing.T, outPath string, infoEntries map[string]string) {
 	t.Helper()
-	var b strings.Builder
+	writeTestPDFWithPages(t, outPath, 1, infoEntries)
+}
 
-	// Track byte offsets for the xref table.
+// writeTestPDFWithPages writes a minimal valid PDF with pageCount pages to outPath
+// with the given info dict entries.
+func writeTestPDFWithPages(t *testing.T, outPath string, pageCount int, infoEntries map[string]string) {
+	t.Helper()
+	require.Positive(t, pageCount, "pageCount must be > 0")
+
+	var b strings.Builder
 	var offsets []int
 	objNum := 1
 
@@ -33,22 +40,35 @@ func writeTestPDF(t *testing.T, outPath string, infoEntries map[string]string) {
 	// Obj 1: Catalog
 	catalogObj := objNum
 	objNum++
-	offsets = append(offsets, b.Len())
-	b.WriteString(fmt.Sprintf("%d 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n", catalogObj))
-
 	// Obj 2: Pages
 	pagesObj := objNum
 	objNum++
-	offsets = append(offsets, b.Len())
-	firstPageObj := objNum
-	b.WriteString(fmt.Sprintf("%d 0 obj\n<< /Type /Pages /Kids [%d 0 R] /Count 1 /MediaBox [0 0 612 792] >>\nendobj\n",
-		pagesObj, firstPageObj))
+	// Obj 3..: Pages
+	pageObjNums := make([]int, pageCount)
+	for i := 0; i < pageCount; i++ {
+		pageObjNums[i] = objNum
+		objNum++
+	}
 
-	// Obj 3: Page
+	// Write Catalog
 	offsets = append(offsets, b.Len())
-	b.WriteString(fmt.Sprintf("%d 0 obj\n<< /Type /Page /Parent %d 0 R >>\nendobj\n",
-		objNum, pagesObj))
-	objNum++
+	b.WriteString(fmt.Sprintf("%d 0 obj\n<< /Type /Catalog /Pages %d 0 R >>\nendobj\n", catalogObj, pagesObj))
+
+	// Write Pages
+	offsets = append(offsets, b.Len())
+	kidsParts := make([]string, pageCount)
+	for i := 0; i < pageCount; i++ {
+		kidsParts[i] = fmt.Sprintf("%d 0 R", pageObjNums[i])
+	}
+	b.WriteString(fmt.Sprintf("%d 0 obj\n<< /Type /Pages /Kids [%s] /Count %d /MediaBox [0 0 612 792] >>\nendobj\n",
+		pagesObj, strings.Join(kidsParts, " "), pageCount))
+
+	// Write each Page
+	for i := 0; i < pageCount; i++ {
+		offsets = append(offsets, b.Len())
+		b.WriteString(fmt.Sprintf("%d 0 obj\n<< /Type /Page /Parent %d 0 R >>\nendobj\n",
+			pageObjNums[i], pagesObj))
+	}
 
 	// Info dict object (optional)
 	infoObj := 0
@@ -89,7 +109,7 @@ func writeTestPDF(t *testing.T, outPath string, infoEntries map[string]string) {
 	b.WriteString("%%EOF\n")
 
 	err := os.WriteFile(outPath, []byte(b.String()), 0644)
-	require.NoError(t, err, "writeTestPDF: failed to write %s", outPath)
+	require.NoError(t, err, "writeTestPDFWithPages: failed to write %s", outPath)
 }
 
 func TestPDFGenerator_SupportedType(t *testing.T) {
@@ -322,6 +342,315 @@ func TestPDFGenerator_PreservesCreator(t *testing.T) {
 
 	// Title must be updated.
 	assert.Equal(t, "New Title", xrt.Title)
+}
+
+func TestPDFGenerator_Generate_Chapters(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "source.pdf")
+	writeTestPDFWithPages(t, srcPath, 5, map[string]string{"Title": "Test Book"})
+
+	destPath := filepath.Join(tmpDir, "dest.pdf")
+
+	startPage0 := 0
+	startPage2 := 2
+	startPage4 := 4
+	book := &models.Book{Title: "Test Book"}
+	file := &models.File{
+		FileType: models.FileTypePDF,
+		Chapters: []*models.Chapter{
+			{Title: "Introduction", SortOrder: 0, StartPage: &startPage0},
+			{Title: "Main Content", SortOrder: 1, StartPage: &startPage2},
+			{Title: "Conclusion", SortOrder: 2, StartPage: &startPage4},
+		},
+	}
+
+	gen := &PDFGenerator{}
+	err := gen.Generate(context.Background(), srcPath, destPath, book, file)
+	require.NoError(t, err)
+
+	// Extract outline from dest and verify the bookmarks match file.Chapters.
+	entries, err := pdf.ExtractOutline(destPath)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "Introduction", entries[0].Title)
+	assert.Equal(t, 0, entries[0].StartPage)
+	assert.Equal(t, "Main Content", entries[1].Title)
+	assert.Equal(t, 2, entries[1].StartPage)
+	assert.Equal(t, "Conclusion", entries[2].Title)
+	assert.Equal(t, 4, entries[2].StartPage)
+}
+
+func TestPDFGenerator_Generate_Chapters_SortOrder(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "source.pdf")
+	writeTestPDFWithPages(t, srcPath, 5, nil)
+
+	destPath := filepath.Join(tmpDir, "dest.pdf")
+
+	// Chapters provided in the wrong order should be written in SortOrder order.
+	startPage0 := 0
+	startPage2 := 2
+	startPage4 := 4
+	book := &models.Book{Title: "Test"}
+	file := &models.File{
+		FileType: models.FileTypePDF,
+		Chapters: []*models.Chapter{
+			{Title: "Third", SortOrder: 2, StartPage: &startPage4},
+			{Title: "First", SortOrder: 0, StartPage: &startPage0},
+			{Title: "Second", SortOrder: 1, StartPage: &startPage2},
+		},
+	}
+
+	err := (&PDFGenerator{}).Generate(context.Background(), srcPath, destPath, book, file)
+	require.NoError(t, err)
+
+	entries, err := pdf.ExtractOutline(destPath)
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "First", entries[0].Title)
+	assert.Equal(t, "Second", entries[1].Title)
+	assert.Equal(t, "Third", entries[2].Title)
+}
+
+func TestPDFGenerator_Generate_Chapters_Nested(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "source.pdf")
+	writeTestPDFWithPages(t, srcPath, 6, nil)
+
+	destPath := filepath.Join(tmpDir, "dest.pdf")
+
+	startPage0 := 0
+	startPage1 := 1
+	startPage3 := 3
+	startPage4 := 4
+	book := &models.Book{Title: "Test"}
+	file := &models.File{
+		FileType: models.FileTypePDF,
+		Chapters: []*models.Chapter{
+			{
+				Title:     "Part 1",
+				SortOrder: 0,
+				StartPage: &startPage0,
+				Children: []*models.Chapter{
+					{Title: "Part 1.1", SortOrder: 0, StartPage: &startPage1},
+				},
+			},
+			{
+				Title:     "Part 2",
+				SortOrder: 1,
+				StartPage: &startPage3,
+				Children: []*models.Chapter{
+					{Title: "Part 2.1", SortOrder: 0, StartPage: &startPage4},
+				},
+			},
+		},
+	}
+
+	err := (&PDFGenerator{}).Generate(context.Background(), srcPath, destPath, book, file)
+	require.NoError(t, err)
+
+	// ExtractOutline flattens nested bookmarks — we expect all four to show up.
+	entries, err := pdf.ExtractOutline(destPath)
+	require.NoError(t, err)
+	require.Len(t, entries, 4)
+	assert.Equal(t, "Part 1", entries[0].Title)
+	assert.Equal(t, 0, entries[0].StartPage)
+	assert.Equal(t, "Part 1.1", entries[1].Title)
+	assert.Equal(t, 1, entries[1].StartPage)
+	assert.Equal(t, "Part 2", entries[2].Title)
+	assert.Equal(t, 3, entries[2].StartPage)
+	assert.Equal(t, "Part 2.1", entries[3].Title)
+	assert.Equal(t, 4, entries[3].StartPage)
+}
+
+func TestPDFGenerator_Generate_Chapters_FiltersInvalid(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "source.pdf")
+	writeTestPDFWithPages(t, srcPath, 3, nil)
+
+	destPath := filepath.Join(tmpDir, "dest.pdf")
+
+	startPage0 := 0
+	startPageOOB := 99 // beyond PageCount
+	pageCount := 3
+	book := &models.Book{Title: "Test"}
+	file := &models.File{
+		FileType:  models.FileTypePDF,
+		PageCount: &pageCount,
+		Chapters: []*models.Chapter{
+			{Title: "Valid", SortOrder: 0, StartPage: &startPage0},
+			{Title: "Missing Page", SortOrder: 1, StartPage: nil},
+			{Title: "Out of Range", SortOrder: 2, StartPage: &startPageOOB},
+		},
+	}
+
+	err := (&PDFGenerator{}).Generate(context.Background(), srcPath, destPath, book, file)
+	require.NoError(t, err)
+
+	entries, err := pdf.ExtractOutline(destPath)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the valid chapter should be written")
+	assert.Equal(t, "Valid", entries[0].Title)
+}
+
+func TestPDFGenerator_Generate_NoChapters_LeavesSourceBookmarks(t *testing.T) {
+	t.Parallel()
+
+	// An empty Chapters slice should skip the bookmark write entirely (no-op)
+	// rather than clearing bookmarks. This covers the case where a caller
+	// passes a file model without chapter relations loaded.
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "source.pdf")
+	writeTestPDFWithPages(t, srcPath, 2, nil)
+
+	destPath := filepath.Join(tmpDir, "dest.pdf")
+
+	book := &models.Book{Title: "Test"}
+	file := &models.File{FileType: models.FileTypePDF, Chapters: nil}
+
+	err := (&PDFGenerator{}).Generate(context.Background(), srcPath, destPath, book, file)
+	require.NoError(t, err)
+
+	// Source PDF had no bookmarks, dest should also have none.
+	entries, err := pdf.ExtractOutline(destPath)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestPDFGenerator_Generate_Chapters_SourceUnmodified(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "source.pdf")
+	writeTestPDFWithPages(t, srcPath, 3, nil)
+
+	srcBefore, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+
+	destPath := filepath.Join(tmpDir, "dest.pdf")
+
+	startPage0 := 0
+	book := &models.Book{Title: "Test"}
+	file := &models.File{
+		FileType: models.FileTypePDF,
+		Chapters: []*models.Chapter{
+			{Title: "Chapter 1", SortOrder: 0, StartPage: &startPage0},
+		},
+	}
+
+	err = (&PDFGenerator{}).Generate(context.Background(), srcPath, destPath, book, file)
+	require.NoError(t, err)
+
+	srcAfter, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, srcBefore, srcAfter, "source file must not be modified when writing chapters")
+}
+
+func TestConvertModelChaptersToPDFBookmarks(t *testing.T) {
+	t.Parallel()
+
+	startPage0 := 0
+	startPage2 := 2
+	startPage5 := 5
+	startPageNeg := -1
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, convertModelChaptersToPDFBookmarks(nil, 10))
+		assert.Nil(t, convertModelChaptersToPDFBookmarks([]*models.Chapter{}, 10))
+	})
+
+	t.Run("converts 0-indexed to 1-indexed pages", func(t *testing.T) {
+		t.Parallel()
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{Title: "A", SortOrder: 0, StartPage: &startPage0},
+			{Title: "B", SortOrder: 1, StartPage: &startPage2},
+		}, 10)
+		require.Len(t, result, 2)
+		assert.Equal(t, "A", result[0].Title)
+		assert.Equal(t, 1, result[0].PageFrom)
+		assert.Equal(t, "B", result[1].Title)
+		assert.Equal(t, 3, result[1].PageFrom)
+	})
+
+	t.Run("drops chapters with nil StartPage", func(t *testing.T) {
+		t.Parallel()
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{Title: "A", SortOrder: 0, StartPage: &startPage0},
+			{Title: "B", SortOrder: 1, StartPage: nil},
+		}, 10)
+		require.Len(t, result, 1)
+		assert.Equal(t, "A", result[0].Title)
+	})
+
+	t.Run("drops chapters with negative StartPage", func(t *testing.T) {
+		t.Parallel()
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{Title: "Bad", SortOrder: 0, StartPage: &startPageNeg},
+			{Title: "Good", SortOrder: 1, StartPage: &startPage0},
+		}, 10)
+		require.Len(t, result, 1)
+		assert.Equal(t, "Good", result[0].Title)
+	})
+
+	t.Run("drops chapters beyond pageCount", func(t *testing.T) {
+		t.Parallel()
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{Title: "In range", SortOrder: 0, StartPage: &startPage2},
+			{Title: "Out of range", SortOrder: 1, StartPage: &startPage5},
+		}, 3)
+		require.Len(t, result, 1)
+		assert.Equal(t, "In range", result[0].Title)
+	})
+
+	t.Run("pageCount 0 disables upper-bound filter", func(t *testing.T) {
+		t.Parallel()
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{Title: "A", SortOrder: 0, StartPage: &startPage5},
+		}, 0)
+		require.Len(t, result, 1)
+		assert.Equal(t, 6, result[0].PageFrom)
+	})
+
+	t.Run("preserves nested chapters", func(t *testing.T) {
+		t.Parallel()
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{
+				Title:     "Parent",
+				SortOrder: 0,
+				StartPage: &startPage0,
+				Children: []*models.Chapter{
+					{Title: "Child", SortOrder: 0, StartPage: &startPage2},
+				},
+			},
+		}, 10)
+		require.Len(t, result, 1)
+		assert.Equal(t, "Parent", result[0].Title)
+		require.Len(t, result[0].Kids, 1)
+		assert.Equal(t, "Child", result[0].Kids[0].Title)
+		assert.Equal(t, 3, result[0].Kids[0].PageFrom)
+	})
+
+	t.Run("sorts by SortOrder", func(t *testing.T) {
+		t.Parallel()
+		result := convertModelChaptersToPDFBookmarks([]*models.Chapter{
+			{Title: "Third", SortOrder: 2, StartPage: &startPage5},
+			{Title: "First", SortOrder: 0, StartPage: &startPage0},
+			{Title: "Second", SortOrder: 1, StartPage: &startPage2},
+		}, 10)
+		require.Len(t, result, 3)
+		assert.Equal(t, "First", result[0].Title)
+		assert.Equal(t, "Second", result[1].Title)
+		assert.Equal(t, "Third", result[2].Title)
+	})
 }
 
 func TestPDFGenerator_Generate_CancelledContext(t *testing.T) {

--- a/pkg/pdf/CLAUDE.md
+++ b/pkg/pdf/CLAUDE.md
@@ -96,7 +96,7 @@ PDF bookmarks (the outline tree) are extracted via go-pdfium's `GetBookmarks` AP
 
 ### Writing Chapters Back
 
-`pkg/filegen/pdf.go` writes `file.Chapters` back to downloaded PDFs as a bookmark outline via `pdfcpu.api.AddBookmarksFile` (with `replace=true`), preserving nested hierarchy. Page numbers are converted from the 0-indexed storage format to the 1-indexed form pdfcpu expects. When `file.Chapters` is empty, the bookmark write is skipped entirely so existing source bookmarks are left untouched. `AddBookmarksFile` requires distinct input/output paths, so the generator writes to a sibling `.bookmarks.tmp` file and renames over the destination.
+`pkg/filegen/pdf.go` writes `file.Chapters` back to downloaded PDFs as a bookmark outline via `pdfcpu.api.AddBookmarksFile` (with `replace=true`), preserving nested hierarchy. Page numbers are converted from the 0-indexed storage format to the 1-indexed form pdfcpu expects, and the generator writes to a sibling `.bookmarks.tmp` file (pdfcpu requires distinct input/output paths) and renames over the destination. When `file.Chapters` is empty the bookmark write is skipped entirely so existing source bookmarks are left untouched. The entire block is **best-effort**: if `AddBookmarksFile` or the rename fails, the generator logs a warning (with `category=pdf_bookmark_write` for aggregation) and returns the properties-only `destPath` rather than failing the whole download — matching the cover-extraction pattern in `pdf.go` Parse, so a metadata quirk can never block an otherwise-valid file.
 
 **Filtering and ordering.** pdfcpu rejects bookmark trees where siblings are not monotonically non-decreasing by page, or where a child's page is less than its parent's. `convertModelChaptersToPDFBookmarks` enforces both constraints rather than trusting `SortOrder` from the database:
 
@@ -104,9 +104,9 @@ PDF bookmarks (the outline tree) are extracted via go-pdfium's `GetBookmarks` AP
 - Child StartPage < parent StartPage → dropped
 - Siblings sorted by `StartPage` (ties broken by `SortOrder` for stability)
 
-This is belt-and-suspenders with the frontend's `normalizeChapterOrder` in `app/components/files/chapterUtils.ts`, which already sorts on save. The backend fallback matters because plugins, sidecar imports, or external API callers can introduce out-of-order state without touching the UI.
+If a parent's StartPage is invalid, the entire subtree is dropped — we do not re-parent grandchildren. In practice the UI produces flat PDF chapters today, so this only matters for sidecar- or plugin-supplied nested chapters.
 
-**Best-effort error handling.** Bookmark writing is best-effort: if `AddBookmarksFile` or the subsequent rename fails, the generator logs a warning and returns the properties-only `destPath` rather than failing the whole download. This matches the cover-extraction pattern in `pdf.go` Parse and prevents a bookmark-write quirk from blocking an otherwise-valid file.
+This is belt-and-suspenders with the frontend's `normalizeChapterOrder` in `app/components/files/chapterUtils.ts`, which already sorts on save. The backend fallback matters because plugins, sidecar imports, or external API callers can introduce out-of-order state without touching the UI.
 
 ### Key Types
 

--- a/pkg/pdf/CLAUDE.md
+++ b/pkg/pdf/CLAUDE.md
@@ -94,6 +94,10 @@ PDF bookmarks (the outline tree) are extracted via go-pdfium's `GetBookmarks` AP
 - **Page index**: each bookmark's `DestInfo.PageIndex` (0-indexed) maps to `ParsedChapter.StartPage`
 - **No DestInfo = skipped**: bookmarks without a page destination are omitted
 
+### Writing Chapters Back
+
+`pkg/filegen/pdf.go` writes `file.Chapters` back to downloaded PDFs as a bookmark outline via `pdfcpu.api.AddBookmarksFile` (with `replace=true`), preserving nested hierarchy. Page numbers are converted from the 0-indexed storage format to the 1-indexed form pdfcpu expects, and out-of-range / nil-StartPage chapters are filtered out. When `file.Chapters` is empty, the bookmark write is skipped entirely so existing source bookmarks are left untouched. `AddBookmarksFile` requires distinct input/output paths, so the generator writes to a sibling `.bookmarks.tmp` file and renames over the destination.
+
 ### Key Types
 
 ```go

--- a/pkg/pdf/CLAUDE.md
+++ b/pkg/pdf/CLAUDE.md
@@ -96,7 +96,17 @@ PDF bookmarks (the outline tree) are extracted via go-pdfium's `GetBookmarks` AP
 
 ### Writing Chapters Back
 
-`pkg/filegen/pdf.go` writes `file.Chapters` back to downloaded PDFs as a bookmark outline via `pdfcpu.api.AddBookmarksFile` (with `replace=true`), preserving nested hierarchy. Page numbers are converted from the 0-indexed storage format to the 1-indexed form pdfcpu expects, and out-of-range / nil-StartPage chapters are filtered out. When `file.Chapters` is empty, the bookmark write is skipped entirely so existing source bookmarks are left untouched. `AddBookmarksFile` requires distinct input/output paths, so the generator writes to a sibling `.bookmarks.tmp` file and renames over the destination.
+`pkg/filegen/pdf.go` writes `file.Chapters` back to downloaded PDFs as a bookmark outline via `pdfcpu.api.AddBookmarksFile` (with `replace=true`), preserving nested hierarchy. Page numbers are converted from the 0-indexed storage format to the 1-indexed form pdfcpu expects. When `file.Chapters` is empty, the bookmark write is skipped entirely so existing source bookmarks are left untouched. `AddBookmarksFile` requires distinct input/output paths, so the generator writes to a sibling `.bookmarks.tmp` file and renames over the destination.
+
+**Filtering and ordering.** pdfcpu rejects bookmark trees where siblings are not monotonically non-decreasing by page, or where a child's page is less than its parent's. `convertModelChaptersToPDFBookmarks` enforces both constraints rather than trusting `SortOrder` from the database:
+
+- nil / negative / `>= pageCount` StartPage → dropped
+- Child StartPage < parent StartPage → dropped
+- Siblings sorted by `StartPage` (ties broken by `SortOrder` for stability)
+
+This is belt-and-suspenders with the frontend's `normalizeChapterOrder` in `app/components/files/chapterUtils.ts`, which already sorts on save. The backend fallback matters because plugins, sidecar imports, or external API callers can introduce out-of-order state without touching the UI.
+
+**Best-effort error handling.** Bookmark writing is best-effort: if `AddBookmarksFile` or the subsequent rename fails, the generator logs a warning and returns the properties-only `destPath` rather than failing the whole download. This matches the cover-extraction pattern in `pdf.go` Parse and prevents a bookmark-write quirk from blocking an otherwise-valid file.
 
 ### Key Types
 

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -131,7 +131,7 @@ Extracted from the PDF info dictionary:
 - **Basic**: title, description (from Subject), tags (from Keywords), release date (from CreationDate), page count, language (from catalog `Lang` property, BCP 47 tag)
 - **Authors**: split from the Author field on commas, ampersands, and semicolons
 - **Cover**: largest embedded image from page 1, falling back to a rendered image of the first page
-- **Chapters**: from the PDF document outline (bookmark tree), flattened to a linear list of page-anchored chapters
+- **Chapters**: from the PDF document outline (bookmark tree), flattened to a linear list of page-anchored chapters. Edited chapters are written back into downloaded PDFs as a bookmark outline so your reader's chapter navigation stays in sync with the edits.
 
 ### Supplements
 

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -131,6 +131,7 @@ Extracted from the PDF info dictionary:
 - **Basic**: title, description (from Subject), tags (from Keywords), release date (from CreationDate), page count, language (from catalog `Lang` property, BCP 47 tag)
 - **Authors**: split from the Author field on commas, ampersands, and semicolons
 - **Cover**: largest embedded image from page 1, falling back to a rendered image of the first page
+- **Chapters**: from the PDF document outline (bookmark tree), flattened to a linear list of page-anchored chapters
 
 ### Supplements
 


### PR DESCRIPTION
## Summary
- `PDFGenerator.Generate` now writes `file.Chapters` back to downloaded PDFs as a bookmark outline via `pdfcpu.api.AddBookmarksFile` (replace=true), preserving nested hierarchy. `convertModelChaptersToPDFBookmarks` sorts siblings by `StartPage`, drops children whose `StartPage` precedes their parent, converts 0-indexed storage to pdfcpu's 1-indexed `PageFrom`, and filters nil / negative / out-of-range pages.
- Bookmark writing is best-effort: on failure the generator logs a structured warning (`category=pdf_bookmark_write`) and returns the properties-only `destPath` instead of failing the whole download, matching the cover-extraction pattern in `pkg/pdf/pdf.go`.
- `convertModelChaptersToMP4` and `convertModelChaptersToCBZ` now sort by the natural position field (timestamp / page) rather than `SortOrder`, so the generated M4B and KePub files render chapters in temporal / page order regardless of DB ordering.
- `downloadcache.ComputeFingerprint` sorts chapters the same way and re-derives `FingerprintChapter.SortOrder` from the sorted index, so fingerprints are stable against `sort_order` drift.
- Frontend `FileChaptersTab.handleSave` normalizes chapter order via a new `normalizeChapterOrder` helper before the mutation fires, so out-of-order edits can't land in the DB even when the input-blur reorder doesn't run (programmatic saves, keyboard shortcuts).
- `website/docs/metadata.md` and `pkg/pdf/CLAUDE.md` now document the read+write round trip and the filter/ordering rules.

## Migration note for plugin authors
This PR quietly changes the semantics of `chapters.sort_order` for page-based and audio formats. Previously `sort_order` reflected the user's drag-and-drop intent in the edit UI. After this PR, the frontend normalizes chapter order on save for CBZ, PDF, and M4B files, so `sort_order` will match the natural position order (`start_page` ascending for CBZ/PDF, `start_timestamp_ms` ascending for M4B) after any save. EPUB chapters are unchanged — their `sort_order` still reflects the href / spine order. Plugins or direct-DB consumers that relied on `sort_order` as a separate signal from the position fields should treat the two as equivalent for CBZ/PDF/M4B going forward.

## Test plan
- Add a PDF with bookmarks, let it scan, and verify chapters appear in the file chapters tab and in the PDF reader's chapter dropdown.
- Edit chapters in the UI (rename / add / delete / reorder), save, then download the file — open the downloaded PDF in a viewer and confirm the bookmark outline matches the edits.
- Reorder chapters in the UI so the drag order disagrees with the natural page/timestamp order (e.g., drag a later chapter above an earlier one), save, and confirm the downloaded PDF/M4B/KePub render chapters in page/timestamp order.
- Edit chapters to include out-of-range `start_page` and verify invalid entries are dropped from the downloaded bookmark outline.
- Upload a PDF without bookmarks, add chapters via the UI, and confirm they appear in the downloaded file.
- Run `mise check:quiet` — should pass (Go test/lint, JS test/lint).