### PR TITLE
[Fix] Stabilize flaky JS test runs

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -491,6 +491,15 @@ describe("MyComponent", () => {
 });
 ```
 
+### Fake Timers and `userEvent`
+
+- `vitest.setup.ts` enables fake timers globally with `shouldAdvanceTime: true`
+- When a test uses `userEvent.setup()`, pass `advanceTimers: vi.advanceTimersByTime` so clicks and typing don't stall or hit the 5s test timeout under heavy load
+
+```typescript
+const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+```
+
 ### E2E Tests
 
 **See `e2e/CLAUDE.md` for detailed E2E patterns**, including:

--- a/app/components/common/SortNameInput.test.tsx
+++ b/app/components/common/SortNameInput.test.tsx
@@ -3,6 +3,9 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 describe("SortNameInput", () => {
   it("shows checkbox and input", () => {
     render(
@@ -89,7 +92,7 @@ describe("SortNameInput", () => {
   });
 
   it("calls onChange with empty string when checkbox is checked", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onChange = vi.fn();
 
     render(
@@ -108,7 +111,7 @@ describe("SortNameInput", () => {
   });
 
   it("enables input and pre-fills with generated value when unchecked", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onChange = vi.fn();
 
     render(
@@ -190,7 +193,7 @@ describe("SortNameInput", () => {
   });
 
   it("allows typing when checkbox is unchecked", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onChange = vi.fn();
 
     render(

--- a/app/components/files/ChapterRow.test.tsx
+++ b/app/components/files/ChapterRow.test.tsx
@@ -6,6 +6,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { FileTypeCBZ, FileTypeM4B, type Chapter } from "@/types";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 // Wrapper to provide router context for Link components
 const renderWithRouter = (ui: React.ReactElement) => {
   return render(<MemoryRouter>{ui}</MemoryRouter>);
@@ -100,7 +103,7 @@ describe("ChapterRow - M4B Playback", () => {
 
   describe("onPlay callback", () => {
     it("calls onPlay with chapterIndex and timestamp when play button clicked in view mode", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onPlay = vi.fn();
 
       renderWithRouter(
@@ -122,7 +125,7 @@ describe("ChapterRow - M4B Playback", () => {
     });
 
     it("calls onPlay with chapterIndex and current timestamp in edit mode", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onPlay = vi.fn();
 
       const editChapter: Chapter = {
@@ -159,7 +162,7 @@ describe("ChapterRow - M4B Playback", () => {
     });
 
     it("does not call onPlay when chapterIndex is undefined", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onPlay = vi.fn();
 
       renderWithRouter(
@@ -181,7 +184,7 @@ describe("ChapterRow - M4B Playback", () => {
     });
 
     it("calls onPlay with updated timestamp after clicking minus button in edit mode", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onPlay = vi.fn();
       const onStartTimestampChange = vi.fn();
 
@@ -232,7 +235,7 @@ describe("ChapterRow - M4B Playback", () => {
 
   describe("onStop callback", () => {
     it("calls onStop when stop button clicked while playing", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onStop = vi.fn();
 
       renderWithRouter(
@@ -277,7 +280,7 @@ describe("ChapterRow - M4B Playback", () => {
     // reserved for explicit commit actions (input blur, page picker).
 
     it("commits but does not reorder after clicking decrement timestamp button", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onBlur = vi.fn();
       const onStartTimestampChange = vi.fn();
 
@@ -313,7 +316,7 @@ describe("ChapterRow - M4B Playback", () => {
     });
 
     it("commits but does not reorder after clicking increment timestamp button", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onBlur = vi.fn();
       const onStartTimestampChange = vi.fn();
 
@@ -417,7 +420,7 @@ describe("ChapterRow - CBZ", () => {
     // reserved for explicit commit actions (input blur, page picker).
 
     it("commits but does not reorder after clicking decrement page button", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onBlur = vi.fn();
       const onStartPageChange = vi.fn();
 
@@ -449,7 +452,7 @@ describe("ChapterRow - CBZ", () => {
     });
 
     it("commits but does not reorder after clicking increment page button", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onBlur = vi.fn();
       const onStartPageChange = vi.fn();
 

--- a/app/components/files/FileChaptersTab.test.tsx
+++ b/app/components/files/FileChaptersTab.test.tsx
@@ -8,6 +8,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useFileChapters } from "@/hooks/queries/chapters";
 import { FileTypeM4B, FileTypePDF, type Chapter, type File } from "@/types";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 // Mock the API hooks
 vi.mock("@/hooks/queries/chapters", () => ({
   useFileChapters: vi.fn(),
@@ -78,7 +81,7 @@ describe("FileChaptersTab - Play Promise handling", () => {
   });
 
   it("handles play() Promise rejection gracefully when interrupted by pause()", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
 
     // Track whether play was called so we only reject after it's called
     let playWasCalled = false;
@@ -238,7 +241,7 @@ describe("FileChaptersTab - M4B Playback", () => {
     });
 
     it("plays audio when play button clicked", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
 
       renderWithProviders(
         <FileChaptersTab
@@ -255,7 +258,7 @@ describe("FileChaptersTab - M4B Playback", () => {
     });
 
     it("stops previous playback when clicking play on different chapter", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
 
       renderWithProviders(
         <FileChaptersTab
@@ -278,7 +281,7 @@ describe("FileChaptersTab - M4B Playback", () => {
     });
 
     it("stops playback when stop button clicked", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
 
       renderWithProviders(
         <FileChaptersTab
@@ -302,7 +305,7 @@ describe("FileChaptersTab - M4B Playback", () => {
 
   describe("edit mode - playback with reordering", () => {
     it("stops playback when entering edit mode", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onEditingChange = vi.fn();
 
       const { rerender } = renderWithProviders(
@@ -356,7 +359,7 @@ describe("FileChaptersTab - M4B Playback", () => {
 
   describe("index-based playback tracking", () => {
     it("only one chapter shows as playing at a time", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
 
       renderWithProviders(
         <FileChaptersTab
@@ -485,7 +488,7 @@ describe("FileChaptersTab - Edit mode play after timestamp change", () => {
   });
 
   it("plays audio after clicking minus button to decrement timestamp", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
 
     renderWithProviders(
       <FileChaptersTab
@@ -513,7 +516,7 @@ describe("FileChaptersTab - Edit mode play after timestamp change", () => {
   });
 
   it("plays audio after clicking plus button to increment timestamp", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
 
     renderWithProviders(
       <FileChaptersTab
@@ -541,7 +544,7 @@ describe("FileChaptersTab - Edit mode play after timestamp change", () => {
   });
 
   it("plays audio with updated timestamp after decrementing (state updates correctly)", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
 
     // Mock currentTime setter to verify correct timestamp is used
     let capturedCurrentTime: number | undefined;
@@ -580,7 +583,7 @@ describe("FileChaptersTab - Edit mode play after timestamp change", () => {
   });
 
   it("can play after clicking minus while already playing", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
 
     renderWithProviders(
       <FileChaptersTab
@@ -672,7 +675,7 @@ describe("FileChaptersTab - PDF chapter page increment regression", () => {
     // element at screen position 0 got reused for the (now-first) second
     // chapter, and the user's next click on that position silently
     // incremented the wrong chapter.
-    const user = userEvent.setup();
+    const user = createUser();
 
     renderWithProviders(
       <FileChaptersTab
@@ -712,7 +715,7 @@ describe("FileChaptersTab - PDF chapter page increment regression", () => {
     // The companion behavior: typing a page number into an input and tabbing
     // out is an explicit "commit" gesture, so the parent does reorder on
     // blur. Only button clicks intentionally skip the reorder.
-    const user = userEvent.setup();
+    const user = createUser();
 
     renderWithProviders(
       <FileChaptersTab

--- a/app/components/library/AddToListDialog.test.tsx
+++ b/app/components/library/AddToListDialog.test.tsx
@@ -6,6 +6,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { List } from "@/types";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 // Mock data
 const mockLists = [
   { id: 1, name: "Reading List", book_count: 5, permission: "owner" as const },
@@ -91,7 +94,7 @@ describe("AddToListDialog", () => {
       // The fix: Only initialize selections when dialog opens (closed->open transition),
       // not every time query data changes.
 
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const queryClient = createQueryClient();
 
@@ -202,7 +205,7 @@ describe("AddToListDialog", () => {
     });
 
     it("should reinitialize selections when dialog closes and reopens", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const queryClient = createQueryClient();
 
@@ -264,7 +267,7 @@ describe("AddToListDialog", () => {
 
     it("should NOT reset selections when dialog stays open and component re-renders", async () => {
       // This tests that normal re-renders (without data changes) don't reset state
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const queryClient = createQueryClient();
 
@@ -320,7 +323,7 @@ describe("AddToListDialog", () => {
       //
       // The fix: Store initial list IDs when dialog opens, compare against that.
 
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const queryClient = createQueryClient();
 

--- a/app/components/library/CreateListDialog.test.tsx
+++ b/app/components/library/CreateListDialog.test.tsx
@@ -6,6 +6,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { List } from "@/types";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 // Mock useFormDialogClose hook
 vi.mock("@/hooks/useFormDialogClose", () => ({
   useFormDialogClose: (
@@ -47,7 +50,7 @@ describe("CreateListDialog", () => {
       // The fix: Only initialize form when dialog opens (closed->open transition),
       // not every time list prop changes.
 
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const onUpdate = vi.fn();
       const queryClient = createQueryClient();
@@ -142,7 +145,7 @@ describe("CreateListDialog", () => {
     });
 
     it("should reinitialize form when dialog closes and reopens", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const onUpdate = vi.fn();
       const queryClient = createQueryClient();
@@ -270,7 +273,7 @@ describe("CreateListDialog", () => {
 
   describe("initialization and state preservation (create mode)", () => {
     it("should NOT reset form when component re-renders in create mode", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const onCreate = vi.fn();
       const queryClient = createQueryClient();
@@ -308,7 +311,7 @@ describe("CreateListDialog", () => {
     });
 
     it("should reset form when dialog closes and reopens in create mode", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const onCreate = vi.fn();
       const queryClient = createQueryClient();
@@ -373,7 +376,7 @@ describe("CreateListDialog", () => {
       //
       // The fix: Store initial values when dialog opens, compare against that.
 
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const onUpdate = vi.fn();
       const queryClient = createQueryClient();

--- a/app/components/library/FileEditDialog.test.tsx
+++ b/app/components/library/FileEditDialog.test.tsx
@@ -14,6 +14,9 @@ import {
 
 import { FileRoleMain, FileTypeCBZ, type File } from "@/types";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 // Define global that's normally set by Vite
 beforeAll(() => {
   // @ts-expect-error - global defined by Vite
@@ -270,7 +273,7 @@ describe("FileEditDialog", () => {
       //    if file.cover_page hasn't updated from the async query refetch
       // 7. Dialog should close anyway because pendingCoverPage was reset
 
-      const user = userEvent.setup();
+      const user = createUser();
       const { onOpenChange } = renderDialog();
 
       // Wait for dialog to render
@@ -329,7 +332,7 @@ describe("FileEditDialog", () => {
         .spyOn(URL, "createObjectURL")
         .mockReturnValue("blob:test-url");
 
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const queryClient = createQueryClient();
 

--- a/app/components/library/MetadataEditDialog.test.tsx
+++ b/app/components/library/MetadataEditDialog.test.tsx
@@ -4,6 +4,9 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 // Mock useFormDialogClose hook
 vi.mock("@/hooks/useFormDialogClose", () => ({
   useFormDialogClose: (
@@ -34,7 +37,7 @@ describe("MetadataEditDialog", () => {
       // The fix: Only initialize form when dialog opens (closed->open transition),
       // not every time props change.
 
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const onSave = vi.fn();
       const queryClient = createQueryClient();
@@ -125,7 +128,7 @@ describe("MetadataEditDialog", () => {
     });
 
     it("should reinitialize form when dialog closes and reopens", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const onSave = vi.fn();
       const queryClient = createQueryClient();
@@ -203,7 +206,7 @@ describe("MetadataEditDialog", () => {
       //
       // The fix: Store initial values when dialog opens, compare against that.
 
-      const user = userEvent.setup();
+      const user = createUser();
       const onOpenChange = vi.fn();
       const onSave = vi.fn();
       const queryClient = createQueryClient();

--- a/app/components/library/RoleDialog.test.tsx
+++ b/app/components/library/RoleDialog.test.tsx
@@ -6,6 +6,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { Role } from "@/types";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 // Mock the mutation hooks
 const mockCreateRole = vi.fn();
 const mockUpdateRole = vi.fn();
@@ -62,7 +65,7 @@ describe("RoleDialog", () => {
       // This can cause issues if the parent component hasn't unmounted the dialog yet
       // and is tracking some state based on the form values.
 
-      const user = userEvent.setup();
+      const user = createUser();
       const queryClient = createQueryClient();
       const onOpenChange = vi.fn();
 
@@ -179,7 +182,7 @@ describe("RoleDialog", () => {
       // those edits just because the role prop changed (e.g., background refetch).
       // The form should only initialize once when the dialog opens.
 
-      const user = userEvent.setup();
+      const user = createUser();
       const queryClient = createQueryClient();
       const onOpenChange = vi.fn();
 
@@ -336,7 +339,7 @@ describe("RoleDialog", () => {
     });
 
     it("should detect changes in create mode when name is entered", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       const queryClient = createQueryClient();
       const onOpenChange = vi.fn();
 

--- a/app/components/pages/CreateLibrary.test.tsx
+++ b/app/components/pages/CreateLibrary.test.tsx
@@ -5,6 +5,9 @@ import userEvent from "@testing-library/user-event";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 // Define global that's normally set by Vite
 beforeAll(() => {
   // @ts-expect-error - global defined by Vite
@@ -104,7 +107,7 @@ describe("CreateLibrary", () => {
     });
 
     it("should have unsaved changes when name is entered", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       renderPage();
 
       await waitFor(() => {
@@ -121,7 +124,7 @@ describe("CreateLibrary", () => {
     });
 
     it("should have unsaved changes when library path is entered", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       renderPage();
 
       await waitFor(() => {
@@ -137,7 +140,7 @@ describe("CreateLibrary", () => {
     });
 
     it("should have unsaved changes when organize file structure is unchecked", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       renderPage();
 
       await waitFor(() => {
@@ -158,7 +161,7 @@ describe("CreateLibrary", () => {
     });
 
     it("should NOT have unsaved changes when returning to initial defaults", async () => {
-      const user = userEvent.setup();
+      const user = createUser();
       renderPage();
 
       await waitFor(() => {

--- a/app/components/ui/form-dialog.test.tsx
+++ b/app/components/ui/form-dialog.test.tsx
@@ -10,6 +10,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 describe("FormDialog", () => {
   // Store original addEventListener/removeEventListener
   let addEventListenerSpy: ReturnType<typeof vi.spyOn>;
@@ -25,7 +28,7 @@ describe("FormDialog", () => {
     removeEventListenerSpy.mockRestore();
   });
   it("should close without confirmation when hasChanges is false", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onOpenChange = vi.fn();
 
     render(
@@ -51,7 +54,7 @@ describe("FormDialog", () => {
   });
 
   it("should close directly when clicking X button even with unsaved changes", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onOpenChange = vi.fn();
 
     render(
@@ -76,7 +79,7 @@ describe("FormDialog", () => {
   });
 
   it("should show UnsavedChangesDialog when pressing ESC with hasChanges", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onOpenChange = vi.fn();
 
     render(
@@ -105,7 +108,7 @@ describe("FormDialog", () => {
   });
 
   it("handleStay should keep dialog open when clicking Stay button", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onOpenChange = vi.fn();
 
     render(
@@ -143,7 +146,7 @@ describe("FormDialog", () => {
   });
 
   it("handleDiscard should close dialog when clicking Discard button", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onOpenChange = vi.fn();
 
     render(
@@ -175,7 +178,7 @@ describe("FormDialog", () => {
   });
 
   it("should not show multiple confirmation dialogs on rapid ESC presses", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onOpenChange = vi.fn();
 
     render(
@@ -278,7 +281,7 @@ describe("FormDialog", () => {
   });
 
   it("should close when hasChanges changes from true to false", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onOpenChange = vi.fn();
 
     const { rerender } = render(
@@ -314,7 +317,7 @@ describe("FormDialog", () => {
   });
 
   it("should reset confirmation dialog when open becomes false externally", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onOpenChange = vi.fn();
 
     const { rerender } = render(

--- a/app/components/ui/unsaved-changes-dialog.test.tsx
+++ b/app/components/ui/unsaved-changes-dialog.test.tsx
@@ -3,6 +3,9 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 describe("UnsavedChangesDialog", () => {
   it("should render dialog content when open", () => {
     render(
@@ -30,7 +33,7 @@ describe("UnsavedChangesDialog", () => {
   });
 
   it("should call onStay when Stay button is clicked", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onStay = vi.fn();
     const onDiscard = vi.fn();
 
@@ -50,7 +53,7 @@ describe("UnsavedChangesDialog", () => {
   });
 
   it("should call onDiscard when Discard button is clicked", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onStay = vi.fn();
     const onDiscard = vi.fn();
 
@@ -70,7 +73,7 @@ describe("UnsavedChangesDialog", () => {
   });
 
   it("should call onStay when dialog is closed via ESC key", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onStay = vi.fn();
     const onDiscard = vi.fn();
 
@@ -89,7 +92,7 @@ describe("UnsavedChangesDialog", () => {
   });
 
   it("should call onStay when dialog is closed via overlay click", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onStay = vi.fn();
     const onDiscard = vi.fn();
 
@@ -141,7 +144,7 @@ describe("UnsavedChangesDialog", () => {
   });
 
   it("should handle rapid button clicks without errors", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onStay = vi.fn();
     const onDiscard = vi.fn();
 
@@ -178,7 +181,7 @@ describe("UnsavedChangesDialog", () => {
   });
 
   it("should render close button that triggers onStay", async () => {
-    const user = userEvent.setup();
+    const user = createUser();
     const onStay = vi.fn();
     const onDiscard = vi.fn();
 

--- a/app/hooks/useNavigateAfterSave.test.tsx
+++ b/app/hooks/useNavigateAfterSave.test.tsx
@@ -5,6 +5,9 @@ import { useMemo, useState } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
 // Mock useNavigate
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
@@ -364,7 +367,7 @@ describe("useNavigateAfterSave", () => {
 
     it("should navigate after save when setChangesSaved and requestNavigate are called in same handler", async () => {
       // This test reproduces the EXACT bug scenario from CreateLibrary/CreateUser/Setup
-      const user = userEvent.setup();
+      const user = createUser();
 
       render(
         <MemoryRouter>

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -157,6 +157,17 @@ await expect(page).toHaveURL("/settings/libraries");
 
 **Solution:** Understand app routing logic and test actual behavior.
 
+### 4. SPA Navigation Under Load
+
+**Problem:** `page.goto()` defaults to waiting for the full `"load"` event, which can be slower than the UI becoming usable when the dev server is busy during `mise check:quiet`.
+
+**Solution:** For SPA routes, prefer `waitUntil: "domcontentloaded"` and then assert on the stable UI the test actually needs:
+
+```typescript
+await page.goto("/setup", { waitUntil: "domcontentloaded" });
+await expect(page.getByRole("heading", { name: "Welcome!" })).toBeVisible();
+```
+
 ## Test File Structure
 
 ```typescript

