### PR TITLE
[Fix] Close several cover recovery and display gaps

### DIFF
--- a/app/components/library/CoverGalleryTabs.test.tsx
+++ b/app/components/library/CoverGalleryTabs.test.tsx
@@ -1,0 +1,58 @@
+import CoverGalleryTabs from "./CoverGalleryTabs";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { File } from "@/types";
+
+function makeFile(overrides: Partial<File> = {}): File {
+  return {
+    id: 1,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    library_id: 1,
+    book_id: 1,
+    filepath: "/library/book.epub",
+    file_type: "epub",
+    file_role: "main",
+    filesize_bytes: 1000,
+    cover_image_filename: "cover.jpg",
+    ...overrides,
+  };
+}
+
+describe("CoverGalleryTabs", () => {
+  it("re-renders cover image after error when cacheBuster changes", () => {
+    const files = [
+      makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
+      makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
+    ];
+
+    const { container, rerender } = render(
+      <CoverGalleryTabs cacheBuster={111} files={files} />,
+    );
+
+    // Initial render: the first file's cover <img> is present with cacheBuster=111
+    let img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toContain(
+      "/api/books/files/1/cover?t=111",
+    );
+
+    // Simulate the cover failing to load (e.g. 404 because the cover didn't
+    // exist on disk at that time)
+    fireEvent.error(img!);
+
+    // Once errored, the <img> is unmounted and only the placeholder remains
+    expect(container.querySelector("img")).toBeNull();
+
+    // A rescan/refresh completes: cacheBuster changes, so the cover URL
+    // changes. The <img> must be re-rendered to attempt the new URL.
+    rerender(<CoverGalleryTabs cacheBuster={222} files={files} />);
+
+    img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toContain(
+      "/api/books/files/1/cover?t=222",
+    );
+  });
+});

--- a/app/components/library/CoverGalleryTabs.tsx
+++ b/app/components/library/CoverGalleryTabs.tsx
@@ -93,11 +93,19 @@ function CoverGalleryTabs({
     }
   }, [coverUrl]);
 
-  // Reset cover state when selection changes
+  // Reset loading state on tab change so the placeholder shows while the
+  // new file's cover loads.
   useEffect(() => {
     setCoverLoaded(false);
-    setCoverError(false);
   }, [selectedFileId]);
+
+  // Reset the error flag whenever the URL changes — either because the user
+  // picked a different tab, or because a rescan bumped the cache-buster. If
+  // we only reset on tab change, a previously-failed cover stays unmounted
+  // even after the underlying file gets a valid cover.
+  useEffect(() => {
+    setCoverError(false);
+  }, [coverUrl]);
 
   const handleCoverLoad = () => {
     if (coverUrl) {

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -819,15 +819,19 @@ const BookDetail = () => {
     );
   };
 
-  useEffect(() => {
-    setCoverError(false);
-  }, [bookQuery.data?.id]);
-
   // Cache-busting parameter for cover images - computed early for hook ordering
   const coverCacheBuster = bookQuery.dataUpdatedAt;
   const coverUrl = bookQuery.data?.id
     ? `/api/books/${bookQuery.data.id}/cover?t=${coverCacheBuster}`
     : null;
+
+  // Reset the error flag whenever the URL changes — either because we
+  // navigated to a different book, or because a rescan bumped the
+  // cache-buster. If we only reset on book id, a previously-missing cover
+  // stays unmounted after a successful rescan until the user refreshes.
+  useEffect(() => {
+    setCoverError(false);
+  }, [coverUrl]);
 
   // Check cache synchronously before paint to avoid placeholder flash
   // Must be called before early returns to maintain hook ordering

--- a/pkg/epub/opf.go
+++ b/pkg/epub/opf.go
@@ -315,12 +315,22 @@ func ParseOPF(filename string, r io.ReadCloser) (*ParseOPFResult, error) {
 			}
 		}
 	}
