### PR TITLE
[Fix] Clean up DB rows when a book directory is removed or renamed

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -35,7 +35,7 @@ Each domain (books, jobs, libraries, chapters) has:
 - Main job type: scan job that processes ebook/audiobook files
 - Extracts metadata from EPUB (via `pkg/epub/`) and M4B files (via `pkg/mp4/`)
 - Generates cover images with filename-based storage strategy
-- **Library monitor** (`monitor.go`): watches library paths for filesystem changes via fsnotify, debounces events, and triggers targeted single-file rescans
+- **Library monitor** (`monitor.go`): watches library paths for filesystem changes via fsnotify, debounces events, and triggers targeted single-file rescans. Remove/Rename events landing on a directory path (which fsnotify emits for the directory itself, not the files inside) are queued as `pendingEvent{IsDirectory: true}` and fan out to per-file cleanup for every DB file whose filepath sits under that directory, so removing or renaming a book folder cleans up its book/file rows instead of leaving them orphaned. File-identity across directory renames is not preserved — the old book row is deleted and a new one is created by the Create event on the new path; content-hash-based move detection is a separate ticket.
 
 ### scanInternal and File Organization
 

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -610,9 +610,12 @@ func (svc *Service) listFilesWithTotal(ctx context.Context, opts ListFilesOption
 	}
 	if opts.FilepathPrefix != nil {
 		// Match the directory itself (should not happen for files) or any descendant.
-		// Escape LIKE wildcards so paths containing % or _ don't over-match.
-		escaped := escapeLikePattern(*opts.FilepathPrefix)
-		q = q.Where("f.filepath = ? OR f.filepath LIKE ? ESCAPE '\\'", *opts.FilepathPrefix, escaped+string(os.PathSeparator)+"%")
+		// Escape LIKE wildcards so paths containing % or _ don't over-match. The
+		// path separator is escaped too — on Windows it's `\`, which is our
+		// ESCAPE char, so an unescaped separator would turn the trailing % into
+		// a literal and silently match nothing.
+		escaped := escapeLikePattern(*opts.FilepathPrefix) + escapeLikePattern(string(os.PathSeparator)) + "%"
+		q = q.Where("f.filepath = ? OR f.filepath LIKE ? ESCAPE '\\'", *opts.FilepathPrefix, escaped)
 	}
 
 	if opts.includeTotal {

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -55,9 +55,11 @@ type RetrieveFileOptions struct {
 }
 
 type ListFilesOptions struct {
-	Limit  *int
-	Offset *int
-	BookID *int
+	Limit          *int
+	Offset         *int
+	BookID         *int
+	LibraryID      *int
+	FilepathPrefix *string // Matches files whose filepath equals this value or is a descendant (prefix + "/")
 
 	includeTotal bool
 }
@@ -492,6 +494,14 @@ func (svc *Service) DeleteFileIdentifiers(ctx context.Context, fileID int) error
 	return errors.WithStack(err)
 }
 
