### PR TITLE
[Fix] Clean up stale book folder after root-level organize

### DIFF
--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -804,6 +804,17 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 			if err != nil {
 				return errors.WithStack(err)
 			}
+
+			// Write a fresh book sidecar at the renamed folder so the
+			// organized book is never left sidecar-less — the old-named
+			// sidecar was just deleted above.
+			if err := sidecar.WriteBookSidecarFromModel(book); err != nil {
+				log.Warn("failed to write book sidecar after folder rename", logger.Data{
+					"book_id": book.ID,
+					"path":    book.Filepath,
+					"error":   err.Error(),
+				})
+			}
 		}
 
 		// Rename files inside the folder (whether or not folder was renamed)
@@ -933,10 +944,9 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 			// folder is orphaned (contains only the stale sidecar) because
 			// OrganizeRootLevelFile computed the new folder from the current
 			// title and moved the media file + associated covers there.
-			//
-			// Mirrors the sidecar cleanup in the isDirectoryBased branch
-			// above. Write a fresh sidecar at the new folder so the organized
-			// book has a current sidecar with no gap.
+			// Then write a fresh sidecar at the new folder so the organized
+			// book is never left sidecar-less (same pattern as the
+			// isDirectoryBased branch above).
 			svc.cleanUpStaleRootLevelBookFolder(ctx, oldBookPath)
 			if err := sidecar.WriteBookSidecarFromModel(book); err != nil {
 				log.Warn("failed to write book sidecar after organize", logger.Data{

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/identifiers"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/sidecar"
 	"github.com/shishobooks/shisho/pkg/sortname"
 	"github.com/uptrace/bun"
 )
@@ -913,6 +914,7 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 
 		// Update book filepath to the new folder
 		if newBookPath != "" && newBookPath != book.Filepath {
+			oldBookPath := book.Filepath
 			book.Filepath = newBookPath
 			book.UpdatedAt = now
 
@@ -923,6 +925,25 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 				Exec(ctx)
 			if err != nil {
 				return errors.WithStack(err)
+			}
+
+			// Clean up the synthetic pre-organize folder that scan_unified.go
+			// created just to hold an early book sidecar. If an enricher
+			// changed book.Title between that sidecar write and now, the
+			// folder is orphaned (contains only the stale sidecar) because
+			// OrganizeRootLevelFile computed the new folder from the current
+			// title and moved the media file + associated covers there.
+			//
+			// Mirrors the sidecar cleanup in the isDirectoryBased branch
+			// above. Write a fresh sidecar at the new folder so the organized
+			// book has a current sidecar with no gap.
+			svc.cleanUpStaleRootLevelBookFolder(ctx, oldBookPath)
+			if err := sidecar.WriteBookSidecarFromModel(book); err != nil {
+				log.Warn("failed to write book sidecar after organize", logger.Data{
+					"book_id": book.ID,
+					"path":    book.Filepath,
+					"error":   err.Error(),
+				})
 			}
 		}
 	} else {
@@ -1000,6 +1021,45 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 	}
 
 	return nil
+}
+
+// cleanUpStaleRootLevelBookFolder removes the synthetic book folder that
+// scan_unified.go may have created to hold an early book sidecar. It's only
+// safe to call after root-level file organization has relocated the media
+// files (and any cover sidecars) to the new folder — at that point the old
+// folder should contain nothing but the stale book metadata.json.
+//
+// Missing directory or non-empty directory (e.g. user dropped extra files
+// in there) are both logged and tolerated: we only clean up what we know we
+// put there.
+func (svc *Service) cleanUpStaleRootLevelBookFolder(ctx context.Context, oldBookPath string) {
+	log := logger.FromContext(ctx)
+
+	if oldBookPath == "" {
+		return
+	}
+
+	info, err := os.Stat(oldBookPath)
+	if err != nil || !info.IsDir() {
+		return
+	}
+
+	staleSidecarPath := sidecar.BookSidecarPath(oldBookPath)
+	if staleSidecarPath != "" {
+		if err := os.Remove(staleSidecarPath); err != nil && !os.IsNotExist(err) {
+			log.Warn("failed to remove stale book sidecar", logger.Data{
+				"path":  staleSidecarPath,
+				"error": err.Error(),
+			})
+		}
+	}
+
+	if err := os.Remove(oldBookPath); err != nil && !os.IsNotExist(err) {
+		log.Warn("failed to remove stale book folder", logger.Data{
+			"path":  oldBookPath,
+			"error": err.Error(),
+		})
+	}
 }
 
 // CreateAuthor creates a book-author association.

