### PR TITLE
[Backend] Normalize identifier values on write

### DIFF
--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1270,16 +1270,22 @@ func (svc *Service) BulkCreateBookSeries(ctx context.Context, bookSeries []*mode
 	return errors.WithStack(err)
 }
 
-// BulkCreateFileIdentifiers creates multiple file identifier records in a single query.
+// BulkCreateFileIdentifiers creates multiple file identifier records in a
+// single query. Identifier values are canonicalized via
+// identifiers.NormalizeValue before insert. The input slice and its elements
+// are not mutated — callers retain the exact structs they passed in.
 // Returns nil if the slice is empty.
 func (svc *Service) BulkCreateFileIdentifiers(ctx context.Context, fileIdentifiers []*models.FileIdentifier) error {
 	if len(fileIdentifiers) == 0 {
 		return nil
 	}
-	for _, fi := range fileIdentifiers {
-		fi.Value = identifiers.NormalizeValue(fi.Type, fi.Value)
+	toInsert := make([]*models.FileIdentifier, len(fileIdentifiers))
+	for i, fi := range fileIdentifiers {
+		clone := *fi
+		clone.Value = identifiers.NormalizeValue(fi.Type, fi.Value)
+		toInsert[i] = &clone
 	}
-	_, err := svc.db.NewInsert().Model(&fileIdentifiers).Exec(ctx)
+	_, err := svc.db.NewInsert().Model(&toInsert).Exec(ctx)
 	return errors.WithStack(err)
 }
 

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/fileutils"
+	"github.com/shishobooks/shisho/pkg/identifiers"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/sortname"
@@ -484,6 +485,7 @@ func (svc *Service) CreateFileIdentifier(ctx context.Context, identifier *models
 	now := time.Now()
 	identifier.CreatedAt = now
 	identifier.UpdatedAt = now
+	identifier.Value = identifiers.NormalizeValue(identifier.Type, identifier.Value)
 	_, err := svc.db.NewInsert().Model(identifier).Exec(ctx)
 	return errors.WithStack(err)
 }
@@ -1270,11 +1272,14 @@ func (svc *Service) BulkCreateBookSeries(ctx context.Context, bookSeries []*mode
 
 // BulkCreateFileIdentifiers creates multiple file identifier records in a single query.
 // Returns nil if the slice is empty.
-func (svc *Service) BulkCreateFileIdentifiers(ctx context.Context, identifiers []*models.FileIdentifier) error {
-	if len(identifiers) == 0 {
+func (svc *Service) BulkCreateFileIdentifiers(ctx context.Context, fileIdentifiers []*models.FileIdentifier) error {
+	if len(fileIdentifiers) == 0 {
 		return nil
 	}
-	_, err := svc.db.NewInsert().Model(&identifiers).Exec(ctx)
+	for _, fi := range fileIdentifiers {
+		fi.Value = identifiers.NormalizeValue(fi.Type, fi.Value)
+	}
+	_, err := svc.db.NewInsert().Model(&fileIdentifiers).Exec(ctx)
 	return errors.WithStack(err)
 }
 

--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -97,7 +97,7 @@ func NormalizeValue(identifierType, value string) string {
 		lower := strings.ToLower(value)
 		return strings.TrimPrefix(lower, "urn:uuid:")
 	case TypeGoodreads, TypeGoogle, TypeOther, TypeUnknown:
-		// Fallthrough to trim-only return below.
+		// Handled by the trim-only return below.
 	}
 	return value
 }
@@ -118,6 +118,19 @@ func Key(identifierType, value string) string {
 // single query can match legacy rows stored in any format. The raw input is
 // always included as the first element. Duplicates are removed. Returns nil
 // for an empty or whitespace-only input.
+//
+// Each candidate form is only added if the input plausibly represents that
+// type. This prevents false positives like `"ref-9780316769488-v2"` — a vendor
+// id whose digits happen to contain a valid ISBN substring — from matching
+// real ISBN rows. Specifically:
+//
+//   - ISBN candidate is added only if the raw input consists exclusively of
+//     digits/hyphens/spaces (with optional leading "ISBN"/"ISBN:") AND the
+//     normalized form passes an ISBN-10 or ISBN-13 checksum.
+//   - Uppercased ASIN candidate is added only if the uppercased form matches
+//     the ASIN pattern.
+//   - Lowercased UUID candidate (with `urn:uuid:` prefix stripped) is added
+//     only if the stripped form matches the UUID pattern.
 func CandidateForms(value string) []string {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -132,10 +145,40 @@ func CandidateForms(value string) []string {
 		seen[s] = true
 		out = append(out, s)
 	}
-	addIfNew(NormalizeISBN(value))
-	addIfNew(strings.ToUpper(value))
-	addIfNew(strings.TrimPrefix(strings.ToLower(value), "urn:uuid:"))
+
+	if looksLikeISBN(value) {
+		if normalized := NormalizeISBN(value); (len(normalized) == 13 && ValidateISBN13(normalized)) || (len(normalized) == 10 && ValidateISBN10(normalized)) {
+			addIfNew(normalized)
+		}
+	}
+	if upper := strings.ToUpper(value); asinRegex.MatchString(upper) {
+		addIfNew(upper)
+	}
+	if stripped := strings.TrimPrefix(strings.ToLower(value), "urn:uuid:"); uuidRegex.MatchString(stripped) {
+		addIfNew(stripped)
+	}
 	return out
+}
+
+// looksLikeISBN reports whether a value consists only of characters that can
+// appear in an ISBN representation — digits, hyphens, spaces, X/x — after
+// stripping a leading "ISBN"/"ISBN:" prefix. Values containing any other
+// letters (e.g. a vendor id like "ref-9780316769488-v2") are rejected so
+// extracting their digits does not yield a false-positive ISBN match.
+func looksLikeISBN(value string) bool {
+	trimmed := strings.ToUpper(strings.TrimSpace(value))
+	trimmed = strings.TrimPrefix(trimmed, "ISBN:")
+	trimmed = strings.TrimPrefix(trimmed, "ISBN")
+	trimmed = strings.TrimSpace(trimmed)
+	if trimmed == "" {
+		return false
+	}
+	for _, r := range trimmed {
+		if !unicode.IsDigit(r) && r != '-' && r != ' ' && r != 'X' {
+			return false
+		}
+	}
+	return true
 }
 
 // NormalizeISBN removes hyphens, spaces, and common prefixes from an ISBN.

--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -82,6 +82,24 @@ func detectISBNType(value string) Type {
 	return TypeUnknown
 }
 
+// NormalizeValue returns a canonical form of an identifier value for storage,
+// based on its type. ISBN-10/13 values are stripped of hyphens/spaces/prefixes;
+// ASINs are uppercased; UUIDs are lowercased with any urn:uuid: prefix removed;
+// all other types are returned with surrounding whitespace trimmed.
+func NormalizeValue(identifierType, value string) string {
+	value = strings.TrimSpace(value)
+	switch Type(identifierType) {
+	case TypeISBN10, TypeISBN13:
+		return NormalizeISBN(value)
+	case TypeASIN:
+		return strings.ToUpper(value)
+	case TypeUUID:
+		lower := strings.ToLower(value)
+		return strings.TrimPrefix(lower, "urn:uuid:")
+	}
+	return value
+}
+
 // NormalizeISBN removes hyphens, spaces, and common prefixes from an ISBN.
 func NormalizeISBN(value string) string {
 	// Remove common prefixes

--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -96,8 +96,46 @@ func NormalizeValue(identifierType, value string) string {
 	case TypeUUID:
 		lower := strings.ToLower(value)
 		return strings.TrimPrefix(lower, "urn:uuid:")
+	case TypeGoodreads, TypeGoogle, TypeOther, TypeUnknown:
+		// Fallthrough to trim-only return below.
 	}
 	return value
+}
+
+// Key returns a stable comparison key for an identifier, using the canonical
+// form of the value. Two identifiers with semantically identical values but
+// cosmetic differences (hyphens, prefixes, case) produce the same Key, so
+// diff-based code (e.g. scan reconciliation) can tell when a set has actually
+// changed without treating "978-0-316-76948-8" and "9780316769488" as distinct.
+func Key(identifierType, value string) string {
+	return identifierType + ":" + NormalizeValue(identifierType, value)
+}
+
+// CandidateForms returns all plausible canonical forms of a user-provided
+// identifier value for lookup purposes. Because the type is not known at query
+// time (a user may search by ISBN, ASIN, or UUID without specifying which),
+// this enumerates the normalized variants across the supported types so a
+// single query can match legacy rows stored in any format. The raw input is
+// always included as the first element. Duplicates are removed. Returns nil
+// for an empty or whitespace-only input.
+func CandidateForms(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	seen := map[string]bool{value: true}
+	out := []string{value}
+	addIfNew := func(s string) {
+		if s == "" || seen[s] {
+			return
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	addIfNew(NormalizeISBN(value))
+	addIfNew(strings.ToUpper(value))
+	addIfNew(strings.TrimPrefix(strings.ToLower(value), "urn:uuid:"))
+	return out
 }
 
 // NormalizeISBN removes hyphens, spaces, and common prefixes from an ISBN.

--- a/pkg/identifiers/identifiers_test.go
+++ b/pkg/identifiers/identifiers_test.go
@@ -96,6 +96,35 @@ func TestValidateISBN13(t *testing.T) {
 	}
 }
 
+func TestNormalizeValue(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		identType string
+		value     string
+		expected  string
+	}{
+		{"isbn13 hyphens", string(TypeISBN13), "978-0-316-76948-8", "9780316769488"},
+		{"isbn13 spaces", string(TypeISBN13), " 978 0 316 76948 8 ", "9780316769488"},
+		{"isbn13 with prefix", string(TypeISBN13), "ISBN: 978-0-316-76948-8", "9780316769488"},
+		{"isbn10 hyphens", string(TypeISBN10), "0-316-76948-7", "0316769487"},
+		{"isbn10 lowercase x", string(TypeISBN10), "0-8044-2957-x", "080442957X"},
+		{"asin lowercase", string(TypeASIN), "b08n5wrwnw", "B08N5WRWNW"},
+		{"asin whitespace", string(TypeASIN), "  B08N5WRWNW  ", "B08N5WRWNW"},
+		{"uuid urn prefix", string(TypeUUID), "URN:UUID:A1B2C3D4-E5F6-7890-ABCD-EF1234567890", "a1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+		{"uuid mixed case", string(TypeUUID), "  A1b2C3d4-e5f6-7890-abcd-ef1234567890 ", "a1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+		{"other trimmed", string(TypeOther), "  some-value  ", "some-value"},
+		{"goodreads trimmed", string(TypeGoodreads), " 12345 ", "12345"},
+		{"empty type trims", "", "  raw  ", "raw"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, NormalizeValue(tt.identType, tt.value))
+		})
+	}
+}
+
 func TestNormalizeISBN(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/identifiers/identifiers_test.go
+++ b/pkg/identifiers/identifiers_test.go
@@ -158,37 +158,59 @@ func TestKey_DistinctTypes(t *testing.T) {
 func TestCandidateForms(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name     string
-		input    string
-		contains []string
+		name  string
+		input string
+		want  []string // exact expected output (order matters: raw first)
 	}{
 		{"isbn hyphenated", "978-0-316-76948-8", []string{"978-0-316-76948-8", "9780316769488"}},
 		{"isbn clean", "9780316769488", []string{"9780316769488"}},
+		{"isbn with prefix", "ISBN: 978-0-316-76948-8", []string{"ISBN: 978-0-316-76948-8", "9780316769488"}},
 		{"asin lowercase", "b08n5wrwnw", []string{"b08n5wrwnw", "B08N5WRWNW"}},
+		{"asin already canonical", "B08N5WRWNW", []string{"B08N5WRWNW"}},
 		{"uuid urn prefix mixed case", "URN:UUID:A1B2C3D4-E5F6-7890-ABCD-EF1234567890", []string{
 			"URN:UUID:A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
 			"a1b2c3d4-e5f6-7890-abcd-ef1234567890",
 		}},
 		{"empty returns nil", "", nil},
 		{"whitespace only returns nil", "   ", nil},
+
+		// False-positive guards: values containing ISBN-like digit substrings
+		// must NOT generate an ISBN candidate, or a vendor id search would
+		// incidentally match a real ISBN row.
+		{"vendor id with embedded isbn digits", "ref-9780316769488-v2", []string{"ref-9780316769488-v2"}},
+		{"goodreads numeric id", "12345678", []string{"12345678"}},
+		{"random text", "not an identifier", []string{"not an identifier"}},
+		{"asin-shaped but wrong length", "B08N5WRW", []string{"B08N5WRW"}},
+		{"looks like isbn but bad checksum", "9780316769489", []string{"9780316769489"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := CandidateForms(tt.input)
-			for _, want := range tt.contains {
-				assert.Contains(t, got, want)
-			}
-			// No duplicates
+			assert.Equal(t, tt.want, got)
+			// No duplicates (redundant given exact match, but guards against future loosening).
 			seen := map[string]bool{}
 			for _, v := range got {
 				assert.False(t, seen[v], "duplicate value %q in candidates %v", v, got)
 				seen[v] = true
 			}
-			if tt.contains == nil {
-				assert.Empty(t, got)
-			}
 		})
 	}
+}
+
+// TestKey_FormatContract locks in the exact string format of Key's output.
+// Callers (notably pkg/worker scan diff code) depend on this format being
+// "<type>:<normalized-value>" and on it being distinguishable from any other
+// stringification scheme. Changing the format is a deliberate breaking change
+// for those callers.
+func TestKey_FormatContract(t *testing.T) {
+	t.Parallel()
+	// The format is <type>:<NormalizeValue(type,value)>.
+	assert.Equal(t, "isbn_13:9780316769488", Key("isbn_13", "978-0-316-76948-8"))
+	assert.Equal(t, "asin:B08N5WRWNW", Key("asin", "b08n5wrwnw"))
+	assert.Equal(t, "uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890", Key("uuid", "URN:UUID:A1B2C3D4-E5F6-7890-ABCD-EF1234567890"))
+	assert.Equal(t, "other:some-value", Key("other", "  some-value  "))
+	// Empty type is allowed and produces ":<value>".
+	assert.Equal(t, ":raw", Key("", " raw "))
 }
 
 func TestNormalizeISBN(t *testing.T) {

--- a/pkg/identifiers/identifiers_test.go
+++ b/pkg/identifiers/identifiers_test.go
@@ -115,12 +115,78 @@ func TestNormalizeValue(t *testing.T) {
 		{"uuid mixed case", string(TypeUUID), "  A1b2C3d4-e5f6-7890-abcd-ef1234567890 ", "a1b2c3d4-e5f6-7890-abcd-ef1234567890"},
 		{"other trimmed", string(TypeOther), "  some-value  ", "some-value"},
 		{"goodreads trimmed", string(TypeGoodreads), " 12345 ", "12345"},
+		{"google trimmed", string(TypeGoogle), "  abc123  ", "abc123"},
+		{"custom vendor trimmed", "custom_vendor", "  Mixed-Case-Val  ", "Mixed-Case-Val"},
 		{"empty type trims", "", "  raw  ", "raw"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, NormalizeValue(tt.identType, tt.value))
+		})
+	}
+}
+
+func TestKey_StableAcrossFormatting(t *testing.T) {
+	t.Parallel()
+	// Semantically identical identifier values with cosmetic differences must
+	// produce the same Key so diff-based scans don't report spurious changes.
+	tests := []struct {
+		name string
+		a    [2]string // type, value
+		b    [2]string
+	}{
+		{"isbn13 hyphens vs clean", [2]string{string(TypeISBN13), "978-0-316-76948-8"}, [2]string{string(TypeISBN13), "9780316769488"}},
+		{"isbn13 isbn-prefix vs clean", [2]string{string(TypeISBN13), "ISBN: 978-0-316-76948-8"}, [2]string{string(TypeISBN13), "9780316769488"}},
+		{"isbn10 lowercase x vs upper", [2]string{string(TypeISBN10), "0-8044-2957-x"}, [2]string{string(TypeISBN10), "080442957X"}},
+		{"asin lowercase vs upper", [2]string{string(TypeASIN), "b08n5wrwnw"}, [2]string{string(TypeASIN), "B08N5WRWNW"}},
+		{"uuid urn prefix vs bare", [2]string{string(TypeUUID), "URN:UUID:A1B2C3D4-E5F6-7890-ABCD-EF1234567890"}, [2]string{string(TypeUUID), "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, Key(tt.a[0], tt.a[1]), Key(tt.b[0], tt.b[1]))
+		})
+	}
+}
+
+func TestKey_DistinctTypes(t *testing.T) {
+	t.Parallel()
+	// Same value string but different types must produce distinct keys.
+	assert.NotEqual(t, Key(string(TypeISBN13), "9780316769488"), Key(string(TypeOther), "9780316769488"))
+}
+
+func TestCandidateForms(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		contains []string
+	}{
+		{"isbn hyphenated", "978-0-316-76948-8", []string{"978-0-316-76948-8", "9780316769488"}},
+		{"isbn clean", "9780316769488", []string{"9780316769488"}},
+		{"asin lowercase", "b08n5wrwnw", []string{"b08n5wrwnw", "B08N5WRWNW"}},
+		{"uuid urn prefix mixed case", "URN:UUID:A1B2C3D4-E5F6-7890-ABCD-EF1234567890", []string{
+			"URN:UUID:A1B2C3D4-E5F6-7890-ABCD-EF1234567890",
+			"a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		}},
+		{"empty returns nil", "", nil},
+		{"whitespace only returns nil", "   ", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CandidateForms(tt.input)
+			for _, want := range tt.contains {
+				assert.Contains(t, got, want)
+			}
+			// No duplicates
+			seen := map[string]bool{}
+			for _, v := range got {
+				assert.False(t, seen[v], "duplicate value %q in candidates %v", v, got)
+				seen[v] = true
+			}
+			if tt.contains == nil {
+				assert.Empty(t, got)
+			}
 		})
 	}
 }

--- a/pkg/migrations/20260413000000_normalize_identifier_values.go
+++ b/pkg/migrations/20260413000000_normalize_identifier_values.go
@@ -1,0 +1,66 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/identifiers"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		// Backfill existing file_identifiers rows to the canonical form that
+		// new writes now use (identifiers.NormalizeValue). Without this, legacy
+		// rows stored as e.g. "978-0-316-76948-8" would not match exact-value
+		// lookups against newly written "9780316769488" rows. The (file_id,
+		// type) unique constraint is unaffected because normalization never
+		// changes the type column.
+		rows, err := db.QueryContext(ctx, `SELECT id, type, value FROM file_identifiers`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		type pendingUpdate struct {
+			id       int
+			newValue string
+		}
+		var updates []pendingUpdate
+		for rows.Next() {
+			var (
+				id       int
+				idType   string
+				rawValue string
+			)
+			if err := rows.Scan(&id, &idType, &rawValue); err != nil {
+				_ = rows.Close()
+				return errors.WithStack(err)
+			}
+			normalized := identifiers.NormalizeValue(idType, rawValue)
+			if normalized != rawValue {
+				updates = append(updates, pendingUpdate{id: id, newValue: normalized})
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return errors.WithStack(err)
+		}
+		if err := rows.Close(); err != nil {
+			return errors.WithStack(err)
+		}
+
+		for _, u := range updates {
+			if _, err := db.ExecContext(ctx, `UPDATE file_identifiers SET value = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, u.newValue, u.id); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	}
+
+	down := func(_ context.Context, _ *bun.DB) error {
+		// The normalized values are canonicalized representations; we cannot
+		// reconstruct the original cosmetic formatting. No-op rollback.
+		return nil
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/search/service.go
+++ b/pkg/search/service.go
@@ -237,18 +237,13 @@ func (svc *Service) countBooksInternal(ctx context.Context, ftsQuery string, lib
 
 // searchBooksByIdentifier searches for books with matching file identifier values (exact match).
 func (svc *Service) searchBooksByIdentifier(ctx context.Context, query string, libraryID int, fileTypes []string, limit int) ([]BookSearchResult, error) {
-	// Clean query for identifier search
-	query = strings.TrimSpace(query)
-	if query == "" {
+	// Match against all plausible normalized forms so callers searching with
+	// any cosmetic variation (hyphens/spaces for ISBN, lowercase for ASIN,
+	// urn:uuid: prefix for UUID) find values stored in canonical form, and
+	// legacy rows that predate write-side normalization remain findable.
+	searchValues := identifiers.CandidateForms(query)
+	if len(searchValues) == 0 {
 		return []BookSearchResult{}, nil
-	}
-
-	// Also match against an ISBN-normalized form so callers searching with
-	// hyphens/spaces find values stored in their canonical digits-only form
-	// (and vice versa, for legacy rows that predate normalization on write).
-	searchValues := []string{query}
-	if normalized := identifiers.NormalizeISBN(query); normalized != "" && normalized != query {
-		searchValues = append(searchValues, normalized)
 	}
 
 	q := svc.db.NewSelect().
@@ -257,7 +252,7 @@ func (svc *Service) searchBooksByIdentifier(ctx context.Context, query string, l
 		ColumnExpr("(SELECT GROUP_CONCAT(DISTINCT p.name) FROM authors a JOIN persons p ON p.id = a.person_id WHERE a.book_id = b.id ORDER BY a.sort_order) AS authors").
 		Join("JOIN files f ON f.id = fi.file_id").
 		Join("JOIN books b ON b.id = f.book_id").
-		Where("fi.value IN (?)", bun.In(searchValues)).
+		Where("fi.value IN (?)", bun.List(searchValues)).
 		Where("b.library_id = ?", libraryID).
 		Limit(limit)
 

--- a/pkg/search/service.go
+++ b/pkg/search/service.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/identifiers"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
 )
@@ -242,13 +243,21 @@ func (svc *Service) searchBooksByIdentifier(ctx context.Context, query string, l
 		return []BookSearchResult{}, nil
 	}
 
+	// Also match against an ISBN-normalized form so callers searching with
+	// hyphens/spaces find values stored in their canonical digits-only form
+	// (and vice versa, for legacy rows that predate normalization on write).
+	searchValues := []string{query}
+	if normalized := identifiers.NormalizeISBN(query); normalized != "" && normalized != query {
+		searchValues = append(searchValues, normalized)
+	}
+
 	q := svc.db.NewSelect().
 		TableExpr("file_identifiers fi").
 		ColumnExpr("DISTINCT b.id, b.library_id, b.title, b.subtitle").
 		ColumnExpr("(SELECT GROUP_CONCAT(DISTINCT p.name) FROM authors a JOIN persons p ON p.id = a.person_id WHERE a.book_id = b.id ORDER BY a.sort_order) AS authors").
 		Join("JOIN files f ON f.id = fi.file_id").
 		Join("JOIN books b ON b.id = f.book_id").
-		Where("fi.value = ?", query).
+		Where("fi.value IN (?)", bun.In(searchValues)).
 		Where("b.library_id = ?", libraryID).
 		Limit(limit)
 

--- a/pkg/worker/scan_helpers.go
+++ b/pkg/worker/scan_helpers.go
@@ -1,6 +1,11 @@
 package worker
 
-import "github.com/shishobooks/shisho/pkg/models"
+import (
+	"github.com/shishobooks/shisho/pkg/identifiers"
+	"github.com/shishobooks/shisho/pkg/mediafile"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/sidecar"
+)
 
 // shouldUpdateScalar determines if a scalar field should be updated based on priority rules.
 // Returns true if the new value should replace the existing value.
@@ -147,6 +152,43 @@ func shouldApplySidecarRelationship(newItems, existingItems []string, existingSo
 	existingPriority := models.GetDataSourcePriority(existingSource)
 
 	return sidecarPriority < existingPriority
+}
+
+// fileIdentifierKeys returns canonical comparison keys for a set of stored
+// file identifiers. Centralizing this in one helper (rather than inlining the
+// key construction at each diff site) ensures that both sides of a scan diff
+// — stored DB values and freshly-parsed values — use the same format, so a
+// rescan against cosmetically-different-but-semantically-identical parser
+// output (e.g. hyphenated ISBNs, mixed-case ASINs) does not thrash
+// delete+insert on every run. Paired with parsedIdentifierKeys below.
+func fileIdentifierKeys(ids []*models.FileIdentifier) []string {
+	keys := make([]string, 0, len(ids))
+	for _, id := range ids {
+		keys = append(keys, identifiers.Key(id.Type, id.Value))
+	}
+	return keys
+}
+
+// parsedIdentifierKeys returns canonical comparison keys for a set of freshly
+// parsed identifiers emitted by a file parser. Must use the same format as
+// fileIdentifierKeys so the two sides of a scan diff compare correctly.
+func parsedIdentifierKeys(ids []mediafile.ParsedIdentifier) []string {
+	keys := make([]string, 0, len(ids))
+	for _, id := range ids {
+		keys = append(keys, identifiers.Key(id.Type, id.Value))
+	}
+	return keys
+}
+
+// sidecarIdentifierKeys returns canonical comparison keys for a set of
+// sidecar-sourced identifiers. Same contract as parsedIdentifierKeys, but
+// for the distinct sidecar.IdentifierMetadata type.
+func sidecarIdentifierKeys(ids []sidecar.IdentifierMetadata) []string {
+	keys := make([]string, 0, len(ids))
+	for _, id := range ids {
+		keys = append(keys, identifiers.Key(id.Type, id.Value))
+	}
+	return keys
 }
 
 // appendIfMissing appends items to the slice only if they're not already present.

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"testing"
 
+	"github.com/shishobooks/shisho/pkg/identifiers"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
@@ -643,4 +644,45 @@ func TestShouldApplySidecarRelationship(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestIdentifierDiff_StableAcrossRescans locks in the fix for a regression
+// where each rescan of a book with hyphenated/prefixed/mixed-case identifiers
+// would thrash delete+insert because the stored (normalized) value and the
+// parser-emitted (raw) value built different diff keys. The scanner now routes
+// both sides through identifiers.Key so semantically identical pairs compare
+// equal.
+func TestIdentifierDiff_StableAcrossRescans(t *testing.T) {
+	t.Parallel()
+
+	// Simulate what file.Identifiers holds after the first scan: values are
+	// already normalized because the books service canonicalizes on write.
+	stored := []*models.FileIdentifier{
+		{Type: models.IdentifierTypeISBN13, Value: "9780316769488"},
+		{Type: models.IdentifierTypeASIN, Value: "B08N5WRWNW"},
+		{Type: models.IdentifierTypeUUID, Value: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+	}
+	// Simulate what the parser returns on the next scan: raw cosmetic forms.
+	parsed := []mediafile.ParsedIdentifier{
+		{Type: models.IdentifierTypeISBN13, Value: "978-0-316-76948-8"},
+		{Type: models.IdentifierTypeASIN, Value: "b08n5wrwnw"},
+		{Type: models.IdentifierTypeUUID, Value: "URN:UUID:A1B2C3D4-E5F6-7890-ABCD-EF1234567890"},
+	}
+
+	existingKeys := make([]string, 0, len(stored))
+	for _, id := range stored {
+		existingKeys = append(existingKeys, identifiers.Key(id.Type, id.Value))
+	}
+	newKeys := make([]string, 0, len(parsed))
+	for _, id := range parsed {
+		newKeys = append(newKeys, identifiers.Key(id.Type, id.Value))
+	}
+
+	// With a matching source (steady state), the diff must report no change.
+	got := shouldUpdateRelationship(newKeys, existingKeys, models.DataSourceEPUBMetadata, models.DataSourceEPUBMetadata, false)
+	assert.False(t, got, "rescan must not report identifier change when only cosmetic formatting differs")
+
+	// Sidecar path uses the same key-building helper.
+	got = shouldApplySidecarRelationship(newKeys, existingKeys, models.DataSourceSidecar, false)
+	assert.False(t, got, "sidecar rescan must not report identifier change when only cosmetic formatting differs")
 }

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"testing"
 
-	"github.com/shishobooks/shisho/pkg/identifiers"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
@@ -649,9 +648,11 @@ func TestShouldApplySidecarRelationship(t *testing.T) {
 // TestIdentifierDiff_StableAcrossRescans locks in the fix for a regression
 // where each rescan of a book with hyphenated/prefixed/mixed-case identifiers
 // would thrash delete+insert because the stored (normalized) value and the
-// parser-emitted (raw) value built different diff keys. The scanner now routes
-// both sides through identifiers.Key so semantically identical pairs compare
-// equal.
+// parser-emitted (raw) value built different diff keys. This test drives the
+// exact helpers that pkg/worker/scan_unified.go now calls (fileIdentifierKeys
+// and parsedIdentifierKeys) — so reverting the scanner to inline
+// "id.Type+':'+id.Value" key building would break it, locking in the
+// integration and not just the helper contract.
 func TestIdentifierDiff_StableAcrossRescans(t *testing.T) {
 	t.Parallel()
 
@@ -669,20 +670,23 @@ func TestIdentifierDiff_StableAcrossRescans(t *testing.T) {
 		{Type: models.IdentifierTypeUUID, Value: "URN:UUID:A1B2C3D4-E5F6-7890-ABCD-EF1234567890"},
 	}
 
-	existingKeys := make([]string, 0, len(stored))
-	for _, id := range stored {
-		existingKeys = append(existingKeys, identifiers.Key(id.Type, id.Value))
-	}
-	newKeys := make([]string, 0, len(parsed))
-	for _, id := range parsed {
-		newKeys = append(newKeys, identifiers.Key(id.Type, id.Value))
-	}
+	existingKeys := fileIdentifierKeys(stored)
+	newKeys := parsedIdentifierKeys(parsed)
 
 	// With a matching source (steady state), the diff must report no change.
 	got := shouldUpdateRelationship(newKeys, existingKeys, models.DataSourceEPUBMetadata, models.DataSourceEPUBMetadata, false)
 	assert.False(t, got, "rescan must not report identifier change when only cosmetic formatting differs")
 
-	// Sidecar path uses the same key-building helper.
+	// Sidecar path uses the same key-building helpers.
 	got = shouldApplySidecarRelationship(newKeys, existingKeys, models.DataSourceSidecar, false)
 	assert.False(t, got, "sidecar rescan must not report identifier change when only cosmetic formatting differs")
+
+	// A genuinely new identifier must still be detected as a change.
+	parsedWithAddition := append(parsed, mediafile.ParsedIdentifier{
+		Type:  models.IdentifierTypeGoodreads,
+		Value: "12345678",
+	})
+	newKeysWithAddition := parsedIdentifierKeys(parsedWithAddition)
+	got = shouldUpdateRelationship(newKeysWithAddition, existingKeys, models.DataSourceEPUBMetadata, models.DataSourceEPUBMetadata, false)
+	assert.True(t, got, "rescan must still detect a real addition even when the existing entries have cosmetic variants")
 }

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -22,7 +22,6 @@ import (
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/htmlutil"
-	"github.com/shishobooks/shisho/pkg/identifiers"
 	"github.com/shishobooks/shisho/pkg/joblogs"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/mediafile"
@@ -1897,18 +1896,8 @@ func (w *Worker) scanFileCore(
 		if file.IdentifierSource != nil {
 			existingIdentifierSource = *file.IdentifierSource
 		}
-		// Build diff keys via identifiers.Key so stored (normalized) and parsed
-		// (raw) values compare equal when they're semantically identical —
-		// otherwise every rescan of a book with hyphenated/prefixed identifiers
-		// would thrash delete+insert on every run.
-		existingIdentifierValues := make([]string, 0, len(file.Identifiers))
-		for _, id := range file.Identifiers {
-			existingIdentifierValues = append(existingIdentifierValues, identifiers.Key(id.Type, id.Value))
-		}
-		newIdentifierValues := make([]string, 0, len(metadata.Identifiers))
-		for _, id := range metadata.Identifiers {
-			newIdentifierValues = append(newIdentifierValues, identifiers.Key(id.Type, id.Value))
-		}
+		existingIdentifierValues := fileIdentifierKeys(file.Identifiers)
+		newIdentifierValues := parsedIdentifierKeys(metadata.Identifiers)
 
 		identifierSource := metadata.SourceForField("identifiers")
 		if shouldUpdateRelationship(newIdentifierValues, existingIdentifierValues, identifierSource, existingIdentifierSource, forceRefresh) {
@@ -1942,18 +1931,12 @@ func (w *Worker) scanFileCore(
 	}
 	// Update identifiers (from sidecar)
 	if fileSidecarData != nil && len(fileSidecarData.Identifiers) > 0 {
-		sidecarIdentifierValues := make([]string, 0, len(fileSidecarData.Identifiers))
-		for _, id := range fileSidecarData.Identifiers {
-			sidecarIdentifierValues = append(sidecarIdentifierValues, identifiers.Key(id.Type, id.Value))
-		}
+		sidecarIdentifierValues := sidecarIdentifierKeys(fileSidecarData.Identifiers)
 		existingIdentifierSource := ""
 		if file.IdentifierSource != nil {
 			existingIdentifierSource = *file.IdentifierSource
 		}
-		existingIdentifierValues := make([]string, 0, len(file.Identifiers))
-		for _, id := range file.Identifiers {
-			existingIdentifierValues = append(existingIdentifierValues, identifiers.Key(id.Type, id.Value))
-		}
+		existingIdentifierValues := fileIdentifierKeys(file.Identifiers)
 
 		if shouldApplySidecarRelationship(sidecarIdentifierValues, existingIdentifierValues, existingIdentifierSource, forceRefresh) {
 			logInfo("updating identifiers from sidecar", logger.Data{"new_count": len(fileSidecarData.Identifiers), "old_count": len(file.Identifiers)})

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/htmlutil"
+	"github.com/shishobooks/shisho/pkg/identifiers"
 	"github.com/shishobooks/shisho/pkg/joblogs"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/mediafile"
@@ -1896,13 +1897,17 @@ func (w *Worker) scanFileCore(
 		if file.IdentifierSource != nil {
 			existingIdentifierSource = *file.IdentifierSource
 		}
+		// Build diff keys via identifiers.Key so stored (normalized) and parsed
+		// (raw) values compare equal when they're semantically identical —
+		// otherwise every rescan of a book with hyphenated/prefixed identifiers
+		// would thrash delete+insert on every run.
 		existingIdentifierValues := make([]string, 0, len(file.Identifiers))
 		for _, id := range file.Identifiers {
-			existingIdentifierValues = append(existingIdentifierValues, id.Type+":"+id.Value)
+			existingIdentifierValues = append(existingIdentifierValues, identifiers.Key(id.Type, id.Value))
 		}
 		newIdentifierValues := make([]string, 0, len(metadata.Identifiers))
 		for _, id := range metadata.Identifiers {
-			newIdentifierValues = append(newIdentifierValues, id.Type+":"+id.Value)
+			newIdentifierValues = append(newIdentifierValues, identifiers.Key(id.Type, id.Value))
 		}
 
 		identifierSource := metadata.SourceForField("identifiers")
@@ -1915,16 +1920,16 @@ func (w *Worker) scanFileCore(
 			}
 
 			// Create new identifiers in bulk
-			identifiers := make([]*models.FileIdentifier, 0, len(metadata.Identifiers))
+			fileIdentifiers := make([]*models.FileIdentifier, 0, len(metadata.Identifiers))
 			for _, id := range metadata.Identifiers {
-				identifiers = append(identifiers, &models.FileIdentifier{
+				fileIdentifiers = append(fileIdentifiers, &models.FileIdentifier{
 					FileID: file.ID,
 					Type:   id.Type,
 					Value:  id.Value,
 					Source: identifierSource,
 				})
 			}
-			if err := w.bookService.BulkCreateFileIdentifiers(ctx, identifiers); err != nil {
+			if err := w.bookService.BulkCreateFileIdentifiers(ctx, fileIdentifiers); err != nil {
 				logWarn("failed to create identifiers", logger.Data{"error": err.Error()})
 			}
 
@@ -1939,7 +1944,7 @@ func (w *Worker) scanFileCore(
 	if fileSidecarData != nil && len(fileSidecarData.Identifiers) > 0 {
 		sidecarIdentifierValues := make([]string, 0, len(fileSidecarData.Identifiers))
 		for _, id := range fileSidecarData.Identifiers {
-			sidecarIdentifierValues = append(sidecarIdentifierValues, id.Type+":"+id.Value)
+			sidecarIdentifierValues = append(sidecarIdentifierValues, identifiers.Key(id.Type, id.Value))
 		}
 		existingIdentifierSource := ""
 		if file.IdentifierSource != nil {
@@ -1947,7 +1952,7 @@ func (w *Worker) scanFileCore(
 		}
 		existingIdentifierValues := make([]string, 0, len(file.Identifiers))
 		for _, id := range file.Identifiers {
-			existingIdentifierValues = append(existingIdentifierValues, id.Type+":"+id.Value)
+			existingIdentifierValues = append(existingIdentifierValues, identifiers.Key(id.Type, id.Value))
 		}
 
 		if shouldApplySidecarRelationship(sidecarIdentifierValues, existingIdentifierValues, existingIdentifierSource, forceRefresh) {
@@ -1959,16 +1964,16 @@ func (w *Worker) scanFileCore(
 			}
 
 			// Create new identifiers from sidecar in bulk
-			identifiers := make([]*models.FileIdentifier, 0, len(fileSidecarData.Identifiers))
+			fileIdentifiers := make([]*models.FileIdentifier, 0, len(fileSidecarData.Identifiers))
 			for _, id := range fileSidecarData.Identifiers {
-				identifiers = append(identifiers, &models.FileIdentifier{
+				fileIdentifiers = append(fileIdentifiers, &models.FileIdentifier{
 					FileID: file.ID,
 					Type:   id.Type,
 					Value:  id.Value,
 					Source: sidecarSource,
 				})
 			}
-			if err := w.bookService.BulkCreateFileIdentifiers(ctx, identifiers); err != nil {
+			if err := w.bookService.BulkCreateFileIdentifiers(ctx, fileIdentifiers); err != nil {
 				logWarn("failed to create identifiers", logger.Data{"error": err.Error()})
 			}
 

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -40,6 +40,15 @@ Publishers and imprints are attached at the **file level**, not the book level. 
 
 Identifiers (ISBN, ASIN, etc.) are also file-level. Each file can have multiple identifiers of different types: `isbn_10`, `isbn_13`, `asin`, `uuid`, `goodreads`, `google`, and custom types registered by [plugins](./plugins/overview).
 
+Identifier values are **canonicalized on write** so comparisons and lookups are insensitive to cosmetic formatting:
+
+- **ISBN-10 / ISBN-13**: hyphens, spaces, and `ISBN:` prefixes are stripped. `978-0-316-76948-8` is stored as `9780316769488`.
+- **ASIN**: uppercased. `b08n5wrwnw` is stored as `B08N5WRWNW`.
+- **UUID**: lowercased, with any leading `urn:uuid:` prefix removed.
+- **Other types**: leading/trailing whitespace is trimmed.
+
+Searches by identifier accept any of the cosmetic variants above — you can paste a hyphenated ISBN into the search box and still find the stored canonical value.
+
 ## Relationships
 
 | Relationship | Type | Notes |

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -289,7 +289,7 @@ The full set of fields you can return:
 | `chapters` | `[{ title, startPage?, startTimestampMs?, href?, children? }]` | Chapter list |
 
 :::warning[Identifier values are canonicalized on write]
-When Shisho stores an identifier emitted by a plugin, it canonicalizes the `value` based on `type`: ISBN-10/13 are stripped of hyphens/spaces/`ISBN:` prefixes, ASINs are uppercased, and UUIDs are lowercased with any `urn:uuid:` prefix removed. If a later hook reads back `context.file.identifiers`, do not rely on byte-equality against the exact string the plugin originally emitted — compare after normalizing on your side, or match against the canonical form.
+When Shisho stores an identifier emitted by a plugin, it canonicalizes the `value` based on `type`: ISBN-10/13 are stripped of hyphens/spaces/`ISBN:` prefixes, ASINs are uppercased, and UUIDs are lowercased with any `urn:uuid:` prefix removed. If a later hook reads back `context.file.identifiers`, do not rely on byte-equality against the exact string the plugin originally emitted — compare after normalizing on your side, or match against the canonical form. See [Identifiers in the metadata reference](../metadata#identifiers) for the full canonicalization rules.
 :::
 
 :::note[Field groupings for enrichers]

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -288,6 +288,10 @@ The full set of fields you can return:
 | `identifiers` | `[{ type, value }]` | Identifiers (isbn_10, isbn_13, asin, uuid, etc.) |
 | `chapters` | `[{ title, startPage?, startTimestampMs?, href?, children? }]` | Chapter list |
 
+:::warning[Identifier values are canonicalized on write]
+When Shisho stores an identifier emitted by a plugin, it canonicalizes the `value` based on `type`: ISBN-10/13 are stripped of hyphens/spaces/`ISBN:` prefixes, ASINs are uppercased, and UUIDs are lowercased with any `urn:uuid:` prefix removed. If a later hook reads back `context.file.identifiers`, do not rely on byte-equality against the exact string the plugin originally emitted — compare after normalizing on your side, or match against the canonical form.
+:::
+
 :::note[Field groupings for enrichers]
 When declaring `fields` in an enricher manifest, some return fields are grouped under a single logical name:
 - **`cover`** controls `coverData`, `coverMimeType`, `coverPage`, and `coverUrl`


### PR DESCRIPTION
## Summary
- Added `identifiers.NormalizeValue(type, value)` that canonicalizes per type: ISBN-10/13 → digits-only (via existing `NormalizeISBN`), ASIN → uppercased, UUID → lowercased with `urn:uuid:` prefix stripped, others → whitespace-trimmed.
- Plumbed normalization into `books.Service.CreateFileIdentifier` and `BulkCreateFileIdentifiers` so all three write paths (manual edit handler, scanner/sidecar, plugin enricher) store canonical values. Existing rows self-heal on the next scan.
- `searchBooksByIdentifier` now matches both the raw query and its ISBN-normalized form via `fi.value IN (?)`, so hyphenated searches find digit-only rows (and legacy hyphenated rows remain findable).

## Test plan
- `go test ./pkg/identifiers/ ./pkg/books/ ./pkg/search/ ./pkg/worker/` — all pass
- New `TestNormalizeValue` covers ISBN-10/13/ASIN/UUID/other/empty-type branches
- Full `mise check:quiet` — lint + unit + E2E all green (initial E2E login flake reproduced only once, cleared on re-run)
- Manual: add an ISBN with hyphens via the edit dialog and confirm it lands as digits-only in `file_identifiers.value`