### PR TITLE
[CI] Gate plugin-sdk and docs builds on PRs via mise tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
       - run: pnpm install --frozen-lockfile
-      - run: pnpm -C website build
+      - run: mise build:docs
 
   test-js:
     name: JS Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,8 +166,7 @@ jobs:
         run: npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version --allow-same-version
 
       - name: Build testing module
-        working-directory: ./packages/plugin-sdk
-        run: pnpm build
+        run: mise build:sdk
 
       - name: Publish to npm
         working-directory: ./packages/plugin-sdk

--- a/.mise.toml
+++ b/.mise.toml
@@ -21,6 +21,14 @@ CGO_ENABLED=0 go build -o ./build/api/api -installsuffix cgo \
 description = "Build development API binary (used by air)"
 run = "go build -o ./build/api/api-air ./cmd/api"
 
+[tasks."build:sdk"]
+description = "Build the @shisho/plugin-sdk testing module"
+run = "pnpm -C packages/plugin-sdk build"
+
+[tasks."build:docs"]
+description = "Build the Docusaurus documentation site"
+run = "pnpm -C website build"
+
 # === Dev Server ===
 
 [tasks.start]
@@ -59,7 +67,7 @@ run = "golangci-lint run"
 
 [tasks."lint:js"]
 description = "Run all JS/TS linting"
-depends = ["tygo", "lint:eslint", "lint:prettier", "lint:types"]
+depends = ["tygo", "lint:eslint", "lint:prettier", "lint:types", "build:sdk"]
 
 [tasks."lint:eslint"]
 description = "Run ESLint"

--- a/packages/plugin-sdk/testing/index.ts
+++ b/packages/plugin-sdk/testing/index.ts
@@ -34,10 +34,10 @@ export interface MockShishoOptions {
   /**
    * Path-based filesystem mock.
    * - string values are returned by readTextFile/readFile
-   * - Buffer values are returned by readFile (as ArrayBuffer)
+   * - Uint8Array (or Buffer) values are returned by readFile (as ArrayBuffer)
    * - string[] values are returned by listDir
    */
-  fs?: Record<string, string | Buffer | string[]>;
+  fs?: Record<string, string | Uint8Array | string[]>;
   /**
    * Override the `sleep` implementation. Defaults to a no-op so tests asserting
    * exponential backoff with e.g. `shisho.sleep(1000 * Math.pow(2, attempt))`
@@ -492,7 +492,6 @@ export function createMockShisho(
         const encoder = new TextEncoder();
         return encoder.encode(entry).buffer as ArrayBuffer;
       }
-      // Buffer
       return entry.buffer.slice(
         entry.byteOffset,
         entry.byteOffset + entry.byteLength,
@@ -519,7 +518,6 @@ export function createMockShisho(
       if (typeof entry === "string") {
         return entry;
       }
-      // Buffer -> string
       const decoder = new TextDecoder();
       return decoder.decode(entry);
     },


### PR DESCRIPTION
## Summary
- The v0.0.27 release failed at `npm publish` because `packages/plugin-sdk/testing/index.ts` referenced Node's `Buffer` type but the testing `tsconfig.json` doesn't pull in `@types/node`. The plugin-sdk build was never run on PRs — only during the release job — so the regression slipped through. Replaced `Buffer` with `Uint8Array` in the mock `fs` option type (Buffer extends Uint8Array, so callers passing a Buffer still type-check).
- Added `build:sdk` and `build:docs` mise tasks as a single source of truth for those commands. Wired `build:sdk` into `lint:js` depends so every PR and local `mise check:quiet` run it (it's cheap — ~1s `tsc`). Left `docs-build` as its own CI job since Docusaurus is slow enough to not want in local check.
- Pointed `ci.yml`'s `docs-build` job and `release.yml`'s "Build testing module" step at the new mise tasks so the commands live in exactly one place.

## Test plan
- `mise lint:js` locally — confirms `build:sdk` runs in parallel with the other lint steps and passes
- `mise build:sdk` locally — confirms the SDK testing module compiles cleanly
- `mise build:docs` locally — confirms the Docusaurus build still works via the new task
- On PR: the `JS Lint` CI job should now fail if someone reintroduces a `Buffer` reference (or any other SDK-build regression), instead of the failure showing up at release time