-	// 2. EPUB 3: item with properties="cover-image".
+	// 2. EPUB 3: item with properties="cover-image". The properties
+	// attribute is a whitespace-separated token list per the spec, so
+	// match tokens rather than running a substring check.
 	if coverFilepath == "" {
 		for _, item := range pkg.Manifest.Item {
-			if strings.Contains(item.Properties, "cover-image") && strings.HasPrefix(item.MediaType, "image/") {
-				coverFilepath = basePath + item.Href
-				coverMimeType = item.MediaType
+			if !strings.HasPrefix(item.MediaType, "image/") {
+				continue
+			}
+			for _, prop := range strings.Fields(item.Properties) {
+				if prop == "cover-image" {
+					coverFilepath = basePath + item.Href
+					coverMimeType = item.MediaType
+					break
+				}
+			}
+			if coverFilepath != "" {
 				break
 			}
 		}

--- a/pkg/epub/opf.go
+++ b/pkg/epub/opf.go
@@ -306,11 +306,38 @@ func ParseOPF(filename string, r io.ReadCloser) (*ParseOPFResult, error) {
 
 	coverFilepath := ""
 	coverMimeType := ""
+	// 1. Preferred: <meta name="cover" content="ID"/> pointing at a manifest item.
 	if metaContent["cover"] != "" {
 		for _, item := range pkg.Manifest.Item {
 			if item.ID == metaContent["cover"] {
 				coverFilepath = basePath + item.Href
 				coverMimeType = item.MediaType
+			}
+		}
+	}
+	// 2. EPUB 3: item with properties="cover-image".
+	if coverFilepath == "" {
+		for _, item := range pkg.Manifest.Item {
+			if strings.Contains(item.Properties, "cover-image") && strings.HasPrefix(item.MediaType, "image/") {
+				coverFilepath = basePath + item.Href
+				coverMimeType = item.MediaType
+				break
+			}
+		}
+	}
+	// 3. Fallback: image manifest item whose id matches a common cover convention
+	// (e.g. id="cover-image" or id="cover" with no explicit <meta>/properties hint).
+	// Some older EPUBs (notably legacy HarperCollins exports) ship only this.
+	if coverFilepath == "" {
+		for _, item := range pkg.Manifest.Item {
+			if !strings.HasPrefix(item.MediaType, "image/") {
+				continue
+			}
+			id := strings.ToLower(item.ID)
+			if id == "cover-image" || id == "cover" || id == "coverimage" {
+				coverFilepath = basePath + item.Href
+				coverMimeType = item.MediaType
+				break
 			}
 		}
 	}

--- a/pkg/epub/opf_test.go
+++ b/pkg/epub/opf_test.go
@@ -156,6 +156,59 @@ func TestParseOPF_Language_ISO6392T(t *testing.T) {
 	assert.Equal(t, "en", *result.OPF.Language)
 }
 
+// TestParseOPF_Cover_ManifestIDFallback verifies that when an OPF has no
+// <meta name="cover" .../> element but the manifest contains an image item
+// with id="cover-image" (a common EPUB 2.x convention used by e.g. older
+// HarperCollins titles), the parser still discovers the cover.
+func TestParseOPF_Cover_ManifestIDFallback(t *testing.T) {
+	t.Parallel()
+	opfXML := `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>Test Book</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="bookid">urn:uuid:test</dc:identifier>
+  </metadata>
+  <manifest>
+    <item href="chapter1.xhtml" id="ch1" media-type="application/xhtml+xml"/>
+    <item href="Images/Cover.jpg" id="cover-image" media-type="image/jpeg"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+  </spine>
+</package>`
+
+	result, err := ParseOPF("OEBPS/content.opf", io.NopCloser(strings.NewReader(opfXML)))
+	require.NoError(t, err)
+	assert.Equal(t, "OEBPS/Images/Cover.jpg", result.OPF.CoverFilepath)
+	assert.Equal(t, "image/jpeg", result.OPF.CoverMimeType)
+}
+
+// TestParseOPF_Cover_PropertiesFallback verifies EPUB 3's properties="cover-image"
+// attribute is discovered when there's no <meta name="cover"/> reference.
+func TestParseOPF_Cover_PropertiesFallback(t *testing.T) {
+	t.Parallel()
+	opfXML := `<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+    <dc:identifier id="bookid">urn:uuid:test</dc:identifier>
+  </metadata>
+  <manifest>
+    <item href="chapter1.xhtml" id="ch1" media-type="application/xhtml+xml"/>
+    <item href="cover.png" id="img1" media-type="image/png" properties="cover-image"/>
+  </manifest>
+  <spine>
+    <itemref idref="ch1"/>
+  </spine>
+</package>`
+
+	result, err := ParseOPF("content.opf", io.NopCloser(strings.NewReader(opfXML)))
+	require.NoError(t, err)
+	assert.Equal(t, "cover.png", result.OPF.CoverFilepath)
+	assert.Equal(t, "image/png", result.OPF.CoverMimeType)
+}
+
 func TestParseOPF_Language_Missing(t *testing.T) {
 	t.Parallel()
 	// No dc:language element: Language should be nil

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2217,32 +2217,32 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 		}
 	}
 
-	// Handle cover extraction
+	// Handle cover extraction. extractAndSaveCover also adopts a cover file
+	// that already sits next to the source file on disk, so we always call
+	// it — even when the parser returned no cover data for the source.
 	var coverImagePath *string
 	var coverMimeType *string
 	var coverSource *string
 	var coverPage *int
 
-	if metadata != nil && len(metadata.CoverData) > 0 {
-		coverFilename, extractedMimeType, wasPreExisting, err := w.extractAndSaveCover(ctx, path, bookPath, isRootLevelFile, metadata, opts.JobLog)
-		if err != nil {
-			logWarn("failed to extract cover", logger.Data{"error": err.Error()})
-		} else if coverFilename != "" {
-			coverImagePath = &coverFilename
-			if extractedMimeType != "" {
-				coverMimeType = &extractedMimeType
-			}
-			if wasPreExisting {
-				existingCoverSource := models.DataSourceExistingCover
-				coverSource = &existingCoverSource
-			} else {
-				cs := metadata.SourceForField("cover")
-				coverSource = &cs
-			}
+	coverFilename, extractedMimeType, wasPreExisting, err := w.extractAndSaveCover(ctx, path, bookPath, isRootLevelFile, metadata, opts.JobLog)
+	if err != nil {
+		logWarn("failed to extract cover", logger.Data{"error": err.Error()})
+	} else if coverFilename != "" {
+		coverImagePath = &coverFilename
+		if extractedMimeType != "" {
+			coverMimeType = &extractedMimeType
 		}
-		if metadata.CoverPage != nil {
-			coverPage = metadata.CoverPage
+		if wasPreExisting {
+			existingCoverSource := models.DataSourceExistingCover
+			coverSource = &existingCoverSource
+		} else {
+			cs := metadata.SourceForField("cover")
+			coverSource = &cs
 		}
+	}
+	if metadata != nil && metadata.CoverPage != nil {
+		coverPage = metadata.CoverPage
 	}
 
 	// Create file record
@@ -2593,10 +2593,6 @@ func (w *Worker) extractAndSaveCover(
 		}
 	}
 
-	if metadata == nil || len(metadata.CoverData) == 0 {
-		return "", "", false, nil
-	}
-
 	// Determine cover directory
 	coverDir := bookPath
 	if isRootLevelFile {
@@ -2606,13 +2602,22 @@ func (w *Worker) extractAndSaveCover(
 	// Build cover base name: <filename>.cover
 	coverBaseName := filepath.Base(filePath) + ".cover"
 
-	// Check if cover already exists
+	// Check if a cover already exists alongside the file. A user may have
+	// dropped a `book.epub.cover.jpg` next to an EPUB that has no embedded
+	// cover; in that case we want to adopt the existing file instead of
+	// leaving the record without a cover, which would otherwise only get
+	// picked up on a later "Refresh all metadata".
 	existingCoverPath := fileutils.CoverExistsWithBaseName(coverDir, coverBaseName)
 	if existingCoverPath != "" {
 		logInfo("cover already exists, using existing", logger.Data{"path": existingCoverPath})
-		// Detect MIME type from file extension
 		existingMime := fileutils.MimeTypeFromExtension(filepath.Ext(existingCoverPath))
 		return filepath.Base(existingCoverPath), existingMime, true, nil
+	}
+
+	// No cover on disk — fall back to whatever the parser extracted from
+	// the file itself.
+	if metadata == nil || len(metadata.CoverData) == 0 {
+		return "", "", false, nil
 	}
 
 	// Normalize the cover image
@@ -3367,6 +3372,13 @@ func (w *Worker) recoverMissingCover(ctx context.Context, file *models.File, job
 		return nil
 	}
 
+	logWarn := func(msg string, data logger.Data) {
+		log.Warn(msg, data)
+		if jobLog != nil {
+			jobLog.Warn(msg, data)
+		}
+	}
+
 	// Cover doesn't exist on disk - check if we need to extract one
 	// This handles both: 1) missing cover that was previously extracted, and
 	// 2) file that never had a cover (e.g., promoted supplement)
@@ -3376,25 +3388,45 @@ func (w *Worker) recoverMissingCover(ctx context.Context, file *models.File, job
 		logInfo("no cover exists, extracting", nil)
 	}
 
-	// Extract cover from the media file
-	var metadata *mediafile.ParsedMetadata
-	var parseErr error
-
-	switch file.FileType {
-	case models.FileTypeM4B:
-		metadata, parseErr = mp4.Parse(file.Filepath)
-	case models.FileTypeEPUB:
-		metadata, parseErr = epub.Parse(file.Filepath)
-	case models.FileTypeCBZ:
-		metadata, parseErr = cbz.Parse(file.Filepath)
-	case models.FileTypePDF:
-		metadata, parseErr = pdf.Parse(file.Filepath)
-	default:
-		return nil // Unknown file type, skip
+	// Page-based formats (CBZ, PDF) may have a user-selected cover page in
+	// file.CoverPage (set via the page picker UI). Re-extract from that
+	// specific page so recovery preserves the user's choice instead of
+	// silently resetting to page 0.
+	if models.IsPageBasedFileType(file.FileType) && file.CoverPage != nil {
+		pageNum := *file.CoverPage
+		var coverFilename, coverMimeType string
+		var err error
+		switch file.FileType {
+		case models.FileTypeCBZ:
+			coverFilename, coverMimeType, err = extractCBZPageCover(file.Filepath, coverDir, coverBaseName, pageNum)
+		case models.FileTypePDF:
+			coverFilename, coverMimeType, err = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, pageNum)
+		}
+		if err == nil && coverFilename != "" {
+			logInfo("recovered cover from selected page", logger.Data{"page": pageNum})
+			file.CoverImageFilename = &coverFilename
+			file.CoverMimeType = &coverMimeType
+			// Leave CoverSource alone — the user's selection still stands.
+			if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
+				Columns: []string{"cover_image_filename", "cover_mime_type"},
+			}); err != nil {
+				return errors.WithStack(err)
+			}
+			return nil
+		}
+		if err != nil {
+			logWarn("failed to extract cover from selected page, falling back to parser", logger.Data{"page": pageNum, "error": err.Error()})
+		}
 	}
 
+	// Delegate parsing to parseFileMetadata so plugin-registered file parsers
+	// are also consulted (previously a hard-coded switch left plugin types
+	// stuck with no cover after deletion). Unsupported file types return an
+	// error we treat as "nothing to recover".
+	metadata, parseErr := w.parseFileMetadata(ctx, file.Filepath, file.FileType)
 	if parseErr != nil {
-		return errors.WithStack(parseErr)
+		logInfo("cannot parse file for cover recovery", logger.Data{"error": parseErr.Error()})
+		return nil
 	}
 
 	if metadata == nil || len(metadata.CoverData) == 0 {

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -3391,7 +3391,10 @@ func (w *Worker) recoverMissingCover(ctx context.Context, file *models.File, job
 	// Page-based formats (CBZ, PDF) may have a user-selected cover page in
 	// file.CoverPage (set via the page picker UI). Re-extract from that
 	// specific page so recovery preserves the user's choice instead of
-	// silently resetting to page 0.
+	// silently resetting to page 0. If the page extraction fails we bail
+	// out rather than falling through to the generic parser — otherwise
+	// we'd write a page-0 cover to disk while file.CoverPage still points
+	// at the user's selection, leaving the two out of sync.
 	if models.IsPageBasedFileType(file.FileType) && file.CoverPage != nil {
 		pageNum := *file.CoverPage
 		var coverFilename, coverMimeType string
@@ -3402,21 +3405,23 @@ func (w *Worker) recoverMissingCover(ctx context.Context, file *models.File, job
 		case models.FileTypePDF:
 			coverFilename, coverMimeType, err = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, pageNum)
 		}
-		if err == nil && coverFilename != "" {
-			logInfo("recovered cover from selected page", logger.Data{"page": pageNum})
-			file.CoverImageFilename = &coverFilename
-			file.CoverMimeType = &coverMimeType
-			// Leave CoverSource alone — the user's selection still stands.
-			if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
-				Columns: []string{"cover_image_filename", "cover_mime_type"},
-			}); err != nil {
-				return errors.WithStack(err)
-			}
+		if err != nil {
+			logWarn("failed to extract cover from selected page", logger.Data{"page": pageNum, "error": err.Error()})
 			return nil
 		}
-		if err != nil {
-			logWarn("failed to extract cover from selected page, falling back to parser", logger.Data{"page": pageNum, "error": err.Error()})
+		if coverFilename == "" {
+			return nil
 		}
+		logInfo("recovered cover from selected page", logger.Data{"page": pageNum})
+		file.CoverImageFilename = &coverFilename
+		file.CoverMimeType = &coverMimeType
+		// Leave CoverSource alone — the user's selection still stands.
+		if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
+			Columns: []string{"cover_image_filename", "cover_mime_type"},
+		}); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
 	}
 
 	// Delegate parsing to parseFileMetadata so plugin-registered file parsers

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -1,6 +1,11 @@
 package worker
 
 import (
+	"archive/zip"
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +19,37 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// writeCBZWithColoredPages creates a CBZ at path with len(colors) pages,
+// each page being a small solid-color PNG. Page order is 001.png, 002.png,
+// ... so page index matches the colors slice index.
+func writeCBZWithColoredPages(t *testing.T, path string, colors []color.RGBA) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	defer func() {
+		require.NoError(t, zw.Close())
+	}()
+
+	for i, c := range colors {
+		img := image.NewRGBA(image.Rect(0, 0, 20, 20))
+		for y := 0; y < 20; y++ {
+			for x := 0; x < 20; x++ {
+				img.Set(x, y, c)
+			}
+		}
+		var buf bytes.Buffer
+		require.NoError(t, png.Encode(&buf, img))
+		name := filepath.Base(path) + "_" + string(rune('0'+i/100)) + string(rune('0'+(i/10)%10)) + string(rune('0'+i%10)) + ".png"
+		w, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = w.Write(buf.Bytes())
+		require.NoError(t, err)
+	}
+}
 
 func TestScan_ZeroEntryPoints(t *testing.T) {
 	t.Parallel()
@@ -2643,6 +2679,286 @@ func TestScanFileByID_CoverRecovery(t *testing.T) {
 	// Verify cover file was recovered
 	recoveredCoverPath := fileutils.CoverExistsWithBaseName(bookDir, coverBaseName)
 	assert.NotEmpty(t, recoveredCoverPath, "cover file should be recovered after resync")
+}
+
+// TestRecoverMissingCover_RespectsCoverPage verifies that when a user has
+// selected a specific cover page for a CBZ (via the page picker) and the
+// cover file is subsequently deleted, the resync recovery path extracts
+// the cover from the user-selected page — not page 0.
+func TestRecoverMissingCover_RespectsCoverPage(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "Page Picker Comic")
+	cbzPath := filepath.Join(bookDir, "comic.cbz")
+	// Three distinctively-colored pages so we can verify which one was used.
+	writeCBZWithColoredPages(t, cbzPath, []color.RGBA{
+		{R: 255, G: 0, B: 0, A: 255},   // page 0: red
+		{R: 0, G: 255, B: 0, A: 255},   // page 1: green
+		{R: 30, G: 40, B: 250, A: 255}, // page 2: blue
+	})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	file := files[0]
+
+	// Simulate the user picking page 2 (blue) via the page picker.
+	coverPage := 2
+	file.CoverPage = &coverPage
+	require.NoError(t, tc.bookService.UpdateFile(tc.ctx, file, books.UpdateFileOptions{
+		Columns: []string{"cover_page"},
+	}))
+	// Rewrite the on-disk cover to the blue page so initial state matches the
+	// selection — we're testing recovery, not the initial pick flow.
+	existingCoverPath := fileutils.CoverExistsWithBaseName(bookDir, "comic.cbz.cover")
+	require.NotEmpty(t, existingCoverPath)
+	require.NoError(t, os.Remove(existingCoverPath))
+	newCover, newMime, err := extractCBZPageCover(cbzPath, bookDir, "comic.cbz.cover", 2)
+	require.NoError(t, err)
+	file.CoverImageFilename = &newCover
+	file.CoverMimeType = &newMime
+	require.NoError(t, tc.bookService.UpdateFile(tc.ctx, file, books.UpdateFileOptions{
+		Columns: []string{"cover_image_filename", "cover_mime_type"},
+	}))
+
+	// User now deletes the cover file off disk.
+	existingCoverPath = fileutils.CoverExistsWithBaseName(bookDir, "comic.cbz.cover")
+	require.NotEmpty(t, existingCoverPath)
+	require.NoError(t, os.Remove(existingCoverPath))
+
+	// Trigger the recovery path.
+	_, err = tc.worker.scanInternal(tc.ctx, ScanOptions{
+		BookID:       file.BookID,
+		ForceRefresh: true,
+	}, nil)
+	require.NoError(t, err)
+
+	// Cover should be back on disk and contain the blue page, not red.
+	recoveredCoverPath := fileutils.CoverExistsWithBaseName(bookDir, "comic.cbz.cover")
+	require.NotEmpty(t, recoveredCoverPath, "cover should be recovered")
+
+	coverBytes, err := os.ReadFile(recoveredCoverPath)
+	require.NoError(t, err)
+	img, _, err := image.Decode(bytes.NewReader(coverBytes))
+	require.NoError(t, err)
+
+	bounds := img.Bounds()
+	r, g, b, _ := img.At((bounds.Min.X+bounds.Max.X)/2, (bounds.Min.Y+bounds.Max.Y)/2).RGBA()
+	// 16-bit values; >> 8 to get 0-255 range.
+	assert.Less(t, int(r>>8), 80, "red channel should be low (page 2 is blue)")
+	assert.Less(t, int(g>>8), 80, "green channel should be low (page 2 is blue)")
+	assert.Greater(t, int(b>>8), 150, "blue channel should be high (page 2 is blue)")
+
+	// The user's selected cover page should be preserved in the DB.
+	refreshed, err := tc.bookService.RetrieveFileWithRelations(tc.ctx, file.ID)
+	require.NoError(t, err)
+	require.NotNil(t, refreshed.CoverPage)
+	assert.Equal(t, 2, *refreshed.CoverPage)
+}
+
+// TestRecoverMissingCover_UnsupportedFileTypeDoesNotError verifies that
+// recoverMissingCover gracefully returns nil (not an error) for a file type
+// that isn't a built-in format and has no plugin parser registered — rather
+// than silently falling through and losing the chance to extract a cover.
+// Previously the function had a hard-coded switch over EPUB/CBZ/M4B/PDF with
+// `default: return nil`; it now delegates to parseFileMetadata, so the fix
+// is to make sure the "unsupported file type" error path is swallowed.
+func TestRecoverMissingCover_UnsupportedFileTypeDoesNotError(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "Unsupported Type")
+	// Create a "file" with a made-up extension that no built-in parser
+	// handles and no plugin is registered for.
+	filePath := filepath.Join(bookDir, "book.xyz")
+	require.NoError(t, os.WriteFile(filePath, []byte("not a real book file"), 0o644))
+
+	book := &models.Book{
+		LibraryID:    1,
+		Filepath:     bookDir,
+		Title:        "Unsupported",
+		TitleSource:  models.DataSourceFilepath,
+		SortTitle:    "Unsupported",
+		AuthorSource: models.DataSourceFilepath,
+	}
+	require.NoError(t, tc.bookService.CreateBook(tc.ctx, book))
+
+	file := &models.File{
+		LibraryID:     1,
+		BookID:        book.ID,
+		Filepath:      filePath,
+		FileType:      "xyz",
+		FileRole:      models.FileRoleMain,
+		FilesizeBytes: 20,
+	}
+	require.NoError(t, tc.bookService.CreateFile(tc.ctx, file))
+
+	err := tc.worker.recoverMissingCover(tc.ctx, file, nil)
+	assert.NoError(t, err, "recoverMissingCover should swallow unsupported-file-type errors")
+}
+
+// TestScanFileCreateNew_ExistingCoverOnDisk verifies that when an EPUB has
+// no embedded cover but a sibling cover file already lives next to it on
+// disk (e.g. user-placed `book.epub.cover.jpg`), the initial scan picks it
+// up instead of leaving the file with no cover. Previously the first scan
+// skipped cover handling whenever metadata.CoverData was empty, so users
+// had to run "Refresh all metadata" to have the existing cover detected.
+func TestScanFileCreateNew_ExistingCoverOnDisk(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Test Author] No Embedded Cover")
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{
+		Title:    "No Embedded Cover",
+		Authors:  []string{"Test Author"},
+		HasCover: false,
+	})
+
+	// User drops a cover file next to the epub before the first scan.
+	existingCoverPath := filepath.Join(bookDir, "book.epub.cover.jpg")
+	require.NoError(t, os.WriteFile(existingCoverPath, []byte("\xff\xd8\xff\xe0fake-jpeg-bytes"), 0o644))
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	file := files[0]
+
+	require.NotNil(t, file.CoverImageFilename, "file should have a cover image filename after initial scan")
+	assert.Equal(t, "book.epub.cover.jpg", *file.CoverImageFilename)
+	require.NotNil(t, file.CoverSource)
+	assert.Equal(t, models.DataSourceExistingCover, *file.CoverSource)
+}
+
+// TestScanBook_CoverRecovery_RefreshMode verifies that the book-level resync
+// path (used by "Rescan > Refresh all metadata" from the UI) re-extracts a
+// cover whose file was removed from disk. This exercises scanBook → scanFileByID
+// with ForceRefresh=true, matching the real resync handler.
+func TestScanBook_CoverRecovery_RefreshMode(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Test Author] Cover Book")
+	testgen.GenerateEPUB(t, bookDir, "test.epub", testgen.EPUBOptions{
+		Title:    "Cover Book",
+		Authors:  []string{"Test Author"},
+		HasCover: true,
+	})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	bookID := files[0].BookID
+
+	coverBaseName := "test.epub.cover"
+	existingCoverPath := fileutils.CoverExistsWithBaseName(bookDir, coverBaseName)
+	require.NotEmpty(t, existingCoverPath, "cover file should exist after initial scan")
+
+	// Simulate the user deleting the cover file off disk.
+	require.NoError(t, os.Remove(existingCoverPath))
+	require.Empty(t, fileutils.CoverExistsWithBaseName(bookDir, coverBaseName))
+
+	// Trigger the same path the UI's "Refresh all metadata" uses: book-level
+	// resync with ForceRefresh=true.
+	result, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		BookID:       bookID,
+		ForceRefresh: true,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	recoveredCoverPath := fileutils.CoverExistsWithBaseName(bookDir, coverBaseName)
+	assert.NotEmpty(t, recoveredCoverPath, "cover file should be recovered after book-level refresh resync")
+}
+
+// TestScanBook_CoverRecovery_RefreshMode_CBZ verifies cover recovery on book-level
+// refresh resync for CBZ files.
+func TestScanBook_CoverRecovery_RefreshMode_CBZ(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Test Author] Comic Book")
+	testgen.GenerateCBZ(t, bookDir, "test.cbz", testgen.CBZOptions{
+		Title:        "Comic Book",
+		HasComicInfo: true,
+	})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	bookID := files[0].BookID
+
+	coverBaseName := "test.cbz.cover"
+	existingCoverPath := fileutils.CoverExistsWithBaseName(bookDir, coverBaseName)
+	require.NotEmpty(t, existingCoverPath, "cover file should exist after initial scan")
+
+	require.NoError(t, os.Remove(existingCoverPath))
+	require.Empty(t, fileutils.CoverExistsWithBaseName(bookDir, coverBaseName))
+
+	result, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		BookID:       bookID,
+		ForceRefresh: true,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	recoveredCoverPath := fileutils.CoverExistsWithBaseName(bookDir, coverBaseName)
+	assert.NotEmpty(t, recoveredCoverPath, "CBZ cover file should be recovered after book-level refresh resync")
+}
+
+// TestScanBook_CoverRecovery_RefreshMode_PDF verifies cover recovery on book-level
+// refresh resync for PDF files.
+func TestScanBook_CoverRecovery_RefreshMode_PDF(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Test Author] PDF Book")
+	testgen.GeneratePDF(t, bookDir, "test.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	bookID := files[0].BookID
+
+	coverBaseName := "test.pdf.cover"
+	existingCoverPath := fileutils.CoverExistsWithBaseName(bookDir, coverBaseName)
+	require.NotEmpty(t, existingCoverPath, "cover file should exist after initial scan")
+
+	require.NoError(t, os.Remove(existingCoverPath))
+	require.Empty(t, fileutils.CoverExistsWithBaseName(bookDir, coverBaseName))
+
+	result, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		BookID:       bookID,
+		ForceRefresh: true,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	recoveredCoverPath := fileutils.CoverExistsWithBaseName(bookDir, coverBaseName)
+	assert.NotEmpty(t, recoveredCoverPath, "PDF cover file should be recovered after book-level refresh resync")
 }
 
 // TestScanFileCore_SidecarReading_FileLevelFields verifies that file sidecar files

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -21,8 +22,8 @@ import (
 )
 
 // writeCBZWithColoredPages creates a CBZ at path with len(colors) pages,
