### PR TITLE
[Frontend] Collapse library filters into a single sheet/drawer button

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -938,6 +938,28 @@ When using raw `<button>` elements outside of the Button component, always add `
 - Missing cursor-pointer feels broken/unresponsive
 - Consistency across the UI is essential for professional UX
 
+### Dynamic Class Composition with `cn()`
+
+**Always use `cn()` from `@/libraries/utils` for dynamic className composition.** Never use template literals to concatenate class strings.
+
+```tsx
+// Good - cn()
+<span className={cn("inline-flex h-5 w-5 rounded-sm", colorClass)}>
+
+// Good - cn() with conditionals
+<button className={cn(
+  "h-8 rounded-md border px-3 text-xs cursor-pointer",
+  isSelected
+    ? "border-primary bg-primary text-primary-foreground"
+    : "border-border bg-card hover:bg-accent",
+)}>
+
+// Bad - template literal
+<span className={`inline-flex h-5 w-5 rounded-sm ${colorClass}`}>
+```
+
+`cn()` wraps `clsx` + `tailwind-merge`, so it handles conditional classes, deduplication, and Tailwind conflict resolution. Template literals bypass all of that.
+
 ## Known Radix UI Issues
 
 ### Dialog + DropdownMenu pointer-events Bug

--- a/app/components/library/ActiveFilterChips.tsx
+++ b/app/components/library/ActiveFilterChips.tsx
@@ -11,7 +11,10 @@ interface FilterTypeConfig {
   colorClass: string;
 }
 
-const FILTER_TYPES: Record<string, FilterTypeConfig> = {
+const FILTER_TYPES: Record<
+  "fileType" | "genre" | "tag" | "language",
+  FilterTypeConfig
+> = {
   fileType: {
     icon: <File className="h-3 w-3 shrink-0" />,
     colorClass: "text-chart-5",

--- a/app/components/library/ActiveFilterChips.tsx
+++ b/app/components/library/ActiveFilterChips.tsx
@@ -2,15 +2,9 @@ import { Bookmark, File, Languages, Tags, X } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Badge } from "@/components/ui/badge";
+import { FILE_TYPE_OPTIONS } from "@/constants/fileTypes";
 import { getLanguageName } from "@/constants/languages";
 import type { Genre, Tag } from "@/types";
-
-const FILE_TYPE_LABELS: Record<string, string> = {
-  epub: "EPUB",
-  m4b: "M4B",
-  cbz: "CBZ",
-  pdf: "PDF",
-};
 
 interface FilterTypeConfig {
   icon: ReactNode;
@@ -37,6 +31,7 @@ const FILTER_TYPES: Record<string, FilterTypeConfig> = {
 };
 
 interface ActiveFilterChipsProps {
+  hasActiveFilters: boolean;
   selectedFileTypes: string[];
   selectedGenres: Genre[];
   selectedTags: Tag[];
@@ -49,6 +44,7 @@ interface ActiveFilterChipsProps {
 }
 
 export const ActiveFilterChips = ({
+  hasActiveFilters,
   selectedFileTypes,
   selectedGenres,
   selectedTags,
@@ -59,13 +55,7 @@ export const ActiveFilterChips = ({
   onClearLanguage,
   onClearAll,
 }: ActiveFilterChipsProps) => {
-  const hasFilters =
-    selectedFileTypes.length > 0 ||
-    selectedGenres.length > 0 ||
-    selectedTags.length > 0 ||
-    Boolean(languageParam);
-
-  if (!hasFilters) return null;
+  if (!hasActiveFilters) return null;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -80,7 +70,8 @@ export const ActiveFilterChips = ({
           <span className={FILTER_TYPES.fileType.colorClass}>
             {FILTER_TYPES.fileType.icon}
           </span>
-          {FILE_TYPE_LABELS[fileType] ?? fileType}
+          {FILE_TYPE_OPTIONS.find((o) => o.value === fileType)?.label ??
+            fileType}
           <X className="h-3 w-3 text-muted-foreground" />
         </Badge>
       ))}

--- a/app/components/library/ActiveFilterChips.tsx
+++ b/app/components/library/ActiveFilterChips.tsx
@@ -1,0 +1,136 @@
+import { Bookmark, File, Languages, Tags, X } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { getLanguageName } from "@/constants/languages";
+import type { Genre, Tag } from "@/types";
+
+const FILE_TYPE_LABELS: Record<string, string> = {
+  epub: "EPUB",
+  m4b: "M4B",
+  cbz: "CBZ",
+  pdf: "PDF",
+};
+
+interface FilterTypeConfig {
+  icon: ReactNode;
+  colorClass: string;
+}
+
+const FILTER_TYPES: Record<string, FilterTypeConfig> = {
+  fileType: {
+    icon: <File className="h-3 w-3 shrink-0" />,
+    colorClass: "text-chart-5",
+  },
+  genre: {
+    icon: <Bookmark className="h-3 w-3 shrink-0" />,
+    colorClass: "text-primary",
+  },
+  tag: {
+    icon: <Tags className="h-3 w-3 shrink-0" />,
+    colorClass: "text-chart-2",
+  },
+  language: {
+    icon: <Languages className="h-3 w-3 shrink-0" />,
+    colorClass: "text-chart-5",
+  },
+};
+
+interface ActiveFilterChipsProps {
+  selectedFileTypes: string[];
+  selectedGenres: Genre[];
+  selectedTags: Tag[];
+  languageParam: string;
+  onToggleFileType: (fileType: string) => void;
+  onToggleGenre: (genreId: number) => void;
+  onToggleTag: (tagId: number) => void;
+  onClearLanguage: () => void;
+  onClearAll: () => void;
+}
+
+export const ActiveFilterChips = ({
+  selectedFileTypes,
+  selectedGenres,
+  selectedTags,
+  languageParam,
+  onToggleFileType,
+  onToggleGenre,
+  onToggleTag,
+  onClearLanguage,
+  onClearAll,
+}: ActiveFilterChipsProps) => {
+  const hasFilters =
+    selectedFileTypes.length > 0 ||
+    selectedGenres.length > 0 ||
+    selectedTags.length > 0 ||
+    Boolean(languageParam);
+
+  if (!hasFilters) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="text-xs text-muted-foreground">Filtering by</span>
+      {selectedFileTypes.map((fileType) => (
+        <Badge
+          className="cursor-pointer gap-1.5"
+          key={fileType}
+          onClick={() => onToggleFileType(fileType)}
+          variant="secondary"
+        >
+          <span className={FILTER_TYPES.fileType.colorClass}>
+            {FILTER_TYPES.fileType.icon}
+          </span>
+          {FILE_TYPE_LABELS[fileType] ?? fileType}
+          <X className="h-3 w-3 text-muted-foreground" />
+        </Badge>
+      ))}
+      {selectedGenres.map((genre) => (
+        <Badge
+          className="cursor-pointer gap-1.5"
+          key={genre.id}
+          onClick={() => onToggleGenre(genre.id)}
+          variant="secondary"
+        >
+          <span className={FILTER_TYPES.genre.colorClass}>
+            {FILTER_TYPES.genre.icon}
+          </span>
+          {genre.name}
+          <X className="h-3 w-3 text-muted-foreground" />
+        </Badge>
+      ))}
+      {selectedTags.map((tag) => (
+        <Badge
+          className="cursor-pointer gap-1.5"
+          key={tag.id}
+          onClick={() => onToggleTag(tag.id)}
+          variant="secondary"
+        >
+          <span className={FILTER_TYPES.tag.colorClass}>
+            {FILTER_TYPES.tag.icon}
+          </span>
+          {tag.name}
+          <X className="h-3 w-3 text-muted-foreground" />
+        </Badge>
+      ))}
+      {languageParam && (
+        <Badge
+          className="cursor-pointer gap-1.5"
+          onClick={onClearLanguage}
+          variant="secondary"
+        >
+          <span className={FILTER_TYPES.language.colorClass}>
+            {FILTER_TYPES.language.icon}
+          </span>
+          {getLanguageName(languageParam) ?? languageParam}
+          <X className="h-3 w-3 text-muted-foreground" />
+        </Badge>
+      )}
+      <button
+        className="text-xs text-muted-foreground underline-offset-2 hover:underline hover:text-foreground ml-1 cursor-pointer"
+        onClick={onClearAll}
+      >
+        clear all
+      </button>
+    </div>
+  );
+};

--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -122,27 +122,27 @@ const FilterContent = ({
     {/* File Type */}
     <div>
       <SectionHeader
-        icon={<File className="h-3 w-3" />}
         colorClass="bg-chart-5/20 text-chart-5"
-        label="File type"
         detail={
           selectedFileTypes.length > 0
             ? `${selectedFileTypes.length} of ${fileTypeOptions.length}`
             : undefined
         }
+        icon={<File className="h-3 w-3" />}
+        label="File type"
       />
       <div className="flex flex-wrap gap-1.5">
         {fileTypeOptions.map((option) => {
           const isSelected = selectedFileTypes.includes(option.value);
           return (
             <button
-              key={option.value}
-              onClick={() => onToggleFileType(option.value)}
               className={`inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium cursor-pointer transition-colors ${
                 isSelected
                   ? "border-primary bg-primary text-primary-foreground"
                   : "border-border bg-card hover:bg-accent"
               }`}
+              key={option.value}
+              onClick={() => onToggleFileType(option.value)}
             >
               {option.label}
             </button>
@@ -154,14 +154,14 @@ const FilterContent = ({
     {/* Genres */}
     <div>
       <SectionHeader
-        icon={<Bookmark className="h-3 w-3" />}
         colorClass="bg-primary/20 text-primary"
-        label="Genres"
         detail={
           selectedGenreIds.length > 0
             ? `${selectedGenreIds.length} selected`
             : undefined
         }
+        icon={<Bookmark className="h-3 w-3" />}
+        label="Genres"
       />
       <Command shouldFilter={false}>
         <CommandInput
@@ -208,14 +208,14 @@ const FilterContent = ({
     {/* Tags */}
     <div>
       <SectionHeader
-        icon={<Tags className="h-3 w-3" />}
         colorClass="bg-chart-2/20 text-chart-2"
-        label="Tags"
         detail={
           selectedTagIds.length > 0
             ? `${selectedTagIds.length} selected`
             : undefined
         }
+        icon={<Tags className="h-3 w-3" />}
+        label="Tags"
       />
       <Command shouldFilter={false}>
         <CommandInput
@@ -263,8 +263,8 @@ const FilterContent = ({
     {languageOptions.length > 0 && (
       <div>
         <SectionHeader
-          icon={<Languages className="h-3 w-3" />}
           colorClass="bg-chart-5/20 text-chart-5"
+          icon={<Languages className="h-3 w-3" />}
           label="Language"
         />
         <Select onValueChange={onLanguageChange} value={languageParam || "all"}>

--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -1,0 +1,376 @@
+import {
+  Bookmark,
+  File,
+  Languages,
+  ListFilter,
+  Square,
+  SquareCheckBig,
+  Tags,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import type { Genre, Tag } from "@/types";
+
+interface FilterSheetProps {
+  selectedFileTypes: string[];
+  fileTypeOptions: { value: string; label: string }[];
+  onToggleFileType: (fileType: string) => void;
+  selectedGenreIds: number[];
+  genres: Genre[];
+  genresLoading: boolean;
+  genresError: boolean;
+  genreSearchInput: string;
+  onGenreSearchChange: (value: string) => void;
+  onToggleGenre: (genreId: number) => void;
+  selectedTagIds: number[];
+  tags: Tag[];
+  tagsLoading: boolean;
+  tagsError: boolean;
+  tagSearchInput: string;
+  onTagSearchChange: (value: string) => void;
+  onToggleTag: (tagId: number) => void;
+  languageParam: string;
+  languageOptions: { value: string; label: string }[];
+  onLanguageChange: (value: string) => void;
+  onClearAll: () => void;
+  hasActiveFilters: boolean;
+}
+
+const SectionHeader = ({
+  icon,
+  colorClass,
+  label,
+  detail,
+}: {
+  icon: React.ReactNode;
+  colorClass: string;
+  label: string;
+  detail?: string;
+}) => (
+  <div className="flex items-center gap-2 mb-3">
+    <span
+      className={`inline-flex h-5 w-5 items-center justify-center rounded-sm ${colorClass}`}
+    >
+      {icon}
+    </span>
+    <div className="text-xs font-semibold">{label}</div>
+    {detail && (
+      <span className="ml-auto text-[10px] text-muted-foreground">
+        {detail}
+      </span>
+    )}
+  </div>
+);
+
+const FilterContent = ({
+  selectedFileTypes,
+  fileTypeOptions,
+  onToggleFileType,
+  selectedGenreIds,
+  genres,
+  genresLoading,
+  genresError,
+  genreSearchInput,
+  onGenreSearchChange,
+  onToggleGenre,
+  selectedTagIds,
+  tags,
+  tagsLoading,
+  tagsError,
+  tagSearchInput,
+  onTagSearchChange,
+  onToggleTag,
+  languageParam,
+  languageOptions,
+  onLanguageChange,
+}: Omit<FilterSheetProps, "onClearAll" | "hasActiveFilters">) => (
+  <div className="space-y-6">
+    {/* File Type */}
+    <div>
+      <SectionHeader
+        icon={<File className="h-3 w-3" />}
+        colorClass="bg-chart-5/20 text-chart-5"
+        label="File type"
+        detail={
+          selectedFileTypes.length > 0
+            ? `${selectedFileTypes.length} of ${fileTypeOptions.length}`
+            : undefined
+        }
+      />
+      <div className="flex flex-wrap gap-1.5">
+        {fileTypeOptions.map((option) => {
+          const isSelected = selectedFileTypes.includes(option.value);
+          return (
+            <button
+              key={option.value}
+              onClick={() => onToggleFileType(option.value)}
+              className={`inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium cursor-pointer transition-colors ${
+                isSelected
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-card hover:bg-accent"
+              }`}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+
+    {/* Genres */}
+    <div>
+      <SectionHeader
+        icon={<Bookmark className="h-3 w-3" />}
+        colorClass="bg-primary/20 text-primary"
+        label="Genres"
+        detail={
+          selectedGenreIds.length > 0
+            ? `${selectedGenreIds.length} selected`
+            : undefined
+        }
+      />
+      <Command shouldFilter={false}>
+        <CommandInput
+          onValueChange={onGenreSearchChange}
+          placeholder="Search genres..."
+          value={genreSearchInput}
+        />
+        <CommandList>
+          {genresLoading ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              Loading...
+            </div>
+          ) : genresError ? (
+            <div className="py-6 text-center text-sm text-destructive">
+              Error loading genres
+            </div>
+          ) : genres.length === 0 ? (
+            <CommandEmpty>No genres found.</CommandEmpty>
+          ) : (
+            <CommandGroup>
+              {genres.map((genre: Genre) => (
+                <CommandItem
+                  key={genre.id}
+                  onSelect={() => onToggleGenre(genre.id)}
+                  value={genre.name}
+                >
+                  {selectedGenreIds.includes(genre.id) ? (
+                    <SquareCheckBig className="mr-2 h-4 w-4" />
+                  ) : (
+                    <Square className="mr-2 h-4 w-4" />
+                  )}
+                  {genre.name}
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {genre.book_count}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    </div>
+
+    {/* Tags */}
+    <div>
+      <SectionHeader
+        icon={<Tags className="h-3 w-3" />}
+        colorClass="bg-chart-2/20 text-chart-2"
+        label="Tags"
+        detail={
+          selectedTagIds.length > 0
+            ? `${selectedTagIds.length} selected`
+            : undefined
+        }
+      />
+      <Command shouldFilter={false}>
+        <CommandInput
+          onValueChange={onTagSearchChange}
+          placeholder="Search tags..."
+          value={tagSearchInput}
+        />
+        <CommandList>
+          {tagsLoading ? (
+            <div className="py-6 text-center text-sm text-muted-foreground">
+              Loading...
+            </div>
+          ) : tagsError ? (
+            <div className="py-6 text-center text-sm text-destructive">
+              Error loading tags
+            </div>
+          ) : tags.length === 0 ? (
+            <CommandEmpty>No tags found.</CommandEmpty>
+          ) : (
+            <CommandGroup>
+              {tags.map((tag: Tag) => (
+                <CommandItem
+                  key={tag.id}
+                  onSelect={() => onToggleTag(tag.id)}
+                  value={tag.name}
+                >
+                  {selectedTagIds.includes(tag.id) ? (
+                    <SquareCheckBig className="mr-2 h-4 w-4" />
+                  ) : (
+                    <Square className="mr-2 h-4 w-4" />
+                  )}
+                  {tag.name}
+                  <span className="ml-auto text-xs text-muted-foreground">
+                    {tag.book_count}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    </div>
+
+    {/* Language */}
+    {languageOptions.length > 0 && (
+      <div>
+        <SectionHeader
+          icon={<Languages className="h-3 w-3" />}
+          colorClass="bg-chart-5/20 text-chart-5"
+          label="Language"
+        />
+        <Select onValueChange={onLanguageChange} value={languageParam || "all"}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Language" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Languages</SelectItem>
+            {languageOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    )}
+  </div>
+);
+
+const FilterButton = ({
+  hasActiveFilters,
+  ...props
+}: {
+  hasActiveFilters: boolean;
+} & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+  <Button aria-label="Filters" size="icon" variant="outline" {...props}>
+    <ListFilter
+      className={`h-4 w-4 ${hasActiveFilters ? "text-primary" : ""}`}
+    />
+    {hasActiveFilters && (
+      <span
+        className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary"
+        style={{ boxShadow: "0 0 0 2px hsl(var(--background))" }}
+      />
+    )}
+  </Button>
+);
+
+export const FilterSheet = (props: FilterSheetProps) => {
+  const { onClearAll, hasActiveFilters, ...filterContentProps } = props;
+  const isDesktop = useMediaQuery("(min-width: 768px)");
+
+  if (isDesktop) {
+    return (
+      <Sheet>
+        <SheetTrigger asChild>
+          <FilterButton
+            className="relative"
+            hasActiveFilters={hasActiveFilters}
+          />
+        </SheetTrigger>
+        <SheetContent className="flex flex-col overflow-hidden">
+          <SheetHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+            <SheetTitle>Filters</SheetTitle>
+            {hasActiveFilters && (
+              <button
+                className="text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+                onClick={onClearAll}
+              >
+                Clear all
+              </button>
+            )}
+          </SheetHeader>
+          <div className="flex-1 overflow-y-auto pr-1">
+            <FilterContent {...filterContentProps} />
+          </div>
+          <SheetFooter className="pt-4">
+            <SheetClose asChild>
+              <Button className="w-full sm:w-auto">Done</Button>
+            </SheetClose>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <FilterButton
+          className="relative"
+          hasActiveFilters={hasActiveFilters}
+        />
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader className="flex flex-row items-center justify-between">
+          <DrawerTitle>Filters</DrawerTitle>
+          {hasActiveFilters && (
+            <button
+              className="text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+              onClick={onClearAll}
+            >
+              Clear all
+            </button>
+          )}
+        </DrawerHeader>
+        <div className="overflow-y-auto px-4 pb-4 max-h-[70vh]">
+          <FilterContent {...filterContentProps} />
+        </div>
+        <DrawerFooter>
+          <DrawerClose asChild>
+            <Button>Done</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -21,6 +21,7 @@ import {
   Drawer,
   DrawerClose,
   DrawerContent,
+  DrawerDescription,
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
@@ -37,12 +38,14 @@ import {
   Sheet,
   SheetClose,
   SheetContent,
+  SheetDescription,
   SheetFooter,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { cn } from "@/libraries/utils";
 import type { Genre, Tag } from "@/types";
 
 interface FilterSheetProps {
@@ -83,7 +86,10 @@ const SectionHeader = ({
 }) => (
   <div className="flex items-center gap-2 mb-3">
     <span
-      className={`inline-flex h-5 w-5 items-center justify-center rounded-sm ${colorClass}`}
+      className={cn(
+        "inline-flex h-5 w-5 items-center justify-center rounded-sm",
+        colorClass,
+      )}
     >
       {icon}
     </span>
@@ -136,11 +142,12 @@ const FilterContent = ({
           const isSelected = selectedFileTypes.includes(option.value);
           return (
             <button
-              className={`inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium cursor-pointer transition-colors ${
+              className={cn(
+                "inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium cursor-pointer transition-colors",
                 isSelected
                   ? "border-primary bg-primary text-primary-foreground"
-                  : "border-border bg-card hover:bg-accent"
-              }`}
+                  : "border-border bg-card hover:bg-accent",
+              )}
               key={option.value}
               onClick={() => onToggleFileType(option.value)}
             >
@@ -290,11 +297,12 @@ const FilterButton = ({
   ...props
 }: {
   hasActiveFilters: boolean;
-} & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+} & Omit<
+  React.ComponentPropsWithoutRef<typeof Button>,
+  "hasActiveFilters"
+>) => (
   <Button aria-label="Filters" size="icon" variant="outline" {...props}>
-    <ListFilter
-      className={`h-4 w-4 ${hasActiveFilters ? "text-primary" : ""}`}
-    />
+    <ListFilter className={cn("h-4 w-4", hasActiveFilters && "text-primary")} />
     {hasActiveFilters && (
       <span
         className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary"
@@ -320,6 +328,9 @@ export const FilterSheet = (props: FilterSheetProps) => {
         <SheetContent className="flex flex-col overflow-hidden">
           <SheetHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
             <SheetTitle>Filters</SheetTitle>
+            <SheetDescription className="sr-only">
+              Filter books by file type, genre, tag, or language
+            </SheetDescription>
             {hasActiveFilters && (
               <button
                 className="text-xs text-muted-foreground hover:text-foreground cursor-pointer"
@@ -353,6 +364,9 @@ export const FilterSheet = (props: FilterSheetProps) => {
       <DrawerContent>
         <DrawerHeader className="flex flex-row items-center justify-between">
           <DrawerTitle>Filters</DrawerTitle>
+          <DrawerDescription className="sr-only">
+            Filter books by file type, genre, tag, or language
+          </DrawerDescription>
           {hasActiveFilters && (
             <button
               className="text-xs text-muted-foreground hover:text-foreground cursor-pointer"

--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -50,7 +50,7 @@ import type { Genre, Tag } from "@/types";
 
 interface FilterSheetProps {
   selectedFileTypes: string[];
-  fileTypeOptions: { value: string; label: string }[];
+  fileTypeOptions: readonly { value: string; label: string }[];
   onToggleFileType: (fileType: string) => void;
   selectedGenreIds: number[];
   genres: Genre[];
@@ -304,10 +304,7 @@ const FilterButton = ({
   <Button aria-label="Filters" size="icon" variant="outline" {...props}>
     <ListFilter className={cn("h-4 w-4", hasActiveFilters && "text-primary")} />
     {hasActiveFilters && (
-      <span
-        className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary"
-        style={{ boxShadow: "0 0 0 2px hsl(var(--background))" }}
-      />
+      <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background" />
     )}
   </Button>
 );

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -400,28 +400,28 @@ const HomeContent = () => {
             placeholder="Search books..."
           />
           <FilterSheet
-            selectedFileTypes={selectedFileTypes}
             fileTypeOptions={FILE_TYPE_OPTIONS}
-            onToggleFileType={toggleFileType}
-            selectedGenreIds={selectedGenreIds}
-            genres={genres}
-            genresLoading={genresQuery.isLoading}
-            genresError={genresQuery.isError}
             genreSearchInput={genreSearchInput}
-            onGenreSearchChange={setGenreSearchInput}
-            onToggleGenre={toggleGenreFilter}
-            selectedTagIds={selectedTagIds}
-            tags={tags}
-            tagsLoading={tagsQuery.isLoading}
-            tagsError={tagsQuery.isError}
-            tagSearchInput={tagSearchInput}
-            onTagSearchChange={setTagSearchInput}
-            onToggleTag={toggleTagFilter}
-            languageParam={languageParam}
-            languageOptions={languageOptions}
-            onLanguageChange={setLanguageFilter}
-            onClearAll={clearAllFilters}
+            genres={genres}
+            genresError={genresQuery.isError}
+            genresLoading={genresQuery.isLoading}
             hasActiveFilters={hasActiveFilters}
+            languageOptions={languageOptions}
+            languageParam={languageParam}
+            onClearAll={clearAllFilters}
+            onGenreSearchChange={setGenreSearchInput}
+            onLanguageChange={setLanguageFilter}
+            onTagSearchChange={setTagSearchInput}
+            onToggleFileType={toggleFileType}
+            onToggleGenre={toggleGenreFilter}
+            onToggleTag={toggleTagFilter}
+            selectedFileTypes={selectedFileTypes}
+            selectedGenreIds={selectedGenreIds}
+            selectedTagIds={selectedTagIds}
+            tagSearchInput={tagSearchInput}
+            tags={tags}
+            tagsError={tagsQuery.isError}
+            tagsLoading={tagsQuery.isLoading}
           />
           <div className="flex-1" />
           {isSelectionMode ? (
@@ -436,15 +436,15 @@ const HomeContent = () => {
           )}
         </div>
         <ActiveFilterChips
-          selectedFileTypes={selectedFileTypes}
-          selectedGenres={selectedGenres}
-          selectedTags={selectedTags}
           languageParam={languageParam}
+          onClearAll={clearAllFilters}
+          onClearLanguage={() => setLanguageFilter("all")}
           onToggleFileType={toggleFileType}
           onToggleGenre={toggleGenreFilter}
           onToggleTag={toggleTagFilter}
-          onClearLanguage={() => setLanguageFilter("all")}
-          onClearAll={clearAllFilters}
+          selectedFileTypes={selectedFileTypes}
+          selectedGenres={selectedGenres}
+          selectedTags={selectedTags}
         />
       </div>
 

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -1,40 +1,15 @@
-import {
-  CheckSquare,
-  ChevronsUpDown,
-  Square,
-  SquareCheckBig,
-  X,
-} from "lucide-react";
+import { CheckSquare } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 
+import { ActiveFilterChips } from "@/components/library/ActiveFilterChips";
+import { FilterSheet } from "@/components/library/FilterSheet";
 import Gallery from "@/components/library/Gallery";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import { SearchInput } from "@/components/library/SearchInput";
 import { SelectableBookItem } from "@/components/library/SelectableBookItem";
 import { SelectionToolbar } from "@/components/library/SelectionToolbar";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { getLanguageName } from "@/constants/languages";
 import { BulkSelectionProvider } from "@/contexts/BulkSelection";
 import { useBooks } from "@/hooks/queries/books";
@@ -153,11 +128,6 @@ const HomeContent = () => {
 
     return options.sort((a, b) => a.label.localeCompare(b.label));
   }, [languagesQuery.data]);
-
-  // State for filter popovers
-  const [fileTypePopoverOpen, setFileTypePopoverOpen] = useState(false);
-  const [genrePopoverOpen, setGenrePopoverOpen] = useState(false);
-  const [tagPopoverOpen, setTagPopoverOpen] = useState(false);
 
   // State for genre/tag search inputs
   const [genreSearchInput, setGenreSearchInput] = useState("");
@@ -289,6 +259,24 @@ const HomeContent = () => {
     });
   };
 
+  const clearAllFilters = () => {
+    setSearchParams((prev) => {
+      const newParams = new URLSearchParams(prev);
+      newParams.delete("file_types");
+      newParams.delete("genre_ids");
+      newParams.delete("tag_ids");
+      newParams.delete("language");
+      newParams.set("page", "1");
+      return newParams;
+    });
+  };
+
+  const hasActiveFilters =
+    selectedFileTypes.length > 0 ||
+    selectedGenreIds.length > 0 ||
+    selectedTagIds.length > 0 ||
+    Boolean(languageParam);
+
   // Build query with search and file types
   const booksQueryParams: Parameters<typeof useBooks>[0] = {
     limit,
@@ -404,257 +392,61 @@ const HomeContent = () => {
       )}
 
       {/* Search and Filters */}
-      <div className="mb-6 flex flex-wrap items-center gap-4">
-        <SearchInput
-          initialValue={searchQuery}
-          onDebouncedChange={handleDebouncedSearchChange}
-          placeholder="Search books..."
-        />
-        {/* File Type Filter */}
-        <Popover
-          onOpenChange={setFileTypePopoverOpen}
-          open={fileTypePopoverOpen}
-        >
-          <PopoverTrigger asChild>
-            <Button
-              aria-expanded={fileTypePopoverOpen}
-              className="justify-between"
-              role="combobox"
-              variant="outline"
-            >
-              {selectedFileTypes.length > 0
-                ? `${selectedFileTypes.length} file type${selectedFileTypes.length > 1 ? "s" : ""}`
-                : "File types"}
-              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+      <div className="mb-6 space-y-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <SearchInput
+            initialValue={searchQuery}
+            onDebouncedChange={handleDebouncedSearchChange}
+            placeholder="Search books..."
+          />
+          <FilterSheet
+            selectedFileTypes={selectedFileTypes}
+            fileTypeOptions={FILE_TYPE_OPTIONS}
+            onToggleFileType={toggleFileType}
+            selectedGenreIds={selectedGenreIds}
+            genres={genres}
+            genresLoading={genresQuery.isLoading}
+            genresError={genresQuery.isError}
+            genreSearchInput={genreSearchInput}
+            onGenreSearchChange={setGenreSearchInput}
+            onToggleGenre={toggleGenreFilter}
+            selectedTagIds={selectedTagIds}
+            tags={tags}
+            tagsLoading={tagsQuery.isLoading}
+            tagsError={tagsQuery.isError}
+            tagSearchInput={tagSearchInput}
+            onTagSearchChange={setTagSearchInput}
+            onToggleTag={toggleTagFilter}
+            languageParam={languageParam}
+            languageOptions={languageOptions}
+            onLanguageChange={setLanguageFilter}
+            onClearAll={clearAllFilters}
+            hasActiveFilters={hasActiveFilters}
+          />
+          <div className="flex-1" />
+          {isSelectionMode ? (
+            <Button onClick={exitSelectionMode} variant="outline">
+              Cancel
             </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[200px] p-0">
-            <Command>
-              <CommandList>
-                <CommandGroup>
-                  {FILE_TYPE_OPTIONS.map((option) => (
-                    <CommandItem
-                      key={option.value}
-                      onSelect={() => toggleFileType(option.value)}
-                      value={option.value}
-                    >
-                      {selectedFileTypes.includes(option.value) ? (
-                        <SquareCheckBig className="mr-2 h-4 w-4" />
-                      ) : (
-                        <Square className="mr-2 h-4 w-4" />
-                      )}
-                      {option.label}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-
-        {/* Genre Filter */}
-        <Popover onOpenChange={setGenrePopoverOpen} open={genrePopoverOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              aria-expanded={genrePopoverOpen}
-              className="justify-between"
-              role="combobox"
-              variant="outline"
-            >
-              {selectedGenres.length > 0
-                ? `${selectedGenres.length} genre${selectedGenres.length > 1 ? "s" : ""}`
-                : "Genres"}
-              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          ) : (
+            <Button onClick={enterSelectionMode} variant="outline">
+              <CheckSquare className="h-4 w-4" />
+              Select
             </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[200px] p-0">
-            <Command shouldFilter={false}>
-              <CommandInput
-                onValueChange={setGenreSearchInput}
-                placeholder="Search genres..."
-                value={genreSearchInput}
-              />
-              <CommandList>
-                {genresQuery.isLoading ? (
-                  <div className="py-6 text-center text-sm text-muted-foreground">
-                    Loading...
-                  </div>
-                ) : genresQuery.isError ? (
-                  <div className="py-6 text-center text-sm text-destructive">
-                    Error loading genres
-                  </div>
-                ) : genres.length === 0 ? (
-                  <CommandEmpty>No genres found.</CommandEmpty>
-                ) : (
-                  <CommandGroup>
-                    {genres.map((genre: Genre) => (
-                      <CommandItem
-                        key={genre.id}
-                        onSelect={() => toggleGenreFilter(genre.id)}
-                        value={genre.name}
-                      >
-                        {selectedGenreIds.includes(genre.id) ? (
-                          <SquareCheckBig className="mr-2 h-4 w-4" />
-                        ) : (
-                          <Square className="mr-2 h-4 w-4" />
-                        )}
-                        {genre.name}
-                        <span className="ml-auto text-xs text-muted-foreground">
-                          {genre.book_count}
-                        </span>
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-
-        {/* Tag Filter */}
-        <Popover onOpenChange={setTagPopoverOpen} open={tagPopoverOpen}>
-          <PopoverTrigger asChild>
-            <Button
-              aria-expanded={tagPopoverOpen}
-              className="justify-between"
-              role="combobox"
-              variant="outline"
-            >
-              {selectedTags.length > 0
-                ? `${selectedTags.length} tag${selectedTags.length > 1 ? "s" : ""}`
-                : "Tags"}
-              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[200px] p-0">
-            <Command shouldFilter={false}>
-              <CommandInput
-                onValueChange={setTagSearchInput}
-                placeholder="Search tags..."
-                value={tagSearchInput}
-              />
-              <CommandList>
-                {tagsQuery.isLoading ? (
-                  <div className="py-6 text-center text-sm text-muted-foreground">
-                    Loading...
-                  </div>
-                ) : tagsQuery.isError ? (
-                  <div className="py-6 text-center text-sm text-destructive">
-                    Error loading tags
-                  </div>
-                ) : tags.length === 0 ? (
-                  <CommandEmpty>No tags found.</CommandEmpty>
-                ) : (
-                  <CommandGroup>
-                    {tags.map((tag: Tag) => (
-                      <CommandItem
-                        key={tag.id}
-                        onSelect={() => toggleTagFilter(tag.id)}
-                        value={tag.name}
-                      >
-                        {selectedTagIds.includes(tag.id) ? (
-                          <SquareCheckBig className="mr-2 h-4 w-4" />
-                        ) : (
-                          <Square className="mr-2 h-4 w-4" />
-                        )}
-                        {tag.name}
-                        <span className="ml-auto text-xs text-muted-foreground">
-                          {tag.book_count}
-                        </span>
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                )}
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
-        {/* Language Filter - only shown when 2+ distinct languages */}
-        {languageOptions.length > 0 && (
-          <Select
-            onValueChange={setLanguageFilter}
-            value={languageParam || "all"}
-          >
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="Language" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">All Languages</SelectItem>
-              {languageOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-        {isSelectionMode ? (
-          <Button onClick={exitSelectionMode} variant="outline">
-            Cancel
-          </Button>
-        ) : (
-          <Button onClick={enterSelectionMode} variant="outline">
-            <CheckSquare className="h-4 w-4" />
-            Select
-          </Button>
-        )}
-      </div>
-
-      {/* Active Filters */}
-      {(selectedFileTypes.length > 0 ||
-        selectedGenres.length > 0 ||
-        selectedTags.length > 0 ||
-        languageParam) && (
-        <div className="mb-6 flex flex-wrap items-center gap-2">
-          <span className="text-sm text-muted-foreground">Filtering by:</span>
-          {selectedFileTypes.map((fileType) => {
-            const option = FILE_TYPE_OPTIONS.find((o) => o.value === fileType);
-            return (
-              <Badge
-                className="cursor-pointer gap-1"
-                key={fileType}
-                onClick={() => toggleFileType(fileType)}
-                variant="secondary"
-              >
-                {option?.label ?? fileType}
-                <X className="h-3 w-3" />
-              </Badge>
-            );
-          })}
-          {selectedGenres.map((genre) => (
-            <Badge
-              className="cursor-pointer gap-1"
-              key={genre.id}
-              onClick={() => toggleGenreFilter(genre.id)}
-              variant="secondary"
-            >
-              Genre: {genre.name}
-              <X className="h-3 w-3" />
-            </Badge>
-          ))}
-          {selectedTags.map((tag) => (
-            <Badge
-              className="cursor-pointer gap-1"
-              key={tag.id}
-              onClick={() => toggleTagFilter(tag.id)}
-              variant="secondary"
-            >
-              Tag: {tag.name}
-              <X className="h-3 w-3" />
-            </Badge>
-          ))}
-          {languageParam && (
-            <Badge
-              className="cursor-pointer gap-1"
-              onClick={() => setLanguageFilter("all")}
-              variant="secondary"
-            >
-              Language: {getLanguageName(languageParam) ?? languageParam}
-              <X className="h-3 w-3" />
-            </Badge>
           )}
         </div>
-      )}
+        <ActiveFilterChips
+          selectedFileTypes={selectedFileTypes}
+          selectedGenres={selectedGenres}
+          selectedTags={selectedTags}
+          languageParam={languageParam}
+          onToggleFileType={toggleFileType}
+          onToggleGenre={toggleGenreFilter}
+          onToggleTag={toggleTagFilter}
+          onClearLanguage={() => setLanguageFilter("all")}
+          onClearAll={clearAllFilters}
+        />
+      </div>
 
       <Gallery
         emptyMessage={

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -10,6 +10,7 @@ import { SearchInput } from "@/components/library/SearchInput";
 import { SelectableBookItem } from "@/components/library/SelectableBookItem";
 import { SelectionToolbar } from "@/components/library/SelectionToolbar";
 import { Button } from "@/components/ui/button";
+import { FILE_TYPE_OPTIONS } from "@/constants/fileTypes";
 import { getLanguageName } from "@/constants/languages";
 import { BulkSelectionProvider } from "@/contexts/BulkSelection";
 import { useBooks } from "@/hooks/queries/books";
@@ -23,13 +24,6 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import type { Book, Genre, Tag } from "@/types";
 
 const ITEMS_PER_PAGE = 24;
-
-const FILE_TYPE_OPTIONS = [
-  { value: "epub", label: "EPUB" },
-  { value: "m4b", label: "M4B" },
-  { value: "cbz", label: "CBZ" },
-  { value: "pdf", label: "PDF" },
-];
 
 const HomeContent = () => {
   const { libraryId } = useParams();
@@ -436,6 +430,7 @@ const HomeContent = () => {
           )}
         </div>
         <ActiveFilterChips
+          hasActiveFilters={hasActiveFilters}
           languageParam={languageParam}
           onClearAll={clearAllFilters}
           onClearLanguage={() => setLanguageFilter("all")}

--- a/app/components/ui/drawer.tsx
+++ b/app/components/ui/drawer.tsx
@@ -1,0 +1,116 @@
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/libraries/utils";
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+);
+Drawer.displayName = "Drawer";
+
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+const DrawerPortal = DrawerPrimitive.Portal;
+
+const DrawerClose = DrawerPrimitive.Close;
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+));
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className,
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+));
+DrawerContent.displayName = "DrawerContent";
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+);
+DrawerHeader.displayName = "DrawerHeader";
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+);
+DrawerFooter.displayName = "DrawerFooter";
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/app/components/ui/sheet.tsx
+++ b/app/components/ui/sheet.tsx
@@ -1,0 +1,131 @@
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/libraries/utils";
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+interface SheetContentProps extends React.ComponentPropsWithoutRef<
+  typeof SheetPrimitive.Content
+> {
+  side?: "top" | "right" | "bottom" | "left";
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+        side === "left" &&
+          "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        side === "right" &&
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+        side === "top" &&
+          "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        side === "bottom" &&
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        className,
+      )}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary cursor-pointer">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className,
+    )}
+    {...props}
+  />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetPortal,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/app/constants/fileTypes.ts
+++ b/app/constants/fileTypes.ts
@@ -1,0 +1,6 @@
+export const FILE_TYPE_OPTIONS = [
+  { value: "epub", label: "EPUB" },
+  { value: "m4b", label: "M4B" },
+  { value: "cbz", label: "CBZ" },
+  { value: "pdf", label: "PDF" },
+];

--- a/app/constants/fileTypes.ts
+++ b/app/constants/fileTypes.ts
@@ -3,4 +3,4 @@ export const FILE_TYPE_OPTIONS = [
   { value: "m4b", label: "M4B" },
   { value: "cbz", label: "CBZ" },
   { value: "pdf", label: "PDF" },
-];
+] as const;

--- a/app/hooks/useMediaQuery.ts
+++ b/app/hooks/useMediaQuery.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/app/hooks/useMediaQuery.ts
+++ b/app/hooks/useMediaQuery.ts
@@ -7,6 +7,7 @@ export function useMediaQuery(query: string): boolean {
 
   useEffect(() => {
     const mql = window.matchMedia(query);
+    setMatches(mql.matches);
     const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
     mql.addEventListener("change", handler);
     return () => mql.removeEventListener("change", handler);

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
     "typescript": "~6.0.2",
+    "vaul": "^1.1.2",
     "vite": "^8.0.8",
     "zod": "^4.3.6"
   },

--- a/pkg/migrations/20260417000000_add_file_type_index.go
+++ b/pkg/migrations/20260417000000_add_file_type_index.go
@@ -9,7 +9,7 @@ import (
 
 func init() {
 	up := func(_ context.Context, db *bun.DB) error {
-		_, err := db.Exec(`CREATE INDEX ix_files_file_type_book_id ON files (file_type, book_id)`)
+		_, err := db.Exec(`CREATE INDEX IF NOT EXISTS ix_files_file_type_book_id ON files (file_type, book_id)`)
 		return errors.WithStack(err)
 	}
 

--- a/pkg/migrations/20260417000000_add_file_type_index.go
+++ b/pkg/migrations/20260417000000_add_file_type_index.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`CREATE INDEX ix_files_file_type_book_id ON files (file_type, book_id)`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`DROP INDEX IF EXISTS ix_files_file_type_book_id`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       typescript:
         specifier: ~6.0.2
         version: 6.0.2
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       vite:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
@@ -7625,6 +7628,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -16809,6 +16818,15 @@ snapshots:
   value-equal@1.0.1: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace the inline filter buttons (file type, genre, tag, language) on the library Home page with a single icon-only filter button (`list-filter` icon) that opens a side sheet on desktop and a bottom drawer on mobile
- Active filters are shown as removable badge chips below the search bar, with per-type icons and colors matching sidebar conventions (Bookmark for genres, Tags for tags, File for file type, Languages for language)
- The filter button shows a primary-colored dot indicator when any filters are active
- Add composite index on `files(file_type, book_id)` to speed up file type filtering queries

## Test plan
- Navigate to a library and verify the search bar is present with a single filter icon button next to it
- Click the filter button on desktop (≥768px) and verify a right-side sheet opens with File type, Genres, Tags, and Language sections, each with a colored icon header
- Click the filter button on mobile (<768px viewport) and verify a bottom drawer opens with the same sections
- Toggle file type, genre, tag, and language filters and verify the book gallery updates correctly
- Close the sheet/drawer and verify active filter chips appear below the search bar with per-type icons
- Click the X on individual filter chips to remove them, and verify "clear all" removes all filters
- Verify the filter button shows a small primary-colored dot when any filters are active
- Refresh the page and verify filters persist via URL parameters
- Run `mise db:migrate` and verify the new index is applied (file type filtering should be noticeably faster on large libraries)