### PR TITLE
[Fix] Use ResolveCoverDirForWrite in plugin persistMetadata cover write

### DIFF
--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1815,7 +1815,11 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 	// Apply cover data (caller is responsible for downloading cover URLs before calling persistMetadata).
 	// Skip for files with cover_page — their covers are derived from page content (CBZ, PDF).
 	if len(md.CoverData) > 0 && targetFile != nil && targetFile.CoverPage == nil {
-		coverDir := book.Filepath
+		// Use the write-side helper so root-level files (whose book.Filepath
+		// may be a synthetic organized-folder path that does not yet exist
+		// on disk) land their cover next to the file instead of silently
+		// failing on os.WriteFile.
+		coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, targetFile.Filepath)
 		coverBaseName := filepath.Base(targetFile.Filepath) + ".cover"
 
 		// Normalize the cover image

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -102,6 +102,11 @@ func TestPersistMetadata_CoverWrite_RootLevelFile_SyntheticBookPath(t *testing.T
 		CoverMimeType: "image/jpeg",
 	}
 
+	// persistMetadata will also attempt to write book/file sidecars under
+	// the synthetic bookPath and log warnings when those writes fail. That
+	// is expected: the test deliberately uses a nonexistent bookPath, and
+	// sidecar failures are non-fatal. The assertions below only cover the
+	// cover-write path.
 	err = h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
 	require.NoError(t, err)
 

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -1,0 +1,121 @@
+package plugins
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/mediafile"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makePersistTestJPEG(width, height int) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	_ = jpeg.Encode(&buf, img, &jpeg.Options{Quality: 80})
+	return buf.Bytes()
+}
+
+// stubBookStoreForPersist is a minimal bookStore implementation used by
+// persistMetadata cover-write tests. Only UpdateFile and RetrieveBook
+// need to produce meaningful results for the cover-only persist path.
+type stubBookStoreForPersist struct {
+	book *models.Book
+}
+
+func (s *stubBookStoreForPersist) UpdateBook(_ context.Context, _ *models.Book, _ []string) error {
+	return nil
+}
+
+func (s *stubBookStoreForPersist) RetrieveBook(_ context.Context, _ int) (*models.Book, error) {
+	return s.book, nil
+}
+
+func (s *stubBookStoreForPersist) UpdateFile(_ context.Context, _ *models.File, _ []string) error {
+	return nil
+}
+
+func (s *stubBookStoreForPersist) DeleteNarratorsForFile(_ context.Context, _ int) (int, error) {
+	return 0, nil
+}
+
+func (s *stubBookStoreForPersist) CreateNarrator(_ context.Context, _ *models.Narrator) error {
+	return nil
+}
+
+// TestPersistMetadata_CoverWrite_RootLevelFile_SyntheticBookPath is a
+// regression test for a bug where persistMetadata wrote plugin-provided
+// cover data unconditionally to book.Filepath as the cover directory. For
+// root-level new files, scanFileCreateNew computes a synthetic organized-
+// folder bookPath that does not exist on disk, so os.WriteFile failed with
+// "no such file or directory" and the cover was silently dropped. The fix
+// uses fileutils.ResolveCoverDirForWrite, which falls back to the file's
+// parent directory when book.Filepath does not resolve to a real directory.
+func TestPersistMetadata_CoverWrite_RootLevelFile_SyntheticBookPath(t *testing.T) {
+	t.Parallel()
+
+	// A real file lives at the library root.
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "book.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0600))
+
+	// Synthetic book.Filepath that does NOT exist on disk, mirroring what
+	// scanFileCreateNew computes for root-level new files in libraries with
+	// OrganizeFileStructure enabled.
+	syntheticBookPath := filepath.Join(libraryDir, "Author Name", "Book Title")
+	_, err := os.Stat(syntheticBookPath)
+	require.True(t, os.IsNotExist(err), "synthetic bookPath must not exist on disk")
+
+	file := &models.File{
+		ID:       1,
+		BookID:   1,
+		Filepath: filePath,
+		FileType: models.FileTypeEPUB,
+	}
+	book := &models.Book{
+		ID:        1,
+		LibraryID: 1,
+		Filepath:  syntheticBookPath,
+		Files:     []*models.File{file},
+	}
+
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore: &stubBookStoreForPersist{book: book},
+		},
+	}
+
+	md := &mediafile.ParsedMetadata{
+		CoverData:     makePersistTestJPEG(400, 600),
+		CoverMimeType: "image/jpeg",
+	}
+
+	err = h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	// Cover must land next to the file in the library dir, not under the
+	// nonexistent synthetic organized-folder path.
+	expectedCoverPath := filepath.Join(libraryDir, "book.epub.cover.jpg")
+	_, err = os.Stat(expectedCoverPath)
+	require.NoError(t, err, "cover should be written next to the file at library dir")
+
+	// Nothing should have been written under the synthetic path.
+	_, err = os.Stat(syntheticBookPath)
+	assert.True(t, os.IsNotExist(err), "synthetic bookPath must still not exist after persist")
+
+	// CoverImageFilename should be set (to the filename only, not a full path).
+	require.NotNil(t, file.CoverImageFilename, "CoverImageFilename should be set on the file")
+	assert.Equal(t, "book.epub.cover.jpg", *file.CoverImageFilename)
+}


### PR DESCRIPTION
## Summary
- `pkg/plugins/handler.go` `persistMetadata` wrote plugin-provided covers to `coverDir := book.Filepath`. For root-level new files, `scanFileCreateNew` computes `book.Filepath` as a synthetic organized-folder path that does not exist on disk, so `os.WriteFile` failed with "no such file or directory" and the cover was silently dropped.
- Route the write through `fileutils.ResolveCoverDirForWrite`, which falls back to `filepath.Dir(targetFile.Filepath)` when `book.Filepath` is not a real directory — the same fix PR #79 applied to the other cover-write sites.
- Added a regression test (`TestPersistMetadata_CoverWrite_RootLevelFile_SyntheticBookPath`) that reproduces the bug and pins the file-dir fallback behavior.

## Test plan
- `mise check:quiet` — passes
- `go test ./pkg/plugins/ -run TestPersistMetadata_CoverWrite_RootLevelFile_SyntheticBookPath` — verified Red (pre-fix: "no such file or directory") → Green (post-fix: cover lands at `{libraryDir}/{filename}.cover.jpg`)