### PR TITLE
[Backend] Wire plugin hook context to vm.Interrupt() for real cancellation

### DIFF
--- a/packages/plugin-sdk/host-api.d.ts
+++ b/packages/plugin-sdk/host-api.d.ts
@@ -400,18 +400,12 @@ export interface ShishoHostAPI {
    *
    * Goja has no Promise/setTimeout support, so this is a synchronous delay
    * backed by Go's `time.Sleep`. Use it to implement exponential backoff
-   * between retries when calling rate-limited APIs.
+   * between retries when calling rate-limited APIs. The sleep honors the
+   * hook's deadline: if the ctx is cancelled while the plugin is sleeping,
+   * the call unblocks immediately and the hook throws.
    *
-   * **Not interruptible by hook timeouts.** Because sleep blocks in a Go
-   * syscall the VM cannot interrupt, the hook's deadline (1 minute for
-   * parsers and enrichers, 5 minutes for converters and output generators)
-   * will not fire until the sleep returns. While sleeping, the plugin's
-   * runtime mutex is held, so other goroutines waiting to invoke a hook on
-   * the same plugin are blocked as well. Keep total backoff well under the
-   * hook's timeout. Sleeps longer than 5 minutes are rejected.
-   *
-   * @param ms Finite non-negative milliseconds, capped at 5 minutes. Throws on
-   * negative, NaN, Infinity, or values exceeding the cap.
+   * @param ms Finite non-negative milliseconds. Throws on negative, NaN, or
+   * Infinity.
    * @example
    * // Exponential backoff: 1s, 2s, 4s
    * var resp;

--- a/packages/plugin-sdk/testing/index.ts
+++ b/packages/plugin-sdk/testing/index.ts
@@ -25,14 +25,6 @@ export interface MockFetchResponse {
   headers?: Record<string, string>;
 }
 
