### PR TITLE
[Frontend] Polish identify workflow UI

### DIFF
--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner";
 
 import PagePicker from "@/components/files/PagePicker";
 import CoverPlaceholder from "@/components/library/CoverPlaceholder";
+import { LanguageCombobox } from "@/components/library/LanguageCombobox";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -37,7 +38,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
   Popover,
-  PopoverAnchor,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
@@ -52,14 +52,12 @@ import {
   SortableList,
   type DragHandleProps,
 } from "@/components/ui/SortableList";
-import { getLanguageName, LANGUAGES } from "@/constants/languages";
 import {
   useSetFileCoverPage,
   useUpdateFile,
   useUploadFileCover,
 } from "@/hooks/queries/books";
 import { useImprintsList } from "@/hooks/queries/imprints";
-import { useLibraryLanguages } from "@/hooks/queries/libraries";
 import { usePeopleList } from "@/hooks/queries/people";
 import { usePluginIdentifierTypes } from "@/hooks/queries/plugins";
 import { usePublishersList } from "@/hooks/queries/publishers";
@@ -142,8 +140,6 @@ export function FileEditDialog({
   const [fileRole, setFileRole] = useState(file.file_role ?? FileRoleMain);
   const [showDowngradeConfirm, setShowDowngradeConfirm] = useState(false);
   const [language, setLanguage] = useState(file.language || "");
-  const [languageOpen, setLanguageOpen] = useState(false);
-  const [languageSearch, setLanguageSearch] = useState("");
   // Abridged is intentionally a binary checkbox in the UI, not a three-state
   // control, even though the data model supports true/false/null. Rationale:
   // most books are unabridged, so showing an "Unknown" default on every book
@@ -202,11 +198,6 @@ export function FileEditDialog({
 
   // Query for plugin-defined identifier types
   const { data: pluginIdentifierTypes } = usePluginIdentifierTypes();
-
-  // Query for library languages (for language combobox)
-  const { data: libraryLanguages } = useLibraryLanguages(file.library_id, {
-    enabled: open,
-  });
 
   // Helper to set preview URL and handle cleanup of old URL
   const updatePendingCoverPreview = useCallback((url: string | null) => {
@@ -292,7 +283,6 @@ export function FileEditDialog({
     setFileRole(initialFileRole);
     setShowDowngradeConfirm(false);
     setLanguage(initialLanguage);
-    setLanguageSearch("");
     setAbridged(initialAbridged);
     setPendingCoverPage(null);
     setPendingCoverFile(null);
@@ -468,60 +458,6 @@ export function FileEditDialog({
     !filteredImprints.find(
       (i) => i.name.toLowerCase() === imprintSearch.toLowerCase(),
     );
-
-  // Merged language list: curated LANGUAGES + any library-specific tags not already in the list
-  const mergedLanguages = useMemo(() => {
-    const curatedTags = new Set(LANGUAGES.map((l) => l.tag));
-    const extras: { tag: string; name: string }[] = [];
-    if (libraryLanguages) {
-      for (const tag of libraryLanguages) {
-        if (!curatedTags.has(tag)) {
-          extras.push({ tag, name: tag });
-        }
-      }
-    }
-    return [...LANGUAGES, ...extras];
-  }, [libraryLanguages]);
-
-  // Filter languages by search text (match both name and tag)
-  const filteredLanguages = useMemo(() => {
-    if (!languageSearch.trim()) return mergedLanguages;
-    const searchLower = languageSearch.trim().toLowerCase();
-    return mergedLanguages.filter(
-      (l) =>
-        l.name.toLowerCase().includes(searchLower) ||
-        l.tag.toLowerCase().includes(searchLower),
-    );
-  }, [mergedLanguages, languageSearch]);
-
-  // Show "use custom tag" option if search text doesn't exactly match a known tag or name
-  const showCustomLanguageOption = useMemo(() => {
-    if (!languageSearch.trim()) return false;
-    const searchLower = languageSearch.trim().toLowerCase();
-    return !mergedLanguages.some(
-      (l) =>
-        l.tag.toLowerCase() === searchLower ||
-        l.name.toLowerCase() === searchLower,
-    );
-  }, [languageSearch, mergedLanguages]);
-
-  const handleSelectLanguage = (tag: string) => {
-    setLanguage(tag);
-    setLanguageOpen(false);
-    setLanguageSearch("");
-  };
-
-  const handleCreateLanguage = () => {
-    if (languageSearch.trim()) {
-      setLanguage(languageSearch.trim());
-    }
-    setLanguageOpen(false);
-    setLanguageSearch("");
-  };
-
-  const handleClearLanguage = () => {
-    setLanguage("");
-  };
 
   const handleCoverUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const uploadedFile = event.target.files?.[0];
@@ -1071,97 +1007,11 @@ export function FileEditDialog({
               {/* Language */}
               <div className="space-y-2">
                 <Label>Language</Label>
-                <Popover
-                  modal
-                  onOpenChange={setLanguageOpen}
-                  open={languageOpen}
-                >
-                  {language ? (
-                    <PopoverAnchor asChild>
-                      <div className="flex items-center gap-2">
-                        <Badge
-                          className="flex items-center gap-1 max-w-full cursor-pointer"
-                          onClick={() => setLanguageOpen(true)}
-                          variant="secondary"
-                        >
-                          <span className="truncate" title={language}>
-                            {getLanguageName(language) || language}
-                          </span>
-                        </Badge>
-                        <button
-                          className="cursor-pointer text-muted-foreground hover:text-destructive shrink-0"
-                          onClick={handleClearLanguage}
-                          type="button"
-                        >
-                          <X className="h-3 w-3" />
-                        </button>
-                      </div>
-                    </PopoverAnchor>
-                  ) : (
-                    <PopoverTrigger asChild>
-                      <Button
-                        aria-expanded={languageOpen}
-                        className="w-full justify-between"
-                        role="combobox"
-                        variant="outline"
-                      >
-                        Select language...
-                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                      </Button>
-                    </PopoverTrigger>
-                  )}
-                  <PopoverContent align="start" className="w-full p-0">
-                    <Command shouldFilter={false}>
-                      <CommandInput
-                        onValueChange={setLanguageSearch}
-                        placeholder="Search languages..."
-                        value={languageSearch}
-                      />
-                      <CommandList>
-                        {filteredLanguages.length === 0 &&
-                          !showCustomLanguageOption && (
-                            <div className="p-4 text-center text-sm text-muted-foreground">
-                              No matching languages.
-                            </div>
-                          )}
-                        <CommandGroup>
-                          {filteredLanguages.map((l) => (
-                            <CommandItem
-                              key={l.tag}
-                              onSelect={() => handleSelectLanguage(l.tag)}
-                              value={l.tag}
-                            >
-                              <Check
-                                className={`mr-2 h-4 w-4 shrink-0 ${
-                                  language === l.tag
-                                    ? "opacity-100"
-                                    : "opacity-0"
-                                }`}
-                              />
-                              <span className="truncate" title={l.name}>
-                                {l.name}
-                              </span>
-                              <span className="ml-auto text-xs text-muted-foreground shrink-0">
-                                {l.tag}
-                              </span>
-                            </CommandItem>
-                          ))}
-                          {showCustomLanguageOption && (
-                            <CommandItem
-                              onSelect={handleCreateLanguage}
-                              value={`create-${languageSearch}`}
-                            >
-                              <Plus className="mr-2 h-4 w-4 shrink-0" />
-                              <span className="truncate">
-                                Use custom tag: &quot;{languageSearch}&quot;
-                              </span>
-                            </CommandItem>
-                          )}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
+                <LanguageCombobox
+                  libraryId={file.library_id}
+                  onChange={setLanguage}
+                  value={language}
+                />
               </div>
 
               {/* Abridged */}

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -14,6 +14,7 @@ import {
 import { FormDialog } from "@/components/ui/form-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { getLanguageName } from "@/constants/languages";
 import {
   usePluginIdentifierTypes,
   usePluginOrder,
@@ -393,45 +394,45 @@ export function IdentifyBookDialog({
                         <div className="flex-1 min-w-0">
                           {/* Zone 1: Identity */}
                           <div>
-                            {/* Title + subtitle */}
-                            <div>
-                              <div className="flex items-start justify-between gap-2">
+                            {/* Title + subtitle + badges */}
+                            <div className="flex items-start justify-between gap-4">
+                              <div className="min-w-0 flex-1">
                                 <p className="font-medium leading-tight">
                                   {result.title}
                                 </p>
-                                <div className="flex items-center gap-1 shrink-0">
-                                  {result.confidence != null && (
-                                    <Badge
-                                      className={cn(
-                                        "text-xs",
-                                        result.confidence >= 0.9
-                                          ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-                                          : result.confidence >= 0.7
-                                            ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
-                                            : "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-                                      )}
-                                      variant="secondary"
-                                    >
-                                      {Math.round(result.confidence * 100)}%
-                                    </Badge>
-                                  )}
-                                  <Badge className="text-xs" variant="outline">
-                                    {pluginLabel(result)}
-                                  </Badge>
-                                </div>
+                                {result.subtitle && (
+                                  <p className="text-sm text-muted-foreground/80 leading-tight mt-0.5">
+                                    {result.subtitle}
+                                  </p>
+                                )}
+                                {result.series && (
+                                  <p className="text-xs text-muted-foreground font-medium mt-0.5">
+                                    {result.series}
+                                    {result.series_number != null &&
+                                      ` #${result.series_number}`}
+                                  </p>
+                                )}
                               </div>
-                              {result.subtitle && (
-                                <p className="text-sm text-muted-foreground/80 leading-tight">
-                                  {result.subtitle}
-                                </p>
-                              )}
-                              {result.series && (
-                                <p className="text-xs text-muted-foreground font-medium mt-0.5">
-                                  {result.series}
-                                  {result.series_number != null &&
-                                    ` #${result.series_number}`}
-                                </p>
-                              )}
+                              <div className="flex items-center gap-1 shrink-0">
+                                {result.confidence != null && (
+                                  <Badge
+                                    className={cn(
+                                      "text-xs",
+                                      result.confidence >= 0.9
+                                        ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                                        : result.confidence >= 0.7
+                                          ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
+                                          : "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+                                    )}
+                                    variant="secondary"
+                                  >
+                                    {Math.round(result.confidence * 100)}%
+                                  </Badge>
+                                )}
+                                <Badge className="text-xs" variant="outline">
+                                  {pluginLabel(result)}
+                                </Badge>
+                              </div>
                             </div>
 
                             {/* People */}
@@ -457,22 +458,44 @@ export function IdentifyBookDialog({
                               ) : null;
                             })()}
 
-                            {/* Date + publisher */}
-                            {(result.release_date || result.publisher) && (
-                              <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground/80 mt-2">
-                                {result.release_date && (
-                                  <span>{formatDate(result.release_date)}</span>
-                                )}
-                                {result.release_date && result.publisher && (
-                                  <span className="text-muted-foreground/50">
-                                    ·
-                                  </span>
-                                )}
-                                {result.publisher && (
-                                  <span>{result.publisher}</span>
-                                )}
-                              </div>
-                            )}
+                            {/* Date + publisher + language + abridged */}
+                            {(() => {
+                              const metaItems: string[] = [];
+                              if (result.release_date) {
+                                metaItems.push(formatDate(result.release_date));
+                              }
+                              if (result.publisher) {
+                                metaItems.push(result.publisher);
+                              }
+                              if (result.language) {
+                                metaItems.push(
+                                  getLanguageName(result.language) ||
+                                    result.language,
+                                );
+                              }
+                              if (result.abridged != null) {
+                                metaItems.push(
+                                  result.abridged ? "Abridged" : "Unabridged",
+                                );
+                              }
+                              return metaItems.length > 0 ? (
+                                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground/80 mt-2">
+                                  {metaItems.map((item, i) => (
+                                    <span
+                                      className="flex items-center gap-x-2"
+                                      key={`${i}-${item}`}
+                                    >
+                                      {i > 0 && (
+                                        <span className="text-muted-foreground/50">
+                                          ·
+                                        </span>
+                                      )}
+                                      <span>{item}</span>
+                                    </span>
+                                  ))}
+                                </div>
+                              ) : null;
+                            })()}
                           </div>
 
                           {/* Zone 2: Identifiers */}

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -3,16 +3,14 @@ import {
   type FieldStatus,
   type IdentifierEntry,
 } from "./identify-utils";
+import { LanguageCombobox } from "./LanguageCombobox";
 import equal from "fast-deep-equal";
 import {
   ArrowLeft,
-  Check,
   ChevronDown,
-  ChevronsUpDown,
   ChevronUp,
   ExternalLink,
   Loader2,
-  Plus,
   X,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -21,29 +19,15 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { getLanguageName, LANGUAGES } from "@/constants/languages";
-import { useLibraryLanguages } from "@/hooks/queries/libraries";
+import { getLanguageName } from "@/constants/languages";
 import {
   usePluginApply,
   usePluginIdentifierTypes,
@@ -531,62 +515,6 @@ export function IdentifyReviewForm({
   const [identifiers, setIdentifiers] = useState<IdentifierEntry[]>(
     defaults.identifiers.value,
   );
-
-  // Language combobox state (mirrors FileEditDialog)
-  const [languageOpen, setLanguageOpen] = useState(false);
-  const [languageSearch, setLanguageSearch] = useState("");
-  const { data: libraryLanguages } = useLibraryLanguages(book.library_id);
-
-  const mergedLanguages = useMemo(() => {
-    const curatedTags = new Set(LANGUAGES.map((l) => l.tag));
-    const extras: { tag: string; name: string }[] = [];
-    if (libraryLanguages) {
-      for (const tag of libraryLanguages) {
-        if (!curatedTags.has(tag)) {
-          extras.push({ tag, name: tag });
-        }
-      }
-    }
-    return [...LANGUAGES, ...extras];
-  }, [libraryLanguages]);
-
-  const filteredLanguages = useMemo(() => {
-    if (!languageSearch.trim()) return mergedLanguages;
-    const searchLower = languageSearch.trim().toLowerCase();
-    return mergedLanguages.filter(
-      (l) =>
-        l.name.toLowerCase().includes(searchLower) ||
-        l.tag.toLowerCase().includes(searchLower),
-    );
-  }, [mergedLanguages, languageSearch]);
-
-  const showCustomLanguageOption = useMemo(() => {
-    if (!languageSearch.trim()) return false;
-    const searchLower = languageSearch.trim().toLowerCase();
-    return !mergedLanguages.some(
-      (l) =>
-        l.tag.toLowerCase() === searchLower ||
-        l.name.toLowerCase() === searchLower,
-    );
-  }, [languageSearch, mergedLanguages]);
-
-  const handleSelectLanguage = (tag: string) => {
-    setLanguage(tag);
-    setLanguageOpen(false);
-    setLanguageSearch("");
-  };
-
-  const handleCreateLanguage = () => {
-    if (languageSearch.trim()) {
-      setLanguage(languageSearch.trim());
-    }
-    setLanguageOpen(false);
-    setLanguageSearch("");
-  };
-
-  const handleClearLanguage = () => {
-    setLanguage("");
-  };
 
   // Cover state — page-based formats (CBZ, PDF) derive covers from page
   // content and shouldn't be overwritten by plugin images.
@@ -1117,109 +1045,12 @@ export function IdentifyReviewForm({
         onUseCurrent={() => setLanguage(file?.language ?? "")}
         status={defaults.language.status}
       >
-        <Popover
-          modal
-          onOpenChange={isDisabled("language") ? undefined : setLanguageOpen}
-          open={languageOpen}
-        >
-          {language ? (
-            <PopoverAnchor asChild>
-              <div className="flex items-center gap-2">
-                <Badge
-                  className={cn(
-                    "flex items-center gap-1 max-w-full",
-                    !isDisabled("language") && "cursor-pointer",
-                  )}
-                  onClick={() => {
-                    if (!isDisabled("language")) setLanguageOpen(true);
-                  }}
-                  variant="secondary"
-                >
-                  <span
-                    className="truncate"
-                    title={getLanguageName(language) || language}
-                  >
-                    {getLanguageName(language)
-                      ? `${getLanguageName(language)} (${language})`
-                      : language}
-                  </span>
-                </Badge>
-                {!isDisabled("language") && (
-                  <button
-                    className="cursor-pointer text-muted-foreground hover:text-destructive shrink-0"
-                    onClick={handleClearLanguage}
-                    type="button"
-                  >
-                    <X className="h-3 w-3" />
-                  </button>
-                )}
-              </div>
-            </PopoverAnchor>
-          ) : (
-            <PopoverTrigger asChild>
-              <Button
-                aria-expanded={languageOpen}
-                className="w-full justify-between"
-                disabled={isDisabled("language")}
-                role="combobox"
-                variant="outline"
-              >
-                Select language...
-                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-              </Button>
-            </PopoverTrigger>
-          )}
-          <PopoverContent align="start" className="w-full p-0">
-            <Command shouldFilter={false}>
-              <CommandInput
-                onValueChange={setLanguageSearch}
-                placeholder="Search languages..."
-                value={languageSearch}
-              />
-              <CommandList>
-                {filteredLanguages.length === 0 &&
-                  !showCustomLanguageOption && (
-                    <div className="p-4 text-center text-sm text-muted-foreground">
-                      No matching languages.
-                    </div>
-                  )}
-                <CommandGroup>
-                  {filteredLanguages.map((l) => (
-                    <CommandItem
-                      key={l.tag}
-                      onSelect={() => handleSelectLanguage(l.tag)}
-                      value={l.tag}
-                    >
-                      <Check
-                        className={cn(
-                          "mr-2 h-4 w-4 shrink-0",
-                          language === l.tag ? "opacity-100" : "opacity-0",
-                        )}
-                      />
-                      <span className="truncate" title={l.name}>
-                        {l.name}
-                      </span>
-                      <span className="ml-auto text-xs text-muted-foreground shrink-0">
-                        {l.tag}
-                      </span>
-                    </CommandItem>
-                  ))}
-                  {showCustomLanguageOption && (
-                    <CommandItem
-                      onSelect={handleCreateLanguage}
-                      value={`create-${languageSearch}`}
-                    >
-                      <Plus className="mr-2 h-4 w-4 shrink-0" />
-                      <span className="truncate">
-                        Use custom tag: &quot;{languageSearch}&quot;
-                      </span>
-                    </CommandItem>
-                  )}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
+        <LanguageCombobox
+          disabled={isDisabled("language")}
+          libraryId={book.library_id}
+          onChange={setLanguage}
+          value={language}
+        />
       </FieldWrapper>
 
       {/* Abridged */}

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -6,10 +6,13 @@ import {
 import equal from "fast-deep-equal";
 import {
   ArrowLeft,
+  Check,
   ChevronDown,
+  ChevronsUpDown,
   ChevronUp,
   ExternalLink,
   Loader2,
+  Plus,
   X,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -18,15 +21,29 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { getLanguageName } from "@/constants/languages";
+import { getLanguageName, LANGUAGES } from "@/constants/languages";
+import { useLibraryLanguages } from "@/hooks/queries/libraries";
 import {
   usePluginApply,
   usePluginIdentifierTypes,
@@ -514,6 +531,62 @@ export function IdentifyReviewForm({
   const [identifiers, setIdentifiers] = useState<IdentifierEntry[]>(
     defaults.identifiers.value,
   );
+
+  // Language combobox state (mirrors FileEditDialog)
+  const [languageOpen, setLanguageOpen] = useState(false);
+  const [languageSearch, setLanguageSearch] = useState("");
+  const { data: libraryLanguages } = useLibraryLanguages(book.library_id);
+
+  const mergedLanguages = useMemo(() => {
+    const curatedTags = new Set(LANGUAGES.map((l) => l.tag));
+    const extras: { tag: string; name: string }[] = [];
+    if (libraryLanguages) {
+      for (const tag of libraryLanguages) {
+        if (!curatedTags.has(tag)) {
+          extras.push({ tag, name: tag });
+        }
+      }
+    }
+    return [...LANGUAGES, ...extras];
+  }, [libraryLanguages]);
+
+  const filteredLanguages = useMemo(() => {
+    if (!languageSearch.trim()) return mergedLanguages;
+    const searchLower = languageSearch.trim().toLowerCase();
+    return mergedLanguages.filter(
+      (l) =>
+        l.name.toLowerCase().includes(searchLower) ||
+        l.tag.toLowerCase().includes(searchLower),
+    );
+  }, [mergedLanguages, languageSearch]);
+
+  const showCustomLanguageOption = useMemo(() => {
+    if (!languageSearch.trim()) return false;
+    const searchLower = languageSearch.trim().toLowerCase();
+    return !mergedLanguages.some(
+      (l) =>
+        l.tag.toLowerCase() === searchLower ||
+        l.name.toLowerCase() === searchLower,
+    );
+  }, [languageSearch, mergedLanguages]);
+
+  const handleSelectLanguage = (tag: string) => {
+    setLanguage(tag);
+    setLanguageOpen(false);
+    setLanguageSearch("");
+  };
+
+  const handleCreateLanguage = () => {
+    if (languageSearch.trim()) {
+      setLanguage(languageSearch.trim());
+    }
+    setLanguageOpen(false);
+    setLanguageSearch("");
+  };
+
+  const handleClearLanguage = () => {
+    setLanguage("");
+  };
 
   // Cover state — page-based formats (CBZ, PDF) derive covers from page
   // content and shouldn't be overwritten by plugin images.
@@ -1044,12 +1117,109 @@ export function IdentifyReviewForm({
         onUseCurrent={() => setLanguage(file?.language ?? "")}
         status={defaults.language.status}
       >
-        <Input
-          disabled={isDisabled("language")}
-          onChange={(e) => setLanguage(e.target.value)}
-          placeholder="e.g. en, en-US, zh-Hans"
-          value={language}
-        />
+        <Popover
+          modal
+          onOpenChange={isDisabled("language") ? undefined : setLanguageOpen}
+          open={languageOpen}
+        >
+          {language ? (
+            <PopoverAnchor asChild>
+              <div className="flex items-center gap-2">
+                <Badge
+                  className={cn(
+                    "flex items-center gap-1 max-w-full",
+                    !isDisabled("language") && "cursor-pointer",
+                  )}
+                  onClick={() => {
+                    if (!isDisabled("language")) setLanguageOpen(true);
+                  }}
+                  variant="secondary"
+                >
+                  <span
+                    className="truncate"
+                    title={getLanguageName(language) || language}
+                  >
+                    {getLanguageName(language)
+                      ? `${getLanguageName(language)} (${language})`
+                      : language}
+                  </span>
+                </Badge>
+                {!isDisabled("language") && (
+                  <button
+                    className="cursor-pointer text-muted-foreground hover:text-destructive shrink-0"
+                    onClick={handleClearLanguage}
+                    type="button"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+            </PopoverAnchor>
+          ) : (
+            <PopoverTrigger asChild>
+              <Button
+                aria-expanded={languageOpen}
+                className="w-full justify-between"
+                disabled={isDisabled("language")}
+                role="combobox"
+                variant="outline"
+              >
+                Select language...
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+          )}
+          <PopoverContent align="start" className="w-full p-0">
+            <Command shouldFilter={false}>
+              <CommandInput
+                onValueChange={setLanguageSearch}
+                placeholder="Search languages..."
+                value={languageSearch}
+              />
+              <CommandList>
+                {filteredLanguages.length === 0 &&
+                  !showCustomLanguageOption && (
+                    <div className="p-4 text-center text-sm text-muted-foreground">
+                      No matching languages.
+                    </div>
+                  )}
+                <CommandGroup>
+                  {filteredLanguages.map((l) => (
+                    <CommandItem
+                      key={l.tag}
+                      onSelect={() => handleSelectLanguage(l.tag)}
+                      value={l.tag}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4 shrink-0",
+                          language === l.tag ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      <span className="truncate" title={l.name}>
+                        {l.name}
+                      </span>
+                      <span className="ml-auto text-xs text-muted-foreground shrink-0">
+                        {l.tag}
+                      </span>
+                    </CommandItem>
+                  ))}
+                  {showCustomLanguageOption && (
+                    <CommandItem
+                      onSelect={handleCreateLanguage}
+                      value={`create-${languageSearch}`}
+                    >
+                      <Plus className="mr-2 h-4 w-4 shrink-0" />
+                      <span className="truncate">
+                        Use custom tag: &quot;{languageSearch}&quot;
+                      </span>
+                    </CommandItem>
+                  )}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
       </FieldWrapper>
 
       {/* Abridged */}

--- a/app/components/library/LanguageCombobox.tsx
+++ b/app/components/library/LanguageCombobox.tsx
@@ -1,0 +1,183 @@
+import { Check, ChevronsUpDown, Plus, X } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { getLanguageName, LANGUAGES } from "@/constants/languages";
+import { useLibraryLanguages } from "@/hooks/queries/libraries";
+import { cn } from "@/libraries/utils";
+
+interface LanguageComboboxProps {
+  value: string;
+  onChange: (value: string) => void;
+  libraryId?: number;
+  disabled?: boolean;
+}
+
+export function LanguageCombobox({
+  value,
+  onChange,
+  libraryId,
+  disabled,
+}: LanguageComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const { data: libraryLanguages } = useLibraryLanguages(libraryId);
+
+  const mergedLanguages = useMemo(() => {
+    const curatedTags = new Set(LANGUAGES.map((l) => l.tag));
+    const extras: { tag: string; name: string }[] = [];
+    if (libraryLanguages) {
+      for (const tag of libraryLanguages) {
+        if (!curatedTags.has(tag)) {
+          extras.push({ tag, name: tag });
+        }
+      }
+    }
+    return [...LANGUAGES, ...extras];
+  }, [libraryLanguages]);
+
+  const filteredLanguages = useMemo(() => {
+    if (!search.trim()) return mergedLanguages;
+    const searchLower = search.trim().toLowerCase();
+    return mergedLanguages.filter(
+      (l) =>
+        l.name.toLowerCase().includes(searchLower) ||
+        l.tag.toLowerCase().includes(searchLower),
+    );
+  }, [mergedLanguages, search]);
+
+  const showCustomOption = useMemo(() => {
+    if (!search.trim()) return false;
+    const searchLower = search.trim().toLowerCase();
+    return !mergedLanguages.some(
+      (l) =>
+        l.tag.toLowerCase() === searchLower ||
+        l.name.toLowerCase() === searchLower,
+    );
+  }, [search, mergedLanguages]);
+
+  const handleSelect = (tag: string) => {
+    onChange(tag);
+    setOpen(false);
+    setSearch("");
+  };
+
+  const handleCreate = () => {
+    if (search.trim()) onChange(search.trim());
+    setOpen(false);
+    setSearch("");
+  };
+
+  const handleClear = () => onChange("");
+
+  const displayName = getLanguageName(value);
+  const badgeLabel = displayName ? `${displayName} (${value})` : value;
+
+  return (
+    <Popover modal onOpenChange={disabled ? undefined : setOpen} open={open}>
+      {value ? (
+        <PopoverAnchor asChild>
+          <div className="flex items-center gap-2">
+            <Badge
+              className={cn(
+                "flex items-center gap-1 max-w-full",
+                !disabled && "cursor-pointer",
+              )}
+              onClick={() => {
+                if (!disabled) setOpen(true);
+              }}
+              variant="secondary"
+            >
+              <span className="truncate" title={badgeLabel}>
+                {badgeLabel}
+              </span>
+            </Badge>
+            {!disabled && (
+              <button
+                aria-label="Clear language"
+                className="cursor-pointer text-muted-foreground hover:text-destructive shrink-0"
+                onClick={handleClear}
+                type="button"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+        </PopoverAnchor>
+      ) : (
+        <PopoverTrigger asChild>
+          <Button
+            aria-expanded={open}
+            className="w-full justify-between"
+            disabled={disabled}
+            role="combobox"
+            variant="outline"
+          >
+            Select language...
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+      )}
+      <PopoverContent align="start" className="w-full p-0">
+        <Command shouldFilter={false}>
+          <CommandInput
+            onValueChange={setSearch}
+            placeholder="Search languages..."
+            value={search}
+          />
+          <CommandList>
+            {filteredLanguages.length === 0 && !showCustomOption && (
+              <div className="p-4 text-center text-sm text-muted-foreground">
+                No matching languages.
+              </div>
+            )}
+            <CommandGroup>
+              {filteredLanguages.map((l) => (
+                <CommandItem
+                  key={l.tag}
+                  onSelect={() => handleSelect(l.tag)}
+                  value={l.tag}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4 shrink-0",
+                      value === l.tag ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="truncate" title={l.name}>
+                    {l.name}
+                  </span>
+                  <span className="ml-auto text-xs text-muted-foreground shrink-0">
+                    {l.tag}
+                  </span>
+                </CommandItem>
+              ))}
+              {showCustomOption && (
+                <CommandItem onSelect={handleCreate} value={`create-${search}`}>
+                  <Plus className="mr-2 h-4 w-4 shrink-0" />
+                  <span className="truncate">
+                    Use custom tag: &quot;{search}&quot;
+                  </span>
+                </CommandItem>
+              )}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
## Summary
- Restructure the identify search result row so the title, subtitle, and series share a column beside the confidence/plugin badges — the subtitle no longer butts up against the badges on long titles.
- Show `language` and `abridged`/`unabridged` alongside release date and publisher on identify search results.
- Replace the compare dialog's plain `Language` text input with the same library-aware language combobox used in the file edit dialog (curated list + library languages + custom tag fallback).

## Test plan
- Run `mise start`, open a book, click Identify, run a search, and confirm that:
  - Long subtitles no longer crowd the confidence/plugin badges.
  - Rows show language and abridged status (where the plugin returns them) in the meta line.
- Pick a result, open the compare dialog, scroll to Language, and confirm:
  - The field renders as a combobox that matches the file edit dialog.
  - Searching filters the curated list, selecting a language sets the badge, and clearing works.
  - The custom tag fallback appears for unknown entries.
- Run `mise check:quiet` — should pass.