-// each page being a small solid-color PNG. Page order is 001.png, 002.png,
-// ... so page index matches the colors slice index.
+// each page being a small solid-color PNG. Entries are named page_000.png,
+// page_001.png, ... so the page index matches the colors slice index.
 func writeCBZWithColoredPages(t *testing.T, path string, colors []color.RGBA) {
 	t.Helper()
 	f, err := os.Create(path)
@@ -43,7 +44,7 @@ func writeCBZWithColoredPages(t *testing.T, path string, colors []color.RGBA) {
 		}
 		var buf bytes.Buffer
 		require.NoError(t, png.Encode(&buf, img))
-		name := filepath.Base(path) + "_" + string(rune('0'+i/100)) + string(rune('0'+(i/10)%10)) + string(rune('0'+i%10)) + ".png"
+		name := fmt.Sprintf("page_%03d.png", i)
 		w, err := zw.Create(name)
 		require.NoError(t, err)
 		_, err = w.Write(buf.Bytes())


### PR DESCRIPTION
## Summary
- Frontend: reset `coverError` when the cover URL changes (not just when the book id changes) in `BookDetail` and `CoverGalleryTabs`. Previously a book that 404'd once stayed showing the placeholder after a resync repaired the cover, until a hard refresh remounted the component.
- EPUB parser: fall back to manifest items with `properties="cover-image"` or `id="cover-image"`/`cover` when there's no `<meta name="cover"/>`. Legacy EPUB 2.x files (e.g. older HarperCollins exports) only ship this form, so Shisho previously parsed them with no cover at all.
- Initial scan: `extractAndSaveCover` now checks for a sibling `book.ext.cover.*` file on disk before giving up when the parser returned no cover data, so a user-placed cover is picked up on the first scan instead of only via "Refresh all metadata".
- `recoverMissingCover`: delegates to `parseFileMetadata` instead of a hard-coded switch, so plugin-registered file parsers also participate in cover recovery. It also now respects `file.CoverPage` for CBZ/PDF via `extractCBZPageCover`/`extractPDFPageCover`, so a user's page-picker selection survives a resync.

## Test plan
- `mise check:quiet` passes (tests + Go lint + JS lint).
- New unit tests: `TestParseOPF_Cover_ManifestIDFallback`, `TestParseOPF_Cover_PropertiesFallback`, `CoverGalleryTabs.test.tsx` (cover re-renders after error when `cacheBuster` changes), `TestScanFileCreateNew_ExistingCoverOnDisk`, `TestScanBook_CoverRecovery_RefreshMode{,_CBZ,_PDF}`, `TestRecoverMissingCover_RespectsCoverPage`, `TestRecoverMissingCover_UnsupportedFileTypeDoesNotError`.
- Manually verified on the real-world EPUB that hit the original report (`The Secret Hour.epub`): `epub.Parse` now returns 271496 cover bytes after the OPF fallback.
- For UI: delete a cover from disk, run Rescan → "Refresh all metadata"; the cover should reappear without a page refresh.