--- a/pkg/books/service_organize_test.go
+++ b/pkg/books/service_organize_test.go
@@ -136,3 +136,187 @@ func TestOrganizeBookFiles_RootLevel_CleansUpStaleBookFolderAfterTitleChange(t *
 	require.NoError(t, err)
 	assert.Equal(t, newBookFolder, reloaded.Filepath)
 }
+
+// TestOrganizeBookFiles_RootLevel_PreservesUserFilesInStaleFolder pins the
+// "leave user data alone" contract: if the stale pre-organize folder happens
+// to contain files the user put there, organization must NOT delete them
+// along with the stale sidecar. The folder stays behind with the user files
+// intact.
+func TestOrganizeBookFiles_RootLevel_PreservesUserFilesInStaleFolder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	libDir := t.TempDir()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	libraryPath := &models.LibraryPath{LibraryID: library.ID, Filepath: libDir}
+	_, err = db.NewInsert().Model(libraryPath).Exec(ctx)
+	require.NoError(t, err)
+
+	oldBookFolder := filepath.Join(libDir, "[Test Author] Old Title")
+	require.NoError(t, os.MkdirAll(oldBookFolder, 0755))
+	require.NoError(t, sidecar.WriteBookSidecar(oldBookFolder, &sidecar.BookSidecar{Title: "Old Title"}))
+
+	// A file the user dropped into the (synthetic) book folder. Must survive.
+	userFile := filepath.Join(oldBookFolder, "notes.txt")
+	require.NoError(t, os.WriteFile(userFile, []byte("user notes"), 0644))
+
+	rootLevelFile := filepath.Join(libDir, "source.epub")
+	require.NoError(t, os.WriteFile(rootLevelFile, []byte("epub"), 0644))
+
+	person := &models.Person{
+		LibraryID: library.ID,
+		Name:      "Test Author",
+		SortName:  "Author, Test",
+	}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "New Title",
+		TitleSource:     models.DataSourcePlugin,
+		SortTitle:       "New Title",
+		SortTitleSource: models.DataSourcePlugin,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        oldBookFolder,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	author := &models.Author{BookID: book.ID, PersonID: person.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      rootLevelFile,
+		FilesizeBytes: 4,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	loadedBook, err := svc.RetrieveBook(ctx, RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.OrganizeBookFiles(ctx, loadedBook))
+
+	// Media file was still moved to the correct new folder.
+	newBookFolder := filepath.Join(libDir, "[Test Author] New Title")
+	assert.FileExists(t, filepath.Join(newBookFolder, "New Title.epub"))
+	assert.FileExists(t, sidecar.BookSidecarPath(newBookFolder))
+
+	// Stale sidecar was removed, but the user file and the folder itself
+	// survived because os.Remove refused to delete a non-empty directory.
+	assert.NoFileExists(t, sidecar.BookSidecarPath(oldBookFolder), "stale sidecar should be removed")
+	assert.FileExists(t, userFile, "user-dropped file must be preserved")
+	info, err := os.Stat(oldBookFolder)
+	require.NoError(t, err, "stale folder should still exist because it was non-empty")
+	assert.True(t, info.IsDir())
+}
+
+// TestOrganizeBookFiles_DirectoryBased_WritesFreshSidecarAfterFolderRename
+// asserts that when an enricher changes book.Title and organization renames
+// the book folder to match, a fresh book sidecar is written at the new
+// folder path. The directory-based branch previously deleted the old sidecar
+// (carried along by the folder rename under its old filename) without
+// re-seeding a new one, leaving the book sidecar-less until the next scan.
+func TestOrganizeBookFiles_DirectoryBased_WritesFreshSidecarAfterFolderRename(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	libDir := t.TempDir()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	// Directory-based book: files already live under book.Filepath.
+	oldBookFolder := filepath.Join(libDir, "[Test Author] Old Title")
+	require.NoError(t, os.MkdirAll(oldBookFolder, 0755))
+
+	// Old-title book sidecar (the pre-enricher state).
+	require.NoError(t, sidecar.WriteBookSidecar(oldBookFolder, &sidecar.BookSidecar{Title: "Old Title"}))
+
+	// The media file inside the book folder.
+	oldFilePath := filepath.Join(oldBookFolder, "Old Title.epub")
+	require.NoError(t, os.WriteFile(oldFilePath, []byte("epub"), 0644))
+
+	person := &models.Person{
+		LibraryID: library.ID,
+		Name:      "Test Author",
+		SortName:  "Author, Test",
+	}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "New Title",
+		TitleSource:     models.DataSourcePlugin,
+		SortTitle:       "New Title",
+		SortTitleSource: models.DataSourcePlugin,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        oldBookFolder,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	author := &models.Author{BookID: book.ID, PersonID: person.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      oldFilePath,
+		FilesizeBytes: 4,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	loadedBook, err := svc.RetrieveBook(ctx, RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.OrganizeBookFiles(ctx, loadedBook))
+
+	newBookFolder := filepath.Join(libDir, "[Test Author] New Title")
+	newFilePath := filepath.Join(newBookFolder, "New Title.epub")
+
+	assert.FileExists(t, newFilePath, "file should be renamed inside the renamed folder")
+	_, err = os.Stat(oldBookFolder)
+	assert.True(t, os.IsNotExist(err), "old folder should no longer exist after rename")
+
+	// The old-named sidecar that was carried along by the folder rename
+	// should be gone, and a fresh sidecar with the new folder name should
+	// exist so the book is never left sidecar-less.
+	oldNamedSidecarInNewFolder := filepath.Join(newBookFolder, "[Test Author] Old Title.metadata.json")
+	assert.NoFileExists(t, oldNamedSidecarInNewFolder, "stale-named sidecar should be removed")
+	assert.FileExists(t, sidecar.BookSidecarPath(newBookFolder), "fresh book sidecar should exist at new folder")
+
+	reloaded, err := svc.RetrieveBook(ctx, RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+	assert.Equal(t, newBookFolder, reloaded.Filepath)
+}

--- a/pkg/books/service_organize_test.go
+++ b/pkg/books/service_organize_test.go
@@ -1,0 +1,138 @@
+package books
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/sidecar"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOrganizeBookFiles_RootLevel_CleansUpStaleBookFolderAfterTitleChange
+// reproduces a bug where an enricher updates book.Title between initial
+// sidecar write and organization, leaving an orphaned folder containing
+// just the stale book sidecar next to the correctly organized folder.
+//
+// Sequence exercised:
+//  1. Scan creates book.Filepath from the original title ("Old Title") and
+//     writes a book sidecar inside that synthetic folder.
+//  2. Enricher updates book.Title to "New Title".
+//  3. Organization runs: it moves the root-level file into a new folder
+//     computed from the new title and updates book.Filepath.
+//
+// The test asserts that the stale folder from step (1) is cleaned up and a
+// fresh book sidecar lives at the new folder after organization.
+func TestOrganizeBookFiles_RootLevel_CleansUpStaleBookFolderAfterTitleChange(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	libDir := t.TempDir()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	libraryPath := &models.LibraryPath{
+		LibraryID: library.ID,
+		Filepath:  libDir,
+	}
+	_, err = db.NewInsert().Model(libraryPath).Exec(ctx)
+	require.NoError(t, err)
+
+	// The scan first derives an organized folder from the file's initial
+	// title "Old Title", creates that directory, and writes a book sidecar
+	// into it. Replicate that synthetic pre-organize state on disk.
+	oldBookFolder := filepath.Join(libDir, "[Test Author] Old Title")
+	require.NoError(t, os.MkdirAll(oldBookFolder, 0755))
+	staleSidecar := &sidecar.BookSidecar{Title: "Old Title"}
+	require.NoError(t, sidecar.WriteBookSidecar(oldBookFolder, staleSidecar))
+	staleSidecarPath := sidecar.BookSidecarPath(oldBookFolder)
+	require.FileExists(t, staleSidecarPath, "sanity: stale sidecar should exist before organize")
+
+	// The media file itself sits at the library root (pre-organization).
+	rootLevelFile := filepath.Join(libDir, "source.epub")
+	require.NoError(t, os.WriteFile(rootLevelFile, []byte("epub"), 0644))
+
+	// Set up the book in the DB with the post-enricher title but the
+	// pre-organize synthetic filepath, matching the state when
+	// organizeBookFiles is invoked by the monitor/scan job.
+	person := &models.Person{
+		LibraryID: library.ID,
+		Name:      "Test Author",
+		SortName:  "Author, Test",
+	}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "New Title",
+		TitleSource:     models.DataSourcePlugin,
+		SortTitle:       "New Title",
+		SortTitleSource: models.DataSourcePlugin,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        oldBookFolder,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	author := &models.Author{
+		BookID:    book.ID,
+		PersonID:  person.ID,
+		SortOrder: 1,
+	}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      rootLevelFile,
+		FilesizeBytes: 4,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Reload the book so Authors relation is populated the same way the
+	// production caller (monitor.organizeBooks) loads it.
+	loadedBook, err := svc.RetrieveBook(ctx, RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.OrganizeBookFiles(ctx, loadedBook))
+
+	newBookFolder := filepath.Join(libDir, "[Test Author] New Title")
+	newFilePath := filepath.Join(newBookFolder, "New Title.epub")
+
+	// File moved to the new organized folder.
+	assert.FileExists(t, newFilePath, "epub should be moved into new organized folder")
+	_, err = os.Stat(rootLevelFile)
+	assert.True(t, os.IsNotExist(err), "root-level file should no longer exist at original path")
+
+	// Fresh book sidecar exists at the new folder.
+	newSidecarPath := sidecar.BookSidecarPath(newBookFolder)
+	assert.FileExists(t, newSidecarPath, "new book sidecar should exist in organized folder")
+
+	// Old synthetic folder (and its stale sidecar) are cleaned up.
+	_, err = os.Stat(staleSidecarPath)
+	assert.True(t, os.IsNotExist(err), "stale book sidecar should be removed")
+	_, err = os.Stat(oldBookFolder)
+	assert.True(t, os.IsNotExist(err), "old synthetic book folder should be removed")
+
+	// DB book.Filepath reflects the new organized folder.
+	reloaded, err := svc.RetrieveBook(ctx, RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+	assert.Equal(t, newBookFolder, reloaded.Filepath)
+}


### PR DESCRIPTION
## Summary
- When a root-level file is scanned with `OrganizeFileStructure` enabled, the scan mkdirs a synthetic book folder from the initial title and writes an early book sidecar inside it. If an enricher then updates `book.Title` before organization runs, `OrganizeRootLevelFile` computes a new folder from the updated title and leaves the original folder orphaned, containing only the stale sidecar.
- Extend the existing sidecar-cleanup pattern from the directory-based branch to the root-level branch in `organizeBookFiles`: after the DB filepath update, remove the stale book sidecar + empty old folder, and write a fresh sidecar at the organized path so the book always has a current sidecar.
- Added `TestOrganizeBookFiles_RootLevel_CleansUpStaleBookFolderAfterTitleChange` to `pkg/books/service_organize_test.go` covering the scenario.

## Test plan
- `mise test` — new test passes, nothing else regresses.
- `mise check:quiet` — all project checks pass.
- Manually reproduce the original scenario: drop a root-level EPUB whose file metadata title differs from the enricher's resolved title into a library with `organize_file_structure` enabled, and confirm only one organized folder remains after processing.