### PR TITLE
[Fix] Trigger file organization after identify/apply metadata

### DIFF
--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -679,6 +679,13 @@ func (svc *Service) GetFirstBookInSeriesByID(ctx context.Context, seriesID int) 
 	return &book, nil
 }
 
+// OrganizeBookFiles is the public entry point for triggering file organization.
+// It checks the library's OrganizeFileStructure setting internally and returns
+// early if disabled.
+func (svc *Service) OrganizeBookFiles(ctx context.Context, book *models.Book) error {
+	return svc.organizeBookFiles(ctx, book)
+}
+
 // organizeBookFiles renames files and folders based on updated book metadata.
 func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) error {
 	log := logger.FromContext(ctx)

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -55,6 +55,7 @@ type bookStore interface {
 	UpdateFile(ctx context.Context, file *models.File, columns []string) error
 	DeleteNarratorsForFile(ctx context.Context, fileID int) (int, error)
 	CreateNarrator(ctx context.Context, narrator *models.Narrator) error
+	OrganizeBookFiles(ctx context.Context, book *models.Book) error
 }
 
 // relationStore provides book relationship CRUD operations.
@@ -2047,6 +2048,17 @@ func (h *handler) applyMetadata(c echo.Context) error {
 	// Persist metadata (no field filtering — user already selected fields)
 	if err := h.persistMetadata(ctx, book, targetFile, md, payload.PluginScope, payload.PluginID, log); err != nil {
 		return errors.Wrap(err, "failed to apply metadata")
+	}
+
+	// Organize files if title, authors, or narrators changed (these affect directory/file names).
+	// organizeBookFiles checks the library's OrganizeFileStructure setting internally.
+	if md.Title != "" || len(md.Authors) > 0 || len(md.Narrators) > 0 {
+		freshBook, err := h.enrich.bookStore.RetrieveBook(ctx, payload.BookID)
+		if err == nil {
+			if orgErr := h.enrich.bookStore.OrganizeBookFiles(ctx, freshBook); orgErr != nil {
+				log.Warn("failed to organize book files after metadata apply", logger.Data{"book_id": book.ID, "error": orgErr.Error()})
+			}
+		}
 	}
 
 	// Reload and return updated book

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -2050,11 +2050,13 @@ func (h *handler) applyMetadata(c echo.Context) error {
 		return errors.Wrap(err, "failed to apply metadata")
 	}
 
-	// Organize files if title, authors, or narrators changed (these affect directory/file names).
+	// Organize files if title, authors, narrators, or series changed (these affect directory/file names).
 	// organizeBookFiles checks the library's OrganizeFileStructure setting internally.
-	if md.Title != "" || len(md.Authors) > 0 || len(md.Narrators) > 0 {
+	if md.Title != "" || len(md.Authors) > 0 || len(md.Narrators) > 0 || md.Series != "" {
 		freshBook, err := h.enrich.bookStore.RetrieveBook(ctx, payload.BookID)
-		if err == nil {
+		if err != nil {
+			log.Warn("failed to retrieve book for file organization", logger.Data{"book_id": payload.BookID, "error": err.Error()})
+		} else {
 			if orgErr := h.enrich.bookStore.OrganizeBookFiles(ctx, freshBook); orgErr != nil {
 				log.Warn("failed to organize book files after metadata apply", logger.Data{"book_id": book.ID, "error": orgErr.Error()})
 			}

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -25,6 +25,29 @@ func (s *stubBookStoreForApply) OrganizeBookFiles(_ context.Context, _ *models.B
 	return nil
 }
 
+// stubRelStoreForApply is a no-op relationStore for applyMetadata tests.
+type stubRelStoreForApply struct{}
+
+func (s *stubRelStoreForApply) DeleteAuthors(_ context.Context, _ int) error { return nil }
+func (s *stubRelStoreForApply) CreateAuthor(_ context.Context, _ *models.Author) error {
+	return nil
+}
+func (s *stubRelStoreForApply) DeleteBookSeries(_ context.Context, _ int) error { return nil }
+func (s *stubRelStoreForApply) CreateBookSeries(_ context.Context, _ *models.BookSeries) error {
+	return nil
+}
+func (s *stubRelStoreForApply) FindOrCreateSeries(_ context.Context, _ string, _ int, _ string) (*models.Series, error) {
+	return &models.Series{ID: 1}, nil
+}
+func (s *stubRelStoreForApply) DeleteBookGenres(_ context.Context, _ int) error { return nil }
+func (s *stubRelStoreForApply) CreateBookGenre(_ context.Context, _ *models.BookGenre) error {
+	return nil
+}
+func (s *stubRelStoreForApply) DeleteBookTags(_ context.Context, _ int) error { return nil }
+func (s *stubRelStoreForApply) CreateBookTag(_ context.Context, _ *models.BookTag) error {
+	return nil
+}
+
 // newApplyTestHandler creates a handler wired with stubs for applyMetadata testing.
 func newApplyTestHandler(store *stubBookStoreForApply) *handler {
 	mgr := &Manager{
@@ -40,6 +63,7 @@ func newApplyTestHandler(store *stubBookStoreForApply) *handler {
 		manager: mgr,
 		enrich: &enrichDeps{
 			bookStore: store,
+			relStore:  &stubRelStoreForApply{},
 		},
 	}
 }
@@ -122,6 +146,25 @@ func TestApplyMetadata_OrganizesFiles_WhenNarratorsChange(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, store.organizeCalled, "OrganizeBookFiles should be called when narrators change")
+}
+
+func TestApplyMetadata_OrganizesFiles_WhenSeriesChanges(t *testing.T) {
+	t.Parallel()
+
+	book := &models.Book{ID: 1, LibraryID: 1, Title: "Book"}
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContext(t, map[string]any{
+		"series":        "My Series",
+		"series_number": 2,
+	})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	assert.True(t, store.organizeCalled, "OrganizeBookFiles should be called when series changes")
 }
 
 func TestApplyMetadata_SkipsOrganize_WhenNoRelevantFieldsChange(t *testing.T) {

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -1,0 +1,143 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubBookStoreForApply extends stubBookStoreForPersist with OrganizeBookFiles tracking.
+type stubBookStoreForApply struct {
+	stubBookStoreForPersist
+	organizeCalled bool
+}
+
+func (s *stubBookStoreForApply) OrganizeBookFiles(_ context.Context, _ *models.Book) error {
+	s.organizeCalled = true
+	return nil
+}
+
+// newApplyTestHandler creates a handler wired with stubs for applyMetadata testing.
+func newApplyTestHandler(store *stubBookStoreForApply) *handler {
+	mgr := &Manager{
+		plugins: map[string]*Runtime{
+			pluginKey("test", "enricher"): {
+				manifest: &Manifest{},
+				scope:    "test",
+				pluginID: "enricher",
+			},
+		},
+	}
+	return &handler{
+		manager: mgr,
+		enrich: &enrichDeps{
+			bookStore: store,
+		},
+	}
+}
+
+// newApplyEchoContext creates an Echo context with the given fields payload and an all-access user.
+func newApplyEchoContext(t *testing.T, fields map[string]any) echo.Context {
+	t.Helper()
+	payload := applyPayload{
+		BookID:      1,
+		Fields:      fields,
+		PluginScope: "test",
+		PluginID:    "enricher",
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// User with access to all libraries (nil LibraryID)
+	c.Set("user", &models.User{
+		ID:            1,
+		LibraryAccess: []*models.UserLibraryAccess{{LibraryID: nil}},
+	})
+	return c
+}
+
+func TestApplyMetadata_OrganizesFiles_WhenTitleChanges(t *testing.T) {
+	t.Parallel()
+
+	book := &models.Book{ID: 1, LibraryID: 1, Title: "Old Title"}
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContext(t, map[string]any{"title": "New Title"})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	assert.True(t, store.organizeCalled, "OrganizeBookFiles should be called when title changes")
+}
+
+func TestApplyMetadata_OrganizesFiles_WhenAuthorsChange(t *testing.T) {
+	t.Parallel()
+
+	book := &models.Book{ID: 1, LibraryID: 1, Title: "Book"}
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContext(t, map[string]any{
+		"authors": []any{
+			map[string]any{"name": "New Author", "role": "writer"},
+		},
+	})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	assert.True(t, store.organizeCalled, "OrganizeBookFiles should be called when authors change")
+}
+
+func TestApplyMetadata_OrganizesFiles_WhenNarratorsChange(t *testing.T) {
+	t.Parallel()
+
+	book := &models.Book{ID: 1, LibraryID: 1, Title: "Book"}
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContext(t, map[string]any{
+		"narrators": []any{"New Narrator"},
+	})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	assert.True(t, store.organizeCalled, "OrganizeBookFiles should be called when narrators change")
+}
+
+func TestApplyMetadata_SkipsOrganize_WhenNoRelevantFieldsChange(t *testing.T) {
+	t.Parallel()
+
+	book := &models.Book{ID: 1, LibraryID: 1, Title: "Book"}
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContext(t, map[string]any{
+		"description": "A new description",
+	})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	assert.False(t, store.organizeCalled, "OrganizeBookFiles should NOT be called when only description changes")
+}

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -55,6 +55,10 @@ func (s *stubBookStoreForPersist) CreateNarrator(_ context.Context, _ *models.Na
 	return nil
 }
 
+func (s *stubBookStoreForPersist) OrganizeBookFiles(_ context.Context, _ *models.Book) error {
+	return nil
+}
+
 // TestPersistMetadata_CoverWrite_RootLevelFile_SyntheticBookPath is a
 // regression test for a bug where persistMetadata wrote plugin-provided
 // cover data unconditionally to book.Filepath as the cover directory. For

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -290,3 +290,7 @@ func (a *bookUpdaterAdapter) DeleteNarratorsForFile(ctx context.Context, fileID 
 func (a *bookUpdaterAdapter) CreateNarrator(ctx context.Context, narrator *models.Narrator) error {
 	return a.svc.CreateNarrator(ctx, narrator)
 }
+
+func (a *bookUpdaterAdapter) OrganizeBookFiles(ctx context.Context, book *models.Book) error {
+	return a.svc.OrganizeBookFiles(ctx, book)
+}


### PR DESCRIPTION
## Summary
- When applying metadata from a plugin via the identify dialog, file organization was not triggered even when the library had `OrganizeFileStructure` enabled
- Adds `OrganizeBookFiles` to the `bookStore` interface and calls it in `applyMetadata` when title, authors, or narrators change — matching the pattern used by the book edit handler
- The `organizeBookFiles` method already checks the library's `OrganizeFileStructure` setting internally, so no library fetch is needed in the caller

## Test plan
- Apply metadata with a title change via identify dialog on a library with `OrganizeFileStructure` enabled — book directory should be renamed
- Apply metadata with author changes — directory should include `[Author Name]` prefix
- Apply metadata with narrator changes — filename should reflect narrator
- Apply metadata with only description/genres/tags — no file organization should be triggered
- Run `mise test` — all Go tests pass (170 new lines across 4 test cases)