### PR TITLE
[Backend] Surface plugin search errors in identify dialog

### DIFF
--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -131,6 +131,8 @@ export function IdentifyBookDialog({
 
   const results = searchMutation.data?.results ?? [];
   const pluginErrors = searchMutation.data?.errors ?? [];
+  const skippedPlugins = searchMutation.data?.skipped_plugins ?? [];
+  const selectedFileType = selectedFile?.file_type;
 
   // Detect plugin IDs that appear under multiple scopes
   const ambiguousIds = useMemo(() => {
@@ -362,9 +364,9 @@ export function IdentifyBookDialog({
                         </p>
                         <p
                           className="text-muted-foreground break-words"
-                          title={err.error}
+                          title={err.message}
                         >
-                          {err.error}
+                          {err.message}
                         </p>
                       </div>
                     </div>
@@ -374,16 +376,26 @@ export function IdentifyBookDialog({
 
               {searchMutation.isSuccess &&
                 results.length === 0 &&
-                pluginErrors.length === 0 && (
-                  <div className="text-center py-12 text-muted-foreground space-y-2">
-                    <p>No results found.</p>
-                    <p className="text-xs">
-                      {hasEnricherPlugins
-                        ? "Try a different search query."
-                        : "No metadata enricher plugins are installed. Install one from the plugin settings to search for books."}
-                    </p>
-                  </div>
-                )}
+                pluginErrors.length === 0 &&
+                (() => {
+                  const allSkippedForFileType =
+                    skippedPlugins.length > 0 && hasEnricherPlugins;
+                  const skippedNames = skippedPlugins
+                    .map((p) => p.plugin_name || p.plugin_id)
+                    .join(", ");
+                  return (
+                    <div className="text-center py-12 text-muted-foreground space-y-2">
+                      <p>No results found.</p>
+                      <p className="text-xs">
+                        {!hasEnricherPlugins
+                          ? "No metadata enricher plugins are installed. Install one from the plugin settings to search for books."
+                          : allSkippedForFileType
+                            ? `No installed enricher${skippedPlugins.length === 1 ? "" : "s"} support${skippedPlugins.length === 1 ? "s" : ""} ${selectedFileType?.toUpperCase() ?? "this file type"} files (${skippedNames}).`
+                            : "Try a different search query."}
+                      </p>
+                    </div>
+                  );
+                })()}
 
               {searchMutation.isSuccess && results.length > 0 && (
                 <div className="space-y-2">

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -1,5 +1,5 @@
 import { IdentifyReviewForm } from "./IdentifyReviewForm";
-import { ExternalLink, Loader2, Search, X } from "lucide-react";
+import { AlertTriangle, ExternalLink, Loader2, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -130,6 +130,7 @@ export function IdentifyBookDialog({
   };
 
   const results = searchMutation.data?.results ?? [];
+  const pluginErrors = searchMutation.data?.errors ?? [];
 
   // Detect plugin IDs that appear under multiple scopes
   const ambiguousIds = useMemo(() => {
@@ -347,16 +348,42 @@ export function IdentifyBookDialog({
                 </div>
               )}
 
-              {searchMutation.isSuccess && results.length === 0 && (
-                <div className="text-center py-12 text-muted-foreground space-y-2">
-                  <p>No results found.</p>
-                  <p className="text-xs">
-                    {hasEnricherPlugins
-                      ? "Try a different search query."
-                      : "No metadata enricher plugins are installed. Install one from the plugin settings to search for books."}
-                  </p>
+              {searchMutation.isSuccess && pluginErrors.length > 0 && (
+                <div className="mb-3 space-y-2">
+                  {pluginErrors.map((err) => (
+                    <div
+                      className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2.5 text-xs"
+                      key={`${err.plugin_scope}-${err.plugin_id}`}
+                    >
+                      <AlertTriangle className="h-4 w-4 shrink-0 text-destructive mt-0.5" />
+                      <div className="min-w-0 flex-1">
+                        <p className="font-medium text-destructive">
+                          {err.plugin_name || err.plugin_id} failed
+                        </p>
+                        <p
+                          className="text-muted-foreground break-words"
+                          title={err.error}
+                        >
+                          {err.error}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
                 </div>
               )}
+
+              {searchMutation.isSuccess &&
+                results.length === 0 &&
+                pluginErrors.length === 0 && (
+                  <div className="text-center py-12 text-muted-foreground space-y-2">
+                    <p>No results found.</p>
+                    <p className="text-xs">
+                      {hasEnricherPlugins
+                        ? "Try a different search query."
+                        : "No metadata enricher plugins are installed. Install one from the plugin settings to search for books."}
+                    </p>
+                  </div>
+                )}
 
               {searchMutation.isSuccess && results.length > 0 && (
                 <div className="space-y-2">

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -570,12 +570,19 @@ export interface PluginSearchError {
   plugin_scope: string;
   plugin_id: string;
   plugin_name: string;
-  error: string;
+  message: string;
+}
+
+export interface PluginSearchSkipped {
+  plugin_scope: string;
+  plugin_id: string;
+  plugin_name: string;
 }
 
 export interface PluginSearchResponse {
   results: PluginSearchResult[];
   errors?: PluginSearchError[];
+  skipped_plugins?: PluginSearchSkipped[];
 }
 
 export const usePluginSearch = () => {

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -566,8 +566,16 @@ export interface PluginSearchResult {
   confidence?: number;
 }
 
+export interface PluginSearchError {
+  plugin_scope: string;
+  plugin_id: string;
+  plugin_name: string;
+  error: string;
+}
+
 export interface PluginSearchResponse {
   results: PluginSearchResult[];
+  errors?: PluginSearchError[];
 }
 
 export const usePluginSearch = () => {

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1344,7 +1344,17 @@ type PluginSearchError struct {
 	PluginScope string `json:"plugin_scope"`
 	PluginID    string `json:"plugin_id"`
 	PluginName  string `json:"plugin_name"`
-	Error       string `json:"error"`
+	Message     string `json:"message"`
+}
+
+// PluginSearchSkipped reports an enricher that was skipped because it does
+// not declare support for the target file type. The frontend uses this to
+// distinguish "no plugins handle this file type" from "plugins ran and
+// returned nothing".
+type PluginSearchSkipped struct {
+	PluginScope string `json:"plugin_scope"`
+	PluginID    string `json:"plugin_id"`
+	PluginName  string `json:"plugin_name"`
 }
 
 // searchMetadata runs search() across all enricher plugins available for manual invocation
@@ -1452,10 +1462,12 @@ func (h *handler) searchMetadata(c echo.Context) error {
 	log := logger.FromContext(ctx)
 	var allResults []EnrichSearchResult
 	var pluginErrors []PluginSearchError
+	var skippedPlugins []PluginSearchSkipped
 	for _, rt := range runtimes {
+		manifest := rt.Manifest()
 		// Skip plugins that don't handle this file type
 		if fileType != "" {
-			enricherCap := rt.Manifest().Capabilities.MetadataEnricher
+			enricherCap := manifest.Capabilities.MetadataEnricher
 			if enricherCap == nil {
 				continue
 			}
@@ -1467,13 +1479,17 @@ func (h *handler) searchMetadata(c echo.Context) error {
 				}
 			}
 			if !handles {
+				skippedPlugins = append(skippedPlugins, PluginSearchSkipped{
+					PluginScope: rt.Scope(),
+					PluginID:    rt.PluginID(),
+					PluginName:  manifest.Name,
+				})
 				continue
 			}
 		}
 
 		resp, sErr := h.manager.RunMetadataSearch(ctx, rt, searchCtx)
 		if sErr != nil {
-			manifest := rt.Manifest()
 			log.Warn("enricher search failed", logger.Data{
 				"scope":  rt.Scope(),
 				"plugin": rt.PluginID(),
@@ -1483,7 +1499,7 @@ func (h *handler) searchMetadata(c echo.Context) error {
 				PluginScope: rt.Scope(),
 				PluginID:    rt.PluginID(),
 				PluginName:  manifest.Name,
-				Error:       sErr.Error(),
+				Message:     sErr.Error(),
 			})
 			continue
 		}
@@ -1493,7 +1509,6 @@ func (h *handler) searchMetadata(c echo.Context) error {
 
 		// Compute disabled fields for this plugin
 		var disabledFields []string
-		manifest := rt.Manifest()
 		if manifest.Capabilities.MetadataEnricher != nil {
 			declaredFields := manifest.Capabilities.MetadataEnricher.Fields
 			effectiveSettings, fErr := h.service.GetEffectiveFieldSettings(ctx, book.LibraryID, rt.Scope(), rt.PluginID(), declaredFields)
@@ -1517,8 +1532,9 @@ func (h *handler) searchMetadata(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
-		"results": allResults,
-		"errors":  pluginErrors,
+		"results":         allResults,
+		"errors":          pluginErrors,
+		"skipped_plugins": skippedPlugins,
 	})
 }
 

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1338,6 +1338,15 @@ type EnrichSearchResult struct {
 	DisabledFields []string `json:"disabled_fields,omitempty"`
 }
 
+// PluginSearchError reports a plugin whose search() hook failed so the
+// frontend can surface it to the user instead of silently dropping it.
+type PluginSearchError struct {
+	PluginScope string `json:"plugin_scope"`
+	PluginID    string `json:"plugin_id"`
+	PluginName  string `json:"plugin_name"`
+	Error       string `json:"error"`
+}
+
 // searchMetadata runs search() across all enricher plugins available for manual invocation
 // and returns aggregated results.
 func (h *handler) searchMetadata(c echo.Context) error {
@@ -1440,7 +1449,9 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		searchCtx["file"] = fileCtx
 	}
 
+	log := logger.FromContext(ctx)
 	var allResults []EnrichSearchResult
+	var pluginErrors []PluginSearchError
 	for _, rt := range runtimes {
 		// Skip plugins that don't handle this file type
 		if fileType != "" {
@@ -1462,7 +1473,19 @@ func (h *handler) searchMetadata(c echo.Context) error {
 
 		resp, sErr := h.manager.RunMetadataSearch(ctx, rt, searchCtx)
 		if sErr != nil {
-			continue // Skip failed plugins
+			manifest := rt.Manifest()
+			log.Warn("enricher search failed", logger.Data{
+				"scope":  rt.Scope(),
+				"plugin": rt.PluginID(),
+				"error":  sErr.Error(),
+			})
+			pluginErrors = append(pluginErrors, PluginSearchError{
+				PluginScope: rt.Scope(),
+				PluginID:    rt.PluginID(),
+				PluginName:  manifest.Name,
+				Error:       sErr.Error(),
+			})
+			continue
 		}
 		if resp == nil {
 			continue
@@ -1495,6 +1518,7 @@ func (h *handler) searchMetadata(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, map[string]interface{}{
 		"results": allResults,
+		"errors":  pluginErrors,
 	})
 }
 


### PR DESCRIPTION
## Summary
- Log a warning and collect per-plugin errors in `searchMetadata` instead of silently `continue`-ing when a plugin's `search()` hook fails.
- Add `errors` to the `/plugins/search` response payload (`PluginSearchError` with scope/id/name/error).
- Render failed plugins as a destructive-styled banner above the results list in the Identify Book dialog so users can see which plugin crashed.

## Test plan
- Install an enricher plugin whose `search()` throws; trigger Identify on a book and confirm the plugin's failure is shown in the dialog and logged on the server.
- Install a working enricher and confirm results still render normally with no error banner.
- Trigger Identify with both a working and a failing plugin enabled; confirm results render and the failing plugin appears in the error banner.
- Trigger Identify with only a failing plugin; confirm the error banner is shown instead of "No results found".