### PR TITLE
[Fix] Preload supplements into scan cache to avoid UNIQUE rescans

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -45,6 +45,13 @@ Each domain (books, jobs, libraries, chapters) has:
 - **`Monitor.processPendingEvents`** handles this by collecting book IDs from `FileCreated` results and calling `organizeBooks()` after processing all events.
 - **Any new caller of `scanInternal(FilePath)`** must also handle organization, or files will be left unorganized in the library root.
 
+### Scan Cache Must Include Supplements
+
+**CRITICAL — the `ScanCache.knownFiles` map preloaded in `ProcessScanJob` must contain BOTH main and supplement files.** Supplements can share scannable extensions (`.pdf`/`.epub`/`.cbz`/`.m4b`) with main files — e.g. a user-demoted `Cribsheet.pdf` sitting next to a main `Cribsheet.epub`. During the filesystem walk, every file with a scannable extension becomes a scan target, so a supplement at a tracked path must resolve via the cache and early-return in `scanFileByPath`. If the cache is main-only (the old behavior), the supplement falls through to `scanFileCreateNew`, which tries to insert a duplicate file row and hits `UNIQUE(filepath, library_id)` — warned-and-continued on every scan.
+
+- Preload via `ListAllFilesForLibrary`, not `ListFilesForLibrary` (which is still main-only, used for orphan cleanup).
+- `scanFileByPath` early-returns with `&ScanResult{File: existing}` when the cached file has `FileRole == FileRoleSupplement` — supplements have no metadata to rescan.
+
 ### File Types
 
 - To learn more about all the file types that we support, refer to:

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1376,6 +1376,19 @@ func (svc *Service) ListFilesForLibrary(ctx context.Context, libraryID int) ([]*
 	return files, errors.WithStack(err)
 }
 
+// ListAllFilesForLibrary returns all files (main and supplement) for a library.
+// Used to preload the scan cache so the path-based scan walk can detect
+// supplement files that share scannable extensions (e.g. .pdf) with main files
+// and skip them instead of trying to re-create them as main files.
+func (svc *Service) ListAllFilesForLibrary(ctx context.Context, libraryID int) ([]*models.File, error) {
+	var files []*models.File
+	err := svc.db.NewSelect().
+		Model(&files).
+		Where("library_id = ?", libraryID).
+		Scan(ctx)
+	return files, errors.WithStack(err)
+}
+
 // DeleteBook deletes a book and all its associated records.
 // All child records (files, authors, book_series, book_genres, book_tags) cascade via FK.
 // File children (narrators, identifiers, chapters) cascade from files via FK.

--- a/pkg/books/service_test.go
+++ b/pkg/books/service_test.go
@@ -1245,3 +1245,51 @@ func TestDeleteFileAndCleanup_PromotesOldestSupplementFirst(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.FileRoleSupplement, updatedNewer.FileRole, "newer supplement should remain as supplement")
 }
+
+func TestListAllFilesForLibrary_IncludesSupplements(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	library, book := setupTestLibraryAndBook(t, db)
+
+	mainFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/test/main.epub",
+		FilesizeBytes: 100,
+	}
+	_, err := db.NewInsert().Model(mainFile).Exec(ctx)
+	require.NoError(t, err)
+
+	supplementFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      "pdf",
+		FileRole:      models.FileRoleSupplement,
+		Filepath:      "/test/supplement.pdf",
+		FilesizeBytes: 200,
+	}
+	_, err = db.NewInsert().Model(supplementFile).Exec(ctx)
+	require.NoError(t, err)
+
+	// ListFilesForLibrary keeps returning main-only (unchanged invariant for orphan cleanup)
+	mainOnly, err := svc.ListFilesForLibrary(ctx, library.ID)
+	require.NoError(t, err)
+	require.Len(t, mainOnly, 1)
+	assert.Equal(t, mainFile.ID, mainOnly[0].ID)
+
+	// New method returns both main and supplement files for the library
+	all, err := svc.ListAllFilesForLibrary(ctx, library.ID)
+	require.NoError(t, err)
+	require.Len(t, all, 2)
+	roles := map[string]struct{}{}
+	for _, f := range all {
+		roles[f.FileRole] = struct{}{}
+	}
+	assert.Contains(t, roles, models.FileRoleMain)
+	assert.Contains(t, roles, models.FileRoleSupplement)
+}

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -263,14 +263,26 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 		jobLog.Info("processing library", logger.Data{"library_id": library.ID})
 		filesToScan := make([]string, 0)
 
