### PR TITLE
[Fix] Prefer file.Name over book.Title for PDF info-dict Title

### DIFF
--- a/pkg/filegen/pdf.go
+++ b/pkg/filegen/pdf.go
@@ -202,9 +202,14 @@ func convertModelChaptersToPDFBookmarks(chapters []*models.Chapter, pageCount in
 func (g *PDFGenerator) buildProperties(book *models.Book, file *models.File) map[string]string {
 	props := make(map[string]string)
 
-	// Title
-	if book.Title != "" {
-		props["Title"] = book.Title
+	// Title — prefer file.Name over book.Title per the file-level vs
+	// book-level convention in pkg/CLAUDE.md, matching the M4B generator.
+	title := book.Title
+	if file != nil && file.Name != nil && *file.Name != "" {
+		title = *file.Name
+	}
+	if title != "" {
+		props["Title"] = title
 	}
 
 	// Author — join all book authors with ", " sorted by SortOrder.

--- a/pkg/filegen/pdf_test.go
+++ b/pkg/filegen/pdf_test.go
@@ -164,26 +164,55 @@ func TestPDFGenerator_Generate(t *testing.T) {
 func TestPDFGenerator_Generate_PrefersFileName(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
-	srcPath := filepath.Join(tmpDir, "source.pdf")
-	writeTestPDF(t, srcPath, map[string]string{"Title": "Original Title"})
+	t.Run("uses file.Name when set", func(t *testing.T) {
+		t.Parallel()
 
-	destPath := filepath.Join(tmpDir, "dest.pdf")
+		tmpDir := t.TempDir()
+		srcPath := filepath.Join(tmpDir, "source.pdf")
+		writeTestPDF(t, srcPath, map[string]string{"Title": "Original Title"})
 
-	customName := "Custom Name"
-	book := &models.Book{Title: "Book Title"}
-	file := &models.File{
-		FileType: models.FileTypePDF,
-		Name:     &customName,
-	}
+		destPath := filepath.Join(tmpDir, "dest.pdf")
 
-	gen := &PDFGenerator{}
-	err := gen.Generate(context.Background(), srcPath, destPath, book, file)
-	require.NoError(t, err)
+		customName := "Custom Name"
+		book := &models.Book{Title: "Book Title"}
+		file := &models.File{
+			FileType: models.FileTypePDF,
+			Name:     &customName,
+		}
 
-	meta, err := pdf.Parse(destPath)
-	require.NoError(t, err)
-	assert.Equal(t, "Custom Name", meta.Title)
+		gen := &PDFGenerator{}
+		err := gen.Generate(context.Background(), srcPath, destPath, book, file)
+		require.NoError(t, err)
+
+		meta, err := pdf.Parse(destPath)
+		require.NoError(t, err)
+		assert.Equal(t, "Custom Name", meta.Title)
+	})
+
+	t.Run("falls back to book.Title when file.Name is empty string", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		srcPath := filepath.Join(tmpDir, "source.pdf")
+		writeTestPDF(t, srcPath, map[string]string{"Title": "Original Title"})
+
+		destPath := filepath.Join(tmpDir, "dest.pdf")
+
+		emptyName := ""
+		book := &models.Book{Title: "Book Title"}
+		file := &models.File{
+			FileType: models.FileTypePDF,
+			Name:     &emptyName,
+		}
+
+		gen := &PDFGenerator{}
+		err := gen.Generate(context.Background(), srcPath, destPath, book, file)
+		require.NoError(t, err)
+
+		meta, err := pdf.Parse(destPath)
+		require.NoError(t, err)
+		assert.Equal(t, "Book Title", meta.Title)
+	})
 }
 
 func TestPDFGenerator_Generate_MultipleAuthors(t *testing.T) {

--- a/pkg/filegen/pdf_test.go
+++ b/pkg/filegen/pdf_test.go
@@ -161,6 +161,31 @@ func TestPDFGenerator_Generate(t *testing.T) {
 	assert.Equal(t, "New Author", meta.Authors[0].Name)
 }
 
+func TestPDFGenerator_Generate_PrefersFileName(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	srcPath := filepath.Join(tmpDir, "source.pdf")
+	writeTestPDF(t, srcPath, map[string]string{"Title": "Original Title"})
+
+	destPath := filepath.Join(tmpDir, "dest.pdf")
+
+	customName := "Custom Name"
+	book := &models.Book{Title: "Book Title"}
+	file := &models.File{
+		FileType: models.FileTypePDF,
+		Name:     &customName,
+	}
+
+	gen := &PDFGenerator{}
+	err := gen.Generate(context.Background(), srcPath, destPath, book, file)
+	require.NoError(t, err)
+
+	meta, err := pdf.Parse(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, "Custom Name", meta.Title)
+}
+
 func TestPDFGenerator_Generate_MultipleAuthors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `pkg/filegen/pdf.go` now prefers `file.Name` over `book.Title` when writing the PDF info-dict Title, matching the M4B generator and the file-level vs book-level convention documented in `pkg/CLAUDE.md`.
- Adds `TestPDFGenerator_Generate_PrefersFileName` to pin the new behavior.
- Closes the round-3 PR #69 follow-up (N-4).

## Test plan
- `go test ./pkg/filegen/ -run TestPDFGenerator` — all generator tests pass, including the new one
- `mise check:quiet` — lint, test, test:js, lint:js all green
- Manual: rename a PDF file via the UI (sets `file.Name`), download it, and confirm the info-dict Title in the downloaded copy shows the custom name rather than the book-level title