### PR TITLE
[Refactor] Consolidate file cover path resolution via fileutils.ResolveCoverPath

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -94,12 +94,15 @@ newCoverPath := filepath.Base(fileutils.ComputeNewCoverPath(*file.CoverImageFile
 file.CoverImageFilename = &newCoverPath
 ```
 
-**Why this matters:** The `bookCover` handler constructs the full path as:
-```go
-coverPath := filepath.Join(coverDir, *coverFile.CoverImageFilename)
-```
+**Why this matters:** Handlers resolve the full path at runtime by joining `book.Filepath` with `CoverImageFilename`. If `CoverImageFilename` contains a full path, this results in an invalid doubled path like `/path/to/path/to/cover.jpg`.
 
-If `CoverImageFilename` contains a full path, this results in an invalid doubled path like `/path/to/path/to/cover.jpg`.
+**Use the shared resolution helpers in `pkg/fileutils/operations.go`** rather than hand-rolling `os.Stat` / `!info.IsDir()` / `filepath.Dir` dances:
+
+- **`ResolveCoverPath(bookFilepath, coverFilename) string`** — read-side callers (serving, fingerprinting, file-generation) that already have a resolved `book.Filepath` from the DB. Example: `fileutils.ResolveCoverPath(file.Book.Filepath, *file.CoverImageFilename)` in the `fileCover` handler.
+- **`ResolveCoverDir(bookFilepath) string`** — same read-side contract but returns just the directory (e.g. for `uploadFileCover`, which enumerates existing cover files). Stat-failure fallback returns the path unchanged — **safe only for read-side callers** whose `bookFilepath` is known to exist.
+- **`ResolveCoverDirForWrite(bookFilepath, fileFilepath) string`** — write-side callers in the scanner where `bookFilepath` may be a synthetic organized-folder path that does not yet exist on disk (`scanFileCreateNew` computes `bookPath` for root-level new files before the organized directory is created). Falls back to `filepath.Dir(fileFilepath)` — the library directory where the file actually lives — when the book path doesn't resolve to a real directory.
+
+For callers that only hold a `file.Filepath` (e.g. `deleteFileFromDisk`, `recoverMissingCover`), prefer the pure-string `filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)` — it's always correct (the cover lives alongside the file for both root-level and directory-backed books) and immune to stat races when the main file has already been removed.
 
 ### Data Source Priority System
 

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -75,7 +75,6 @@ Each book has an optional `PrimaryFileID` (`*int`) that designates which file is
 ### Cover Image System
 
 - Individual file covers: `{filename}.cover.{ext}`
-- Book model has `ResolveCoverImage()` method that finds covers dynamically
 - API endpoints: `/books/{id}/cover` and `/files/{id}/cover`
 
 **CRITICAL - CoverImageFilename stores FILENAME ONLY:**

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1479,23 +1479,7 @@ func (h *handler) bookCover(c echo.Context) error {
 		return errcodes.NotFound("Cover")
 	}
 
-	// Determine if this is a root-level book by checking if book.Filepath is a file
-	isRootLevelBook := false
-	if info, err := os.Stat(book.Filepath); err == nil && !info.IsDir() {
-		isRootLevelBook = true
-	}
-
-	// Determine the directory where covers are located
-	var coverDir string
-	if isRootLevelBook {
-		// For root-level books, covers are in the same directory as the file
-		coverDir = filepath.Dir(book.Filepath)
-	} else {
-		// For directory-based books, covers are in the book directory
-		coverDir = book.Filepath
-	}
-
-	coverPath := filepath.Join(coverDir, *coverFile.CoverImageFilename)
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
 	return errors.WithStack(c.File(coverPath))
 }
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -748,19 +748,22 @@ func (h *handler) updateFile(c echo.Context) error {
 
 		// When downgrading from main to supplement, clear all main-file-only metadata
 		if oldRole == models.FileRoleMain && newRole == models.FileRoleSupplement {
-			// Delete cover image file if it exists. CoverImageFilename stores just
-			// the filename; fileutils.ResolveCoverPath joins it with the book's
-			// cover directory (book dir, or its parent for root-level books).
-			if file.CoverImageFilename != nil && file.Book != nil {
-				coverPath := fileutils.ResolveCoverPath(file.Book.Filepath, *file.CoverImageFilename)
-				if coverPath != "" {
-					if err := os.Remove(coverPath); err != nil && !os.IsNotExist(err) {
-						log.Warn("failed to delete cover image on downgrade", logger.Data{
-							"error":   err.Error(),
-							"path":    coverPath,
-							"file_id": file.ID,
-						})
-					}
+			// Delete cover image file if it exists. CoverImageFilename stores
+			// just the filename — use a pure-string join against
+			// filepath.Dir(file.Filepath) rather than stat'ing book.Filepath.
+			// book.Filepath may be a synthetic organized-folder path that
+			// never exists on disk for root-level files, and ResolveCoverPath
+			// would fall back to that junk path. The cover always lives
+			// alongside the file for both root-level and directory-backed
+			// books, so filepath.Dir(file.Filepath) is always correct.
+			if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
+				coverPath := filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)
+				if err := os.Remove(coverPath); err != nil && !os.IsNotExist(err) {
+					log.Warn("failed to delete cover image on downgrade", logger.Data{
+						"error":   err.Error(),
+						"path":    coverPath,
+						"file_id": file.ID,
+					})
 				}
 			}
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1326,17 +1326,7 @@ func (h *handler) uploadFileCover(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Determine cover directory
-	isRootLevelBook := false
-	if info, err := os.Stat(book.Filepath); err == nil && !info.IsDir() {
-		isRootLevelBook = true
-	}
-	var coverDir string
-	if isRootLevelBook {
-		coverDir = filepath.Dir(book.Filepath)
-	} else {
-		coverDir = book.Filepath
-	}
+	coverDir := fileutils.ResolveCoverDir(book.Filepath)
 
 	// Generate the cover filename: {filename}.cover.{ext}
 	filename := filepath.Base(file.Filepath)

--- a/pkg/books/handlers_cover_page.go
+++ b/pkg/books/handlers_cover_page.go
@@ -77,18 +77,7 @@ func (h *handler) updateFileCoverPage(c echo.Context) error {
 		return errcodes.ValidationError("Failed to extract page from file")
 	}
 
-	// Determine cover directory (same logic as fileCover and uploadFileCover)
-	// Use file.Book which is already loaded by RetrieveFile
-	isRootLevelBook := false
-	if info, err := os.Stat(file.Book.Filepath); err == nil && !info.IsDir() {
-		isRootLevelBook = true
-	}
-	var coverDir string
-	if isRootLevelBook {
-		coverDir = filepath.Dir(file.Book.Filepath)
-	} else {
-		coverDir = file.Book.Filepath
-	}
+	coverDir := fileutils.ResolveCoverDir(file.Book.Filepath)
 
 	// Generate the cover filename: {filename}.cover.{ext}
 	filename := filepath.Base(file.Filepath)

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -897,4 +897,34 @@ func TestUpdateFile_DowngradeMainToSupplement_DeletesCoverFile(t *testing.T) {
 			return book, libraryDir, epubPath
 		})
 	})
+
+	// Regression: for root-level files in non-organized libraries,
+	// scanFileCreateNew stores a synthetic organized-folder path in
+	// book.Filepath (e.g. /library/Author/Title) that never gets created
+	// on disk. Resolving the cover via book.Filepath would stat that
+	// junk path, fall back to using it as a directory, and silently
+	// miss the real cover that lives next to the file at
+	// /library/root-book.epub.cover.jpg.
+	t.Run("root-level file with synthetic book path", func(t *testing.T) {
+		t.Parallel()
+		runDowngrade(t, func(t *testing.T, libraryID int) (*models.Book, string, string) {
+			t.Helper()
+			libraryDir := t.TempDir()
+			epubPath := filepath.Join(libraryDir, "root-book.epub")
+			// Synthetic organized-folder path — this is what scanFileCreateNew
+			// computes at pkg/worker/scan_unified.go:2106 for root-level files,
+			// regardless of whether OrganizeFileStructure is enabled.
+			syntheticBookPath := filepath.Join(libraryDir, "Author Name", "Book Title")
+			book := &models.Book{
+				LibraryID:       libraryID,
+				Title:           "Root Book",
+				TitleSource:     models.DataSourceFilepath,
+				SortTitle:       "Root Book",
+				SortTitleSource: models.DataSourceFilepath,
+				AuthorSource:    models.DataSourceFilepath,
+				Filepath:        syntheticBookPath,
+			}
+			return book, libraryDir, epubPath
+		})
+	})
 }

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1490,18 +1490,20 @@ func (svc *Service) DeleteBookAndFiles(ctx context.Context, bookID int, library 
 
 // deleteFileFromDisk deletes a file and its associated cover and sidecar from disk.
 func deleteFileFromDisk(file *models.File) error {
+	// Resolve the cover path before deleting the main file, because
+	// ResolveCoverPath stats file.Filepath to locate the cover directory.
+	var coverPath string
+	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
+		coverPath = fileutils.ResolveCoverPath(file.Filepath, *file.CoverImageFilename)
+	}
+
 	// Delete the main file
 	if err := os.Remove(file.Filepath); err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "failed to delete main file")
 	}
 
 	// Delete cover image if exists (best effort)
-	// Cover filename may be stored as relative or absolute path
-	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
-		coverPath := *file.CoverImageFilename
-		if !filepath.IsAbs(coverPath) {
-			coverPath = filepath.Join(filepath.Dir(file.Filepath), coverPath)
-		}
+	if coverPath != "" {
 		_ = os.Remove(coverPath)
 	}
 

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1490,22 +1490,20 @@ func (svc *Service) DeleteBookAndFiles(ctx context.Context, bookID int, library 
 
 // deleteFileFromDisk deletes a file and its associated cover and sidecar from disk.
 func deleteFileFromDisk(file *models.File) error {
-	// Resolve the cover path before deleting the main file, because
-	// ResolveCoverDir stats file.Filepath to decide between filepath.Dir
-	// (the root-level case, where file.Filepath stats as a file) and using
-	// it as-is. Once the file is gone, that stat would fail.
-	var coverPath string
-	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
-		coverPath = fileutils.ResolveCoverPath(file.Filepath, *file.CoverImageFilename)
-	}
-
 	// Delete the main file
 	if err := os.Remove(file.Filepath); err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "failed to delete main file")
 	}
 
-	// Delete cover image if exists (best effort)
-	if coverPath != "" {
+	// Delete cover image if exists (best effort). Use a pure-string join
+	// rather than fileutils.ResolveCoverPath here: that helper stats the
+	// first argument, and file.Filepath may have been removed manually
+	// by the user before this function runs (or just now, above). For
+	// both root-level and directory-backed books, the cover lives
+	// alongside the file, so filepath.Dir(file.Filepath) is always the
+	// cover dir regardless of whether the main file exists on disk.
+	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
+		coverPath := filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)
 		_ = os.Remove(coverPath)
 	}
 

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1491,7 +1491,9 @@ func (svc *Service) DeleteBookAndFiles(ctx context.Context, bookID int, library 
 // deleteFileFromDisk deletes a file and its associated cover and sidecar from disk.
 func deleteFileFromDisk(file *models.File) error {
 	// Resolve the cover path before deleting the main file, because
-	// ResolveCoverPath stats file.Filepath to locate the cover directory.
+	// ResolveCoverDir stats file.Filepath to decide between filepath.Dir
+	// (the root-level case, where file.Filepath stats as a file) and using
+	// it as-is. Once the file is gone, that stat would fail.
 	var coverPath string
 	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
 		coverPath = fileutils.ResolveCoverPath(file.Filepath, *file.CoverImageFilename)

--- a/pkg/books/service_test.go
+++ b/pkg/books/service_test.go
@@ -493,7 +493,10 @@ func TestDeleteBookAndFiles_OrganizedStructure_DeletesEntireDirectory(t *testing
 	err = os.WriteFile(mainFilePath, []byte("test content"), 0644)
 	require.NoError(t, err)
 
-	coverPath := filepath.Join(bookDir, "test.cover.jpg")
+	// CoverImageFilename stores just the filename; the full path is
+	// resolved at runtime relative to the book directory.
+	coverFilename := "test.cover.jpg"
+	coverPath := filepath.Join(bookDir, coverFilename)
 	err = os.WriteFile(coverPath, []byte("cover content"), 0644)
 	require.NoError(t, err)
 
@@ -509,7 +512,7 @@ func TestDeleteBookAndFiles_OrganizedStructure_DeletesEntireDirectory(t *testing
 		FileRole:           models.FileRoleMain,
 		Filepath:           mainFilePath,
 		FilesizeBytes:      12,
-		CoverImageFilename: &coverPath,
+		CoverImageFilename: &coverFilename,
 	}
 	_, err = db.NewInsert().Model(file).Exec(ctx)
 	require.NoError(t, err)

--- a/pkg/books/service_test.go
+++ b/pkg/books/service_test.go
@@ -336,7 +336,10 @@ func TestDeleteBookAndFiles_DeletesBookFilesAndDiskFiles(t *testing.T) {
 	err = os.WriteFile(mainFilePath, []byte("test content"), 0644)
 	require.NoError(t, err)
 
-	coverPath := filepath.Join(tmpDir, "test.cover.jpg")
+	// CoverImageFilename stores just the filename; the full path is
+	// resolved at runtime relative to the book directory.
+	coverFilename := "test.cover.jpg"
+	coverPath := filepath.Join(tmpDir, coverFilename)
 	err = os.WriteFile(coverPath, []byte("cover content"), 0644)
 	require.NoError(t, err)
 
@@ -352,7 +355,7 @@ func TestDeleteBookAndFiles_DeletesBookFilesAndDiskFiles(t *testing.T) {
 		FileRole:           models.FileRoleMain,
 		Filepath:           mainFilePath,
 		FilesizeBytes:      12,
-		CoverImageFilename: &coverPath,
+		CoverImageFilename: &coverFilename,
 	}
 	_, err = db.NewInsert().Model(file).Exec(ctx)
 	require.NoError(t, err)

--- a/pkg/books/service_test.go
+++ b/pkg/books/service_test.go
@@ -386,6 +386,72 @@ func TestDeleteBookAndFiles_DeletesBookFilesAndDiskFiles(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "sidecar should be deleted")
 }
 
+// TestDeleteBookAndFiles_RemovesCoverWhenMainFileAlreadyMissing is a
+// regression test for a bug where deleteFileFromDisk resolved the cover
+// path by stat'ing file.Filepath. If the main file had already been
+// removed from disk (e.g. the user manually deleted it before triggering
+// the app's delete), the stat would fail, ResolveCoverDir would fall
+// back to treating file.Filepath as a directory, and the resulting
+// cover path would be a junk location — silently leaving the cover file
+// orphaned on disk.
+func TestDeleteBookAndFiles_RemovesCoverWhenMainFileAlreadyMissing(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	library := &models.Library{
+		Name:                     "Test Library",
+		OrganizeFileStructure:    false,
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        filepath.Join(tmpDir, "test-book"),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	// Write the cover but NOT the main file, to simulate a user who has
+	// already manually deleted the main file before running the app's
+	// delete.
+	mainFilePath := filepath.Join(tmpDir, "test.epub")
+	coverFilename := "test.cover.jpg"
+	coverPath := filepath.Join(tmpDir, coverFilename)
+	require.NoError(t, os.WriteFile(coverPath, []byte("cover content"), 0644))
+
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           mainFilePath,
+		FilesizeBytes:      12,
+		CoverImageFilename: &coverFilename,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Call DeleteBookAndFiles — main file absence is expected and fine.
+	bookSvc := NewService(db)
+	_, err = bookSvc.DeleteBookAndFiles(ctx, book.ID, library)
+	require.NoError(t, err)
+
+	// The orphaned cover file must be cleaned up even though the main
+	// file was already missing when the delete ran.
+	_, err = os.Stat(coverPath)
+	assert.True(t, os.IsNotExist(err), "cover should be deleted even when main file was already missing")
+}
+
 func TestDeleteBookAndFiles_OrganizedStructure_DeletesEntireDirectory(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/downloadcache/fingerprint.go
+++ b/pkg/downloadcache/fingerprint.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
@@ -276,15 +277,16 @@ func ComputeFingerprint(book *models.Book, file *models.File) (*Fingerprint, err
 		sort.Strings(fp.Tags)
 	}
 
-	// Add cover information if present
+	// Add cover information if present. CoverImageFilename stores only the
+	// filename; resolve it against the book's cover directory so Path is
+	// usable and Stat sees the real file for modtime.
 	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
-		coverPath := *file.CoverImageFilename
+		coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
 		mimeType := ""
 		if file.CoverMimeType != nil {
 			mimeType = *file.CoverMimeType
 		}
 
-		// Get file modification time for the cover
 		var modTime time.Time
 		if info, err := os.Stat(coverPath); err == nil {
 			modTime = info.ModTime()

--- a/pkg/downloadcache/fingerprint_test.go
+++ b/pkg/downloadcache/fingerprint_test.go
@@ -175,6 +175,9 @@ func TestComputeFingerprint(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, fp.Cover)
+		// Path is still resolved via ResolveCoverPath even when stat fails —
+		// locks in the join contract.
+		assert.Equal(t, filepath.Join("/nonexistent", "missing.jpg"), fp.Cover.Path)
 		assert.True(t, fp.Cover.ModTime.IsZero())
 	})
 

--- a/pkg/downloadcache/fingerprint_test.go
+++ b/pkg/downloadcache/fingerprint_test.go
@@ -136,21 +136,22 @@ func TestComputeFingerprint(t *testing.T) {
 		assert.Empty(t, fp.Narrators)
 	})
 
-	t.Run("cover information is included", func(t *testing.T) {
-		// Create a temp file to simulate a cover image
+	t.Run("cover information is resolved against book directory", func(t *testing.T) {
+		// CoverImageFilename stores just the filename; the full path is
+		// resolved at runtime against book.Filepath.
 		tmpDir := t.TempDir()
-		coverPath := filepath.Join(tmpDir, "cover.jpg")
-		err := os.WriteFile(coverPath, []byte("fake cover data"), 0644)
+		coverFilename := "book.epub.cover.jpg"
+		coverAbsPath := filepath.Join(tmpDir, coverFilename)
+		err := os.WriteFile(coverAbsPath, []byte("fake cover data"), 0644)
 		require.NoError(t, err)
 
-		// Get the mod time
-		info, err := os.Stat(coverPath)
+		info, err := os.Stat(coverAbsPath)
 		require.NoError(t, err)
 		modTime := info.ModTime()
 
-		book := &models.Book{Title: "Book with Cover"}
+		book := &models.Book{Title: "Book with Cover", Filepath: tmpDir}
 		file := &models.File{
-			CoverImageFilename: strPtr(coverPath),
+			CoverImageFilename: strPtr(coverFilename),
 			CoverMimeType:      strPtr("image/jpeg"),
 		}
 
@@ -158,15 +159,15 @@ func TestComputeFingerprint(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, fp.Cover)
-		assert.Equal(t, coverPath, fp.Cover.Path)
+		assert.Equal(t, coverAbsPath, fp.Cover.Path)
 		assert.Equal(t, "image/jpeg", fp.Cover.MimeType)
 		assert.Equal(t, modTime.Unix(), fp.Cover.ModTime.Unix())
 	})
 
-	t.Run("cover with non-existent path uses zero time", func(t *testing.T) {
-		book := &models.Book{Title: "Book"}
+	t.Run("cover with non-existent filename uses zero time", func(t *testing.T) {
+		book := &models.Book{Title: "Book", Filepath: "/nonexistent"}
 		file := &models.File{
-			CoverImageFilename: strPtr("/nonexistent/cover.jpg"),
+			CoverImageFilename: strPtr("missing.jpg"),
 			CoverMimeType:      strPtr("image/jpeg"),
 		}
 

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
+	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/people"
@@ -720,21 +721,7 @@ func (h *handler) Cover(c echo.Context) error {
 		return errcodes.NotFound("Cover")
 	}
 
-	// Determine if this is a root-level book by checking if book.Filepath is a file
-	isRootLevelBook := false
-	if info, err := os.Stat(book.Filepath); err == nil && !info.IsDir() {
-		isRootLevelBook = true
-	}
-
-	// Determine the directory where covers are located
-	var coverDir string
-	if isRootLevelBook {
-		coverDir = filepath.Dir(book.Filepath)
-	} else {
-		coverDir = book.Filepath
-	}
-
-	coverPath := filepath.Join(coverDir, *coverFile.CoverImageFilename)
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
 	return errors.WithStack(c.File(coverPath))
 }
 

--- a/pkg/fileutils/operations.go
+++ b/pkg/fileutils/operations.go
@@ -422,13 +422,40 @@ func getBaseNameWithoutExt(path string) string {
 // (e.g. file.Filepath). For directory-backed books (the common case), the
 // book filepath is the cover dir itself. For root-level books (where
 // book.Filepath is the file, not a directory) or when given a file path,
-// the cover dir is the file's parent. If the path cannot be stat'd (e.g.,
-// because it was moved or deleted), falls back to treating it as a directory.
+// the cover dir is the file's parent. If the path cannot be stat'd, returns
+// it unchanged — safe for read-side callers that are resolving a path the
+// DB already tells us exists, but NOT safe for write-side callers whose
+// bookFilepath may be a synthetic path that hasn't been created yet. Those
+// callers must use ResolveCoverDirForWrite.
 func ResolveCoverDir(bookFilepath string) string {
 	if info, err := os.Stat(bookFilepath); err == nil && !info.IsDir() {
 		return filepath.Dir(bookFilepath)
 	}
 	return bookFilepath
+}
+
+// ResolveCoverDirForWrite resolves the directory where a cover image should
+// be written. Unlike ResolveCoverDir (the read-side helper), this handles
+// the case where bookFilepath may be a synthetic organized-folder path that
+// does not yet exist on disk — common when scanning root-level files in
+// libraries with OrganizeFileStructure enabled, where the organized
+// directory is created later in the batch. In that case the cover must
+// land alongside the file at filepath.Dir(fileFilepath), which is where
+// extractAndSaveCover wrote the file-embedded cover.
+//
+// If bookFilepath resolves to a real directory, it's used. Otherwise (stat
+// fails, or bookFilepath is a file), falls back to filepath.Dir(fileFilepath).
+// This is correct for all three scenarios:
+//   - directory-backed books: bookFilepath is a real dir, use it
+//   - root-level books (rescan): bookFilepath == fileFilepath, fall back
+//     gives filepath.Dir(fileFilepath) = library dir, same as before
+//   - root-level books (new file, synthetic path): stat fails, fall back
+//     gives filepath.Dir(fileFilepath) = library dir where the file lives
+func ResolveCoverDirForWrite(bookFilepath, fileFilepath string) string {
+	if info, err := os.Stat(bookFilepath); err == nil && info.IsDir() {
+		return bookFilepath
+	}
+	return filepath.Dir(fileFilepath)
 }
 
 // ResolveCoverPath resolves the full path to a file's cover image on disk.

--- a/pkg/fileutils/operations.go
+++ b/pkg/fileutils/operations.go
@@ -418,9 +418,11 @@ func getBaseNameWithoutExt(path string) string {
 }
 
 // ResolveCoverDir resolves the directory that contains a book's cover images.
-// For directory-backed books (the common case), this is the book's filepath
-// itself. For root-level books (where book.Filepath is the file, not a
-// directory), it's the file's parent. If the path cannot be stat'd (e.g.,
+// Accepts either the book's filepath or any file inside the book directory
+// (e.g. file.Filepath). For directory-backed books (the common case), the
+// book filepath is the cover dir itself. For root-level books (where
+// book.Filepath is the file, not a directory) or when given a file path,
+// the cover dir is the file's parent. If the path cannot be stat'd (e.g.,
 // because it was moved or deleted), falls back to treating it as a directory.
 func ResolveCoverDir(bookFilepath string) string {
 	if info, err := os.Stat(bookFilepath); err == nil && !info.IsDir() {

--- a/pkg/fileutils/operations.go
+++ b/pkg/fileutils/operations.go
@@ -417,22 +417,27 @@ func getBaseNameWithoutExt(path string) string {
 	return strings.TrimSuffix(base, ext)
 }
 
+// ResolveCoverDir resolves the directory that contains a book's cover images.
+// For directory-backed books (the common case), this is the book's filepath
+// itself. For root-level books (where book.Filepath is the file, not a
+// directory), it's the file's parent. If the path cannot be stat'd (e.g.,
+// because it was moved or deleted), falls back to treating it as a directory.
+func ResolveCoverDir(bookFilepath string) string {
+	if info, err := os.Stat(bookFilepath); err == nil && !info.IsDir() {
+		return filepath.Dir(bookFilepath)
+	}
+	return bookFilepath
+}
+
 // ResolveCoverPath resolves the full path to a file's cover image on disk.
 // CoverImageFilename in the database stores only the filename, so the full
 // path must be constructed at runtime by joining it with the book's cover
-// directory. For directory-backed books (the common case), the cover dir is
-// the book's filepath itself; for root-level books (where book.Filepath is
-// the file, not a directory), the cover dir is the file's parent.
-// Returns an empty string if coverFilename is empty.
+// directory. Returns an empty string if coverFilename is empty.
 func ResolveCoverPath(bookFilepath, coverFilename string) string {
 	if coverFilename == "" {
 		return ""
 	}
-	coverDir := bookFilepath
-	if info, err := os.Stat(bookFilepath); err == nil && !info.IsDir() {
-		coverDir = filepath.Dir(bookFilepath)
-	}
-	return filepath.Join(coverDir, coverFilename)
+	return filepath.Join(ResolveCoverDir(bookFilepath), coverFilename)
 }
 
 // ComputeNewCoverFilename computes the new cover filename after a file has been renamed.

--- a/pkg/fileutils/operations_test.go
+++ b/pkg/fileutils/operations_test.go
@@ -912,6 +912,44 @@ func TestResolveCoverDir(t *testing.T) {
 	})
 }
 
+func TestResolveCoverDirForWrite(t *testing.T) {
+	t.Parallel()
+
+	t.Run("directory-backed book returns book dir unchanged", func(t *testing.T) {
+		t.Parallel()
+		bookDir := t.TempDir()
+		filePath := filepath.Join(bookDir, "book.epub")
+		if err := os.WriteFile(filePath, []byte("epub"), 0644); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+		assert.Equal(t, bookDir, ResolveCoverDirForWrite(bookDir, filePath))
+	})
+
+	t.Run("root-level book (rescan) returns library dir", func(t *testing.T) {
+		t.Parallel()
+		libraryDir := t.TempDir()
+		bookFilepath := filepath.Join(libraryDir, "book.epub")
+		if err := os.WriteFile(bookFilepath, []byte("epub"), 0644); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+		// Root-level rescan: bookFilepath == fileFilepath, both point at the file.
+		assert.Equal(t, libraryDir, ResolveCoverDirForWrite(bookFilepath, bookFilepath))
+	})
+
+	t.Run("synthetic (nonexistent) bookFilepath falls back to file's parent", func(t *testing.T) {
+		t.Parallel()
+		libraryDir := t.TempDir()
+		filePath := filepath.Join(libraryDir, "book.epub")
+		if err := os.WriteFile(filePath, []byte("epub"), 0644); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+		// Synthetic bookPath (never created on disk), e.g. for a root-level
+		// new file in a library with OrganizeFileStructure enabled.
+		syntheticBookPath := filepath.Join(libraryDir, "Author", "Title")
+		assert.Equal(t, libraryDir, ResolveCoverDirForWrite(syntheticBookPath, filePath))
+	})
+}
+
 func TestResolveCoverPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/fileutils/operations_test.go
+++ b/pkg/fileutils/operations_test.go
@@ -886,6 +886,32 @@ func TestMoveFileWithAssociatedFiles(t *testing.T) {
 	}
 }
 
+func TestResolveCoverDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("directory-backed book returns book dir unchanged", func(t *testing.T) {
+		t.Parallel()
+		bookDir := t.TempDir()
+		assert.Equal(t, bookDir, ResolveCoverDir(bookDir))
+	})
+
+	t.Run("root-level book returns parent of file", func(t *testing.T) {
+		t.Parallel()
+		libraryDir := t.TempDir()
+		bookFilepath := filepath.Join(libraryDir, "book.epub")
+		if err := os.WriteFile(bookFilepath, []byte("epub"), 0644); err != nil {
+			t.Fatalf("failed to write test file: %v", err)
+		}
+		assert.Equal(t, libraryDir, ResolveCoverDir(bookFilepath))
+	})
+
+	t.Run("nonexistent path is treated as a directory path", func(t *testing.T) {
+		t.Parallel()
+		bookDir := filepath.Join(t.TempDir(), "missing")
+		assert.Equal(t, bookDir, ResolveCoverDir(bookDir))
+	})
+}
+
 func TestResolveCoverPath(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/kobo/handlers.go
+++ b/pkg/kobo/handlers.go
@@ -10,7 +10,6 @@ import (
 	_ "image/png" // Register PNG decoder
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -22,6 +21,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
+	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/models"
 	"golang.org/x/image/draw"
 )
@@ -245,15 +245,7 @@ func (h *handler) handleCover(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Determine cover directory (same logic as eReader handler)
-	var coverDir string
-	if info, statErr := os.Stat(book.Filepath); statErr == nil && !info.IsDir() {
-		coverDir = filepath.Dir(book.Filepath)
-	} else {
-		coverDir = book.Filepath
-	}
-
-	coverPath := filepath.Join(coverDir, *file.CoverImageFilename)
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
 
 	// Parse requested dimensions
 	widthStr := c.Param("w")

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -2,8 +2,6 @@ package series
 
 import (
 	"net/http"
-	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
@@ -11,6 +9,7 @@ import (
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/search"
@@ -271,21 +270,7 @@ func (h *handler) seriesCover(c echo.Context) error {
 		return errcodes.NotFound("Series cover")
 	}
 
-	// Determine if this is a root-level book by checking if book.Filepath is a file
-	isRootLevelBook := false
-	if info, err := os.Stat(book.Filepath); err == nil && !info.IsDir() {
-		isRootLevelBook = true
-	}
-
-	// Determine the directory where covers are located
-	var coverDir string
-	if isRootLevelBook {
-		coverDir = filepath.Dir(book.Filepath)
-	} else {
-		coverDir = book.Filepath
-	}
-
-	coverImagePath := filepath.Join(coverDir, *coverFile.CoverImageFilename)
+	coverImagePath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
 
 	// Set appropriate headers
 	c.Response().Header().Set("Cache-Control", "public, max-age=86400")

--- a/pkg/worker/scan_cover_upgrade_test.go
+++ b/pkg/worker/scan_cover_upgrade_test.go
@@ -5,12 +5,15 @@ import (
 	"image"
 	"image/color"
 	"image/jpeg"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func makeJPEG(width, height int) []byte {
@@ -134,4 +137,66 @@ func TestEnricherCoverPluginSourceCheck(t *testing.T) {
 		source := md.SourceForField("cover")
 		assert.NotEqual(t, "plugin:", source[:7])
 	})
+}
+
+// TestUpgradeEnricherCover_RootLevelFile_SyntheticBookPath is a regression
+// test for a bug where upgradeEnricherCover silently failed to write the
+// upgraded cover when given a synthetic organized-folder bookPath that
+// did not yet exist on disk. For root-level new files in libraries with
+// OrganizeFileStructure enabled, scanFileCreateNew computes bookPath as
+// filepath.Join(libraryPath, organizedFolderName) — a planned path that
+// is not created until later in the batch. The cover dir must fall back
+// to filepath.Dir(file.Filepath) (the library dir where extractAndSaveCover
+// already wrote the embedded cover) in that case.
+func TestUpgradeEnricherCover_RootLevelFile_SyntheticBookPath(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	// Simulate a root-level new file: a real file at the library root,
+	// with a synthetic organized-folder bookPath that does not exist.
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "book.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0644))
+
+	// Write a small existing cover next to the file, as extractAndSaveCover
+	// would have done before enrichers run.
+	existingCoverPath := filepath.Join(libraryDir, "book.epub.cover.jpg")
+	require.NoError(t, os.WriteFile(existingCoverPath, makeJPEG(200, 300), 0644))
+
+	// Synthetic bookPath that does not exist on disk (this is what
+	// scanFileCreateNew computes for a root-level file).
+	syntheticBookPath := filepath.Join(libraryDir, "Author Name", "Book Title")
+	_, err := os.Stat(syntheticBookPath)
+	require.True(t, os.IsNotExist(err), "synthetic bookPath must not exist on disk")
+
+	file := &models.File{
+		Filepath: filePath,
+		FileType: models.FileTypeEPUB,
+	}
+
+	// Plugin-sourced enricher metadata with a larger cover.
+	metadata := &mediafile.ParsedMetadata{
+		CoverData:     makeJPEG(800, 1200),
+		CoverMimeType: "image/jpeg",
+		FieldDataSources: map[string]string{
+			"cover": models.PluginDataSource("test", "enricher"),
+		},
+	}
+
+	tc.worker.upgradeEnricherCover(tc.ctx, metadata, file, syntheticBookPath, nil)
+
+	// The upgraded cover must replace the existing one next to the file
+	// (the library dir), not be silently dropped into the nonexistent
+	// synthetic organized-folder path. Assert by resolution, not just
+	// existence, since the pre-upgrade small cover also lives at this
+	// path.
+	upgradedCoverPath := filepath.Join(libraryDir, "book.epub.cover.jpg")
+	upgradedBytes, err := os.ReadFile(upgradedCoverPath)
+	require.NoError(t, err, "upgraded cover should exist at the library-dir location")
+	upgradedRes := fileutils.ImageResolution(upgradedBytes)
+	assert.Greater(t, upgradedRes, 200*300, "cover on disk should be the upgraded (larger) image, not the pre-upgrade small cover")
+
+	// And nothing should have been written under the synthetic path.
+	_, err = os.Stat(syntheticBookPath)
+	assert.True(t, os.IsNotExist(err), "synthetic bookPath must still not exist after upgrade")
 }

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -1909,7 +1909,10 @@ func (w *Worker) scanFileCore(
 		isDifferent := file.CoverPage == nil || *file.CoverPage != *fileSidecarData.CoverPage
 
 		if shouldApply && isDifferent {
-			coverDir := fileutils.ResolveCoverDir(book.Filepath)
+			// book.Filepath may be a synthetic organized-folder path that
+			// does not yet exist for root-level new files, so use the
+			// write-side helper that falls back to the file's parent dir.
+			coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, file.Filepath)
 
 			// Generate cover filename
 			filename := filepath.Base(file.Filepath)
@@ -2680,8 +2683,11 @@ func (w *Worker) upgradeEnricherCover(
 		return
 	}
 
-	// 4. Determine the cover directory
-	coverDir := fileutils.ResolveCoverDir(bookFilepath)
+	// 4. Determine the cover directory. bookFilepath may be a synthetic
+	// organized-folder path that does not yet exist for root-level new
+	// files (see scanFileCreateNew around line 2106), so use the
+	// write-side helper that falls back to the file's parent dir.
+	coverDir := fileutils.ResolveCoverDirForWrite(bookFilepath, file.Filepath)
 
 	coverBaseName := filepath.Base(file.Filepath) + ".cover"
 	existingCoverPath := fileutils.CoverExistsWithBaseName(coverDir, coverBaseName)

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -1909,17 +1909,7 @@ func (w *Worker) scanFileCore(
 		isDifferent := file.CoverPage == nil || *file.CoverPage != *fileSidecarData.CoverPage
 
 		if shouldApply && isDifferent {
-			// Determine cover directory
-			var coverDir string
-			if file.Book != nil {
-				if info, statErr := os.Stat(file.Book.Filepath); statErr == nil && info.IsDir() {
-					coverDir = file.Book.Filepath
-				} else {
-					coverDir = filepath.Dir(file.Book.Filepath)
-				}
-			} else {
-				coverDir = filepath.Dir(file.Filepath)
-			}
+			coverDir := fileutils.ResolveCoverDir(book.Filepath)
 
 			// Generate cover filename
 			filename := filepath.Base(file.Filepath)
@@ -2690,11 +2680,8 @@ func (w *Worker) upgradeEnricherCover(
 		return
 	}
 
-	// 4. Determine the cover directory (same logic as recoverMissingCover)
-	coverDir := bookFilepath
-	if info, err := os.Stat(bookFilepath); err != nil || !info.IsDir() {
-		coverDir = filepath.Dir(file.Filepath)
-	}
+	// 4. Determine the cover directory
+	coverDir := fileutils.ResolveCoverDir(bookFilepath)
 
 	coverBaseName := filepath.Base(file.Filepath) + ".cover"
 	existingCoverPath := fileutils.CoverExistsWithBaseName(coverDir, coverBaseName)
@@ -3335,18 +3322,12 @@ func (w *Worker) recoverMissingCover(ctx context.Context, file *models.File, job
 		}
 	}
 
-	// Determine cover directory
-	var coverDir string
-	if file.Book != nil {
-		// Check if book filepath is a directory or file
-		if info, err := os.Stat(file.Book.Filepath); err == nil && info.IsDir() {
-			coverDir = file.Book.Filepath
-		} else {
-			coverDir = filepath.Dir(file.Book.Filepath)
-		}
-	} else {
-		coverDir = filepath.Dir(file.Filepath)
-	}
+	// Determine cover directory. recoverMissingCover is called from
+	// scanFileByID only after confirming file.Filepath exists on disk, so
+	// ResolveCoverDir will stat it, see it's a file, and fall back to
+	// filepath.Dir — the correct cover dir for both root-level and
+	// directory-backed books.
+	coverDir := fileutils.ResolveCoverDir(file.Filepath)
 
 	// Check if cover file exists on disk
 	filename := filepath.Base(file.Filepath)

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -3328,12 +3328,10 @@ func (w *Worker) recoverMissingCover(ctx context.Context, file *models.File, job
 		}
 	}
 
-	// Determine cover directory. recoverMissingCover is called from
-	// scanFileByID only after confirming file.Filepath exists on disk, so
-	// ResolveCoverDir will stat it, see it's a file, and fall back to
-	// filepath.Dir — the correct cover dir for both root-level and
-	// directory-backed books.
-	coverDir := fileutils.ResolveCoverDir(file.Filepath)
+	// Determine cover directory. For both root-level and directory-backed
+	// books, the cover lives in the same directory as the file, so
+	// filepath.Dir(file.Filepath) is always correct — no stat needed.
+	coverDir := filepath.Dir(file.Filepath)
 
 	// Check if cover file exists on disk
 	filename := filepath.Base(file.Filepath)


### PR DESCRIPTION
## Summary
- Replace four hand-rolled `os.Stat` / `!info.IsDir()` / `filepath.Join` blocks in `bookCover`, eReader `Cover`, kobo `handleCover`, and series `seriesCover` with calls to the existing `fileutils.ResolveCoverPath` helper.
- Drops 52 lines of duplicated logic so future cover-resolution rules only need to land in one place.
- Drops now-unused `os` / `path/filepath` imports where applicable.

## Test plan
- `mise check:quiet` — lint, Go tests, JS unit, E2E (Chromium + Firefox) all pass.
- Behavior is preserved: `fileutils.ResolveCoverPath` already has test coverage for directory-backed books, root-level books, and empty filename cases in `pkg/fileutils/operations_test.go`.
- Manual smoke check via the existing E2E eReader cover tests (`e2e/ereader.spec.ts`) which exercise the consolidated eReader cover path.

Closes the [Refactor] Extract shared file cover path resolver Notion task.