+// escapeLikePattern escapes the SQLite LIKE wildcards (%, _) and the escape
+// character (\) so a raw filesystem path can be used as a literal prefix in a
+// LIKE clause via `ESCAPE '\'`.
+func escapeLikePattern(s string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return replacer.Replace(s)
+}
+
 func (svc *Service) RetrieveFile(ctx context.Context, opts RetrieveFileOptions) (*models.File, error) {
 	file := &models.File{}
 
@@ -594,6 +604,15 @@ func (svc *Service) listFilesWithTotal(ctx context.Context, opts ListFilesOption
 	}
 	if opts.BookID != nil {
 		q = q.Where("f.book_id = ?", *opts.BookID)
+	}
+	if opts.LibraryID != nil {
+		q = q.Where("f.library_id = ?", *opts.LibraryID)
+	}
+	if opts.FilepathPrefix != nil {
+		// Match the directory itself (should not happen for files) or any descendant.
+		// Escape LIKE wildcards so paths containing % or _ don't over-match.
+		escaped := escapeLikePattern(*opts.FilepathPrefix)
+		q = q.Where("f.filepath = ? OR f.filepath LIKE ? ESCAPE '\\'", *opts.FilepathPrefix, escaped+string(os.PathSeparator)+"%")
 	}
 
 	if opts.includeTotal {

--- a/pkg/worker/monitor.go
+++ b/pkg/worker/monitor.go
@@ -19,6 +19,11 @@ import (
 type pendingEvent struct {
 	Op        fsnotify.Op
 	LibraryID int
+	// IsDirectory marks Remove/Rename events whose path is not a scannable file —
+	// typically a book folder that was removed or renamed. processEvent fans this
+	// out into per-file cleanup for every DB file whose filepath sits under the
+	// directory.
+	IsDirectory bool
 }
 
 // Monitor watches library paths for filesystem changes and triggers targeted rescans
@@ -366,6 +371,44 @@ func (m *Monitor) handleEvent(watcher *fsnotify.Watcher, event fsnotify.Event) {
 		}
 	}
 
+	// Directory-level Remove/Rename: fsnotify emits the event against the
+	// directory path (not the files inside), so the path is not scannable.
+	// Queue a synthetic directory event so processEvent can cascade cleanup
+	// to every DB file whose filepath sits under this directory.
+	if (event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename)) && !m.isScannable(path) {
+		libID := m.findLibraryID(path)
+		if libID == 0 {
+			return
+		}
+
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		existing, ok := m.pending[path]
+		if ok {
+			existing.Op |= event.Op
+			existing.IsDirectory = true
+			m.pending[path] = existing
+		} else {
+			m.pending[path] = pendingEvent{
+				Op:          event.Op,
+				LibraryID:   libID,
+				IsDirectory: true,
+			}
+		}
+
+		m.log.Debug("filesystem directory event queued", logger.Data{
+			"path": path,
+			"op":   event.Op.String(),
+		})
+
+		if m.timer != nil {
+			m.timer.Stop()
+		}
+		m.timer = time.AfterFunc(m.delay, m.processPendingEvents)
+		return
+	}
+
 	// Only care about files with scannable extensions.
 	// For Remove/Rename the file no longer exists so we can't stat it,
 	// but we can still check the extension from the path.
@@ -451,10 +494,9 @@ func (m *Monitor) processPendingEvents() {
 	hadDeletes := false
 	booksToOrganize := make(map[int]struct{})
 	affectedBookIDs := make(map[int]struct{})
-	for path, event := range events {
-		result := m.processEvent(ctx, path, event)
+	applyResult := func(result *ScanResult) {
 		if result == nil {
-			continue
+			return
 		}
 		if result.FileDeleted || result.BookDeleted {
 			hadDeletes = true
@@ -466,6 +508,15 @@ func (m *Monitor) processPendingEvents() {
 		if result.Book != nil {
 			affectedBookIDs[result.Book.ID] = struct{}{}
 		}
+	}
+	for path, event := range events {
+		if event.IsDirectory {
+			for _, result := range m.processDirectoryEvent(ctx, path, event) {
+				applyResult(result)
+			}
+			continue
+		}
+		applyResult(m.processEvent(ctx, path, event))
 	}
 
 	// Organize new books — scanInternal with FilePath mode defers organization,
@@ -506,6 +557,45 @@ func (m *Monitor) requeue(events map[string]pendingEvent) {
 	}
 	m.timer = time.AfterFunc(m.delay, m.processPendingEvents)
 	m.mu.Unlock()
+}
+
+// processDirectoryEvent handles a Remove/Rename event that landed on a
+// directory path. It lists every DB file whose filepath sits at or under that
+// directory in the given library and delegates cleanup to the existing
+// per-file missing-on-disk path via scanInternal(FileID). This covers both
+// "directory removed" and "directory renamed away" — in the rename case the
+// corresponding Create event on the new path is handled independently and may
+// create a fresh book row.
+func (m *Monitor) processDirectoryEvent(ctx context.Context, path string, event pendingEvent) []*ScanResult {
+	log := m.log.Root(logger.Data{"path": path, "op": event.Op.String()})
+
+	files, err := m.worker.bookService.ListFiles(ctx, books.ListFilesOptions{
+		LibraryID:      &event.LibraryID,
+		FilepathPrefix: &path,
+	})
+	if err != nil {
+		log.Err(err).Warn("failed to list files under removed directory")
+		return nil
+	}
+	if len(files) == 0 {
+		return nil
+	}
+
+	log.Info("directory removed, cleaning up files", logger.Data{"count": len(files)})
+
+	results := make([]*ScanResult, 0, len(files))
+	for _, file := range files {
+		result, err := m.worker.scanInternal(ctx, ScanOptions{FileID: file.ID}, nil)
+		if err != nil {
+			log.Err(err).Warn("failed to cleanup file under removed directory", logger.Data{
+				"file_id":       file.ID,
+				"file_filepath": file.Filepath,
+			})
+			continue
+		}
+		results = append(results, result)
+	}
+	return results
 }
 
 // processEvent handles a single accumulated event for a file path.

--- a/pkg/worker/monitor.go
+++ b/pkg/worker/monitor.go
@@ -20,9 +20,9 @@ type pendingEvent struct {
 	Op        fsnotify.Op
 	LibraryID int
 	// IsDirectory marks Remove/Rename events whose path is not a scannable file —
-	// typically a book folder that was removed or renamed. processEvent fans this
-	// out into per-file cleanup for every DB file whose filepath sits under the
-	// directory.
+	// typically a book folder that was removed or renamed. processPendingEvents
+	// dispatches these to processDirectoryEvent, which cascades cleanup to every
+	// DB file whose filepath sits under the directory.
 	IsDirectory bool
 }
 
@@ -373,9 +373,15 @@ func (m *Monitor) handleEvent(watcher *fsnotify.Watcher, event fsnotify.Event) {
 
 	// Directory-level Remove/Rename: fsnotify emits the event against the
 	// directory path (not the files inside), so the path is not scannable.
-	// Queue a synthetic directory event so processEvent can cascade cleanup
-	// to every DB file whose filepath sits under this directory.
+	// Queue a synthetic directory event so processDirectoryEvent can cascade
+	// cleanup to every DB file whose filepath sits under this directory.
+	// Skip shisho-owned files (covers, sidecars) so cover/sidecar removals
+	// don't trigger pointless prefix queries — they're already suppressed
+	// for creates/writes by isShishoSpecialFile below.
 	if (event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename)) && !m.isScannable(path) {
+		if isShishoSpecialFile(filepath.Base(path)) {
+			return
+		}
 		libID := m.findLibraryID(path)
 		if libID == 0 {
 			return
@@ -433,7 +439,10 @@ func (m *Monitor) handleEvent(watcher *fsnotify.Watcher, event fsnotify.Event) {
 	existing, ok := m.pending[path]
 	if ok {
 		// Merge operations so we don't lose information about what happened.
+		// Clear IsDirectory — this event is for a scannable file at this path,
+		// so any prior same-path directory event is superseded (latest wins).
 		existing.Op |= event.Op
+		existing.IsDirectory = false
 		m.pending[path] = existing
 	} else {
 		m.pending[path] = pendingEvent{
@@ -581,7 +590,7 @@ func (m *Monitor) processDirectoryEvent(ctx context.Context, path string, event 
 		return nil
 	}
 
-	log.Info("directory removed, cleaning up files", logger.Data{"count": len(files)})
+	log.Info("directory event, cleaning up files", logger.Data{"count": len(files)})
 
 	results := make([]*ScanResult, 0, len(files))
 	for _, file := range files {

--- a/pkg/worker/monitor_test.go
+++ b/pkg/worker/monitor_test.go
@@ -519,3 +519,255 @@ func TestMonitor_SkipsWhenScanJobActive(t *testing.T) {
 	m.timer.Stop()
 	m.mu.Unlock()
 }
+
+func TestMonitor_HandleEvent_QueuesDirectoryRemoveAsDirectoryEvent(t *testing.T) {
+	t.Parallel()
+	m := newTestMonitor(t)
+	defer func() {
+		m.mu.Lock()
+		if m.timer != nil {
+			m.timer.Stop()
+		}
+		m.mu.Unlock()
+	}()
+
+	dirPath := "/library/books/author-title"
+	m.handleEvent(nil, fsnotify.Event{Name: dirPath, Op: fsnotify.Remove})
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ev, ok := m.pending[dirPath]
+	require.True(t, ok, "directory remove event should be queued")
+	assert.True(t, ev.IsDirectory)
+	assert.Equal(t, fsnotify.Remove, ev.Op)
+	assert.Equal(t, 1, ev.LibraryID)
+}
+
+func TestMonitor_HandleEvent_QueuesDirectoryRenameAsDirectoryEvent(t *testing.T) {
+	t.Parallel()
+	m := newTestMonitor(t)
+	defer func() {
+		m.mu.Lock()
+		if m.timer != nil {
+			m.timer.Stop()
+		}
+		m.mu.Unlock()
+	}()
+
+	dirPath := "/library/books/old-name"
+	m.handleEvent(nil, fsnotify.Event{Name: dirPath, Op: fsnotify.Rename})
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ev, ok := m.pending[dirPath]
+	require.True(t, ok, "directory rename event should be queued")
+	assert.True(t, ev.IsDirectory)
+	assert.Equal(t, fsnotify.Rename, ev.Op)
+}
+
+func TestMonitor_HandleEvent_IgnoresDirectoryRemoveOutsideLibrary(t *testing.T) {
+	t.Parallel()
+	m := newTestMonitor(t)
+
+	m.handleEvent(nil, fsnotify.Event{Name: "/other/path/folder", Op: fsnotify.Remove})
+	assert.Empty(t, m.pending)
+}
+
+func TestMonitor_ProcessEvent_DirectoryRemoveDeletesBookAndFile(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContext(t)
+	libDir := t.TempDir()
+	tc.createLibrary([]string{libDir})
+
+	// Create and scan a book in its own directory.
+	bookDir := testgen.CreateSubDir(t, libDir, "Author - Title")
+	epubPath := testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{
+		Title:   "Dir Delete Me",
+		Authors: []string{"Test Author"},
+	})
+
+	tc.worker.config.LibraryMonitorDelaySeconds = minMonitorDelaySeconds
+	m := newMonitor(tc.worker)
+	m.pathToLibrary[libDir] = 1
+
+	// Seed the DB.
+	result := m.processEvent(tc.ctx, epubPath, pendingEvent{Op: fsnotify.Create, LibraryID: 1})
+	require.NotNil(t, result)
+	require.Len(t, tc.listFiles(), 1)
+	require.Len(t, tc.listBooks(), 1)
+
+	// Remove the whole directory from disk, then fire a directory remove event.
+	require.NoError(t, os.RemoveAll(bookDir))
+
+	results := m.processDirectoryEvent(tc.ctx, bookDir, pendingEvent{
+		Op:          fsnotify.Remove,
+		LibraryID:   1,
+		IsDirectory: true,
+	})
+	require.Len(t, results, 1)
+	assert.True(t, results[0].FileDeleted)
+
+	assert.Empty(t, tc.listFiles())
+	assert.Empty(t, tc.listBooks())
+}
+
+func TestMonitor_ProcessEvent_DirectoryRemoveCascadesToNestedBooks(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContext(t)
+	libDir := t.TempDir()
+	tc.createLibrary([]string{libDir})
+
+	// Two books in sibling subdirs under a common parent.
+	parentDir := testgen.CreateSubDir(t, libDir, "Author")
+	bookDirA := testgen.CreateSubDir(t, parentDir, "Title A")
+	bookDirB := testgen.CreateSubDir(t, parentDir, "Title B")
+	epubA := testgen.GenerateEPUB(t, bookDirA, "a.epub", testgen.EPUBOptions{
+		Title: "A", Authors: []string{"Author"},
+	})
+	epubB := testgen.GenerateEPUB(t, bookDirB, "b.epub", testgen.EPUBOptions{
+		Title: "B", Authors: []string{"Author"},
+	})
+
+	tc.worker.config.LibraryMonitorDelaySeconds = minMonitorDelaySeconds
+	m := newMonitor(tc.worker)
+	m.pathToLibrary[libDir] = 1
+
+	require.NotNil(t, m.processEvent(tc.ctx, epubA, pendingEvent{Op: fsnotify.Create, LibraryID: 1}))
+	require.NotNil(t, m.processEvent(tc.ctx, epubB, pendingEvent{Op: fsnotify.Create, LibraryID: 1}))
+	require.Len(t, tc.listFiles(), 2)
+	require.Len(t, tc.listBooks(), 2)
+
+	// Remove the entire parent subtree from disk.
+	require.NoError(t, os.RemoveAll(parentDir))
+
+	results := m.processDirectoryEvent(tc.ctx, parentDir, pendingEvent{
+		Op:          fsnotify.Remove,
+		LibraryID:   1,
+		IsDirectory: true,
+	})
+	assert.Len(t, results, 2)
+
+	assert.Empty(t, tc.listFiles())
+	assert.Empty(t, tc.listBooks())
+}
+
+func TestMonitor_ProcessEvent_DirectoryRemoveDoesNotMatchSiblingPrefix(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContext(t)
+	libDir := t.TempDir()
+	tc.createLibrary([]string{libDir})
+
+	// Two sibling directories whose names share a prefix: "Author" and "Author Two".
+	// Removing "Author" must not cascade into "Author Two".
+	keepDir := testgen.CreateSubDir(t, libDir, "Author Two")
+	goDir := testgen.CreateSubDir(t, libDir, "Author")
+	keepEpub := testgen.GenerateEPUB(t, keepDir, "keep.epub", testgen.EPUBOptions{
+		Title: "Keep", Authors: []string{"Keep"},
+	})
+	goEpub := testgen.GenerateEPUB(t, goDir, "go.epub", testgen.EPUBOptions{
+		Title: "Go", Authors: []string{"Go"},
+	})
+
+	tc.worker.config.LibraryMonitorDelaySeconds = minMonitorDelaySeconds
+	m := newMonitor(tc.worker)
+	m.pathToLibrary[libDir] = 1
+
+	require.NotNil(t, m.processEvent(tc.ctx, keepEpub, pendingEvent{Op: fsnotify.Create, LibraryID: 1}))
+	require.NotNil(t, m.processEvent(tc.ctx, goEpub, pendingEvent{Op: fsnotify.Create, LibraryID: 1}))
+	require.Len(t, tc.listBooks(), 2)
+
+	// Only remove the "Author" subtree from disk; "Author Two" stays intact.
+	require.NoError(t, os.RemoveAll(goDir))
+
+	results := m.processDirectoryEvent(tc.ctx, goDir, pendingEvent{
+		Op:          fsnotify.Remove,
+		LibraryID:   1,
+		IsDirectory: true,
+	})
+	assert.Len(t, results, 1, "only files under the removed directory should be touched")
+
+	remaining := tc.listFiles()
+	require.Len(t, remaining, 1)
+	assert.Equal(t, keepEpub, remaining[0].Filepath)
+	assert.Len(t, tc.listBooks(), 1)
+}
+
+func TestMonitor_ProcessEvent_DirectoryRenameCleansOldRows(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContext(t)
+	libDir := t.TempDir()
+	tc.createLibrary([]string{libDir})
+
+	// Seed a book in its folder.
+	oldDir := testgen.CreateSubDir(t, libDir, "Old Name")
+	epubPath := testgen.GenerateEPUB(t, oldDir, "book.epub", testgen.EPUBOptions{
+		Title: "Renamed", Authors: []string{"Author"},
+	})
+
+	tc.worker.config.LibraryMonitorDelaySeconds = minMonitorDelaySeconds
+	m := newMonitor(tc.worker)
+	m.pathToLibrary[libDir] = 1
+
+	require.NotNil(t, m.processEvent(tc.ctx, epubPath, pendingEvent{Op: fsnotify.Create, LibraryID: 1}))
+	require.Len(t, tc.listBooks(), 1)
+
+	// Simulate the directory being renamed away on disk (move it to a new name).
+	newDir := filepath.Join(libDir, "New Name")
+	require.NoError(t, os.Rename(oldDir, newDir))
+
+	// Fire the Rename event for the old directory path. The file no longer
+	// exists at the old path, so scanInternal should delete the old rows.
+	results := m.processDirectoryEvent(tc.ctx, oldDir, pendingEvent{
+		Op:          fsnotify.Rename,
+		LibraryID:   1,
+		IsDirectory: true,
+	})
+	require.Len(t, results, 1)
+	assert.True(t, results[0].FileDeleted)
+
+	// The stale book row is gone. (The new book row is created by the
+	// separate Create event on the new path, which is tested elsewhere.)
+	assert.Empty(t, tc.listBooks())
+	assert.Empty(t, tc.listFiles())
+}
+
+func TestMonitor_ProcessEvent_DirectoryRemoveWithMultipleFilesKeepsBookUntilLast(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContext(t)
+	libDir := t.TempDir()
+	tc.createLibrary([]string{libDir})
+
+	// Two files inside the same book folder.
+	bookDir := testgen.CreateSubDir(t, libDir, "Multi")
+	epub1 := testgen.GenerateEPUB(t, bookDir, "one.epub", testgen.EPUBOptions{
+		Title: "Multi", Authors: []string{"Multi"},
+	})
+	epub2 := testgen.GenerateEPUB(t, bookDir, "two.epub", testgen.EPUBOptions{
+		Title: "Multi", Authors: []string{"Multi"},
+	})
+
+	tc.worker.config.LibraryMonitorDelaySeconds = minMonitorDelaySeconds
+	m := newMonitor(tc.worker)
+	m.pathToLibrary[libDir] = 1
+
+	require.NotNil(t, m.processEvent(tc.ctx, epub1, pendingEvent{Op: fsnotify.Create, LibraryID: 1}))
+	require.NotNil(t, m.processEvent(tc.ctx, epub2, pendingEvent{Op: fsnotify.Create, LibraryID: 1}))
+	require.Len(t, tc.listFiles(), 2)
+
+	require.NoError(t, os.RemoveAll(bookDir))
+
+	results := m.processDirectoryEvent(tc.ctx, bookDir, pendingEvent{
+		Op:          fsnotify.Remove,
+		LibraryID:   1,
+		IsDirectory: true,
+	})
+	assert.Len(t, results, 2)
+
+	assert.Empty(t, tc.listFiles())
+	assert.Empty(t, tc.listBooks())
+}

--- a/pkg/worker/monitor_test.go
+++ b/pkg/worker/monitor_test.go
@@ -573,6 +573,24 @@ func TestMonitor_HandleEvent_IgnoresDirectoryRemoveOutsideLibrary(t *testing.T) 
 	assert.Empty(t, m.pending)
 }
 
+func TestMonitor_HandleEvent_SkipsShishoSpecialFileRemove(t *testing.T) {
+	t.Parallel()
+	m := newTestMonitor(t)
+
+	// Shisho-owned files must NOT fall through to the directory-event branch
+	// on Remove/Rename — they're not directories, and issuing a DB prefix
+	// query for every cover/sidecar removal is wasted work.
+	m.handleEvent(nil, fsnotify.Event{
+		Name: "/library/books/book.epub.cover.jpg",
+		Op:   fsnotify.Remove,
+	})
+	m.handleEvent(nil, fsnotify.Event{
+		Name: "/library/books/book.epub.metadata.json",
+		Op:   fsnotify.Rename,
+	})
+	assert.Empty(t, m.pending)
+}
+
 func TestMonitor_ProcessEvent_DirectoryRemoveDeletesBookAndFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Library monitor now queues `Remove`/`Rename` fsnotify events landing on directory paths (previously dropped because directory paths aren't scannable) as `pendingEvent{IsDirectory: true}` and fans them out to the existing per-file `scanInternal(FileID)` missing-on-disk cleanup.
- Added `ListFilesOptions.LibraryID` / `FilepathPrefix` with LIKE-wildcard escaping so the directory cascade can list every file under a given directory in a specific library, while not over-matching sibling directories that share a name prefix or contain `_`/`%`.
- Fixes the orphan/`UNIQUE constraint failed: books.filepath, books.library_id` crash that occurred when a user removed or renamed a book folder on disk. Identity preservation across renames still needs the content-hash ticket.

## Test plan
- `mise check:quiet` — lint + Go tests + JS tests
- New monitor tests: `HandleEvent_QueuesDirectoryRemoveAsDirectoryEvent`, `HandleEvent_QueuesDirectoryRenameAsDirectoryEvent`, `HandleEvent_IgnoresDirectoryRemoveOutsideLibrary`, `ProcessEvent_DirectoryRemoveDeletesBookAndFile`, `ProcessEvent_DirectoryRemoveCascadesToNestedBooks`, `ProcessEvent_DirectoryRemoveDoesNotMatchSiblingPrefix`, `ProcessEvent_DirectoryRenameCleansOldRows`, `ProcessEvent_DirectoryRemoveWithMultipleFilesKeepsBookUntilLast`
- Manual repro of the bug from the Notion ticket (rename `[Author] Title (Series, #1)` → `[Author] Title`) no longer leaves duplicate book rows or crashes on the next organize pass