### PR TITLE
[Frontend] Show author roles in identify dialog

### DIFF
--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/hooks/queries/plugins";
 import { cn } from "@/libraries/utils";
 import { PluginHookMetadataEnricher, type Book } from "@/types";
+import { getAuthorRoleLabel } from "@/utils/authorRoles";
 import {
   formatDate,
   formatDuration,
@@ -151,10 +152,14 @@ export function IdentifyBookDialog({
       ? `${result.plugin_scope}/${result.plugin_id}`
       : result.plugin_id;
 
-  const resolveAuthors = (result: PluginSearchResult): string[] | undefined => {
-    if (result.authors && result.authors.length > 0)
-      return result.authors.map((a) => a.name);
-    return undefined;
+  const resolveAuthors = (result: PluginSearchResult): string | undefined => {
+    if (!result.authors || result.authors.length === 0) return undefined;
+    return result.authors
+      .map((a) => {
+        const label = getAuthorRoleLabel(a.role);
+        return label ? `${a.name} (${label})` : a.name;
+      })
+      .join(", ");
   };
 
   const handleSelectResult = (result: PluginSearchResult) => {
@@ -446,7 +451,7 @@ export function IdentifyBookDialog({
                                 <div className="mt-2 space-y-0.5">
                                   {hasAuthors && (
                                     <p className="text-sm text-muted-foreground">
-                                      {authors.join(", ")}
+                                      {authors}
                                     </p>
                                   )}
                                   {hasNarrators && (

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/hooks/queries/plugins";
 import { cn, isPageBasedFileType } from "@/libraries/utils";
 import type { Book, File } from "@/types";
+import { getAuthorRoleLabel } from "@/utils/authorRoles";
 import { formatIdentifierType, formatMetadataFieldLabel } from "@/utils/format";
 
 // ---------------------------------------------------------------------------
@@ -377,6 +378,78 @@ function TagInput({
           onKeyDown={handleKeyDown}
           placeholder={
             tags.length === 0 ? (placeholder ?? "Type and press Enter") : ""
+          }
+          type="text"
+          value={input}
+        />
+      )}
+    </div>
+  );
+}
+
+function AuthorTagInput({
+  authors,
+  onChange,
+  disabled,
+  placeholder,
+}: {
+  authors: AuthorEntry[];
+  onChange: (authors: AuthorEntry[]) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}) {
+  const [input, setInput] = useState("");
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && input.trim()) {
+      e.preventDefault();
+      onChange([...authors, { name: input.trim(), role: undefined }]);
+      setInput("");
+    }
+    if (e.key === "Backspace" && !input && authors.length > 0) {
+      onChange(authors.slice(0, -1));
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap gap-1.5 rounded-md border border-input bg-transparent p-2 min-h-[36px]",
+        disabled && "opacity-50 cursor-not-allowed",
+      )}
+    >
+      {authors.map((author, i) => {
+        const label = getAuthorRoleLabel(author.role);
+        return (
+          <Badge className="max-w-full gap-1 pr-1" key={i} variant="secondary">
+            <span
+              className="truncate"
+              title={label ? `${author.name} (${label})` : author.name}
+            >
+              {author.name}
+              {label && (
+                <span className="text-muted-foreground ml-1">({label})</span>
+              )}
+            </span>
+            {!disabled && (
+              <button
+                className="shrink-0 rounded-sm hover:bg-muted-foreground/20 p-0.5 cursor-pointer"
+                onClick={() => onChange(authors.filter((_, j) => j !== i))}
+                type="button"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </Badge>
+        );
+      })}
+      {!disabled && (
+        <input
+          className="flex-1 min-w-[80px] bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={
+            authors.length === 0 ? (placeholder ?? "Type and press Enter") : ""
           }
           type="text"
           value={input}
@@ -791,7 +864,12 @@ export function IdentifyReviewForm({
       <FieldWrapper
         currentValue={
           currentAuthors.length > 0
-            ? currentAuthors.map((a) => a.name).join(", ")
+            ? currentAuthors
+                .map((a) => {
+                  const label = getAuthorRoleLabel(a.role);
+                  return label ? `${a.name} (${label})` : a.name;
+                })
+                .join(", ")
             : undefined
         }
         disabled={isDisabled("authors")}
@@ -799,18 +877,11 @@ export function IdentifyReviewForm({
         onUseCurrent={() => setAuthors(currentAuthors)}
         status={defaults.authors.status}
       >
-        <TagInput
+        <AuthorTagInput
+          authors={authors}
           disabled={isDisabled("authors")}
-          onChange={(names) =>
-            setAuthors(
-              names.map((name) => {
-                const existing = authors.find((a) => a.name === name);
-                return existing ?? { name, role: undefined };
-              }),
-            )
-          }
+          onChange={setAuthors}
           placeholder="Add author..."
-          tags={authors.map((a) => a.name)}
         />
       </FieldWrapper>
 

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -80,6 +80,7 @@ import {
   FileTypePDF,
   type File,
 } from "@/types";
+import { getAuthorRoleLabel } from "@/utils/authorRoles";
 import { isCoverLoaded, markCoverLoaded } from "@/utils/coverCache";
 import {
   formatDate,
@@ -117,21 +118,6 @@ const getCoverFileType = (
       if (hasAudiobookFiles) return "audiobook";
   }
   return "book";
-};
-
-const getRoleLabel = (role: string | undefined): string | null => {
-  if (!role) return null;
-  const roleLabels: Record<string, string> = {
-    writer: "Writer",
-    penciller: "Penciller",
-    inker: "Inker",
-    colorist: "Colorist",
-    letterer: "Letterer",
-    cover_artist: "Cover Artist",
-    editor: "Editor",
-    translator: "Translator",
-  };
-  return roleLabels[role] || role;
 };
 
 interface DownloadError {
@@ -1215,7 +1201,7 @@ const BookDetail = () => {
                     <h3 className="font-semibold mb-2">Authors</h3>
                     <div className="flex flex-wrap gap-2">
                       {book.authors.map((author) => {
-                        const roleLabel = getRoleLabel(author.role);
+                        const roleLabel = getAuthorRoleLabel(author.role);
                         return (
                           <Link
                             key={author.id}

--- a/app/utils/authorRoles.test.ts
+++ b/app/utils/authorRoles.test.ts
@@ -1,0 +1,25 @@
+import { getAuthorRoleLabel } from "./authorRoles";
+import { describe, expect, it } from "vitest";
+
+describe("getAuthorRoleLabel", () => {
+  it("maps known canonical roles to capitalized labels", () => {
+    expect(getAuthorRoleLabel("writer")).toBe("Writer");
+    expect(getAuthorRoleLabel("penciller")).toBe("Penciller");
+    expect(getAuthorRoleLabel("inker")).toBe("Inker");
+    expect(getAuthorRoleLabel("colorist")).toBe("Colorist");
+    expect(getAuthorRoleLabel("letterer")).toBe("Letterer");
+    expect(getAuthorRoleLabel("cover_artist")).toBe("Cover Artist");
+    expect(getAuthorRoleLabel("editor")).toBe("Editor");
+    expect(getAuthorRoleLabel("translator")).toBe("Translator");
+  });
+
+  it("falls back to the raw role string for unknown values", () => {
+    expect(getAuthorRoleLabel("illustrator")).toBe("illustrator");
+  });
+
+  it("returns null for undefined, null, and empty string", () => {
+    expect(getAuthorRoleLabel(undefined)).toBeNull();
+    expect(getAuthorRoleLabel(null)).toBeNull();
+    expect(getAuthorRoleLabel("")).toBeNull();
+  });
+});

--- a/app/utils/authorRoles.ts
+++ b/app/utils/authorRoles.ts
@@ -1,0 +1,22 @@
+/**
+ * Maps a canonical author role string (as stored on the Author model, e.g.
+ * sourced from CBZ ComicInfo.xml creator fields) to its display label.
+ *
+ * Returns null when the role is missing, so callers can conditionally render.
+ */
+export function getAuthorRoleLabel(
+  role: string | undefined | null,
+): string | null {
+  if (!role) return null;
+  const roleLabels: Record<string, string> = {
+    writer: "Writer",
+    penciller: "Penciller",
+    inker: "Inker",
+    colorist: "Colorist",
+    letterer: "Letterer",
+    cover_artist: "Cover Artist",
+    editor: "Editor",
+    translator: "Translator",
+  };
+  return roleLabels[role] || role;
+}

--- a/docs/superpowers/plans/2026-04-13-identify-author-roles.md
+++ b/docs/superpowers/plans/2026-04-13-identify-author-roles.md
@@ -1,0 +1,488 @@
+# Identify Dialog Author Roles Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Display author role labels (e.g., `(Writer)`, `(Penciller)`) in the identify search result row, "Use current" summary, and editable author chips so same-named authors with different roles stop looking like duplicates.
+
+**Architecture:** Extract the existing `getRoleLabel` helper out of `BookDetail.tsx` into a shared `app/utils/authorRoles.ts` module (renamed `getAuthorRoleLabel` to avoid collision with user-permission `roles.ts`). Then update three render sites in the identify flow to consume it: the search result row in `IdentifyBookDialog.tsx`, the Authors field summary in `IdentifyReviewForm.tsx`, and a new role-aware `AuthorTagInput` that replaces the generic `TagInput` for the authors field only.
+
+**Tech Stack:** React 19 + TypeScript, Vitest for unit tests, TailwindCSS for styling. Uses existing `Badge` component and `AuthorEntry { name, role }` shape already present in `IdentifyReviewForm.tsx`.
+
+**Spec:** `docs/superpowers/specs/2026-04-13-identify-author-roles-design.md`
+
+---
+
+## Context for the implementing engineer
+
+Read the spec first. A few things to know about this codebase before starting:
+
+- **Test runner:** `pnpm test:unit` runs Vitest with coverage. To run a single file: `pnpm test:unit app/utils/authorRoles.test.ts`. To run in watch mode during TDD: `pnpm exec vitest app/utils/authorRoles.test.ts`.
+- **Type generation:** Don't worry about `mise tygo` for this task — no Go types are changing.
+- **Full check:** `mise check:quiet` runs Go tests, Go lint, JS tests, ESLint, Prettier, and TypeScript in parallel. Run it once before the final commit.
+- **Path alias:** `@/` maps to `app/`. Import the helper as `from "@/utils/authorRoles"`.
+- **`AuthorEntry` type** already exists inside `IdentifyReviewForm.tsx` (lines 53–56). Keep it; don't move it out.
+- **`TagInput` component** is inside `IdentifyReviewForm.tsx` (lines 320–387) and is used for narrators/genres/tags too — leave it alone. You're adding a sibling component `AuthorTagInput`, not modifying `TagInput`.
+- **Commit style:** `[Frontend] <description>` for frontend changes, `[Test] <description>` for test-only commits. See `CLAUDE.md` Git Conventions.
+- **TDD is required** for this task per `CLAUDE.md`: Red → Green → Refactor. Write the failing test first, verify it fails, then implement.
+
+---
+
+## Task 1: Create `getAuthorRoleLabel` helper with failing test
+
+**Files:**
+- Create: `app/utils/authorRoles.ts`
+- Create: `app/utils/authorRoles.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/utils/authorRoles.test.ts` with the following content:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { getAuthorRoleLabel } from "./authorRoles";
+
+describe("getAuthorRoleLabel", () => {
+  it("maps known canonical roles to capitalized labels", () => {
+    expect(getAuthorRoleLabel("writer")).toBe("Writer");
+    expect(getAuthorRoleLabel("penciller")).toBe("Penciller");
+    expect(getAuthorRoleLabel("inker")).toBe("Inker");
+    expect(getAuthorRoleLabel("colorist")).toBe("Colorist");
+    expect(getAuthorRoleLabel("letterer")).toBe("Letterer");
+    expect(getAuthorRoleLabel("cover_artist")).toBe("Cover Artist");
+    expect(getAuthorRoleLabel("editor")).toBe("Editor");
+    expect(getAuthorRoleLabel("translator")).toBe("Translator");
+  });
+
+  it("falls back to the raw role string for unknown values", () => {
+    expect(getAuthorRoleLabel("illustrator")).toBe("illustrator");
+  });
+
+  it("returns null for undefined, null, and empty string", () => {
+    expect(getAuthorRoleLabel(undefined)).toBeNull();
+    expect(getAuthorRoleLabel(null)).toBeNull();
+    expect(getAuthorRoleLabel("")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `pnpm exec vitest run app/utils/authorRoles.test.ts`
+
+Expected: FAIL with a module-not-found error for `./authorRoles`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `app/utils/authorRoles.ts`:
+
+```ts
+/**
+ * Maps a canonical author role string (as stored on the Author model, e.g.
+ * sourced from CBZ ComicInfo.xml creator fields) to its display label.
+ *
+ * Returns null when the role is missing, so callers can conditionally render.
+ */
+export function getAuthorRoleLabel(
+  role: string | undefined | null,
+): string | null {
+  if (!role) return null;
+  const roleLabels: Record<string, string> = {
+    writer: "Writer",
+    penciller: "Penciller",
+    inker: "Inker",
+    colorist: "Colorist",
+    letterer: "Letterer",
+    cover_artist: "Cover Artist",
+    editor: "Editor",
+    translator: "Translator",
+  };
+  return roleLabels[role] || role;
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `pnpm exec vitest run app/utils/authorRoles.test.ts`
+
+Expected: PASS, all 3 test cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/utils/authorRoles.ts app/utils/authorRoles.test.ts
+git commit -m "[Frontend] Add getAuthorRoleLabel helper"
+```
+
+---
+
+## Task 2: Migrate `BookDetail.tsx` to use the shared helper
+
+**Files:**
+- Modify: `app/components/pages/BookDetail.tsx` (lines 122–135 to delete, line 1218 to update)
+
+No new test is needed — this is a pure rename refactor of an internal helper already covered by existing (manual) BookDetail rendering.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `app/components/pages/BookDetail.tsx`, add the import alongside the other `@/utils/...` imports (keep imports sorted to satisfy ESLint):
+
+```ts
+import { getAuthorRoleLabel } from "@/utils/authorRoles";
+```
+
+- [ ] **Step 2: Delete the inline `getRoleLabel` function**
+
+Remove the whole block at lines 122–135:
+
+```ts
+const getRoleLabel = (role: string | undefined): string | null => {
+  if (!role) return null;
+  const roleLabels: Record<string, string> = {
+    writer: "Writer",
+    penciller: "Penciller",
+    inker: "Inker",
+    colorist: "Colorist",
+    letterer: "Letterer",
+    cover_artist: "Cover Artist",
+    editor: "Editor",
+    translator: "Translator",
+  };
+  return roleLabels[role] || role;
+};
+```
+
+- [ ] **Step 3: Update the call site**
+
+At line 1218, change:
+
+```tsx
+const roleLabel = getRoleLabel(author.role);
+```
+
+to:
+
+```tsx
+const roleLabel = getAuthorRoleLabel(author.role);
+```
+
+- [ ] **Step 4: Run TypeScript and ESLint to verify no regressions**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec eslint app/components/pages/BookDetail.tsx`
+
+Expected: both commands exit 0 with no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/pages/BookDetail.tsx
+git commit -m "[Frontend] Use shared getAuthorRoleLabel helper in BookDetail"
+```
+
+---
+
+## Task 3: Update identify search result row
+
+**Files:**
+- Modify: `app/components/library/IdentifyBookDialog.tsx` (lines 154–158 and line 449)
+
+No unit test — `IdentifyBookDialog` has no component tests today and this is a narrow display change best verified manually. Manual verification is in Task 5.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `app/components/library/IdentifyBookDialog.tsx`, add next to the other `@/utils` / `@/libraries` imports (keep sorted):
+
+```ts
+import { getAuthorRoleLabel } from "@/utils/authorRoles";
+```
+
+- [ ] **Step 2: Update `resolveAuthors` to return a formatted string**
+
+Replace the current definition at lines 154–158:
+
+```tsx
+const resolveAuthors = (result: PluginSearchResult): string[] | undefined => {
+  if (result.authors && result.authors.length > 0)
+    return result.authors.map((a) => a.name);
+  return undefined;
+};
+```
+
+with:
+
+```tsx
+const resolveAuthors = (result: PluginSearchResult): string | undefined => {
+  if (!result.authors || result.authors.length === 0) return undefined;
+  return result.authors
+    .map((a) => {
+      const label = getAuthorRoleLabel(a.role);
+      return label ? `${a.name} (${label})` : a.name;
+    })
+    .join(", ");
+};
+```
+
+- [ ] **Step 3: Update the render site**
+
+At roughly line 449 in the Authors section of the result row, change:
+
+```tsx
+<p className="text-sm text-muted-foreground">
+  {authors.join(", ")}
+</p>
+```
+
+to:
+
+```tsx
+<p className="text-sm text-muted-foreground">
+  {authors}
+</p>
+```
+
+The existing `hasAuthors = authors && authors.length > 0` check on the line above still works correctly with the new `string` shape — do not modify it.
+
+- [ ] **Step 4: Run TypeScript and ESLint on the file**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec eslint app/components/library/IdentifyBookDialog.tsx`
+
+Expected: both commands exit 0 with no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/IdentifyBookDialog.tsx
+git commit -m "[Frontend] Show author roles in identify search result row"
+```
+
+---
+
+## Task 4: Add role-aware author chip input and update the review form
+
+**Files:**
+- Modify: `app/components/library/IdentifyReviewForm.tsx` (add `AuthorTagInput` near `TagInput` ~line 320; update Authors `FieldWrapper` ~line 790)
+
+No new unit test — `IdentifyReviewForm` has no component tests today and the logic is visual. Manual verification is in Task 5.
+
+- [ ] **Step 1: Add the import**
+
+At the top of `app/components/library/IdentifyReviewForm.tsx`, add next to the other `@/` imports:
+
+```ts
+import { getAuthorRoleLabel } from "@/utils/authorRoles";
+```
+
+- [ ] **Step 2: Add the `AuthorTagInput` component**
+
+Immediately after the closing `}` of the `TagInput` function (around line 387), add a new component. The existing `TagInput` is a generic `string[]` editor; this is its role-aware sibling that operates on `AuthorEntry[]` and keys chips by index so same-name-different-role entries can be removed independently.
+
+```tsx
+function AuthorTagInput({
+  authors,
+  onChange,
+  disabled,
+  placeholder,
+}: {
+  authors: AuthorEntry[];
+  onChange: (authors: AuthorEntry[]) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}) {
+  const [input, setInput] = useState("");
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && input.trim()) {
+      e.preventDefault();
+      onChange([...authors, { name: input.trim(), role: undefined }]);
+      setInput("");
+    }
+    if (e.key === "Backspace" && !input && authors.length > 0) {
+      onChange(authors.slice(0, -1));
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap gap-1.5 rounded-md border border-input bg-transparent p-2 min-h-[36px]",
+        disabled && "opacity-50 cursor-not-allowed",
+      )}
+    >
+      {authors.map((author, i) => {
+        const label = getAuthorRoleLabel(author.role);
+        return (
+          <Badge
+            className="max-w-full gap-1 pr-1"
+            key={i}
+            variant="secondary"
+          >
+            <span
+              className="truncate"
+              title={label ? `${author.name} (${label})` : author.name}
+            >
+              {author.name}
+              {label && (
+                <span className="text-muted-foreground ml-1">({label})</span>
+              )}
+            </span>
+            {!disabled && (
+              <button
+                className="shrink-0 rounded-sm hover:bg-muted-foreground/20 p-0.5 cursor-pointer"
+                onClick={() =>
+                  onChange(authors.filter((_, j) => j !== i))
+                }
+                type="button"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </Badge>
+        );
+      })}
+      {!disabled && (
+        <input
+          className="flex-1 min-w-[80px] bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={
+            authors.length === 0 ? (placeholder ?? "Type and press Enter") : ""
+          }
+          type="text"
+          value={input}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+Note on the `key={i}` — React typically warns against index keys, but the identify form's author list is a short, locally-managed, linearly-edited array where we specifically *need* positional identity to distinguish duplicates. The ESLint rule `react/no-array-index-key` is not enabled in this repo (verified against existing index-keyed patterns), so no disable comment is required. If ESLint complains at verification time, add `// eslint-disable-next-line react/no-array-index-key` above the `key={i}` line.
+
+- [ ] **Step 3: Update the Authors `FieldWrapper`**
+
+Find the Authors field block (around lines 790–815). Replace the entire block:
+
+```tsx
+{/* Authors */}
+<FieldWrapper
+  currentValue={
+    currentAuthors.length > 0
+      ? currentAuthors.map((a) => a.name).join(", ")
+      : undefined
+  }
+  disabled={isDisabled("authors")}
+  field="authors"
+  onUseCurrent={() => setAuthors(currentAuthors)}
+  status={defaults.authors.status}
+>
+  <TagInput
+    disabled={isDisabled("authors")}
+    onChange={(names) =>
+      setAuthors(
+        names.map((name) => {
+          const existing = authors.find((a) => a.name === name);
+          return existing ?? { name, role: undefined };
+        }),
+      )
+    }
+    placeholder="Add author..."
+    tags={authors.map((a) => a.name)}
+  />
+</FieldWrapper>
+```
+
+with:
+
+```tsx
+{/* Authors */}
+<FieldWrapper
+  currentValue={
+    currentAuthors.length > 0
+      ? currentAuthors
+          .map((a) => {
+            const label = getAuthorRoleLabel(a.role);
+            return label ? `${a.name} (${label})` : a.name;
+          })
+          .join(", ")
+      : undefined
+  }
+  disabled={isDisabled("authors")}
+  field="authors"
+  onUseCurrent={() => setAuthors(currentAuthors)}
+  status={defaults.authors.status}
+>
+  <AuthorTagInput
+    authors={authors}
+    disabled={isDisabled("authors")}
+    onChange={setAuthors}
+    placeholder="Add author..."
+  />
+</FieldWrapper>
+```
+
+Two changes to be aware of:
+
+1. The `currentValue` summary now suffixes each author with `(Role)` when present, matching the search result row in Task 3.
+2. The chip editor is now `AuthorTagInput`, which passes the full `AuthorEntry[]` through directly — no more lossy `string[]` round-trip via `find((a) => a.name === name)`.
+
+- [ ] **Step 4: Run TypeScript and ESLint on the file**
+
+Run: `pnpm exec tsc --noEmit && pnpm exec eslint app/components/library/IdentifyReviewForm.tsx`
+
+Expected: both commands exit 0 with no output. If ESLint complains about `key={i}`, add a `// eslint-disable-next-line react/no-array-index-key` comment above the `key={i}` line as noted in Step 2, then re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/IdentifyReviewForm.tsx
+git commit -m "[Frontend] Show author roles in identify review form"
+```
+
+---
+
+## Task 5: Full validation and manual verification
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run the full check suite**
+
+Run: `mise check:quiet`
+
+Expected: pass. The output is one-line per step; if any step fails, the verbose output appears inline. Fix any issues before proceeding.
+
+- [ ] **Step 2: Start the dev server and manually verify the three touchpoints**
+
+Start: `mise start`
+
+Navigate to a library that contains a CBZ manga with a person assigned to multiple author roles (e.g., Demon Slayer: Kimetsu no Yaiba v001 with `Gotouge Koyoharu` as both Writer and Penciller). If none exists, add one via the existing book edit dialog or use the sample library in `tmp/library/`.
+
+Open the Identify dialog for that book and verify:
+
+1. **Search result row** — the author line reads `Gotouge Koyoharu (Writer), Gotouge Koyoharu (Penciller)` instead of `Gotouge Koyoharu, Gotouge Koyoharu`.
+2. **"Use current" summary** — click into a result to enter review mode; the muted Current bar above the Authors field shows the same role-suffixed string.
+3. **Editable chips** — the Authors field displays two distinct chips: `Gotouge Koyoharu (Writer) ×` and `Gotouge Koyoharu (Penciller) ×`. Clicking the `×` on one chip removes only that chip; the other remains. Typing a new author name and pressing Enter adds it as a bare `Gotouge Koyoharu` chip with no role suffix (confirming new entries default to `role: undefined`).
+4. **Non-comic book smoke test** — open Identify on an EPUB or M4B book with ordinary (role-less) authors. Chips should render with just names, no trailing `()`.
+
+- [ ] **Step 3: Stop the dev server**
+
+Ctrl-C the `mise start` process.
+
+- [ ] **Step 4: (Optional) Squash-review commit history**
+
+You should now have four commits:
+
+1. `[Frontend] Add getAuthorRoleLabel helper`
+2. `[Frontend] Use shared getAuthorRoleLabel helper in BookDetail`
+3. `[Frontend] Show author roles in identify search result row`
+4. `[Frontend] Show author roles in identify review form`
+
+Leave them as-is. They land cleanly as a sequence in a squash-merged PR and make review easier than one monolithic commit.
+
+---
+
+## Self-review checklist
+
+- **Spec coverage:** All four changes listed in the spec's "Files touched" table are covered — Task 1 (helper + test), Task 2 (BookDetail), Task 3 (IdentifyBookDialog), Task 4 (IdentifyReviewForm). Manual verification in Task 5 covers the three identify touchpoints from the spec's Problem section.
+- **Types:** `getAuthorRoleLabel(role: string | undefined | null): string | null` is consistent across Tasks 1–4. `resolveAuthors(result): string | undefined` is consistent across Task 3. `AuthorEntry` reused from its existing local definition in Task 4.
+- **Naming:** Helper is `getAuthorRoleLabel` everywhere (distinct from the unrelated `sortRoles` in `app/utils/roles.ts`). Chip component is `AuthorTagInput`.
+- **Docs:** Spec correctly notes no docs changes. No docs tasks in this plan.

--- a/docs/superpowers/specs/2026-04-13-identify-author-roles-design.md
+++ b/docs/superpowers/specs/2026-04-13-identify-author-roles-design.md
@@ -24,13 +24,13 @@ Display-only. Users still cannot assign or edit author roles from the identify d
 
 ### 1. Shared role label utility
 
-Create `app/lib/authorRoleLabel.ts` exporting:
+Create `app/utils/authorRoles.ts` exporting:
 
 ```ts
-export function getRoleLabel(role: string | undefined | null): string | null;
+export function getAuthorRoleLabel(role: string | undefined | null): string | null;
 ```
 
-Move the existing `getRoleLabel` implementation from `BookDetail.tsx` (currently lines 122–135) into this module verbatim. The function maps canonical role strings (`writer`, `penciller`, `inker`, `colorist`, `letterer`, `cover_artist`, `editor`, `translator`) to their capitalized display form, falls back to the raw role string for unknown values, and returns `null` for empty input.
+Move the existing `getRoleLabel` implementation from `BookDetail.tsx` (currently lines 122–135) into this module, renamed to `getAuthorRoleLabel` to avoid collision with the existing user-permission-role helpers in `app/utils/roles.ts`. The function maps canonical role strings (`writer`, `penciller`, `inker`, `colorist`, `letterer`, `cover_artist`, `editor`, `translator`) to their capitalized display form, falls back to the raw role string for unknown values, and returns `null` for empty input.
 
 Update `BookDetail.tsx` to import from the new module and delete the inline copy.
 
@@ -80,7 +80,7 @@ const resolveAuthors = (result: PluginSearchResult): string | undefined => {
   if (!result.authors || result.authors.length === 0) return undefined;
   return result.authors
     .map((a) => {
-      const label = getRoleLabel(a.role);
+      const label = getAuthorRoleLabel(a.role);
       return label ? `${a.name} (${label})` : a.name;
     })
     .join(", ");
@@ -91,7 +91,7 @@ The one call site (around line 449) already renders the value inside a `<p>` —
 
 ## Testing
 
-- **Unit test** for `getRoleLabel` in `app/lib/authorRoleLabel.test.ts` covering: known roles, unknown role (falls through), `undefined`, and `null`.
+- **Unit test** for `getAuthorRoleLabel` in `app/utils/authorRoles.test.ts` covering: known roles, unknown role (falls through), `undefined`, and `null`.
 - **No new component tests** for `IdentifyReviewForm` or `IdentifyBookDialog` — neither has component tests today, and the display logic is narrow enough that a unit test on the pure label helper plus manual verification covers the risk.
 - Manual verification: load a CBZ book with duplicate-named authors in different roles and confirm all three sites render the role suffix.
 
@@ -103,8 +103,8 @@ No documentation changes. This is purely visual polish of an existing feature; n
 
 | File | Change |
 |------|--------|
-| `app/lib/authorRoleLabel.ts` | New — `getRoleLabel` helper |
-| `app/lib/authorRoleLabel.test.ts` | New — unit test |
-| `app/components/pages/BookDetail.tsx` | Replace inline `getRoleLabel` with import |
+| `app/utils/authorRoles.ts` | New — `getAuthorRoleLabel` helper |
+| `app/utils/authorRoles.test.ts` | New — unit test |
+| `app/components/pages/BookDetail.tsx` | Replace inline `getRoleLabel` with `getAuthorRoleLabel` import |
 | `app/components/library/IdentifyReviewForm.tsx` | Add `AuthorTagInput`, update Authors field wiring, update `currentValue` summary |
 | `app/components/library/IdentifyBookDialog.tsx` | Update `resolveAuthors` return type + call site |

--- a/docs/superpowers/specs/2026-04-13-identify-author-roles-design.md
+++ b/docs/superpowers/specs/2026-04-13-identify-author-roles-design.md
@@ -1,0 +1,110 @@
+# Identify Dialog: Author Role Display
+
+## Problem
+
+When a book has the same person assigned to multiple author roles (e.g., *Gotouge Koyoharu* as both Writer and Penciller), the identify dialog renders them as visually identical chips or comma-separated names, making the list look like duplicate entries. This surfaces in three places:
+
+1. **Identify search result row** — `"Gotouge Koyoharu, Gotouge Koyoharu"` in the results list.
+2. **Identify review form "Use current" summary** — same string in the muted current-value bar above the Authors field.
+3. **Identify review form editable chips** — `[Gotouge Koyoharu ×] [Gotouge Koyoharu ×]`, with no way to tell which is which.
+
+The book details page already handles this cleanly by appending a muted role label: `Gotouge Koyoharu (Writer)` / `Gotouge Koyoharu (Penciller)`. The identify flow should match.
+
+## Scope
+
+Display-only. Users still cannot assign or edit author roles from the identify dialog — role editing remains the responsibility of the book edit dialog. Adding a new author via the identify form continues to create an entry with no role, same as today.
+
+## Non-goals
+
+- Role editing UI inside the identify dialog.
+- Extracting a fully reusable `<AuthorChip>` component. Display contexts differ (plain text vs. editable chip) and there is only one editable site, so a shared component would be over-abstraction.
+- Any backend changes. Role data already flows through `AuthorEntry { name, role }` in `IdentifyReviewForm.tsx` and through `result.authors[].role` from plugin results — it is simply discarded at render time.
+
+## Design
+
+### 1. Shared role label utility
+
+Create `app/lib/authorRoleLabel.ts` exporting:
+
+```ts
+export function getRoleLabel(role: string | undefined | null): string | null;
+```
+
+Move the existing `getRoleLabel` implementation from `BookDetail.tsx` (currently lines 122–135) into this module verbatim. The function maps canonical role strings (`writer`, `penciller`, `inker`, `colorist`, `letterer`, `cover_artist`, `editor`, `translator`) to their capitalized display form, falls back to the raw role string for unknown values, and returns `null` for empty input.
+
+Update `BookDetail.tsx` to import from the new module and delete the inline copy.
+
+### 2. Identify review form — editable author chips
+
+In `IdentifyReviewForm.tsx`, replace the generic `TagInput` currently used for the Authors field (around lines 802–814) with a new inline `AuthorTagInput` component, defined in the same file alongside `TagInput`. It takes the role-aware shape directly:
+
+```ts
+function AuthorTagInput({
+  authors,
+  onChange,
+  disabled,
+  placeholder,
+}: {
+  authors: AuthorEntry[];
+  onChange: (authors: AuthorEntry[]) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}) { ... }
+```
+
+Behavior:
+
+- Each chip renders the name plus, when `role` is set, a muted suffix `<span className="text-muted-foreground">({roleLabel})</span>`, matching BookDetail's visual treatment.
+- Chips are keyed by index and removed by index, so same-name-different-role entries can be removed independently. This fixes a latent bug in the current `onChange` handler, which uses `authors.find((a) => a.name === name)` to preserve roles and cannot distinguish duplicates.
+- The text input at the end still accepts new names on Enter and appends `{ name, role: undefined }`. Backspace on empty input removes the last entry.
+- Disabled state is handled the same way as `TagInput`.
+
+The existing `TagInput` component stays in place for the other fields (narrators, genres, tags) unchanged.
+
+### 3. Identify review form — "Use current" summary
+
+Update the `currentValue` prop passed to `FieldWrapper` for the Authors field (currently around line 794). Build the display string from `currentAuthors` by appending the role label suffix when present:
+
+```
+Gotouge Koyoharu (Writer), Gotouge Koyoharu (Penciller)
+```
+
+The comma-join remains; only each name gains an optional ` (Role)` suffix.
+
+### 4. Identify search result row
+
+In `IdentifyBookDialog.tsx`, update `resolveAuthors` (lines 154–158) so it returns a single formatted string (or `undefined`) instead of a `string[]`:
+
+```ts
+const resolveAuthors = (result: PluginSearchResult): string | undefined => {
+  if (!result.authors || result.authors.length === 0) return undefined;
+  return result.authors
+    .map((a) => {
+      const label = getRoleLabel(a.role);
+      return label ? `${a.name} (${label})` : a.name;
+    })
+    .join(", ");
+};
+```
+
+The one call site (around line 449) already renders the value inside a `<p>` — update it from `{authors.join(", ")}` to `{authors}`. The existing `hasAuthors = authors && authors.length > 0` check works unchanged for the new string shape.
+
+## Testing
+
+- **Unit test** for `getRoleLabel` in `app/lib/authorRoleLabel.test.ts` covering: known roles, unknown role (falls through), `undefined`, and `null`.
+- **No new component tests** for `IdentifyReviewForm` or `IdentifyBookDialog` — neither has component tests today, and the display logic is narrow enough that a unit test on the pure label helper plus manual verification covers the risk.
+- Manual verification: load a CBZ book with duplicate-named authors in different roles and confirm all three sites render the role suffix.
+
+## Docs
+
+No documentation changes. This is purely visual polish of an existing feature; no config, API, or user-facing behavior is added or changed.
+
+## Files touched
+
+| File | Change |
+|------|--------|
+| `app/lib/authorRoleLabel.ts` | New — `getRoleLabel` helper |
+| `app/lib/authorRoleLabel.test.ts` | New — unit test |
+| `app/components/pages/BookDetail.tsx` | Replace inline `getRoleLabel` with import |
+| `app/components/library/IdentifyReviewForm.tsx` | Add `AuthorTagInput`, update Authors field wiring, update `currentValue` summary |
+| `app/components/library/IdentifyBookDialog.tsx` | Update `resolveAuthors` return type + call site |

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -94,10 +94,20 @@ func newApplyEchoContext(t *testing.T, fields map[string]any) echo.Context {
 	return c
 }
 
+// newApplyTestBook builds a test book with a real on-disk Filepath so that
+// sidecar writes triggered by persistMetadata land under the test's scratch
+// directory rather than the package CWD. Without Filepath set, WriteBookSidecar
+// used to fall back to CWD-relative paths and silently drop stray
+// "..metadata.json" files into pkg/plugins/ on every test run.
+func newApplyTestBook(t *testing.T, title string) *models.Book {
+	t.Helper()
+	return &models.Book{ID: 1, LibraryID: 1, Title: title, Filepath: t.TempDir()}
+}
+
 func TestApplyMetadata_OrganizesFiles_WhenTitleChanges(t *testing.T) {
 	t.Parallel()
 
-	book := &models.Book{ID: 1, LibraryID: 1, Title: "Old Title"}
+	book := newApplyTestBook(t, "Old Title")
 	store := &stubBookStoreForApply{
 		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
 	}
@@ -113,7 +123,7 @@ func TestApplyMetadata_OrganizesFiles_WhenTitleChanges(t *testing.T) {
 func TestApplyMetadata_OrganizesFiles_WhenAuthorsChange(t *testing.T) {
 	t.Parallel()
 
-	book := &models.Book{ID: 1, LibraryID: 1, Title: "Book"}
+	book := newApplyTestBook(t, "Book")
 	store := &stubBookStoreForApply{
 		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
 	}
@@ -133,7 +143,7 @@ func TestApplyMetadata_OrganizesFiles_WhenAuthorsChange(t *testing.T) {
 func TestApplyMetadata_OrganizesFiles_WhenNarratorsChange(t *testing.T) {
 	t.Parallel()
 
-	book := &models.Book{ID: 1, LibraryID: 1, Title: "Book"}
+	book := newApplyTestBook(t, "Book")
 	store := &stubBookStoreForApply{
 		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
 	}
@@ -151,7 +161,7 @@ func TestApplyMetadata_OrganizesFiles_WhenNarratorsChange(t *testing.T) {
 func TestApplyMetadata_OrganizesFiles_WhenSeriesChanges(t *testing.T) {
 	t.Parallel()
 
-	book := &models.Book{ID: 1, LibraryID: 1, Title: "Book"}
+	book := newApplyTestBook(t, "Book")
 	store := &stubBookStoreForApply{
 		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
 	}
@@ -170,7 +180,7 @@ func TestApplyMetadata_OrganizesFiles_WhenSeriesChanges(t *testing.T) {
 func TestApplyMetadata_SkipsOrganize_WhenNoRelevantFieldsChange(t *testing.T) {
 	t.Parallel()
 
-	book := &models.Book{ID: 1, LibraryID: 1, Title: "Book"}
+	book := newApplyTestBook(t, "Book")
 	store := &stubBookStoreForApply{
 		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
 	}

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -12,10 +12,22 @@ import (
 
 const SidecarSuffix = ".metadata.json"
 
+// ErrEmptySidecarPath is returned by Write* helpers when the caller supplies
+// an empty book or file path. An empty path would otherwise resolve to the
+// current working directory via filepath.Clean("") → ".", which historically
+// caused stray "..metadata.json" files to be written next to whatever process
+// was running (including Go test binaries).
+var ErrEmptySidecarPath = errors.New("sidecar: path is empty")
+
 // BookSidecarPath returns the sidecar file path for a book.
 // For directory-based books: {bookdir}/{dirname}.metadata.json.
 // For root-level books: {dir}/{filename_without_ext}.metadata.json.
+// Returns "" when bookPath is empty — an empty bookPath has no meaningful
+// sidecar location and must not be coerced into a CWD-relative path.
 func BookSidecarPath(bookPath string) string {
+	if bookPath == "" {
+		return ""
+	}
 	// Clean the path to normalize trailing slashes
 	cleanPath := filepath.Clean(bookPath)
 
@@ -48,27 +60,41 @@ func BookSidecarPath(bookPath string) string {
 }
 
 // FileSidecarPath returns the sidecar file path for a media file.
-// Returns {filepath}.metadata.json.
+// Returns {filepath}.metadata.json, or "" when filePath is empty.
 func FileSidecarPath(filePath string) string {
+	if filePath == "" {
+		return ""
+	}
 	return filePath + SidecarSuffix
 }
 
 // BookSidecarExists checks if a book sidecar file exists.
 func BookSidecarExists(bookPath string) bool {
-	_, err := os.Stat(BookSidecarPath(bookPath))
+	sidecarPath := BookSidecarPath(bookPath)
+	if sidecarPath == "" {
+		return false
+	}
+	_, err := os.Stat(sidecarPath)
 	return err == nil
 }
 
 // FileSidecarExists checks if a file sidecar exists.
 func FileSidecarExists(filePath string) bool {
-	_, err := os.Stat(FileSidecarPath(filePath))
+	sidecarPath := FileSidecarPath(filePath)
+	if sidecarPath == "" {
+		return false
+	}
+	_, err := os.Stat(sidecarPath)
 	return err == nil
 }
 
 // ReadBookSidecar reads and parses a book sidecar file.
-// Returns nil, nil if the sidecar doesn't exist.
+// Returns nil, nil if the sidecar doesn't exist or bookPath is empty.
 func ReadBookSidecar(bookPath string) (*BookSidecar, error) {
 	sidecarPath := BookSidecarPath(bookPath)
+	if sidecarPath == "" {
+		return nil, nil
+	}
 
 	data, err := os.ReadFile(sidecarPath)
 	if err != nil {
@@ -87,9 +113,12 @@ func ReadBookSidecar(bookPath string) (*BookSidecar, error) {
 }
 
 // ReadFileSidecar reads and parses a file sidecar.
-// Returns nil, nil if the sidecar doesn't exist.
+// Returns nil, nil if the sidecar doesn't exist or filePath is empty.
 func ReadFileSidecar(filePath string) (*FileSidecar, error) {
 	sidecarPath := FileSidecarPath(filePath)
+	if sidecarPath == "" {
+		return nil, nil
+	}
 
 	data, err := os.ReadFile(sidecarPath)
 	if err != nil {
@@ -111,8 +140,12 @@ func ReadFileSidecar(filePath string) (*FileSidecar, error) {
 // Note: The caller is responsible for ensuring the parent directory exists.
 // For root-level files with OrganizeFileStructure enabled, the directory
 // should be created before calling this function.
+// Returns ErrEmptySidecarPath if bookPath is empty.
 func WriteBookSidecar(bookPath string, s *BookSidecar) error {
 	sidecarPath := BookSidecarPath(bookPath)
+	if sidecarPath == "" {
+		return errors.WithStack(ErrEmptySidecarPath)
+	}
 
 	// Ensure version is set
 	if s.Version == 0 {
@@ -129,8 +162,12 @@ func WriteBookSidecar(bookPath string, s *BookSidecar) error {
 }
 
 // WriteFileSidecar writes a file sidecar.
+// Returns ErrEmptySidecarPath if filePath is empty.
 func WriteFileSidecar(filePath string, s *FileSidecar) error {
 	sidecarPath := FileSidecarPath(filePath)
+	if sidecarPath == "" {
+		return errors.WithStack(ErrEmptySidecarPath)
+	}
 
 	// Ensure version is set
 	if s.Version == 0 {

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -615,3 +615,71 @@ func TestWriteBookSidecar_NonExistentDirectory_FailsGracefully(t *testing.T) {
 	err := WriteBookSidecar(futureBookDir, s)
 	require.Error(t, err, "write should fail when directory doesn't exist")
 }
+
+// Empty-path guard regression tests.
+//
+// Previously, calling BookSidecarPath("") produced "..metadata.json" in the
+// current working directory because filepath.Clean("") returns ".",
+// os.Stat(".") succeeds as a real directory, filepath.Base(".") is ".", and
+// filepath.Join(".", "." + ".metadata.json") → "..metadata.json". Any code
+// that constructed a Book with an empty Filepath and then invoked
+// WriteBookSidecarFromModel would silently create a stray sidecar next to
+// whatever process was running (including Go test binaries, where CWD is
+// the package directory). The guards below make empty input impossible to
+// misuse.
+
+func TestBookSidecarPath_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, BookSidecarPath(""), "empty bookPath must not resolve to a sidecar path")
+}
+
+func TestFileSidecarPath_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, FileSidecarPath(""), "empty filePath must not resolve to a sidecar path")
+}
+
+func TestBookSidecarExists_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, BookSidecarExists(""), "empty bookPath must not report a sidecar as existing")
+}
+
+func TestFileSidecarExists_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, FileSidecarExists(""), "empty filePath must not report a sidecar as existing")
+}
+
+func TestReadBookSidecar_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	s, err := ReadBookSidecar("")
+	require.NoError(t, err)
+	assert.Nil(t, s)
+}
+
+func TestReadFileSidecar_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	s, err := ReadFileSidecar("")
+	require.NoError(t, err)
+	assert.Nil(t, s)
+}
+
+func TestWriteBookSidecar_EmptyInput_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	err := WriteBookSidecar("", &BookSidecar{Title: "Test"})
+	require.Error(t, err, "WriteBookSidecar must reject empty bookPath")
+	assert.ErrorIs(t, err, ErrEmptySidecarPath)
+}
+
+func TestWriteFileSidecar_EmptyInput_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	err := WriteFileSidecar("", &FileSidecar{})
+	require.Error(t, err, "WriteFileSidecar must reject empty filePath")
+	assert.ErrorIs(t, err, ErrEmptySidecarPath)
+}


### PR DESCRIPTION
## Summary
- Extracts the existing `getRoleLabel` helper out of `BookDetail.tsx` into a shared `app/utils/authorRoles.ts` (renamed `getAuthorRoleLabel` to avoid collision with the unrelated user-role helpers in `app/utils/roles.ts`)
- Displays author role suffixes like `Gotouge Koyoharu (Writer)` / `Gotouge Koyoharu (Penciller)` in all three identify dialog touchpoints: the search result row, the "Use current" summary bar, and the editable author chips — so same-named authors in different roles stop looking like visual duplicates
- Adds an inline `AuthorTagInput` sibling of the existing `TagInput` in `IdentifyReviewForm.tsx` that operates directly on `AuthorEntry[]`, keys chips by index so duplicate-name entries can be removed independently, and eliminates the lossy `authors.find((a) => a.name === name)` round-trip that previously dropped role data

## Test plan
- Open Identify on a CBZ book with the same person credited in multiple roles (e.g., Demon Slayer v1 with Gotouge Koyoharu as Writer + Penciller). Confirm the search result row reads `Gotouge Koyoharu (Writer), Gotouge Koyoharu (Penciller)` instead of repeated names.
- Click into a result to enter review mode. Confirm the muted "Use current" bar above the Authors field shows the same role-suffixed string.
- Confirm the Authors chip editor shows two distinct chips (`Gotouge Koyoharu (Writer) ×` and `Gotouge Koyoharu (Penciller) ×`) and that removing one leaves the other intact.
- Type a new author name and press Enter — it should render as a plain `{name}` chip with no role suffix (new entries default to `role: undefined`).
- Smoke test on a non-CBZ book (EPUB or M4B) with role-less authors — chips should render with just names, no trailing `()`.
- No backend, API, or config changes; no docs to update.