-		// Pre-load all known files for fast lookup during discovery and scan
+		// Pre-load all known files (main + supplement) for fast lookup during
+		// discovery and scan. The cache must include supplements so the scan
+		// walk can detect a supplement sharing a scannable extension (e.g. a
+		// .pdf companion next to a .epub) and skip it instead of trying to
+		// recreate it as a main file and hitting UNIQUE(filepath, library_id).
 		cache := NewScanCache()
-		existingFiles, err := w.bookService.ListFilesForLibrary(ctx, library.ID)
+		allFiles, err := w.bookService.ListAllFilesForLibrary(ctx, library.ID)
 		if err != nil {
 			jobLog.Warn("failed to pre-load files", logger.Data{"error": err.Error()})
 		} else {
-			cache.LoadKnownFiles(existingFiles)
-			jobLog.Info("pre-loaded known files", logger.Data{"count": len(existingFiles)})
+			cache.LoadKnownFiles(allFiles)
+			jobLog.Info("pre-loaded known files", logger.Data{"count": len(allFiles)})
+		}
+		// Orphan cleanup only considers main files — supplements don't need
+		// orphan cleanup (their lifecycle follows the parent book).
+		var existingFiles []*models.File
+		for _, f := range allFiles {
+			if f.FileRole == models.FileRoleMain {
+				existingFiles = append(existingFiles, f)
+			}
 		}
 
 		// Go through all the library paths to find all the .cbz files.

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -215,6 +215,15 @@ func (w *Worker) scanFileByPath(ctx context.Context, opts ScanOptions, cache *Sc
 	// Fast path: check pre-loaded cache for known file (avoids per-file DB query)
 	if cache != nil {
 		if existingFile := cache.GetKnownFile(opts.FilePath); existingFile != nil {
+			// Supplement files share scannable extensions (.pdf/.epub/.cbz/.m4b)
+			// with main files, so the walk picks them up — but they have no
+			// metadata to rescan and must not be routed through the main-file
+			// creation path (which would try to insert a duplicate row and hit
+			// UNIQUE(filepath, library_id)). Nothing to do: the supplement is
+			// already tracked.
+			if existingFile.FileRole == models.FileRoleSupplement {
+				return &ScanResult{File: existingFile}, nil
+			}
 			// File exists in DB — check if it changed on disk
 			if !opts.ForceRefresh && existingFile.FileModifiedAt != nil {
 				stat, err := os.Stat(opts.FilePath)

--- a/pkg/worker/supplement_test.go
+++ b/pkg/worker/supplement_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/internal/testgen"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
@@ -200,4 +201,87 @@ func TestProcessScanJob_RootLevelSupplements(t *testing.T) {
 	}
 	assert.Equal(t, 1, mainCount)
 	assert.Equal(t, 1, suppCount)
+}
+
+// TestProcessScanJob_ScannableSupplementNotRescannedAsMain reproduces the bug
+// where a supplement sharing a scannable extension (e.g. .pdf next to .epub)
+// is walked by the scan loop and re-created as a main file, hitting the
+// UNIQUE constraint on (filepath, library_id).
+//
+// Repro path: main EPUB is scanned normally, then a PDF is added to the book
+// directory and registered directly in the DB as a supplement (simulating a
+// user demoting a file via the file-role update endpoint). A subsequent scan
+// must not try to recreate the PDF as a main file.
+func TestProcessScanJob_ScannableSupplementNotRescannedAsMain(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	// Book dir with main EPUB.
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Emily Oster] Cribsheet")
+	testgen.GenerateEPUB(t, bookDir, "Cribsheet.epub", testgen.EPUBOptions{
+		Title:   "Cribsheet",
+		Authors: []string{"Emily Oster"},
+	})
+
+	// First scan: creates book + main EPUB.
+	require.NoError(t, tc.runScan())
+
+	booksList := tc.listBooks()
+	require.Len(t, booksList, 1)
+	bookID := booksList[0].ID
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+
+	// Now add a PDF to disk and register it as a supplement directly in the DB
+	// (matches what the file-role update handler does).
+	pdfPath := testgen.GeneratePDF(t, bookDir, "Cribsheet.pdf", testgen.PDFOptions{})
+	pdfStat, err := os.Stat(pdfPath)
+	require.NoError(t, err)
+
+	supplementFile := &models.File{
+		LibraryID:     1,
+		BookID:        bookID,
+		Filepath:      pdfPath,
+		FileType:      "pdf",
+		FileRole:      models.FileRoleSupplement,
+		FilesizeBytes: pdfStat.Size(),
+	}
+	require.NoError(t, tc.bookService.CreateFile(tc.ctx, supplementFile))
+	suppID := supplementFile.ID
+
+	require.Len(t, tc.listFiles(), 2)
+
+	// Second scan: the PDF already exists as a supplement. The scan walk
+	// previously walked the PDF, missed it in the cache (cache is main-only),
+	// and tried to recreate it as a main file — hitting UNIQUE(filepath, library_id).
+	log := logger.FromContext(tc.ctx)
+	rescanLog := tc.jobLogService.NewJobLogger(tc.ctx, 1, log)
+	require.NoError(t, tc.worker.ProcessScanJob(tc.ctx, nil, rescanLog))
+
+	// State should be unchanged: same files with same roles and same IDs.
+	afterFiles := tc.listFiles()
+	require.Len(t, afterFiles, 2, "rescan should not add or lose any files")
+
+	var foundSupp bool
+	for _, f := range afterFiles {
+		if filepath.Base(f.Filepath) == "Cribsheet.pdf" {
+			assert.Equal(t, models.FileRoleSupplement, f.FileRole, "PDF should still be a supplement after rescan")
+			assert.Equal(t, suppID, f.ID, "supplement row should not have been recreated")
+			foundSupp = true
+		}
+	}
+	assert.True(t, foundSupp, "supplement PDF row should still exist after rescan")
+
+	// When the bug is present, the scan walks Cribsheet.pdf, calls scanFileCreateNew,
+	// parses PDF metadata, and writes Cribsheet.pdf.cover.jpg to disk before the
+	// CreateFile UNIQUE constraint aborts the insert. A correct scan must early
+	// return for supplements without touching the cover file.
+	coverPath := filepath.Join(bookDir, "Cribsheet.pdf.cover.jpg")
+	_, err = os.Stat(coverPath)
+	assert.True(t, os.IsNotExist(err),
+		"rescan should not extract a cover for an existing supplement PDF (cover file at %s)", coverPath)
 }


### PR DESCRIPTION
## Summary
- Supplement files that share a scannable extension (e.g. a `.pdf` sitting next to a `.epub`) were walked as main-file scan targets, missed the main-only preload cache, and hit `UNIQUE(filepath, library_id)` warnings on every scan
- Added `ListAllFilesForLibrary` (main + supplement) and preload it in `ProcessScanJob`, while still filtering to main-only for orphan cleanup
- `scanFileByPath` now early-returns when the cached file has `FileRole == Supplement`, so the walk no longer routes supplements through `scanFileCreateNew`

## Test plan
- New unit test `TestListAllFilesForLibrary_IncludesSupplements` covers the service method
- New scanner test `TestProcessScanJob_ScannableSupplementNotRescannedAsMain` reproduces the bug (a demoted `Cribsheet.pdf` supplement next to a main `Cribsheet.epub`) and asserts that a rescan does not re-extract the PDF cover — the bug's observable side effect before the fix
- `mise check:quiet` passes locally (lint, test, test:js, lint:js)