### PR TITLE
[CI] Cache build:sdk mise task with sources/outputs

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -24,6 +24,16 @@ run = "go build -o ./build/api/api-air ./cmd/api"
 [tasks."build:sdk"]
 description = "Build the @shisho/plugin-sdk testing module"
 run = "pnpm -C packages/plugin-sdk build"
+sources = [
+  "packages/plugin-sdk/package.json",
+  "packages/plugin-sdk/testing/index.ts",
+  "packages/plugin-sdk/testing/tsconfig.json",
+  "packages/plugin-sdk/*.d.ts",
+]
+outputs = [
+  "packages/plugin-sdk/testing/index.js",
+  "packages/plugin-sdk/testing/index.d.ts",
+]
 
 [tasks."build:docs"]
 description = "Build the Docusaurus documentation site"


### PR DESCRIPTION
## Summary
- Follow-up to #85 (review suggestion S3). The `build:sdk` task added in #85 runs on every PR's `JS Lint` job and every local `mise check:quiet`. Without `sources`/`outputs` declared, the ~800ms `tsc` compile runs every invocation even when nothing changed.
- Declares `sources` as `packages/plugin-sdk/testing/{index.ts,tsconfig.json}` plus `packages/plugin-sdk/*.d.ts` (the parent ambient declarations that flow in via `testing/index.ts`'s `import type { ... } from "../index"`), and `outputs` as `packages/plugin-sdk/testing/{index.js,index.d.ts}`. Matches the existing `tygo` task's pattern.
- Cache hit drops the task from ~800ms to ~20ms. Full `mise check:quiet` speedup is modest since `build:sdk` runs in parallel with slower lint/type-check steps, but it's free and touches the right surface.

## Test plan
- `mise build:sdk` twice locally — second run prints `[build:sdk] sources up-to-date, skipping` and finishes in ~20ms
- `touch packages/plugin-sdk/testing/index.ts && mise build:sdk` — re-runs the compile (invalidates on direct source)
- `touch packages/plugin-sdk/index.d.ts && mise build:sdk` — re-runs the compile (invalidates on parent ambient type change, which is what would catch a Go-struct-driven `tygo`-adjacent SDK type refactor)
- `mise lint:js` still passes end-to-end