-/**
- * Maximum value accepted by `shisho.sleep()` in production (5 minutes, in ms).
- * Mirrors `maxSleepMs` in `pkg/plugins/hostapi.go` — must be kept in sync.
- * Plugin tests can reference this constant instead of hardcoding `300000`
- * when asserting the cap.
- */
-export const MAX_SLEEP_MS = 5 * 60 * 1000;
-
 /** Options for createMockShisho(). */
 export interface MockShishoOptions {
   /** Route-based fetch mock. Keys are URL strings, values are mock responses. */
@@ -54,7 +46,7 @@ export interface MockShishoOptions {
    * arguments each retry passed.
    *
    * The override is still subject to the same validation rules as production
-   * (`MAX_SLEEP_MS` cap, no NaN/Infinity/negative).
+   * (no NaN/Infinity/negative).
    */
   sleep?: (ms: number) => void;
 }
@@ -595,11 +587,6 @@ export function createMockShisho(
       ms < 0
     ) {
       throw new Error("shisho.sleep: ms must be a finite non-negative number");
-    }
-    if (ms > MAX_SLEEP_MS) {
-      throw new Error(
-        `shisho.sleep: ms must be <= ${MAX_SLEEP_MS} (5 minutes)`,
-      );
     }
     sleepImpl(ms);
   };

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -268,12 +268,10 @@ outputGenerator: {
 ```javascript
 shisho.sleep(1000)   // block for 1 second
 shisho.sleep(0)      // no-op
-// Throws on negative, NaN, Infinity, or values > 5 minutes (300000 ms)
+// Throws on negative, NaN, or Infinity
 ```
 
-Synchronous delay backed by Go's `time.Sleep`. Goja has no `setTimeout` / Promise support, so this is the primitive plugins use for exponential backoff between retries (e.g. against rate-limited APIs).
-
-**Not interruptible by hook timeouts.** `time.Sleep` blocks in a Go syscall that the VM can't interrupt, and the existing hook `context.WithTimeout` in `hooks.go` is currently `_ = ctx // reserved for future cancellation support` — so a long sleep will outlive its deadline. The call also holds `Runtime.mu`, which serializes every other hook invocation on the same plugin. The 5-minute cap (`maxSleepMs` in `hostapi.go`) matches the longest existing hook timeout so a single sleep can't exceed any hook type's deadline by more than seconds of overhead. When real cancellation is wired up via `vm.Interrupt()`, this cap can be loosened.
+Synchronous delay used for exponential backoff between retries against rate-limited APIs (Goja has no `setTimeout` / Promise support). The sleep selects on both a timer and the current hook's `context.Context` (stashed on `Runtime.hookCtx` by `invokeHook`), so when the hook deadline fires the call unblocks immediately and the plugin throws — it does not hold `Runtime.mu` past the hook's timeout. `vm.Interrupt()` alone cannot cancel a native wait, which is why the ctx must also be threaded in.
 
 ### shisho.log
 

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -19,13 +19,61 @@ var errJSPanic = errors.New("JS runtime panicked")
 // safeCallJS invokes a goja function with panic recovery. The goja runtime can
 // panic on certain JS exceptions (e.g., nil pointer in handleThrow). This wrapper
 // ensures plugin errors never crash the server.
+//
+// Note on cancellation: when the hook runner calls rt.vm.Interrupt() (see
+// invokeHook), goja surfaces a *goja.InterruptedError as a normal return
+// value from fn — it does not panic. That typed error flows through unwrapped
+// so callers can detect it with errors.As. The recover() here is only for
+// truly-unexpected runtime panics, which are still wrapped as errJSPanic.
 func safeCallJS(fn goja.Callable, this goja.Value, args ...goja.Value) (result goja.Value, err error) {
 	defer func() {
 		if r := recover(); r != nil {
+			// Belt-and-braces: in case goja ever panics with an
+			// *InterruptedError instead of returning it, surface the typed
+			// error so the caller can still distinguish cancellation from a
+			// real JS panic.
+			if ie, ok := r.(*goja.InterruptedError); ok {
+				err = ie
+				return
+			}
 			err = errors.Wrapf(errJSPanic, "%v", r)
 		}
 	}()
 	return fn(this, args...)
+}
+
+// invokeHook runs fn while watching ctx for cancellation. If ctx becomes Done
+// before fn returns, the goja VM is interrupted, causing any in-flight JS to
+// throw *goja.InterruptedError at the next safepoint. The hook ctx is also
+// stored on the runtime so blocking host APIs (sleep, http, ffmpeg, shell)
+// can thread cancellation into their native Go calls — vm.Interrupt only
+// fires between JS statements, not inside time.Sleep / http.Client.Do / etc.
+//
+// Callers must already hold rt.mu (the exclusive hook lock). invokeHook
+// guarantees rt.vm.ClearInterrupt() runs before it returns, so the next hook
+// invocation on the same runtime starts with a clean interrupt flag even if
+// this one was cancelled.
+func invokeHook(ctx context.Context, rt *Runtime, fn func()) {
+	rt.hookCtx = ctx
+	done := make(chan struct{})
+	watcherDone := make(chan struct{})
+	go func() {
+		defer close(watcherDone)
+		select {
+		case <-ctx.Done():
+			rt.vm.Interrupt(ctx.Err())
+		case <-done:
+		}
+	}()
+	defer func() {
+		close(done)
+		// Wait for the watcher so a racing Interrupt() cannot land after we
+		// ClearInterrupt() and poison the next hook on this runtime.
+		<-watcherDone
+		rt.vm.ClearInterrupt()
+		rt.hookCtx = nil
+	}()
+	fn()
 }
 
 // ConvertResult is the result of an input converter hook.
@@ -42,7 +90,6 @@ func (m *Manager) RunInputConverter(ctx context.Context, rt *Runtime, sourcePath
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
-	_ = ctx // reserved for future cancellation support
 
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
@@ -72,10 +119,14 @@ func (m *Manager) RunInputConverter(ctx context.Context, rt *Runtime, sourcePath
 	contextObj.Set("sourcePath", sourcePath) //nolint:errcheck
 	contextObj.Set("targetDir", targetDir)   //nolint:errcheck
 
-	// Call the hook
-	result, err := safeCallJS(convertFn, goja.Undefined(), rt.vm.ToValue(contextObj))
-	if err != nil {
-		return nil, errors.Wrap(err, "inputConverter.convert failed")
+	// Call the hook under a watcher that forwards ctx cancellation into the VM.
+	var result goja.Value
+	var callErr error
+	invokeHook(ctx, rt, func() {
+		result, callErr = safeCallJS(convertFn, goja.Undefined(), rt.vm.ToValue(contextObj))
+	})
+	if callErr != nil {
+		return nil, errors.Wrap(callErr, "inputConverter.convert failed")
 	}
 
 	// Parse the result
@@ -90,7 +141,6 @@ func (m *Manager) RunFileParser(ctx context.Context, rt *Runtime, filePath, file
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
-	_ = ctx // reserved for future cancellation support
 
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
@@ -120,10 +170,14 @@ func (m *Manager) RunFileParser(ctx context.Context, rt *Runtime, filePath, file
 	contextObj.Set("filePath", filePath) //nolint:errcheck
 	contextObj.Set("fileType", fileType) //nolint:errcheck
 
-	// Call the hook
-	result, err := safeCallJS(parseFn, goja.Undefined(), rt.vm.ToValue(contextObj))
-	if err != nil {
-		return nil, errors.Wrap(err, "fileParser.parse failed")
+	// Call the hook under a watcher that forwards ctx cancellation into the VM.
+	var result goja.Value
+	var callErr error
+	invokeHook(ctx, rt, func() {
+		result, callErr = safeCallJS(parseFn, goja.Undefined(), rt.vm.ToValue(contextObj))
+	})
+	if callErr != nil {
+		return nil, errors.Wrap(callErr, "fileParser.parse failed")
 	}
 
 	// Parse the result
@@ -154,7 +208,6 @@ func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx 
 
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
 	defer cancel()
-	_ = ctx // reserved for future cancellation support
 
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
@@ -179,10 +232,14 @@ func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx 
 		return nil, errors.New("metadataEnricher.search is not a function")
 	}
 
-	// Call the hook
-	result, err := safeCallJS(searchFn, goja.Undefined(), rt.vm.ToValue(searchCtx))
-	if err != nil {
-		return nil, errors.Wrap(err, "metadataEnricher.search failed")
+	// Call the hook under a watcher that forwards ctx cancellation into the VM.
+	var result goja.Value
+	var callErr error
+	invokeHook(ctx, rt, func() {
+		result, callErr = safeCallJS(searchFn, goja.Undefined(), rt.vm.ToValue(searchCtx))
+	})
+	if callErr != nil {
+		return nil, errors.Wrap(callErr, "metadataEnricher.search failed")
 	}
 
 	// Parse the result
@@ -197,7 +254,6 @@ func (m *Manager) RunOutputGenerator(ctx context.Context, rt *Runtime, sourcePat
 
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
-	_ = ctx // reserved for future cancellation support
 
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
@@ -229,10 +285,13 @@ func (m *Manager) RunOutputGenerator(ctx context.Context, rt *Runtime, sourcePat
 	contextObj.Set("book", bookCtx)          //nolint:errcheck
 	contextObj.Set("file", fileCtx)          //nolint:errcheck
 
-	// Call the hook
-	_, err := safeCallJS(generateFn, goja.Undefined(), rt.vm.ToValue(contextObj))
-	if err != nil {
-		return errors.Wrap(err, "outputGenerator.generate failed")
+	// Call the hook under a watcher that forwards ctx cancellation into the VM.
+	var callErr error
+	invokeHook(ctx, rt, func() {
+		_, callErr = safeCallJS(generateFn, goja.Undefined(), rt.vm.ToValue(contextObj))
+	})
+	if callErr != nil {
+		return errors.Wrap(callErr, "outputGenerator.generate failed")
 	}
 
 	return nil

--- a/pkg/plugins/hooks_test.go
+++ b/pkg/plugins/hooks_test.go
@@ -791,4 +791,10 @@ func TestRunFileParser_InterruptsLongSleep(t *testing.T) {
 
 	require.Error(t, err, "sleep should be interrupted by ctx, not complete normally")
 	assert.Less(t, elapsed, 1*time.Second, "shisho.sleep must honor the hook ctx and return near the deadline, not block for the full requested duration")
+
+	// After sleep unblocks on ctx.Done, the very next JS statement hits the
+	// watcher's vm.Interrupt() and throws *goja.InterruptedError — same error
+	// type as the while(true){} path, giving callers one shape to match on.
+	var ie *goja.InterruptedError
+	assert.True(t, errors.As(err, &ie), "expected *goja.InterruptedError in chain, got %T: %v", err, err)
 }

--- a/pkg/plugins/hooks_test.go
+++ b/pkg/plugins/hooks_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dop251/goja"
+	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
@@ -658,4 +660,135 @@ func TestRunFingerprint_NoHook(t *testing.T) {
 	_, err := mgr.RunFingerprint(rt, nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not have an outputGenerator hook")
+}
+
+// installCancelTestPlugin writes a fileParser plugin whose parse() runs the
+// given JS body. It installs and loads the plugin and returns its runtime.
+func installCancelTestPlugin(t *testing.T, pluginID, parseBody string) (*Manager, *Runtime) {
+	t.Helper()
+
+	db := setupTestDB(t)
+	service := NewService(db)
+	pluginDir := t.TempDir()
+
+	destDir := filepath.Join(pluginDir, "test", pluginID)
+	require.NoError(t, os.MkdirAll(destDir, 0755))
+
+	manifest := `{
+  "manifestVersion": 1,
+  "id": "` + pluginID + `",
+  "name": "Cancel Test",
+  "version": "1.0.0",
+  "capabilities": {
+    "fileParser": {
+      "description": "Cancel test parser",
+      "types": ["bin"]
+    }
+  }
+}`
+	mainJS := `var plugin = (function() {
+  return {
+    fileParser: {
+      parse: function(context) { ` + parseBody + ` }
+    }
+  };
+})();`
+
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "manifest.json"), []byte(manifest), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644))
+
+	manager := NewManager(service, pluginDir, "")
+	plugin := &models.Plugin{
+		Scope:       "test",
+		ID:          pluginID,
+		Name:        "Cancel Test",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	require.NoError(t, service.InstallPlugin(context.Background(), plugin))
+	require.NoError(t, manager.LoadPlugin(context.Background(), "test", pluginID))
+
+	rt := manager.GetRuntime("test", pluginID)
+	require.NotNil(t, rt)
+	return manager, rt
+}
+
+// runWithDeadline runs fn and enforces that it returns within budget; otherwise
+// it fails the test instead of deadlocking the whole suite.
+func runWithDeadline(t *testing.T, budget time.Duration, fn func() error) error {
+	t.Helper()
+	ch := make(chan error, 1)
+	go func() { ch <- fn() }()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(budget):
+		t.Fatalf("hook did not return within %v — cancellation is not wired", budget)
+		return nil
+	}
+}
+
+// TestRunFileParser_InterruptsInfiniteLoop proves the hook runner's ctx
+// deadline actually fires: a plugin running `while(true){}` is killed by
+// vm.Interrupt() when the ctx expires, the error unwraps to
+// *goja.InterruptedError, and Runtime.mu is released so a follow-up
+// invocation isn't blocked.
+func TestRunFileParser_InterruptsInfiniteLoop(t *testing.T) {
+	t.Parallel()
+
+	mgr, rt := installCancelTestPlugin(t, "loop-parser", "while (true) {}")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := runWithDeadline(t, 5*time.Second, func() error {
+		_, e := mgr.RunFileParser(ctx, rt, "/some/file.bin", "bin")
+		return e
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 3*time.Second, "hook runner should return soon after ctx deadline fires")
+
+	var ie *goja.InterruptedError
+	assert.True(t, errors.As(err, &ie), "expected *goja.InterruptedError in chain, got %T: %v", err, err)
+
+	// A second invocation on the same runtime must not be blocked by a stale
+	// interrupt flag or an un-released mu from the first run.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel2()
+	start2 := time.Now()
+	err2 := runWithDeadline(t, 5*time.Second, func() error {
+		_, e := mgr.RunFileParser(ctx2, rt, "/some/file.bin", "bin")
+		return e
+	})
+	assert.Less(t, time.Since(start2), 3*time.Second, "second invocation should not be blocked on Runtime.mu")
+	require.Error(t, err2, "second invocation should also time out via interrupt")
+}
+
+// TestRunFileParser_InterruptsLongSleep proves that hook ctx cancellation
+// also unblocks native-side waits: shisho.sleep() must respect the hook
+// context and return promptly when the deadline fires, not sit in time.Sleep
+// for the full requested duration.
+func TestRunFileParser_InterruptsLongSleep(t *testing.T) {
+	t.Parallel()
+
+	// 3000ms is short enough that a broken implementation only wastes 3s per
+	// run but long enough that a real cancellation is unambiguous.
+	mgr, rt := installCancelTestPlugin(t, "sleep-parser", "shisho.sleep(3000); return { title: \"done\" };")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := runWithDeadline(t, 5*time.Second, func() error {
+		_, e := mgr.RunFileParser(ctx, rt, "/some/file.bin", "bin")
+		return e
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "sleep should be interrupted by ctx, not complete normally")
+	assert.Less(t, elapsed, 1*time.Second, "shisho.sleep must honor the hook ctx and return near the deadline, not block for the full requested duration")
 }

--- a/pkg/plugins/hostapi.go
+++ b/pkg/plugins/hostapi.go
@@ -44,7 +44,7 @@ func InjectHostAPIs(rt *Runtime, configGetter ConfigGetter) error {
 	}
 
 	// Set up top-level sleep function
-	if err := injectSleepFunction(vm, shishoObj); err != nil {
+	if err := injectSleepFunction(vm, shishoObj, rt); err != nil {
 		return err
 	}
 
@@ -127,24 +127,7 @@ func injectDataDirProperty(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime
 	return err
 }
 
-// maxSleepMs caps shisho.sleep at the longest hook timeout (inputConverter and
-// outputGenerator are 5 minutes; parsers and enrichers are 1 minute). Until
-// context cancellation is wired through to vm.Interrupt(), an unbounded sleep
-// would outlive the hook deadline while still holding Runtime.mu, blocking
-// every other invocation on the same plugin.
-//
-// Must stay in sync with MAX_SLEEP_MS in packages/plugin-sdk/testing/index.ts.
-// If this changes to something other than 5 minutes, update the "5 minutes"
-// text in errSleepExceedsCap, this comment, and the plugin docs.
-const maxSleepMs = float64(5 * 60 * 1000)
-
-var (
-	errSleepNotFinite = errors.New("shisho.sleep: ms must be a finite non-negative number")
-	// Built via fmt.Errorf once at package init so the numeric portion of the
-	// message is derived from maxSleepMs instead of duplicated. Still a static
-	// sentinel — comparable with errors.Is and allocated exactly once.
-	errSleepExceedsCap = fmt.Errorf("shisho.sleep: ms must be <= %d (5 minutes)", int(maxSleepMs)) //nolint:err113 // see comment above
-)
+var errSleepNotFinite = errors.New("shisho.sleep: ms must be a finite non-negative number")
 
 // validateSleepMs enforces the rules for shisho.sleep's ms argument.
 // Extracted so boundary cases can be unit-tested without actually sleeping.
@@ -152,16 +135,18 @@ func validateSleepMs(ms float64) error {
 	if math.IsNaN(ms) || math.IsInf(ms, 0) || ms < 0 {
 		return errSleepNotFinite
 	}
-	if ms > maxSleepMs {
-		return errSleepExceedsCap
-	}
 	return nil
 }
 
 // injectSleepFunction sets up shisho.sleep(ms) as a blocking delay primitive.
 // Plugins use this to implement exponential backoff between retries, since
 // Goja has no Promise/setTimeout support.
-func injectSleepFunction(vm *goja.Runtime, shishoObj *goja.Object) error {
+//
+// The sleep honors the current hook's context (set by invokeHook in hooks.go)
+// so a long sleep inside a hook that has exceeded its deadline unblocks
+// immediately instead of sitting in time.Sleep. vm.Interrupt alone cannot do
+// this — interrupts only fire between JS statements, not inside native calls.
+func injectSleepFunction(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime) error {
 	sleepFn := func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) < 1 {
 			panic(vm.ToValue("shisho.sleep: ms argument is required"))
@@ -170,7 +155,21 @@ func injectSleepFunction(vm *goja.Runtime, shishoObj *goja.Object) error {
 		if err := validateSleepMs(ms); err != nil {
 			panic(vm.ToValue(err.Error()))
 		}
-		time.Sleep(time.Duration(ms * float64(time.Millisecond)))
+		duration := time.Duration(ms * float64(time.Millisecond))
+		ctx := rt.hookCtx
+		if ctx == nil {
+			// No hook ctx (e.g., direct unit test of shisho.sleep outside a
+			// hook runner). Fall back to a plain time.Sleep.
+			time.Sleep(duration)
+			return goja.Undefined()
+		}
+		timer := time.NewTimer(duration)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			panic(vm.NewGoError(ctx.Err()))
+		}
 		return goja.Undefined()
 	}
 	if err := shishoObj.Set("sleep", sleepFn); err != nil {

--- a/pkg/plugins/hostapi.go
+++ b/pkg/plugins/hostapi.go
@@ -168,7 +168,16 @@ func injectSleepFunction(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime) 
 		select {
 		case <-timer.C:
 		case <-ctx.Done():
-			panic(vm.NewGoError(ctx.Err()))
+			// Call vm.Interrupt directly instead of relying on the hook
+			// runner's watcher goroutine. The watcher also races ctx.Done
+			// and would eventually fire, but there's a window where the
+			// select here unblocks first, JS resumes with the statement
+			// after shisho.sleep(...), and the function returns normally
+			// before the watcher gets scheduled. Calling Interrupt inline
+			// guarantees the very next JS instruction throws an uncatchable
+			// *goja.InterruptedError, giving callers one error type for
+			// every cancellation path.
+			rt.vm.Interrupt(ctx.Err())
 		}
 		return goja.Undefined()
 	}

--- a/pkg/plugins/hostapi_ffmpeg.go
+++ b/pkg/plugins/hostapi_ffmpeg.go
@@ -58,8 +58,14 @@ func injectFFmpegNamespace(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime
 			args = append(args, argsObj.Get(strconv.Itoa(i)).String())
 		}
 
-		// Create context with timeout
-		ctx, cancel := context.WithTimeout(context.Background(), defaultFFmpegTimeout)
+		// Use the hook ctx if one is set — that carries the hook deadline and
+		// is the thing cancelled when a plugin gets stuck. Fall back to a
+		// fresh timeout for calls outside of a hook (e.g., direct tests).
+		baseCtx := rt.hookCtx
+		if baseCtx == nil {
+			baseCtx = context.Background()
+		}
+		ctx, cancel := context.WithTimeout(baseCtx, defaultFFmpegTimeout)
 		defer cancel()
 
 		// Build command
@@ -114,8 +120,14 @@ func injectFFmpegNamespace(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime
 		}
 		args = append(args, "-print_format", "json", "-show_format", "-show_streams", "-show_chapters")
 
-		// Create context with timeout
-		ctx, cancel := context.WithTimeout(context.Background(), defaultFFmpegTimeout)
+		// Use the hook ctx if one is set — that carries the hook deadline and
+		// is the thing cancelled when a plugin gets stuck. Fall back to a
+		// fresh timeout for calls outside of a hook (e.g., direct tests).
+		baseCtx := rt.hookCtx
+		if baseCtx == nil {
+			baseCtx = context.Background()
+		}
+		ctx, cancel := context.WithTimeout(baseCtx, defaultFFmpegTimeout)
 		defer cancel()
 
 		// Build command
@@ -191,8 +203,13 @@ func injectFFmpegNamespace(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime
 			panic(vm.ToValue("shisho.ffmpeg.version: plugin does not declare ffmpegAccess capability"))
 		}
 
-		// Create context with timeout (shorter for version check)
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		// Create context with timeout (shorter for version check). Still
+		// derive from the hook ctx so a cancelled hook kills the subprocess.
+		baseCtx := rt.hookCtx
+		if baseCtx == nil {
+			baseCtx = context.Background()
+		}
+		ctx, cancel := context.WithTimeout(baseCtx, 30*time.Second)
 		defer cancel()
 
 		// Run ffmpeg -version

--- a/pkg/plugins/hostapi_http.go
+++ b/pkg/plugins/hostapi_http.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -74,12 +75,18 @@ func injectHTTPNamespace(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime) 
 			panic(vm.ToValue(fmt.Sprintf("shisho.http.fetch: %v", err)))
 		}
 
-		// Build the request
+		// Build the request. Thread the hook ctx in so cancellation cancels
+		// the in-flight request at the network layer — goja's vm.Interrupt
+		// only fires between JS statements, not while blocked on a read.
 		var bodyReader io.Reader
 		if hasBody {
 			bodyReader = strings.NewReader(body)
 		}
-		req, err := http.NewRequest(method, rawURL, bodyReader) //nolint:noctx
+		reqCtx := rt.hookCtx
+		if reqCtx == nil {
+			reqCtx = context.Background()
+		}
+		req, err := http.NewRequestWithContext(reqCtx, method, rawURL, bodyReader)
 		if err != nil {
 			panic(vm.ToValue(fmt.Sprintf("shisho.http.fetch: failed to create request: %v", err)))
 		}

--- a/pkg/plugins/hostapi_shell.go
+++ b/pkg/plugins/hostapi_shell.go
@@ -60,8 +60,13 @@ func injectShellNamespace(vm *goja.Runtime, shishoObj *goja.Object, rt *Runtime)
 			args = append(args, argsObj.Get(strconv.Itoa(i)).String())
 		}
 
-		// Create context with timeout
-		ctx, cancel := context.WithTimeout(context.Background(), defaultShellTimeout)
+		// Use the hook ctx if one is set — carries the hook deadline. Fall
+		// back to a fresh timeout for calls outside of a hook (e.g., tests).
+		baseCtx := rt.hookCtx
+		if baseCtx == nil {
+			baseCtx = context.Background()
+		}
+		ctx, cancel := context.WithTimeout(baseCtx, defaultShellTimeout)
 		defer cancel()
 
 		// Build command - use exec.Command directly (no shell)

--- a/pkg/plugins/hostapi_test.go
+++ b/pkg/plugins/hostapi_test.go
@@ -170,12 +170,11 @@ func TestInjectHostAPIs_Sleep(t *testing.T) {
 }
 
 // TestValidateSleepMs exercises the boundary cases directly without paying
-// the time.Sleep cost — notably the exact cap and cap - 1, which would add
-// 5 minutes of wall-clock time if driven through the JS layer.
+// the time.Sleep cost.
 func TestValidateSleepMs(t *testing.T) {
 	t.Parallel()
 
-	valid := []float64{0, 0.5, 1, 1000, maxSleepMs - 1, maxSleepMs}
+	valid := []float64{0, 0.5, 1, 1000, 1e9}
 	for _, ms := range valid {
 		t.Run(fmt.Sprintf("valid/%v", ms), func(t *testing.T) {
 			assert.NoError(t, validateSleepMs(ms))
@@ -191,8 +190,6 @@ func TestValidateSleepMs(t *testing.T) {
 		{"NaN", math.NaN(), "finite non-negative"},
 		{"+Inf", math.Inf(1), "finite non-negative"},
 		{"-Inf", math.Inf(-1), "finite non-negative"},
-		{"cap + 1", maxSleepMs + 1, "5 minutes"},
-		{"1e18 overflow", 1e18, "5 minutes"},
 	}
 	for _, tc := range cases {
 		t.Run("invalid/"+tc.name, func(t *testing.T) {
@@ -220,8 +217,6 @@ func TestInjectHostAPIs_Sleep_InvalidArgs(t *testing.T) {
 		{"NaN", `shisho.sleep(NaN)`, "finite non-negative"},
 		{"positive Infinity", `shisho.sleep(Infinity)`, "finite non-negative"},
 		{"negative Infinity", `shisho.sleep(-Infinity)`, "finite non-negative"},
-		{"exceeds cap", `shisho.sleep(5 * 60 * 1000 + 1)`, "5 minutes"},
-		{"overflow value", `shisho.sleep(1e18)`, "5 minutes"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/plugins/runtime.go
+++ b/pkg/plugins/runtime.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,6 +46,13 @@ type Runtime struct {
 	// fsCtx is the filesystem context for the current hook invocation.
 	// Set by hook execution code before invoking hooks, cleared after.
 	fsCtx *FSContext
+
+	// hookCtx is the Go context for the current hook invocation. Blocking
+	// host APIs (sleep, http, ffmpeg, shell) read this to thread cancellation
+	// into their native calls — goja's vm.Interrupt only fires between JS
+	// statements, not inside time.Sleep / http.Client.Do / exec.Cmd.Run.
+	// Set by invokeHook before calling JS, cleared after.
+	hookCtx context.Context //nolint:containedctx // see comment above
 
 	// loadWarning holds a non-fatal warning from plugin load (e.g., missing fields declaration).
 	// The Manager can check this after successful load and store it in Plugin.LoadError.

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -611,11 +611,7 @@ for (var attempt = 0; attempt < 3; attempt++) {
 return resp; // retries exhausted — return the last 503
 ```
 
-`shisho.sleep(ms)` throws if `ms` is negative, `NaN`, `Infinity`, or greater than 5 minutes (300000 ms). A value of `0` returns immediately.
-
-:::warning Not interruptible by hook timeouts
-`shisho.sleep` blocks in a Go syscall that the VM cannot interrupt, so the hook's deadline (1 minute for parsers and enrichers, 5 minutes for converters and output generators) will **not** fire until the sleep returns. While sleeping, the plugin's runtime mutex is held, so other goroutines waiting to invoke a hook on the same plugin are blocked as well. Keep total backoff well under the hook's timeout — if you exceed it, the worker will eventually kill the plugin and your cumulative sleeps become dead latency for every other caller.
-:::
+`shisho.sleep(ms)` throws if `ms` is negative, `NaN`, or `Infinity`. A value of `0` returns immediately. The sleep honors the hook's deadline — if the hook's context is cancelled while the plugin is sleeping, the call unblocks immediately and the hook throws.
 
 ### URL Utilities
 


### PR DESCRIPTION
## Summary
- Hook runners now start a watcher that calls `rt.vm.Interrupt(ctx.Err())` on `ctx.Done()` (with matching `ClearInterrupt`), so the 1/5-minute `context.WithTimeout` deadlines that were previously thrown away actually fire and a runaway plugin no longer holds `Runtime.mu` forever.
- Hook ctx is stashed on `Runtime.hookCtx` so blocking host APIs thread cancellation into native calls — `shisho.sleep` selects on timer vs `ctx.Done`, `shisho.http.fetch` uses `NewRequestWithContext`, and the ffmpeg/shell `exec.CommandContext` paths derive from it. goja's interrupt only fires between JS statements, so this threading is what unblocks in-flight syscalls.
- With real cancellation in place, the `shisho.sleep` 5-minute cap is removed — `maxSleepMs`, its sentinel error, the cap branch, the `MAX_SLEEP_MS` SDK export, the "Not interruptible" admonition in the docs, and the CLAUDE.md warning paragraph are all gone.

## Test plan
- `mise check:quiet` — lint + all Go tests + JS tests + lint:js all pass.
- `go test -race -run TestRunFileParser_Interrupts ./pkg/plugins/` — race-free.
- `TestRunFileParser_InterruptsInfiniteLoop` verifies a `while(true){}` parser is killed by `vm.Interrupt`, unwraps to `*goja.InterruptedError`, and that a second invocation on the same runtime isn't blocked by a stale interrupt flag or un-released `Runtime.mu`.
- `TestRunFileParser_InterruptsLongSleep` verifies `shisho.sleep(3000)` under a 150ms ctx returns in well under a second, proving the native wait honors the hook ctx instead of sitting in `time.Sleep` for the full duration.
- Existing hook/host API tests continue to pass (ffmpeg/shell/http still run fine when called without a hook ctx via the `rt.hookCtx == nil` fallback).