### PR TITLE
[Feature] Add shisho.sleep() host API for plugin retry backoff

### DIFF
--- a/packages/plugin-sdk/host-api.d.ts
+++ b/packages/plugin-sdk/host-api.d.ts
@@ -402,14 +402,25 @@ export interface ShishoHostAPI {
    * backed by Go's `time.Sleep`. Use it to implement exponential backoff
    * between retries when calling rate-limited APIs.
    *
-   * @param ms Non-negative number of milliseconds to sleep. Throws on negative or NaN values.
+   * **Not interruptible by hook timeouts.** Because sleep blocks in a Go
+   * syscall the VM cannot interrupt, the hook's deadline (1 minute for
+   * parsers and enrichers, 5 minutes for converters and output generators)
+   * will not fire until the sleep returns. While sleeping, the plugin's
+   * runtime mutex is held, so other goroutines waiting to invoke a hook on
+   * the same plugin are blocked as well. Keep total backoff well under the
+   * hook's timeout. Sleeps longer than 5 minutes are rejected.
+   *
+   * @param ms Finite non-negative milliseconds, capped at 5 minutes. Throws on
+   * negative, NaN, Infinity, or values exceeding the cap.
    * @example
    * // Exponential backoff: 1s, 2s, 4s
+   * var resp;
    * for (var attempt = 0; attempt < 3; attempt++) {
-   *   var resp = shisho.http.fetch(url, {});
+   *   resp = shisho.http.fetch(url, {});
    *   if (resp.status !== 503) return resp;
    *   shisho.sleep(1000 * Math.pow(2, attempt));
    * }
+   * return resp; // retries exhausted — return the last 503
    */
   sleep(ms: number): void;
   log: ShishoLog;

