### PR TITLE
[Fix] Avoid misleading skipped enricher message in identify dialog

### DIFF
--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -132,6 +132,7 @@ export function IdentifyBookDialog({
   const results = searchMutation.data?.results ?? [];
   const pluginErrors = searchMutation.data?.errors ?? [];
   const skippedPlugins = searchMutation.data?.skipped_plugins ?? [];
+  const totalPlugins = searchMutation.data?.total_plugins ?? 0;
   const selectedFileType = selectedFile?.file_type;
 
   // Detect plugin IDs that appear under multiple scopes
@@ -378,11 +379,17 @@ export function IdentifyBookDialog({
                 results.length === 0 &&
                 pluginErrors.length === 0 &&
                 (() => {
-                  const allSkippedForFileType =
-                    skippedPlugins.length > 0 && hasEnricherPlugins;
+                  const fileTypeLabel =
+                    selectedFileType?.toUpperCase() ?? "this file type";
                   const skippedNames = skippedPlugins
                     .map((p) => p.plugin_name || p.plugin_id)
                     .join(", ");
+                  const allSkippedForFileType =
+                    hasEnricherPlugins &&
+                    totalPlugins > 0 &&
+                    skippedPlugins.length >= totalPlugins;
+                  const partialSkip =
+                    skippedPlugins.length > 0 && !allSkippedForFileType;
                   return (
                     <div className="text-center py-12 text-muted-foreground space-y-2">
                       <p>No results found.</p>
@@ -390,9 +397,18 @@ export function IdentifyBookDialog({
                         {!hasEnricherPlugins
                           ? "No metadata enricher plugins are installed. Install one from the plugin settings to search for books."
                           : allSkippedForFileType
-                            ? `No installed enricher${skippedPlugins.length === 1 ? "" : "s"} support${skippedPlugins.length === 1 ? "s" : ""} ${selectedFileType?.toUpperCase() ?? "this file type"} files (${skippedNames}).`
+                            ? `No installed enricher${skippedPlugins.length === 1 ? "" : "s"} support${skippedPlugins.length === 1 ? "s" : ""} ${fileTypeLabel} files (${skippedNames}).`
                             : "Try a different search query."}
                       </p>
+                      {partialSkip && (
+                        <p className="text-xs">
+                          {skippedNames}{" "}
+                          {skippedPlugins.length === 1 ? "was" : "were"} skipped
+                          because {skippedPlugins.length === 1 ? "it" : "they"}{" "}
+                          {skippedPlugins.length === 1 ? "doesn't" : "don't"}{" "}
+                          support {fileTypeLabel} files.
+                        </p>
+                      )}
                     </div>
                   );
                 })()}

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -1,3 +1,4 @@
+import { computeIdentifyEmptyState } from "./identify-utils";
 import { IdentifyReviewForm } from "./IdentifyReviewForm";
 import { AlertTriangle, ExternalLink, Loader2, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -379,35 +380,18 @@ export function IdentifyBookDialog({
                 results.length === 0 &&
                 pluginErrors.length === 0 &&
                 (() => {
-                  const fileTypeLabel =
-                    selectedFileType?.toUpperCase() ?? "this file type";
-                  const skippedNames = skippedPlugins
-                    .map((p) => p.plugin_name || p.plugin_id)
-                    .join(", ");
-                  const allSkippedForFileType =
-                    hasEnricherPlugins &&
-                    totalPlugins > 0 &&
-                    skippedPlugins.length >= totalPlugins;
-                  const partialSkip =
-                    skippedPlugins.length > 0 && !allSkippedForFileType;
+                  const message = computeIdentifyEmptyState({
+                    hasEnricherPlugins,
+                    totalPlugins,
+                    skippedPlugins,
+                    fileType: selectedFileType,
+                  });
                   return (
                     <div className="text-center py-12 text-muted-foreground space-y-2">
                       <p>No results found.</p>
-                      <p className="text-xs">
-                        {!hasEnricherPlugins
-                          ? "No metadata enricher plugins are installed. Install one from the plugin settings to search for books."
-                          : allSkippedForFileType
-                            ? `No installed enricher${skippedPlugins.length === 1 ? "" : "s"} support${skippedPlugins.length === 1 ? "s" : ""} ${fileTypeLabel} files (${skippedNames}).`
-                            : "Try a different search query."}
-                      </p>
-                      {partialSkip && (
-                        <p className="text-xs">
-                          {skippedNames}{" "}
-                          {skippedPlugins.length === 1 ? "was" : "were"} skipped
-                          because {skippedPlugins.length === 1 ? "it" : "they"}{" "}
-                          {skippedPlugins.length === 1 ? "doesn't" : "don't"}{" "}
-                          support {fileTypeLabel} files.
-                        </p>
+                      <p className="text-xs">{message.primary}</p>
+                      {message.secondary && (
+                        <p className="text-xs">{message.secondary}</p>
                       )}
                     </div>
                   );

--- a/app/components/library/identify-utils.test.ts
+++ b/app/components/library/identify-utils.test.ts
@@ -1,0 +1,139 @@
+import {
+  computeIdentifyEmptyState,
+  resolveIdentifiers,
+} from "./identify-utils";
+import { describe, expect, it } from "vitest";
+
+describe("computeIdentifyEmptyState", () => {
+  const baseInput = {
+    hasEnricherPlugins: true,
+    totalPlugins: 0,
+    skippedPlugins: [],
+    fileType: "epub",
+  };
+
+  it("tells the user to install a plugin when none are installed", () => {
+    const result = computeIdentifyEmptyState({
+      ...baseInput,
+      hasEnricherPlugins: false,
+    });
+    expect(result.primary).toContain(
+      "No metadata enricher plugins are installed",
+    );
+    expect(result.secondary).toBeUndefined();
+  });
+
+  it("reports when plugins are installed but none are enabled for this library", () => {
+    const result = computeIdentifyEmptyState({
+      ...baseInput,
+      hasEnricherPlugins: true,
+      totalPlugins: 0,
+    });
+    expect(result.primary).toBe(
+      "No metadata enricher plugins are enabled for this library.",
+    );
+    expect(result.secondary).toBeUndefined();
+  });
+
+  it("reports all-skipped with singular wording for one plugin", () => {
+    const result = computeIdentifyEmptyState({
+      ...baseInput,
+      totalPlugins: 1,
+      skippedPlugins: [
+        { plugin_id: "audible", plugin_name: "Audible Enricher" },
+      ],
+    });
+    expect(result.primary).toBe(
+      "No installed enricher supports EPUB files (Audible Enricher).",
+    );
+    expect(result.secondary).toBeUndefined();
+  });
+
+  it("reports all-skipped with plural wording for multiple plugins", () => {
+    const result = computeIdentifyEmptyState({
+      ...baseInput,
+      totalPlugins: 2,
+      skippedPlugins: [
+        { plugin_id: "audible", plugin_name: "Audible Enricher" },
+        { plugin_id: "librivox", plugin_name: "LibriVox Enricher" },
+      ],
+    });
+    expect(result.primary).toBe(
+      "No installed enrichers support EPUB files (Audible Enricher, LibriVox Enricher).",
+    );
+  });
+
+  it("shows 'try a different query' with a secondary skip note on partial skip", () => {
+    const result = computeIdentifyEmptyState({
+      ...baseInput,
+      totalPlugins: 2,
+      skippedPlugins: [
+        { plugin_id: "audible", plugin_name: "Audible Enricher" },
+      ],
+    });
+    expect(result.primary).toBe("Try a different search query.");
+    expect(result.secondary).toBe(
+      "Audible Enricher was skipped because it doesn't support EPUB files.",
+    );
+  });
+
+  it("pluralizes the secondary skip note when multiple plugins were skipped", () => {
+    const result = computeIdentifyEmptyState({
+      ...baseInput,
+      totalPlugins: 3,
+      skippedPlugins: [
+        { plugin_id: "audible", plugin_name: "Audible Enricher" },
+        { plugin_id: "librivox", plugin_name: "LibriVox Enricher" },
+      ],
+    });
+    expect(result.primary).toBe("Try a different search query.");
+    expect(result.secondary).toBe(
+      "Audible Enricher, LibriVox Enricher were skipped because they don't support EPUB files.",
+    );
+  });
+
+  it("shows 'try a different query' with no secondary note when nothing was skipped", () => {
+    const result = computeIdentifyEmptyState({
+      ...baseInput,
+      totalPlugins: 2,
+      skippedPlugins: [],
+    });
+    expect(result.primary).toBe("Try a different search query.");
+    expect(result.secondary).toBeUndefined();
+  });
+
+  it("falls back to 'this file type' when fileType is undefined", () => {
+    const result = computeIdentifyEmptyState({
+      ...baseInput,
+      totalPlugins: 1,
+      fileType: undefined,
+      skippedPlugins: [
+        { plugin_id: "audible", plugin_name: "Audible Enricher" },
+      ],
+    });
+    expect(result.primary).toBe(
+      "No installed enricher supports this file type files (Audible Enricher).",
+    );
+  });
+
+  it("uses plugin_id as a fallback when plugin_name is missing", () => {
+    const result = computeIdentifyEmptyState({
+      ...baseInput,
+      totalPlugins: 1,
+      skippedPlugins: [{ plugin_id: "audible" }],
+    });
+    expect(result.primary).toBe(
+      "No installed enricher supports EPUB files (audible).",
+    );
+  });
+});
+
+describe("resolveIdentifiers", () => {
+  it("re-exports and works (smoke test)", () => {
+    const result = resolveIdentifiers(
+      [{ type: "goodreads", value: "1" }],
+      [{ type: "goodreads", value: "1" }],
+    );
+    expect(result.status).toBe("unchanged");
+  });
+});

--- a/app/components/library/identify-utils.ts
+++ b/app/components/library/identify-utils.ts
@@ -5,6 +5,66 @@ export interface IdentifierEntry {
   value: string;
 }
 
+export interface SkippedPlugin {
+  plugin_id: string;
+  plugin_name?: string;
+}
+
+export interface IdentifyEmptyStateInput {
+  hasEnricherPlugins: boolean;
+  totalPlugins: number;
+  skippedPlugins: SkippedPlugin[];
+  fileType: string | undefined;
+}
+
+export interface IdentifyEmptyStateMessage {
+  primary: string;
+  secondary?: string;
+}
+
+export function computeIdentifyEmptyState(
+  input: IdentifyEmptyStateInput,
+): IdentifyEmptyStateMessage {
+  const fileTypeLabel = input.fileType?.toUpperCase() ?? "this file type";
+  const skippedNames = input.skippedPlugins
+    .map((p) => p.plugin_name || p.plugin_id)
+    .join(", ");
+
+  if (!input.hasEnricherPlugins) {
+    return {
+      primary:
+        "No metadata enricher plugins are installed. Install one from the plugin settings to search for books.",
+    };
+  }
+
+  if (input.totalPlugins === 0) {
+    return {
+      primary: "No metadata enricher plugins are enabled for this library.",
+    };
+  }
+
+  const allSkipped = input.skippedPlugins.length >= input.totalPlugins;
+
+  if (allSkipped) {
+    const plural = input.skippedPlugins.length !== 1;
+    return {
+      primary: `No installed enricher${plural ? "s" : ""} support${plural ? "" : "s"} ${fileTypeLabel} files (${skippedNames}).`,
+    };
+  }
+
+  if (input.skippedPlugins.length > 0) {
+    const plural = input.skippedPlugins.length !== 1;
+    return {
+      primary: "Try a different search query.",
+      secondary: plural
+        ? `${skippedNames} were skipped because they don't support ${fileTypeLabel} files.`
+        : `${skippedNames} was skipped because it doesn't support ${fileTypeLabel} files.`,
+    };
+  }
+
+  return { primary: "Try a different search query." };
+}
+
 export function resolveIdentifiers(
   current: IdentifierEntry[],
   incoming: IdentifierEntry[],

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -583,6 +583,7 @@ export interface PluginSearchResponse {
   results: PluginSearchResult[];
   errors?: PluginSearchError[];
   skipped_plugins?: PluginSearchSkipped[];
+  total_plugins?: number;
 }
 
 export const usePluginSearch = () => {

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1357,6 +1357,18 @@ type PluginSearchSkipped struct {
 	PluginName  string `json:"plugin_name"`
 }
 
+// PluginSearchResponse is the HTTP response body for POST /plugins/search.
+// TotalPlugins is the number of candidate enricher runtimes considered for
+// this search (after library + mode filtering but before file-type skipping),
+// which lets the frontend distinguish "every enricher was skipped" from
+// "some enrichers ran and returned nothing".
+type PluginSearchResponse struct {
+	Results        []EnrichSearchResult  `json:"results"`
+	Errors         []PluginSearchError   `json:"errors,omitempty"`
+	SkippedPlugins []PluginSearchSkipped `json:"skipped_plugins,omitempty"`
+	TotalPlugins   int                   `json:"total_plugins"`
+}
+
 // searchMetadata runs search() across all enricher plugins available for manual invocation
 // and returns aggregated results.
 func (h *handler) searchMetadata(c echo.Context) error {
@@ -1403,9 +1415,9 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 	if len(runtimes) == 0 {
-		return c.JSON(http.StatusOK, map[string]interface{}{
-			"results":       []EnrichSearchResult{},
-			"total_plugins": 0,
+		return c.JSON(http.StatusOK, PluginSearchResponse{
+			Results:      []EnrichSearchResult{},
+			TotalPlugins: 0,
 		})
 	}
 
@@ -1532,11 +1544,11 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		}
 	}
 
-	return c.JSON(http.StatusOK, map[string]interface{}{
-		"results":         allResults,
-		"errors":          pluginErrors,
-		"skipped_plugins": skippedPlugins,
-		"total_plugins":   len(runtimes),
+	return c.JSON(http.StatusOK, PluginSearchResponse{
+		Results:        allResults,
+		Errors:         pluginErrors,
+		SkippedPlugins: skippedPlugins,
+		TotalPlugins:   len(runtimes),
 	})
 }
 

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1473,7 +1473,7 @@ func (h *handler) searchMetadata(c echo.Context) error {
 	}
 
 	log := logger.FromContext(ctx)
-	var allResults []EnrichSearchResult
+	allResults := make([]EnrichSearchResult, 0)
 	var pluginErrors []PluginSearchError
 	var skippedPlugins []PluginSearchSkipped
 	for _, rt := range runtimes {

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1404,7 +1404,8 @@ func (h *handler) searchMetadata(c echo.Context) error {
 	}
 	if len(runtimes) == 0 {
 		return c.JSON(http.StatusOK, map[string]interface{}{
-			"results": []EnrichSearchResult{},
+			"results":       []EnrichSearchResult{},
+			"total_plugins": 0,
 		})
 	}
 
@@ -1535,6 +1536,7 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		"results":         allResults,
 		"errors":          pluginErrors,
 		"skipped_plugins": skippedPlugins,
+		"total_plugins":   len(runtimes),
 	})
 }
 


### PR DESCRIPTION
## Summary
- Identify dialog was showing "No installed enricher supports EPUB files (Audible Enricher)" whenever any enricher was skipped for the file type, even if another enricher had run and just returned no results.
- Backend `/plugins/search` now returns `total_plugins` (count of candidate runtimes) so the frontend can tell "all enrichers skipped" apart from "partial skip".
- Frontend now only shows the "no enricher supports this file type" message when every candidate enricher was skipped, and surfaces a secondary note about partially skipped plugins otherwise.

## Test plan
- Install two metadata enricher plugins: one supporting EPUB and one that doesn't (e.g., Audible-only).
- Open the identify dialog on an EPUB book and search for a title with no matches.
- Confirm the empty state now reads "Try a different search query." with a secondary note that the non-EPUB enricher was skipped — not the old misleading "No installed enricher supports EPUB files" message.
- Open the identify dialog on a file type that no installed enricher supports (or disable/uninstall all EPUB-supporting enrichers) and confirm the "No installed enricher supports X files" message still appears.