### PR TITLE
[Fix] Prefer existing cover in identify dialog when plugin cover is lower resolution

### DIFF
--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -604,18 +604,18 @@ export function IdentifyReviewForm({
   const currentCoverDims = useImageDimensions(currentCoverUrl);
   const newCoverDims = useImageDimensions(newCoverUrl);
 
-  // When both cover dimensions are loaded and match exactly, default to keeping current
-  const coverDimsMatch =
+  // Prefer keeping the current cover when it's at least as high-resolution
+  // as the plugin cover (by pixel count) — avoids unnecessary writes/churn.
+  const preferCurrentCover =
     !!currentCoverDims &&
     !!newCoverDims &&
-    currentCoverDims.w === newCoverDims.w &&
-    currentCoverDims.h === newCoverDims.h;
+    currentCoverDims.w * currentCoverDims.h >= newCoverDims.w * newCoverDims.h;
   const [coverUserTouched, setCoverUserTouched] = useState(false);
   useEffect(() => {
-    if (coverDimsMatch && !coverUserTouched) {
+    if (preferCurrentCover && !coverUserTouched) {
       setCoverSelection("current");
     }
-  }, [coverDimsMatch, coverUserTouched]);
+  }, [preferCurrentCover, coverUserTouched]);
 
   // ---- Unsaved changes tracking ----
   const hasChanges = useMemo(() => {
@@ -637,7 +637,7 @@ export function IdentifyReviewForm({
       abridged !== defaults.abridged.value ||
       !equal(identifiers, defaults.identifiers.value) ||
       coverSelection !==
-        (newCoverUrl && !disabledFields.has("cover") && !coverDimsMatch
+        (newCoverUrl && !disabledFields.has("cover") && !preferCurrentCover
           ? "new"
           : "current")
     );
@@ -662,7 +662,7 @@ export function IdentifyReviewForm({
     defaults,
     newCoverUrl,
     disabledFields,
-    coverDimsMatch,
+    preferCurrentCover,
   ]);
 
   useEffect(() => {
@@ -745,7 +745,7 @@ export function IdentifyReviewForm({
             <Label>{formatMetadataFieldLabel("cover")}</Label>
             <StatusBadge
               status={
-                isDisabled("cover") || coverDimsMatch
+                isDisabled("cover") || preferCurrentCover
                   ? "unchanged"
                   : currentCoverUrl
                     ? "changed"


### PR DESCRIPTION
## Summary
- The identify review form previously only defaulted to keeping the current cover when plugin and existing covers had identical dimensions
- Now uses pixel-count comparison (`w*h`) so the current cover is also preferred when it's higher resolution than the plugin cover
- Matches the scan-time enricher cover upgrade behavior in `scan_unified.go` which already uses `<=` (enricher must be strictly larger)

## Test plan
- Open identify dialog for a book that already has a high-res cover
- Select a search result that has a lower-resolution cover image
- Verify the cover selector defaults to "current" (not "new")
- Select a result with a higher-resolution cover and verify it defaults to "new"
- Manually toggle the cover selection to confirm user override still works