### PR TITLE
[Frontend] Display series number prominently and polish detail page navigation

### DIFF
--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -310,7 +310,17 @@ const BookItem = ({
             />
           )}
         </div>
-        <div className="mt-2 group-hover:underline font-bold line-clamp-2">
+        <div
+          className={cn(
+            "mt-2 group-hover:underline text-sm font-bold line-clamp-2",
+            seriesNumber && "leading-[1.6]",
+          )}
+        >
+          {seriesNumber && (
+            <span className="inline-flex items-center justify-center align-text-top min-w-5 h-[18px] px-[5px] bg-primary text-primary-foreground rounded text-[11px] font-extrabold tabular-nums tracking-tight mr-1.5">
+              {seriesNumber}
+            </span>
+          )}
           {book.title}
         </div>
       </Link>
@@ -339,25 +349,18 @@ const BookItem = ({
           if (uniqueNames.length === 0) return null;
 
           return (
-            <div className="mt-1 text-sm line-clamp-2 text-neutral-500 dark:text-neutral-500">
+            <div className="mt-1 text-xs line-clamp-2 text-neutral-500 dark:text-neutral-500">
               {uniqueNames.join(", ")}
             </div>
           );
         })()}
       {book.files && (
-        <div className="mt-2 flex gap-2 text-sm">
+        <div className="mt-2 flex gap-2 text-xs">
           {uniqBy(book.files, "file_type").map((f) => (
             <Badge className="uppercase" key={f.id} variant="subtle">
               {f.file_type}
             </Badge>
           ))}
-        </div>
-      )}
-      {seriesNumber && (
-        <div className="mt-1">
-          <Badge className="text-xs" variant="outline">
-            #{seriesNumber}
-          </Badge>
         </div>
       )}
       {addedByUsername && (

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -25,6 +25,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useDeleteBook, useResyncBook } from "@/hooks/queries/books";
 import { type RescanMode } from "@/hooks/queries/resync";
 import { cn } from "@/libraries/utils";
@@ -310,19 +315,24 @@ const BookItem = ({
             />
           )}
         </div>
-        <div
-          className={cn(
-            "mt-2 group-hover:underline text-sm font-bold line-clamp-2",
-            seriesNumber && "leading-[1.6]",
-          )}
-        >
-          {seriesNumber && (
-            <span className="inline-flex items-center justify-center align-text-top min-w-5 h-[18px] px-[5px] bg-primary text-primary-foreground rounded text-[11px] font-extrabold tabular-nums tracking-tight mr-1.5">
-              {seriesNumber}
-            </span>
-          )}
-          {book.title}
-        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className={cn(
+                "mt-2 group-hover:underline text-sm font-bold line-clamp-2",
+                seriesNumber && "leading-[1.6]",
+              )}
+            >
+              {seriesNumber && (
+                <span className="inline-flex items-center justify-center align-text-top min-w-5 h-[18px] px-[5px] bg-primary text-primary-foreground rounded text-[11px] font-extrabold tabular-nums tracking-tight mr-1.5">
+                  {seriesNumber}
+                </span>
+              )}
+              {book.title}
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>{book.title}</TooltipContent>
+        </Tooltip>
       </Link>
       {book.authors &&
         book.authors.length > 0 &&
@@ -357,7 +367,7 @@ const BookItem = ({
       {book.files && (
         <div className="mt-2 flex gap-2 text-xs">
           {uniqBy(book.files, "file_type").map((f) => (
-            <Badge className="uppercase" key={f.id} variant="subtle">
+            <Badge className="text-xs uppercase" key={f.id} variant="secondary">
               {f.file_type}
             </Badge>
           ))}

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useDeleteBook, useResyncBook } from "@/hooks/queries/books";
 import { type RescanMode } from "@/hooks/queries/resync";
+import { useIsTruncated } from "@/hooks/useIsTruncated";
 import { cn } from "@/libraries/utils";
 import {
   AuthorRolePenciller,
@@ -142,6 +143,8 @@ const BookItem = ({
   onSelect,
   onShiftSelect,
 }: BookItemProps) => {
+  const [titleRef, isTitleTruncated] = useIsTruncated<HTMLDivElement>();
+
   // Find the series number for the specific series context (if provided)
   const seriesNumber = seriesId
     ? book.book_series?.find((bs) => bs.series_id === seriesId)?.series_number
@@ -315,13 +318,17 @@ const BookItem = ({
             />
           )}
         </div>
-        <Tooltip>
+        <Tooltip
+          delayDuration={300}
+          open={isTitleTruncated ? undefined : false}
+        >
           <TooltipTrigger asChild>
             <div
               className={cn(
                 "mt-2 group-hover:underline text-sm font-bold line-clamp-2",
                 seriesNumber && "leading-[1.6]",
               )}
+              ref={titleRef}
             >
               {seriesNumber && (
                 <span className="inline-flex items-center justify-center align-text-top min-w-5 h-[18px] px-[5px] bg-primary text-primary-foreground rounded text-[11px] font-extrabold tabular-nums tracking-tight mr-1.5">

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -188,7 +188,7 @@ function StatusBadge({ status }: { status: FieldStatus }) {
     );
   }
   return (
-    <Badge className="text-[0.65rem]" variant="subtle">
+    <Badge className="text-[0.65rem]" variant="outline">
       Unchanged
     </Badge>
   );

--- a/app/components/library/LibraryBreadcrumbs.tsx
+++ b/app/components/library/LibraryBreadcrumbs.tsx
@@ -1,0 +1,53 @@
+import { Fragment } from "react";
+import { Link } from "react-router-dom";
+
+interface BreadcrumbItem {
+  label: string;
+  to?: string;
+}
+
+interface LibraryBreadcrumbsProps {
+  libraryId: string;
+  libraryName?: string;
+  items: BreadcrumbItem[];
+}
+
+const LibraryBreadcrumbs = ({
+  libraryId,
+  libraryName,
+  items,
+}: LibraryBreadcrumbsProps) => (
+  <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
+    <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
+      <li className="shrink-0">
+        <Link
+          className="hover:text-foreground hover:underline"
+          to={`/libraries/${libraryId}`}
+        >
+          {libraryName || "Library"}
+        </Link>
+      </li>
+      {items.map((item, i) => (
+        <Fragment key={i}>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          {item.to ? (
+            <li className="shrink-0">
+              <Link
+                className="hover:text-foreground hover:underline"
+                to={item.to}
+              >
+                {item.label}
+              </Link>
+            </li>
+          ) : (
+            <li className="text-foreground truncate">{item.label}</li>
+          )}
+        </Fragment>
+      ))}
+    </ol>
+  </nav>
+);
+
+export default LibraryBreadcrumbs;

--- a/app/components/pages/AdminPlugins.tsx
+++ b/app/components/pages/AdminPlugins.tsx
@@ -394,7 +394,7 @@ const BrowseTab = () => {
                   )}
                   <Badge variant="secondary">{plugin.scope}</Badge>
                   {alreadyInstalled && (
-                    <Badge variant="subtle">Installed</Badge>
+                    <Badge variant="success">Installed</Badge>
                   )}
                   {!plugin.compatible && (
                     <Badge variant="destructive">Incompatible</Badge>

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1062,14 +1062,22 @@ const BookDetail = () => {
 
   return (
     <LibraryLayout>
-      <div className="mb-6">
-        <Button asChild variant="ghost">
-          <Link to={`/libraries/${libraryId}`}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Books
-          </Link>
-        </Button>
-      </div>
+      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
+        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}`}
+            >
+              {libraryQuery.data?.name || "Library"}
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="text-foreground truncate">{book.title}</li>
+        </ol>
+      </nav>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 md:gap-8">
         {/* Book Cover */}

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -30,6 +30,7 @@ import DownloadFormatPopover from "@/components/library/DownloadFormatPopover";
 import FileCoverThumbnail from "@/components/library/FileCoverThumbnail";
 import { FileEditDialog } from "@/components/library/FileEditDialog";
 import { IdentifyBookDialog } from "@/components/library/IdentifyBookDialog";
+import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MergeIntoDialog } from "@/components/library/MergeIntoDialog";
@@ -1062,22 +1063,11 @@ const BookDetail = () => {
 
   return (
     <LibraryLayout>
-      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
-        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}`}
-            >
-              {libraryQuery.data?.name || "Library"}
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="text-foreground truncate">{book.title}</li>
-        </ol>
-      </nav>
+      <LibraryBreadcrumbs
+        items={[{ label: book.title }]}
+        libraryId={libraryId!}
+        libraryName={libraryQuery.data?.name}
+      />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 md:gap-8">
         {/* Book Cover */}

--- a/app/components/pages/FileDetail.tsx
+++ b/app/components/pages/FileDetail.tsx
@@ -10,6 +10,7 @@ import FileChaptersTab, {
 import FileDetailsTab from "@/components/files/FileDetailsTab";
 import { DeleteConfirmationDialog } from "@/components/library/DeleteConfirmationDialog";
 import { FileEditDialog } from "@/components/library/FileEditDialog";
+import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { Button } from "@/components/ui/button";
@@ -188,34 +189,14 @@ const FileDetail = () => {
 
   return (
     <LibraryLayout>
-      {/* Breadcrumbs */}
-      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
-        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}`}
-            >
-              {library?.name || "Library"}
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="truncate max-w-[120px] sm:max-w-none">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}/books/${bookId}`}
-            >
-              {book.title}
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="text-foreground truncate">{filename}</li>
-        </ol>
-      </nav>
+      <LibraryBreadcrumbs
+        items={[
+          { label: book.title, to: `/libraries/${libraryId}/books/${bookId}` },
+          { label: filename },
+        ]}
+        libraryId={libraryId!}
+        libraryName={library?.name}
+      />
 
       {/* File title with Edit/Save/Cancel buttons */}
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-6">

--- a/app/components/pages/FileDetail.tsx
+++ b/app/components/pages/FileDetail.tsx
@@ -188,16 +188,6 @@ const FileDetail = () => {
 
   return (
     <LibraryLayout>
-      {/* Header with breadcrumbs and back button */}
-      <div className="mb-6">
-        <Button asChild variant="ghost">
-          <Link to={`/libraries/${libraryId}/books/${bookId}`}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Book
-          </Link>
-        </Button>
-      </div>
-
       {/* Breadcrumbs */}
       <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
         <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
+import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
@@ -110,33 +111,14 @@ const GenreDetail = () => {
 
   return (
     <LibraryLayout>
-      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
-        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}`}
-            >
-              {libraryQuery.data?.name || "Library"}
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}/genres`}
-            >
-              Genres
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="text-foreground truncate">{genre.name}</li>
-        </ol>
-      </nav>
+      <LibraryBreadcrumbs
+        items={[
+          { label: "Genres", to: `/libraries/${libraryId}/genres` },
+          { label: genre.name },
+        ]}
+        libraryId={libraryId!}
+        libraryName={libraryQuery.data?.name}
+      />
 
       {/* Genre Header */}
       <div className="mb-8">

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -18,6 +18,7 @@ import {
   useMergeGenre,
   useUpdateGenre,
 } from "@/hooks/queries/genres";
+import { useLibrary } from "@/hooks/queries/libraries";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
 
@@ -26,6 +27,7 @@ const GenreDetail = () => {
   const navigate = useNavigate();
   const genreId = id ? parseInt(id, 10) : undefined;
 
+  const libraryQuery = useLibrary(libraryId);
   const genreQuery = useGenre(genreId);
 
   usePageTitle(genreQuery.data?.name ?? "Genre");
@@ -108,6 +110,34 @@ const GenreDetail = () => {
 
   return (
     <LibraryLayout>
+      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
+        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}`}
+            >
+              {libraryQuery.data?.name || "Library"}
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}/genres`}
+            >
+              Genres
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="text-foreground truncate">{genre.name}</li>
+        </ol>
+      </nav>
+
       {/* Genre Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -2,6 +2,7 @@ import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
+import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
@@ -116,33 +117,14 @@ const ImprintDetail = () => {
 
   return (
     <LibraryLayout>
-      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
-        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}`}
-            >
-              {libraryQuery.data?.name || "Library"}
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}/imprints`}
-            >
-              Imprints
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="text-foreground truncate">{imprint.name}</li>
-        </ol>
-      </nav>
+      <LibraryBreadcrumbs
+        items={[
+          { label: "Imprints", to: `/libraries/${libraryId}/imprints` },
+          { label: imprint.name },
+        ]}
+        libraryId={libraryId!}
+        libraryName={libraryQuery.data?.name}
+      />
 
       {/* Imprint Header */}
       <div className="mb-8">

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -17,6 +17,7 @@ import {
   useMergeImprint,
   useUpdateImprint,
 } from "@/hooks/queries/imprints";
+import { useLibrary } from "@/hooks/queries/libraries";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { File } from "@/types";
@@ -26,6 +27,7 @@ const ImprintDetail = () => {
   const navigate = useNavigate();
   const imprintId = id ? parseInt(id, 10) : undefined;
 
+  const libraryQuery = useLibrary(libraryId);
   const imprintQuery = useImprint(imprintId);
 
   usePageTitle(imprintQuery.data?.name ?? "Imprint");
@@ -114,6 +116,34 @@ const ImprintDetail = () => {
 
   return (
     <LibraryLayout>
+      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
+        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}`}
+            >
+              {libraryQuery.data?.name || "Library"}
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}/imprints`}
+            >
+              Imprints
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="text-foreground truncate">{imprint.name}</li>
+        </ol>
+      </nav>
+
       {/* Imprint Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -10,6 +10,7 @@ import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
 import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useLibrary } from "@/hooks/queries/libraries";
 import {
   useDeletePerson,
   useMergePerson,
@@ -28,6 +29,7 @@ const PersonDetail = () => {
 
   const navigate = useNavigate();
 
+  const libraryQuery = useLibrary(libraryId);
   const personQuery = usePerson(personId);
 
   usePageTitle(personQuery.data?.name ?? "Person");
@@ -115,6 +117,34 @@ const PersonDetail = () => {
 
   return (
     <LibraryLayout>
+      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
+        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}`}
+            >
+              {libraryQuery.data?.name || "Library"}
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}/people`}
+            >
+              People
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="text-foreground truncate">{person.name}</li>
+        </ol>
+      </nav>
+
       {/* Person Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
+import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
@@ -117,33 +118,14 @@ const PersonDetail = () => {
 
   return (
     <LibraryLayout>
-      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
-        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}`}
-            >
-              {libraryQuery.data?.name || "Library"}
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}/people`}
-            >
-              People
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="text-foreground truncate">{person.name}</li>
-        </ol>
-      </nav>
+      <LibraryBreadcrumbs
+        items={[
+          { label: "People", to: `/libraries/${libraryId}/people` },
+          { label: person.name },
+        ]}
+        libraryId={libraryId!}
+        libraryName={libraryQuery.data?.name}
+      />
 
       {/* Person Header */}
       <div className="mb-8">

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -9,6 +9,7 @@ import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
 import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useLibrary } from "@/hooks/queries/libraries";
 import {
   useDeletePublisher,
   useMergePublisher,
@@ -26,6 +27,7 @@ const PublisherDetail = () => {
   const navigate = useNavigate();
   const publisherId = id ? parseInt(id, 10) : undefined;
 
+  const libraryQuery = useLibrary(libraryId);
   const publisherQuery = usePublisher(publisherId);
 
   usePageTitle(publisherQuery.data?.name ?? "Publisher");
@@ -114,6 +116,34 @@ const PublisherDetail = () => {
 
   return (
     <LibraryLayout>
+      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
+        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}`}
+            >
+              {libraryQuery.data?.name || "Library"}
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}/publishers`}
+            >
+              Publishers
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="text-foreground truncate">{publisher.name}</li>
+        </ol>
+      </nav>
+
       {/* Publisher Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -2,6 +2,7 @@ import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
+import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
@@ -116,33 +117,14 @@ const PublisherDetail = () => {
 
   return (
     <LibraryLayout>
-      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
-        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}`}
-            >
-              {libraryQuery.data?.name || "Library"}
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}/publishers`}
-            >
-              Publishers
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="text-foreground truncate">{publisher.name}</li>
-        </ol>
-      </nav>
+      <LibraryBreadcrumbs
+        items={[
+          { label: "Publishers", to: `/libraries/${libraryId}/publishers` },
+          { label: publisher.name },
+        ]}
+        libraryId={libraryId!}
+        libraryName={libraryQuery.data?.name}
+      />
 
       {/* Publisher Header */}
       <div className="mb-8">

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -10,6 +10,7 @@ import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
 import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useLibrary } from "@/hooks/queries/libraries";
 import {
   useDeleteSeries,
   useMergeSeries,
@@ -26,6 +27,7 @@ const SeriesDetail = () => {
   const navigate = useNavigate();
   const seriesId = id ? parseInt(id, 10) : undefined;
 
+  const libraryQuery = useLibrary(libraryId);
   const seriesQuery = useSeries(seriesId);
 
   usePageTitle(seriesQuery.data?.name ?? "Series");
@@ -111,6 +113,34 @@ const SeriesDetail = () => {
 
   return (
     <LibraryLayout>
+      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
+        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}`}
+            >
+              {libraryQuery.data?.name || "Library"}
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}/series`}
+            >
+              Series
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="text-foreground truncate">{series.name}</li>
+        </ol>
+      </nav>
+
       {/* Series Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -167,7 +167,12 @@ const SeriesDetail = () => {
           {seriesBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
               {seriesBooksQuery.data.map((book) => (
-                <BookItem book={book} key={book.id} libraryId={libraryId!} />
+                <BookItem
+                  book={book}
+                  key={book.id}
+                  libraryId={libraryId!}
+                  seriesId={seriesId}
+                />
               ))}
             </div>
           )}

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
+import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
@@ -113,33 +114,14 @@ const SeriesDetail = () => {
 
   return (
     <LibraryLayout>
-      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
-        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}`}
-            >
-              {libraryQuery.data?.name || "Library"}
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}/series`}
-            >
-              Series
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="text-foreground truncate">{series.name}</li>
-        </ol>
-      </nav>
+      <LibraryBreadcrumbs
+        items={[
+          { label: "Series", to: `/libraries/${libraryId}/series` },
+          { label: series.name },
+        ]}
+        libraryId={libraryId!}
+        libraryName={libraryQuery.data?.name}
+      />
 
       {/* Series Header */}
       <div className="mb-8">

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -6,6 +6,11 @@ import Gallery from "@/components/library/Gallery";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import { SearchInput } from "@/components/library/SearchInput";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useLibrary } from "@/hooks/queries/libraries";
 import { useSeriesList } from "@/hooks/queries/series";
 import { usePageTitle } from "@/hooks/usePageTitle";
@@ -88,11 +93,16 @@ const SeriesCard = ({
             />
           )}
         </div>
-        <div className="mt-2 group-hover:underline font-bold line-clamp-2">
-          {seriesItem.name}
-        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="mt-2 group-hover:underline text-sm font-bold line-clamp-2">
+              {seriesItem.name}
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>{seriesItem.name}</TooltipContent>
+        </Tooltip>
       </Link>
-      <div className="mt-1 text-sm line-clamp-1 text-neutral-500 dark:text-neutral-500">
+      <div className="mt-1 text-xs line-clamp-1 text-neutral-500 dark:text-neutral-500">
         <Badge className="text-xs" variant="secondary">
           {bookCount} book{bookCount !== 1 ? "s" : ""}
         </Badge>

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useLibrary } from "@/hooks/queries/libraries";
 import { useSeriesList } from "@/hooks/queries/series";
+import { useIsTruncated } from "@/hooks/useIsTruncated";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { cn } from "@/libraries/utils";
 import type { Series } from "@/types";
@@ -48,6 +49,7 @@ const SeriesCard = ({
   aspectClass,
   isAudiobook,
 }: SeriesCardProps) => {
+  const [titleRef, isTitleTruncated] = useIsTruncated<HTMLDivElement>();
   const coverUrl = `/api/series/${seriesItem.id}/cover?t=${new Date(seriesItem.updated_at).getTime()}`;
   const [coverLoaded, setCoverLoaded] = useState(() => isCoverLoaded(coverUrl));
   const [coverError, setCoverError] = useState(false);
@@ -93,9 +95,15 @@ const SeriesCard = ({
             />
           )}
         </div>
-        <Tooltip>
+        <Tooltip
+          delayDuration={300}
+          open={isTitleTruncated ? undefined : false}
+        >
           <TooltipTrigger asChild>
-            <div className="mt-2 group-hover:underline text-sm font-bold line-clamp-2">
+            <div
+              className="mt-2 group-hover:underline text-sm font-bold line-clamp-2"
+              ref={titleRef}
+            >
               {seriesItem.name}
             </div>
           </TooltipTrigger>

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -10,6 +10,7 @@ import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
 import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useLibrary } from "@/hooks/queries/libraries";
 import {
   useDeleteTag,
   useMergeTag,
@@ -26,6 +27,7 @@ const TagDetail = () => {
   const navigate = useNavigate();
   const tagId = id ? parseInt(id, 10) : undefined;
 
+  const libraryQuery = useLibrary(libraryId);
   const tagQuery = useTag(tagId);
 
   usePageTitle(tagQuery.data?.name ?? "Tag");
@@ -108,6 +110,34 @@ const TagDetail = () => {
 
   return (
     <LibraryLayout>
+      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
+        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}`}
+            >
+              {libraryQuery.data?.name || "Library"}
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="shrink-0">
+            <Link
+              className="hover:text-foreground hover:underline"
+              to={`/libraries/${libraryId}/tags`}
+            >
+              Tags
+            </Link>
+          </li>
+          <li aria-hidden="true" className="shrink-0">
+            ›
+          </li>
+          <li className="text-foreground truncate">{tag.name}</li>
+        </ol>
+      </nav>
+
       {/* Tag Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
+import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
@@ -110,33 +111,14 @@ const TagDetail = () => {
 
   return (
     <LibraryLayout>
-      <nav className="mb-4 text-xs sm:text-sm text-muted-foreground overflow-hidden">
-        <ol className="flex items-center gap-1 sm:gap-2 flex-wrap">
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}`}
-            >
-              {libraryQuery.data?.name || "Library"}
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="shrink-0">
-            <Link
-              className="hover:text-foreground hover:underline"
-              to={`/libraries/${libraryId}/tags`}
-            >
-              Tags
-            </Link>
-          </li>
-          <li aria-hidden="true" className="shrink-0">
-            ›
-          </li>
-          <li className="text-foreground truncate">{tag.name}</li>
-        </ol>
-      </nav>
+      <LibraryBreadcrumbs
+        items={[
+          { label: "Tags", to: `/libraries/${libraryId}/tags` },
+          { label: tag.name },
+        ]}
+        libraryId={libraryId!}
+        libraryName={libraryQuery.data?.name}
+      />
 
       {/* Tag Header */}
       <div className="mb-8">

--- a/app/components/ui/badge.tsx
+++ b/app/components/ui/badge.tsx
@@ -13,8 +13,8 @@ const badgeVariants = cva(
           "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
-        subtle:
-          "border-transparent dark:bg-neutral-700 dark:text-neutral-400 dark:[a&]:hover:bg-neutral-700/90 bg-neutral-200 text-neutral-500",
+        success:
+          "border-transparent bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400",
         destructive:
           "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:

--- a/app/components/ui/tooltip.tsx
+++ b/app/components/ui/tooltip.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/libraries/utils";
 
 function TooltipProvider({
-  delayDuration = 0,
+  delayDuration = 300,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (

--- a/app/components/ui/tooltip.tsx
+++ b/app/components/ui/tooltip.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/libraries/utils";
 
 function TooltipProvider({
-  delayDuration = 300,
+  delayDuration = 0,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (

--- a/app/hooks/useIsTruncated.ts
+++ b/app/hooks/useIsTruncated.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef, useState } from "react";
+
+export function useIsTruncated<T extends HTMLElement>(): [
+  React.RefObject<T | null>,
+  boolean,
+] {
+  const ref = useRef<T | null>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const check = () => {
+      setIsTruncated(el.scrollHeight > el.clientHeight);
+    };
+
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, isTruncated];
+}

--- a/app/index.css
+++ b/app/index.css
@@ -29,7 +29,7 @@
   --popover-foreground: oklch(0.145 0 0);
   --primary: oklch(0.55 0.2 280);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
+  --secondary: oklch(0.94 0 0);
   --secondary-foreground: oklch(0.145 0 0);
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);


### PR DESCRIPTION
## Summary
- Display book series number as an inline purple plate badge in the title line of BookItem when viewing a series (fixes dead code where SeriesDetail never passed seriesId)
- Replace back buttons with breadcrumbs on all detail pages (Book, Series, Person, Genre, Tag, Imprint, Publisher) and remove redundant back button from FileDetail
- Add title tooltips to BookItem and SeriesCard, consolidate badge variants (add `success`, remove `subtle`), darken light-mode `--secondary` token, match text sizes between BookItem and SeriesCard, and add 300ms tooltip delay

## Test plan
- Navigate to a series detail page and verify books show their series number as a purple inline plate before the title
- Verify breadcrumbs appear on all detail pages (Book, Series, Person, Genre, Tag, Imprint, Publisher) with correct links
- Verify FileDetail still has its existing breadcrumbs and no duplicate back button
- Hover over book/series titles to verify tooltip appears after a short delay
- Check AdminPlugins page shows green "Installed" badge
- Verify light-mode secondary badge background is slightly darker than before
- Test cmd+click on breadcrumb links opens in new tab