--- a/packages/plugin-sdk/host-api.d.ts
+++ b/packages/plugin-sdk/host-api.d.ts
@@ -395,6 +395,23 @@ export interface ShishoShell {
 export interface ShishoHostAPI {
   /** Persistent data directory for this plugin. Created lazily on first access. */
   readonly dataDir: string;
+  /**
+   * Block the plugin for the given number of milliseconds.
+   *
+   * Goja has no Promise/setTimeout support, so this is a synchronous delay
+   * backed by Go's `time.Sleep`. Use it to implement exponential backoff
+   * between retries when calling rate-limited APIs.
+   *
+   * @param ms Non-negative number of milliseconds to sleep. Throws on negative or NaN values.
+   * @example
+   * // Exponential backoff: 1s, 2s, 4s
+   * for (var attempt = 0; attempt < 3; attempt++) {
+   *   var resp = shisho.http.fetch(url, {});
+   *   if (resp.status !== 503) return resp;
+   *   shisho.sleep(1000 * Math.pow(2, attempt));
+   * }
+   */
+  sleep(ms: number): void;
   log: ShishoLog;
   config: ShishoConfig;
   http: ShishoHTTP;

--- a/packages/plugin-sdk/testing/index.ts
+++ b/packages/plugin-sdk/testing/index.ts
@@ -27,8 +27,9 @@ export interface MockFetchResponse {
 
 /**
  * Maximum value accepted by `shisho.sleep()` in production (5 minutes, in ms).
- * Mirrors `maxSleepMs` in `pkg/plugins/hostapi.go`. Plugin tests can reference
- * this constant instead of hardcoding `300000` when asserting the cap.
+ * Mirrors `maxSleepMs` in `pkg/plugins/hostapi.go` — must be kept in sync.
+ * Plugin tests can reference this constant instead of hardcoding `300000`
+ * when asserting the cap.
  */
 export const MAX_SLEEP_MS = 5 * 60 * 1000;
 

--- a/packages/plugin-sdk/testing/index.ts
+++ b/packages/plugin-sdk/testing/index.ts
@@ -562,8 +562,25 @@ export function createMockShisho(
     );
   };
 
+  const sleep: ShishoHostAPI["sleep"] = (ms: number): void => {
+    if (
+      typeof ms !== "number" ||
+      Number.isNaN(ms) ||
+      !Number.isFinite(ms) ||
+      ms < 0
+    ) {
+      throw new Error("shisho.sleep: ms must be a finite non-negative number");
+    }
+    const end = Date.now() + ms;
+    while (Date.now() < end) {
+      // Synchronous busy-wait — matches goja's blocking semantics so plugin
+      // tests that assert backoff durations behave the same as production.
+    }
+  };
+
   return {
     dataDir: "/tmp/shisho-mock-data",
+    sleep,
     log,
     config,
     http,

--- a/packages/plugin-sdk/testing/index.ts
+++ b/packages/plugin-sdk/testing/index.ts
@@ -25,6 +25,13 @@ export interface MockFetchResponse {
   headers?: Record<string, string>;
 }
 
+/**
+ * Maximum value accepted by `shisho.sleep()` in production (5 minutes, in ms).
+ * Mirrors `maxSleepMs` in `pkg/plugins/hostapi.go`. Plugin tests can reference
+ * this constant instead of hardcoding `300000` when asserting the cap.
+ */
+export const MAX_SLEEP_MS = 5 * 60 * 1000;
+
 /** Options for createMockShisho(). */
 export interface MockShishoOptions {
   /** Route-based fetch mock. Keys are URL strings, values are mock responses. */
@@ -38,6 +45,17 @@ export interface MockShishoOptions {
    * - string[] values are returned by listDir
    */
   fs?: Record<string, string | Buffer | string[]>;
+  /**
+   * Override the `sleep` implementation. Defaults to a no-op so tests asserting
+   * exponential backoff with e.g. `shisho.sleep(1000 * Math.pow(2, attempt))`
+   * don't actually block for the cumulative wall-clock time. Wrap with your
+   * test framework's spy helper (e.g. `vi.fn()`) if you want to assert the
+   * arguments each retry passed.
+   *
+   * The override is still subject to the same validation rules as production
+   * (`MAX_SLEEP_MS` cap, no NaN/Infinity/negative).
+   */
+  sleep?: (ms: number) => void;
 }
 
 function statusText(status: number): string {
@@ -562,6 +580,12 @@ export function createMockShisho(
     );
   };
 
+  // --- sleep: validate like production, then delegate ---
+  // Defaults to a no-op because plugin tests asserting exponential backoff
+  // (`shisho.sleep(1000 * Math.pow(2, attempt))`) would otherwise add several
+  // seconds of wall-clock per retry path. Authors who want a real wait or
+  // call tracking can pass `options.sleep` (e.g. a `vi.fn()` spy).
+  const sleepImpl = options.sleep ?? (() => {});
   const sleep: ShishoHostAPI["sleep"] = (ms: number): void => {
     if (
       typeof ms !== "number" ||
@@ -571,11 +595,12 @@ export function createMockShisho(
     ) {
       throw new Error("shisho.sleep: ms must be a finite non-negative number");
     }
-    const end = Date.now() + ms;
-    while (Date.now() < end) {
-      // Synchronous busy-wait — matches goja's blocking semantics so plugin
-      // tests that assert backoff durations behave the same as production.
+    if (ms > MAX_SLEEP_MS) {
+      throw new Error(
+        `shisho.sleep: ms must be <= ${MAX_SLEEP_MS} (5 minutes)`,
+      );
     }
+    sleepImpl(ms);
   };
 
   return {

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -268,10 +268,12 @@ outputGenerator: {
 ```javascript
 shisho.sleep(1000)   // block for 1 second
 shisho.sleep(0)      // no-op
-// Throws on negative or NaN values
+// Throws on negative, NaN, Infinity, or values > 5 minutes (300000 ms)
 ```
 
 Synchronous delay backed by Go's `time.Sleep`. Goja has no `setTimeout` / Promise support, so this is the primitive plugins use for exponential backoff between retries (e.g. against rate-limited APIs).
+
+**Not interruptible by hook timeouts.** `time.Sleep` blocks in a Go syscall that the VM can't interrupt, and the existing hook `context.WithTimeout` in `hooks.go` is currently `_ = ctx // reserved for future cancellation support` — so a long sleep will outlive its deadline. The call also holds `Runtime.mu`, which serializes every other hook invocation on the same plugin. The 5-minute cap (`maxSleepMs` in `hostapi.go`) matches the longest existing hook timeout so a single sleep can't exceed any hook type's deadline by more than seconds of overhead. When real cancellation is wired up via `vm.Interrupt()`, this cap can be loosened.
 
 ### shisho.log
 
@@ -620,7 +622,9 @@ Repositories provide a `repository.json` manifest:
 3. Add manifest capability type if needed (in `manifest.go`)
 4. Add tests in `hostapi_newapi_test.go`
 5. **Update `packages/plugin-sdk/host-api.d.ts`** — add the new interface and include it in `ShishoHostAPI`
-6. If a new manifest capability was added, update `packages/plugin-sdk/manifest.d.ts`
+6. **Update `packages/plugin-sdk/testing/index.ts`** — `createMockShisho` returns a `ShishoHostAPI`, so any new required field must be provided (either as a working mock impl or a `notImplemented()` stub). Missing this breaks `tsc --noEmit` for every plugin author who upgrades the SDK.
+7. **Update `website/docs/plugins/development.md`** — add a section for the new API under "Host APIs" with an example and any gotchas
+8. If a new manifest capability was added, update `packages/plugin-sdk/manifest.d.ts`
 
 ### Adding a new hook type
 

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -263,6 +263,16 @@ outputGenerator: {
 
 ## Host APIs (shisho.*)
 
+### shisho.sleep
+
+```javascript
+shisho.sleep(1000)   // block for 1 second
+shisho.sleep(0)      // no-op
+// Throws on negative or NaN values
+```
+
+Synchronous delay backed by Go's `time.Sleep`. Goja has no `setTimeout` / Promise support, so this is the primitive plugins use for exponential backoff between retries (e.g. against rate-limited APIs).
+
 ### shisho.log
 
 ```javascript

--- a/pkg/plugins/hostapi.go
+++ b/pkg/plugins/hostapi.go
@@ -134,6 +134,23 @@ func injectDataDirProperty(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime
 // every other invocation on the same plugin.
 const maxSleepMs = float64(5 * 60 * 1000)
 
+var (
+	errSleepNotFinite  = errors.New("shisho.sleep: ms must be a finite non-negative number")
+	errSleepExceedsCap = errors.New("shisho.sleep: ms must be <= 300000 (5 minutes)")
+)
+
+// validateSleepMs enforces the rules for shisho.sleep's ms argument.
+// Extracted so boundary cases can be unit-tested without actually sleeping.
+func validateSleepMs(ms float64) error {
+	if math.IsNaN(ms) || math.IsInf(ms, 0) || ms < 0 {
+		return errSleepNotFinite
+	}
+	if ms > maxSleepMs {
+		return errSleepExceedsCap
+	}
+	return nil
+}
+
 // injectSleepFunction sets up shisho.sleep(ms) as a blocking delay primitive.
 // Plugins use this to implement exponential backoff between retries, since
 // Goja has no Promise/setTimeout support.
@@ -143,11 +160,8 @@ func injectSleepFunction(vm *goja.Runtime, shishoObj *goja.Object) error {
 			panic(vm.ToValue("shisho.sleep: ms argument is required"))
 		}
 		ms := call.Argument(0).ToFloat()
-		if math.IsNaN(ms) || math.IsInf(ms, 0) || ms < 0 {
-			panic(vm.ToValue("shisho.sleep: ms must be a finite non-negative number"))
-		}
-		if ms > maxSleepMs {
-			panic(vm.ToValue(fmt.Sprintf("shisho.sleep: ms must be <= %.0f (5 minutes)", maxSleepMs)))
+		if err := validateSleepMs(ms); err != nil {
+			panic(vm.ToValue(err.Error()))
 		}
 		time.Sleep(time.Duration(ms * float64(time.Millisecond)))
 		return goja.Undefined()

--- a/pkg/plugins/hostapi.go
+++ b/pkg/plugins/hostapi.go
@@ -127,6 +127,13 @@ func injectDataDirProperty(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime
 	return err
 }
 
+// maxSleepMs caps shisho.sleep at the longest hook timeout (inputConverter and
+// outputGenerator are 5 minutes; parsers and enrichers are 1 minute). Until
+// context cancellation is wired through to vm.Interrupt(), an unbounded sleep
+// would outlive the hook deadline while still holding Runtime.mu, blocking
+// every other invocation on the same plugin.
+const maxSleepMs = float64(5 * 60 * 1000)
+
 // injectSleepFunction sets up shisho.sleep(ms) as a blocking delay primitive.
 // Plugins use this to implement exponential backoff between retries, since
 // Goja has no Promise/setTimeout support.
@@ -136,8 +143,11 @@ func injectSleepFunction(vm *goja.Runtime, shishoObj *goja.Object) error {
 			panic(vm.ToValue("shisho.sleep: ms argument is required"))
 		}
 		ms := call.Argument(0).ToFloat()
-		if math.IsNaN(ms) || ms < 0 {
-			panic(vm.ToValue("shisho.sleep: ms must be a non-negative number"))
+		if math.IsNaN(ms) || math.IsInf(ms, 0) || ms < 0 {
+			panic(vm.ToValue("shisho.sleep: ms must be a finite non-negative number"))
+		}
+		if ms > maxSleepMs {
+			panic(vm.ToValue(fmt.Sprintf("shisho.sleep: ms must be <= %.0f (5 minutes)", maxSleepMs)))
 		}
 		time.Sleep(time.Duration(ms * float64(time.Millisecond)))
 		return goja.Undefined()

--- a/pkg/plugins/hostapi.go
+++ b/pkg/plugins/hostapi.go
@@ -3,7 +3,9 @@ package plugins
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
+	"time"
 
 	"github.com/dop251/goja"
 	"github.com/pkg/errors"
@@ -38,6 +40,11 @@ func InjectHostAPIs(rt *Runtime, configGetter ConfigGetter) error {
 
 	// Set up log namespace
 	if err := injectLogNamespace(vm, shishoObj, pluginTag); err != nil {
+		return err
+	}
+
+	// Set up top-level sleep function
+	if err := injectSleepFunction(vm, shishoObj); err != nil {
 		return err
 	}
 
@@ -118,6 +125,27 @@ func injectDataDirProperty(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime
 
 	_, err := defineProperty(objectVal, shishoObj, vm.ToValue("dataDir"), descriptor)
 	return err
+}
+
+// injectSleepFunction sets up shisho.sleep(ms) as a blocking delay primitive.
+// Plugins use this to implement exponential backoff between retries, since
+// Goja has no Promise/setTimeout support.
+func injectSleepFunction(vm *goja.Runtime, shishoObj *goja.Object) error {
+	sleepFn := func(call goja.FunctionCall) goja.Value {
+		if len(call.Arguments) < 1 {
+			panic(vm.ToValue("shisho.sleep: ms argument is required"))
+		}
+		ms := call.Argument(0).ToFloat()
+		if math.IsNaN(ms) || ms < 0 {
+			panic(vm.ToValue("shisho.sleep: ms must be a non-negative number"))
+		}
+		time.Sleep(time.Duration(ms * float64(time.Millisecond)))
+		return goja.Undefined()
+	}
+	if err := shishoObj.Set("sleep", sleepFn); err != nil {
+		return fmt.Errorf("failed to set shisho.sleep: %w", err)
+	}
+	return nil
 }
 
 // injectLogNamespace sets up shisho.log with debug/info/warn/error methods.

--- a/pkg/plugins/hostapi.go
+++ b/pkg/plugins/hostapi.go
@@ -132,11 +132,18 @@ func injectDataDirProperty(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime
 // context cancellation is wired through to vm.Interrupt(), an unbounded sleep
 // would outlive the hook deadline while still holding Runtime.mu, blocking
 // every other invocation on the same plugin.
+//
+// Must stay in sync with MAX_SLEEP_MS in packages/plugin-sdk/testing/index.ts.
+// If this changes to something other than 5 minutes, update the "5 minutes"
+// text in errSleepExceedsCap, this comment, and the plugin docs.
 const maxSleepMs = float64(5 * 60 * 1000)
 
 var (
-	errSleepNotFinite  = errors.New("shisho.sleep: ms must be a finite non-negative number")
-	errSleepExceedsCap = errors.New("shisho.sleep: ms must be <= 300000 (5 minutes)")
+	errSleepNotFinite = errors.New("shisho.sleep: ms must be a finite non-negative number")
+	// Built via fmt.Errorf once at package init so the numeric portion of the
+	// message is derived from maxSleepMs instead of duplicated. Still a static
+	// sentinel — comparable with errors.Is and allocated exactly once.
+	errSleepExceedsCap = fmt.Errorf("shisho.sleep: ms must be <= %d (5 minutes)", int(maxSleepMs)) //nolint:err113 // see comment above
 )
 
 // validateSleepMs enforces the rules for shisho.sleep's ms argument.

--- a/pkg/plugins/hostapi_test.go
+++ b/pkg/plugins/hostapi_test.go
@@ -154,6 +154,9 @@ func TestInjectHostAPIs_Sleep(t *testing.T) {
 	require.NoError(t, err)
 	elapsed := time.Since(start)
 	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond, "sleep should block for at least the requested duration")
+	// Upper bound guards against regressions that reinterpret the argument
+	// (e.g. as seconds instead of milliseconds).
+	assert.Less(t, elapsed, 5*time.Second, "sleep should not block dramatically longer than requested")
 
 	// Zero is allowed and returns immediately.
 	_, err = rt.vm.RunString(`shisho.sleep(0)`)
@@ -161,6 +164,13 @@ func TestInjectHostAPIs_Sleep(t *testing.T) {
 
 	// Fractional milliseconds are supported.
 	_, err = rt.vm.RunString(`shisho.sleep(1.5)`)
+	require.NoError(t, err)
+
+	// The exact cap (5 minutes) is allowed; skip the actual 5-minute wait by
+	// only asserting the call parses and validates. We don't run this — it
+	// would make the test suite take 5 minutes. Instead, verify that
+	// maxSleepMs - 1 is accepted at the validation layer by running 1ms.
+	_, err = rt.vm.RunString(`shisho.sleep(1)`)
 	require.NoError(t, err)
 }
 
@@ -171,18 +181,24 @@ func TestInjectHostAPIs_Sleep_InvalidArgs(t *testing.T) {
 	require.NoError(t, InjectHostAPIs(rt, cfg))
 
 	tests := []struct {
-		name string
-		js   string
+		name        string
+		js          string
+		wantMessage string
 	}{
-		{"missing argument", `shisho.sleep()`},
-		{"negative", `shisho.sleep(-5)`},
-		{"NaN", `shisho.sleep(NaN)`},
+		{"missing argument", `shisho.sleep()`, "argument is required"},
+		{"negative", `shisho.sleep(-5)`, "finite non-negative"},
+		{"NaN", `shisho.sleep(NaN)`, "finite non-negative"},
+		{"positive Infinity", `shisho.sleep(Infinity)`, "finite non-negative"},
+		{"negative Infinity", `shisho.sleep(-Infinity)`, "finite non-negative"},
+		{"exceeds cap", `shisho.sleep(5 * 60 * 1000 + 1)`, "5 minutes"},
+		{"overflow value", `shisho.sleep(1e18)`, "5 minutes"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := rt.vm.RunString(tc.js)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "shisho.sleep")
+			assert.Contains(t, err.Error(), tc.wantMessage)
 		})
 	}
 }

--- a/pkg/plugins/hostapi_test.go
+++ b/pkg/plugins/hostapi_test.go
@@ -2,6 +2,8 @@ package plugins
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -165,13 +167,41 @@ func TestInjectHostAPIs_Sleep(t *testing.T) {
 	// Fractional milliseconds are supported.
 	_, err = rt.vm.RunString(`shisho.sleep(1.5)`)
 	require.NoError(t, err)
+}
 
-	// The exact cap (5 minutes) is allowed; skip the actual 5-minute wait by
-	// only asserting the call parses and validates. We don't run this — it
-	// would make the test suite take 5 minutes. Instead, verify that
-	// maxSleepMs - 1 is accepted at the validation layer by running 1ms.
-	_, err = rt.vm.RunString(`shisho.sleep(1)`)
-	require.NoError(t, err)
+// TestValidateSleepMs exercises the boundary cases directly without paying
+// the time.Sleep cost — notably the exact cap and cap - 1, which would add
+// 5 minutes of wall-clock time if driven through the JS layer.
+func TestValidateSleepMs(t *testing.T) {
+	t.Parallel()
+
+	valid := []float64{0, 0.5, 1, 1000, maxSleepMs - 1, maxSleepMs}
+	for _, ms := range valid {
+		t.Run(fmt.Sprintf("valid/%v", ms), func(t *testing.T) {
+			assert.NoError(t, validateSleepMs(ms))
+		})
+	}
+
+	cases := []struct {
+		name    string
+		ms      float64
+		message string
+	}{
+		{"negative", -1, "finite non-negative"},
+		{"NaN", math.NaN(), "finite non-negative"},
+		{"+Inf", math.Inf(1), "finite non-negative"},
+		{"-Inf", math.Inf(-1), "finite non-negative"},
+		{"cap + 1", maxSleepMs + 1, "5 minutes"},
+		{"1e18 overflow", 1e18, "5 minutes"},
+	}
+	for _, tc := range cases {
+		t.Run("invalid/"+tc.name, func(t *testing.T) {
+			err := validateSleepMs(tc.ms)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "shisho.sleep")
+			assert.Contains(t, err.Error(), tc.message)
+		})
+	}
 }
 
 func TestInjectHostAPIs_Sleep_InvalidArgs(t *testing.T) {

--- a/pkg/plugins/hostapi_test.go
+++ b/pkg/plugins/hostapi_test.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
@@ -140,6 +141,50 @@ func TestInjectHostAPIs_LogPluginTag(t *testing.T) {
 	// The log calls should not panic (they log internally with the plugin tag)
 	_, err = rt.vm.RunString(`shisho.log.info("test with tag")`)
 	assert.NoError(t, err)
+}
+
+func TestInjectHostAPIs_Sleep(t *testing.T) {
+	t.Parallel()
+	rt := newTestRuntime("official", "test-plugin")
+	cfg := &mockConfigGetter{configs: map[string]*string{}}
+	require.NoError(t, InjectHostAPIs(rt, cfg))
+
+	start := time.Now()
+	_, err := rt.vm.RunString(`shisho.sleep(50)`)
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond, "sleep should block for at least the requested duration")
+
+	// Zero is allowed and returns immediately.
+	_, err = rt.vm.RunString(`shisho.sleep(0)`)
+	require.NoError(t, err)
+
+	// Fractional milliseconds are supported.
+	_, err = rt.vm.RunString(`shisho.sleep(1.5)`)
+	require.NoError(t, err)
+}
+
+func TestInjectHostAPIs_Sleep_InvalidArgs(t *testing.T) {
+	t.Parallel()
+	rt := newTestRuntime("official", "test-plugin")
+	cfg := &mockConfigGetter{configs: map[string]*string{}}
+	require.NoError(t, InjectHostAPIs(rt, cfg))
+
+	tests := []struct {
+		name string
+		js   string
+	}{
+		{"missing argument", `shisho.sleep()`},
+		{"negative", `shisho.sleep(-5)`},
+		{"NaN", `shisho.sleep(NaN)`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := rt.vm.RunString(tc.js)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "shisho.sleep")
+		})
+	}
 }
 
 func TestInjectHostAPIs_ConfigGetAll_Empty(t *testing.T) {

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -596,6 +596,21 @@ var bytes = resp.arrayBuffer(); // response body as ArrayBuffer
 
 Domain patterns support wildcards: `"*.example.com"` matches `example.com`, `api.example.com`, and `a.b.example.com`.
 
+### Sleep
+
+Block the plugin for a number of milliseconds. Goja has no `setTimeout` or `Promise` support, so this is the primitive to use for exponential backoff when retrying rate-limited APIs:
+
+```javascript
+// Exponential backoff between retries
+for (var attempt = 0; attempt < 3; attempt++) {
+  var resp = shisho.http.fetch(url, {});
+  if (resp.status !== 503) return resp;
+  shisho.sleep(1000 * Math.pow(2, attempt));  // 1s, 2s, 4s
+}
+```
+
+`shisho.sleep(ms)` throws if `ms` is negative or `NaN`. A value of `0` returns immediately.
+
 ### URL Utilities
 
 Helpers for URL manipulation that aren't available in the ES5.1 runtime:

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -602,14 +602,20 @@ Block the plugin for a number of milliseconds. Goja has no `setTimeout` or `Prom
 
 ```javascript
 // Exponential backoff between retries
+var resp;
 for (var attempt = 0; attempt < 3; attempt++) {
-  var resp = shisho.http.fetch(url, {});
+  resp = shisho.http.fetch(url, {});
   if (resp.status !== 503) return resp;
   shisho.sleep(1000 * Math.pow(2, attempt));  // 1s, 2s, 4s
 }
+return resp; // retries exhausted — return the last 503
 ```
 
-`shisho.sleep(ms)` throws if `ms` is negative or `NaN`. A value of `0` returns immediately.
+`shisho.sleep(ms)` throws if `ms` is negative, `NaN`, `Infinity`, or greater than 5 minutes (300000 ms). A value of `0` returns immediately.
+
+:::warning Not interruptible by hook timeouts
+`shisho.sleep` blocks in a Go syscall that the VM cannot interrupt, so the hook's deadline (1 minute for parsers and enrichers, 5 minutes for converters and output generators) will **not** fire until the sleep returns. While sleeping, the plugin's runtime mutex is held, so other goroutines waiting to invoke a hook on the same plugin are blocked as well. Keep total backoff well under the hook's timeout — if you exceed it, the worker will eventually kill the plugin and your cumulative sleeps become dead latency for every other caller.
+:::
 
 ### URL Utilities
 


### PR DESCRIPTION
## Summary
- Registers a top-level `shisho.sleep(ms)` function on the plugin host API, backed by Go's `time.Sleep`, so plugins can implement exponential backoff between HTTP retries (goja has no `setTimeout`/`Promise`).
- Validates the argument is a non-negative, non-NaN number; throws a descriptive error otherwise.
- Updates `@shisho/plugin-sdk` (`ShishoHostAPI`), `pkg/plugins/CLAUDE.md`, and `website/docs/plugins/development.md` to document the new primitive.

## Test plan
- New Go tests in `pkg/plugins/hostapi_test.go` cover the happy path (verifies the call blocks for at least the requested duration), zero, fractional milliseconds, and the three error cases (missing argument, negative, `NaN`).
- `mise check:quiet` passes locally (lint, Go tests, JS tests, JS lint).
- Consumer wiring in the `goodreads-enricher` plugin and its vitest mock lives in a separate repo and will be done in a follow-up PR once this ships.