--- a/e2e/setup.spec.ts
+++ b/e2e/setup.spec.ts
@@ -10,6 +10,13 @@
  */
 
 import { expect, getApiBaseURL, request, test } from "./fixtures";
+import type { Page } from "@playwright/test";
+
+async function gotoSetup(page: Page, path = "/setup") {
+  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await expect(page).toHaveURL("/setup");
+  await expect(page.getByRole("heading", { name: "Welcome!" })).toBeVisible();
+}
 
 test.describe("Setup Flow", () => {
   test.beforeAll(async ({ browser }) => {
@@ -21,16 +28,14 @@ test.describe("Setup Flow", () => {
   });
 
   test("redirects to setup when no users exist", async ({ page }) => {
-    await page.goto("/");
-    await expect(page).toHaveURL("/setup");
-    await expect(page.getByRole("heading", { name: "Welcome!" })).toBeVisible();
+    await gotoSetup(page, "/");
     await expect(
       page.getByText("Create your admin account to get started"),
     ).toBeVisible();
   });
 
   test("shows validation error for password mismatch", async ({ page }) => {
-    await page.goto("/setup");
+    await gotoSetup(page);
     await page.getByLabel("Username").fill("testadmin");
     await page.getByLabel("Password", { exact: true }).fill("password123");
     await page.getByLabel("Confirm Password").fill("different456");
@@ -40,7 +45,7 @@ test.describe("Setup Flow", () => {
   });
 
   test("shows validation error for username too short", async ({ page }) => {
-    await page.goto("/setup");
+    await gotoSetup(page);
     await page.getByLabel("Username").fill("ab");
     await page.getByLabel("Password", { exact: true }).fill("password123");
     await page.getByLabel("Confirm Password").fill("password123");
@@ -52,7 +57,7 @@ test.describe("Setup Flow", () => {
   });
 
   test("shows validation error for password too short", async ({ page }) => {
-    await page.goto("/setup");
+    await gotoSetup(page);
     await page.getByLabel("Username").fill("testadmin");
     await page.getByLabel("Password", { exact: true }).fill("short");
     await page.getByLabel("Confirm Password").fill("short");
@@ -64,7 +69,7 @@ test.describe("Setup Flow", () => {
   });
 
   test("shows validation error for empty username", async ({ page }) => {
-    await page.goto("/setup");
+    await gotoSetup(page);
     await page.getByLabel("Password", { exact: true }).fill("password123");
     await page.getByLabel("Confirm Password").fill("password123");
     await page.getByRole("button", { name: "Create Admin Account" }).click();
@@ -73,7 +78,7 @@ test.describe("Setup Flow", () => {
   });
 
   test("shows validation error for empty password", async ({ page }) => {
-    await page.goto("/setup");
+    await gotoSetup(page);
     await page.getByLabel("Username").fill("testadmin");
     await page.getByRole("button", { name: "Create Admin Account" }).click();
     await expect(page.getByText("Password is required")).toBeVisible();
@@ -81,8 +86,7 @@ test.describe("Setup Flow", () => {
   });
 
   test("creates admin account successfully", async ({ page }) => {
-    await page.goto("/setup");
-    await expect(page.getByRole("heading", { name: "Welcome!" })).toBeVisible();
+    await gotoSetup(page);
     await page.getByLabel("Username").fill("testadmin");
     await page.getByLabel("Password", { exact: true }).fill("password123");
     await page.getByLabel("Confirm Password").fill("password123");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,15 @@
+import fs from "fs";
 import path from "path";
 
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+
+const coverageDir = path.resolve(__dirname, "./coverage");
+const coverageTmpDir = path.join(coverageDir, ".tmp");
+
+// Vitest's coverage workers can race the initial temp-dir creation on short runs.
+// Pre-creating the directory avoids intermittent ENOENT failures at write time.
+fs.mkdirSync(coverageTmpDir, { recursive: true });
 
 export default defineConfig({
   plugins: [react() as never],
@@ -19,7 +27,8 @@ export default defineConfig({
       enabled: true,
       provider: "v8",
       reporter: ["text-summary", "lcov", "html"],
-      reportsDirectory: "./coverage",
+      reportsDirectory: coverageDir,
+      include: ["app/**/*.{ts,tsx}"],
       exclude: ["app/**/*.test.{ts,tsx}", "app/types/generated/**"],
     },
   },


### PR DESCRIPTION
## Summary
- fix frontend Vitest tests that used bare `userEvent.setup()` under the repo's global fake-timer setup by passing `advanceTimers: vi.advanceTimersByTime`
- pre-create Vitest's coverage temp directory to avoid intermittent `coverage/.tmp` ENOENT failures on short runs
- make the setup E2E navigate with `domcontentloaded` and wait for stable setup UI, and document both test patterns in the relevant `CLAUDE.md` files

## Test plan
- pnpm e2e:chromium e2e/setup.spec.ts --repeat-each 10
- mise check:quiet run 10 times in a row