### PR TITLE
[CI] Shard Go tests across 5 parallel jobs with gotesplit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,27 @@ jobs:
       - run: mise lint
 
   test:
-    name: Go Test
+    name: Go Test (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    env:
+      TZ: America/Chicago
+      CI: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
-      - run: mise test:race
+      - name: Run tests
+        env:
+          SHARD: ${{ matrix.shard }}
+          SHARDS: "4"
+        run: |
+          packages=$(go list ./pkg/... | awk -v shard="$SHARD" -v shards="$SHARDS" 'NR % shards == shard % shards')
+          echo "Running $(echo "$packages" | wc -l) packages in shard $SHARD/$SHARDS:"
+          echo "$packages"
+          go test -race $packages
 
   lint-js:
     name: JS Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,50 +21,24 @@ jobs:
       - run: mise lint
 
   test:
-    name: Go Test (${{ matrix.name }})
+    name: Go Test (${{ matrix.shard }}/5)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: worker
-            packages: ./pkg/worker/...
-          - name: plugins
-            packages: ./pkg/plugins/...
-          - name: books
-            packages: ./pkg/books/...
-          - name: rest-1
-            shard: 1
-            shards: 2
-          - name: rest-2
-            shard: 2
-            shards: 2
+        shard: [1, 2, 3, 4, 5]
     env:
       TZ: America/Chicago
       CI: "true"
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+      - name: Install gotesplit
+        run: curl -sfL https://raw.githubusercontent.com/Songmu/gotesplit/main/install.sh | sh -s -- -b /usr/local/bin v0.4.0
       - name: Run tests
         env:
-          PACKAGES: ${{ matrix.packages }}
           SHARD: ${{ matrix.shard }}
-          SHARDS: ${{ matrix.shards }}
-        run: |
-          if [ -n "$PACKAGES" ]; then
-            packages="$PACKAGES"
-          else
-            packages=$(go list ./pkg/... \
-              | grep -vE '/pkg/(worker|plugins|books)$' \
-              | awk -v shard="$SHARD" -v shards="$SHARDS" 'NR % shards == shard % shards')
-          fi
-          if [ -z "$packages" ]; then
-            echo "No packages selected — skipping"
-            exit 0
-          fi
-          echo "Running $(echo "$packages" | wc -w) packages:"
-          echo "$packages"
-          go test -race $packages
+        run: gotesplit -total=5 -index=$((SHARD - 1)) ./pkg/... -- -race
 
   lint-js:
     name: JS Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,24 @@ jobs:
       - run: mise lint
 
   test:
-    name: Go Test (${{ matrix.shard }}/4)
+    name: Go Test (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        include:
+          - name: worker
+            packages: ./pkg/worker/...
+          - name: plugins
+            packages: ./pkg/plugins/...
+          - name: books
+            packages: ./pkg/books/...
+          - name: rest-1
+            shard: 1
+            shards: 2
+          - name: rest-2
+            shard: 2
+            shards: 2
     env:
       TZ: America/Chicago
       CI: "true"
@@ -35,11 +47,22 @@ jobs:
       - uses: jdx/mise-action@v4
       - name: Run tests
         env:
+          PACKAGES: ${{ matrix.packages }}
           SHARD: ${{ matrix.shard }}
-          SHARDS: "4"
+          SHARDS: ${{ matrix.shards }}
         run: |
-          packages=$(go list ./pkg/... | awk -v shard="$SHARD" -v shards="$SHARDS" 'NR % shards == shard % shards')
-          echo "Running $(echo "$packages" | wc -l) packages in shard $SHARD/$SHARDS:"
+          if [ -n "$PACKAGES" ]; then
+            packages="$PACKAGES"
+          else
+            packages=$(go list ./pkg/... \
+              | grep -vE '/pkg/(worker|plugins|books)$' \
+              | awk -v shard="$SHARD" -v shards="$SHARDS" 'NR % shards == shard % shards')
+          fi
+          if [ -z "$packages" ]; then
+            echo "No packages selected — skipping"
+            exit 0
+          fi
+          echo "Running $(echo "$packages" | wc -w) packages:"
           echo "$packages"
           go test -race $packages
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ const coverUrl = `/api/books/${id}/cover?t=${query.dataUpdatedAt}`;
 
 ### Testing
 - `mise test` - Run all Go tests with coverage
-- `mise test:race` - Run all Go tests with race detection and coverage (used in CI)
+- `mise test:race` - Run all Go tests with race detection and coverage (local; CI runs the same `-race` tests but sharded across parallel jobs in `.github/workflows/ci.yml`)
 - `mise test:js` - Run all JS tests (unit + E2E) in parallel
 - `mise test:unit` - Run JS unit tests only
 - `mise test:e2e` - Run E2E tests (Chromium + Firefox) in parallel


### PR DESCRIPTION
## Summary
- Splits the Go test job into 5 parallel shards using [gotesplit](https://github.com/Songmu/gotesplit), which distributes individual test functions (not packages) across shards for finer-grained balance
- Cuts CI wall time from ~13m down to ~6m (longest shard), with automatic rebalancing as tests are added — no matrix tweaks needed
- Local `mise test:race` is unchanged; sharding lives only in the CI workflow

## Implementation notes
- gotesplit v0.4.0 is installed per-job via the official `install.sh` script to `/usr/local/bin`
- Command: `gotesplit -total=5 -index=$((SHARD-1)) ./pkg/... -- -race`
- Distribution is count-based, not time-based: each shard gets roughly `total_tests / 5` test functions. If a single slow test ever dominates, we'd need a different approach

## Test plan
- Watch this PR's CI — confirm all 5 `Go Test (N/5)` shards pass and wall time is ~6m on the longest shard
- Observed on PR runs: shard 3 and shard 5 are the current long poles (~6m), shards 1/2/4 finish faster