### PR TITLE
[Feature] Add server log viewer with in-memory ring buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ Temporary Items
 ### Node ###
 # Logs
 logs
+!pkg/logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/Caddyfile
+++ b/Caddyfile
@@ -4,7 +4,7 @@
 :5173 {
     # Logging
     log {
-        output stdout
+        output {$CADDY_ACCESS_LOG_OUTPUT:discard}
         format {$LOG_FORMAT}
     }
 

--- a/app/components/library/LogViewer.tsx
+++ b/app/components/library/LogViewer.tsx
@@ -1,0 +1,208 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Normalized log entry that both JobDetail and AdminLogs map into.
+ */
+export interface LogViewerEntry {
+  id: number;
+  level: string;
+  timestamp: string;
+  message: string;
+  data?: Record<string, unknown> | null;
+  error?: string | null;
+  stackTrace?: string | null;
+}
+
+const levelColors: Record<string, string> = {
+  debug: "bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400",
+  info: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  warn: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  error: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  fatal: "bg-red-200 text-red-900 dark:bg-red-900/50 dark:text-red-300",
+};
+
+const formatTimestamp = (ts: string): string => {
+  try {
+    const d = new Date(ts);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}.${String(d.getMilliseconds()).padStart(3, "0")}`;
+  } catch {
+    return ts;
+  }
+};
+
+function highlightText(text: string, searchTerm?: string): React.ReactNode {
+  if (!searchTerm) return text;
+  try {
+    const regex = new RegExp(
+      `(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
+      "gi",
+    );
+    const parts = text.split(regex);
+    return parts.map((part, i) =>
+      regex.test(part) ? (
+        <mark className="bg-yellow-300 dark:bg-yellow-700" key={i}>
+          {part}
+        </mark>
+      ) : (
+        part
+      ),
+    );
+  } catch {
+    return text;
+  }
+}
+
+interface LogRowProps {
+  entry: LogViewerEntry;
+  searchTerm?: string;
+}
+
+const LogRow = ({ entry, searchTerm }: LogRowProps) => {
+  const [expanded, setExpanded] = useState(false);
+  const hasExpandableContent =
+    (entry.data && Object.keys(entry.data).length > 0) ||
+    entry.error ||
+    entry.stackTrace;
+
+  // Create data preview for collapsed state
+  const dataPreview =
+    entry.data && Object.keys(entry.data).length > 0
+      ? Object.entries(entry.data)
+          .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+          .join(" ")
+      : null;
+
+  return (
+    <div className="py-1.5 px-3 border-b border-border/50 last:border-b-0 font-mono text-xs hover:bg-muted/50 transition-colors">
+      <div
+        className={`flex items-center gap-2 overflow-hidden ${hasExpandableContent ? "cursor-pointer" : ""}`}
+        onClick={() => hasExpandableContent && setExpanded(!expanded)}
+      >
+        {hasExpandableContent ? (
+          expanded ? (
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+          )
+        ) : (
+          <div className="w-3.5 flex-shrink-0" />
+        )}
+        <span className="text-muted-foreground flex-shrink-0 whitespace-nowrap tabular-nums">
+          {formatTimestamp(entry.timestamp)}
+        </span>
+        <Badge
+          className={`${levelColors[entry.level] ?? levelColors.info} text-[10px] px-1.5 py-0 flex-shrink-0 font-mono uppercase`}
+          variant="secondary"
+        >
+          {entry.level.length > 4 ? entry.level.slice(0, 3) : entry.level}
+        </Badge>
+        <span className="text-foreground flex-shrink-0 whitespace-nowrap">
+          {highlightText(entry.message, searchTerm)}
+        </span>
+        {dataPreview && !expanded && (
+          <span className="text-muted-foreground truncate min-w-0">
+            {highlightText(dataPreview, searchTerm)}
+          </span>
+        )}
+      </div>
+      {expanded && (
+        <div className="ml-6 mt-2 space-y-2">
+          {entry.data && Object.keys(entry.data).length > 0 && (
+            <pre className="bg-muted p-2 rounded text-xs overflow-x-auto whitespace-pre-wrap">
+              {highlightText(JSON.stringify(entry.data, null, 2), searchTerm)}
+            </pre>
+          )}
+          {entry.error && (
+            <div className="text-red-500 dark:text-red-400 text-xs">
+              error: {highlightText(entry.error, searchTerm)}
+            </div>
+          )}
+          {entry.stackTrace && (
+            <pre className="bg-red-950/20 p-2 rounded text-xs overflow-x-auto text-red-400 whitespace-pre-wrap">
+              {highlightText(entry.stackTrace, searchTerm)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface LogViewerProps {
+  entries: LogViewerEntry[];
+  searchTerm?: string;
+  emptyMessage?: string;
+  className?: string;
+}
+
+const LogViewer = ({
+  entries,
+  searchTerm,
+  emptyMessage = "No logs found.",
+  className = "max-h-[500px]",
+}: LogViewerProps) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const prevEntriesRef = useRef<LogViewerEntry[]>([]);
+
+  useEffect(() => {
+    if (autoScroll && scrollRef.current && entries.length > 0) {
+      if (entries !== prevEntriesRef.current) {
+        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        prevEntriesRef.current = entries;
+      }
+    }
+  }, [entries, autoScroll]);
+
+  const handleScroll = useCallback(() => {
+    if (!scrollRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+    setAutoScroll(scrollHeight - scrollTop - clientHeight < 50);
+  }, []);
+
+  const jumpToLatest = useCallback(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      setAutoScroll(true);
+    }
+  }, []);
+
+  return (
+    <div className="relative">
+      <div
+        className={`overflow-y-auto border border-border rounded-md bg-muted/20 dark:bg-neutral-950/50 ${className}`}
+        onScroll={handleScroll}
+        ref={scrollRef}
+      >
+        {entries.length === 0 ? (
+          <div className="flex items-center justify-center h-full min-h-[200px] text-muted-foreground text-sm">
+            {emptyMessage}
+          </div>
+        ) : (
+          entries.map((entry) => (
+            <LogRow entry={entry} key={entry.id} searchTerm={searchTerm} />
+          ))
+        )}
+      </div>
+
+      {!autoScroll && entries.length > 0 && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+          <Button
+            className="shadow-lg"
+            onClick={jumpToLatest}
+            size="sm"
+            variant="secondary"
+          >
+            Jump to latest
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LogViewer;

--- a/app/components/pages/AdminLayout.tsx
+++ b/app/components/pages/AdminLayout.tsx
@@ -5,6 +5,7 @@ import {
   LogOut,
   Menu,
   Puzzle,
+  ScrollText,
   Users,
 } from "lucide-react";
 import {
@@ -176,6 +177,13 @@ const AdminLayoutContent = () => {
       isActive: location.pathname === "/settings/plugins",
       show: canViewConfig,
     },
+    {
+      to: "/settings/logs",
+      icon: <ScrollText className="h-4 w-4" />,
+      label: "Logs",
+      isActive: location.pathname === "/settings/logs",
+      show: canViewConfig,
+    },
   ].filter((item) => item.show);
 
   return (
@@ -244,6 +252,14 @@ const AdminLayoutContent = () => {
                   isActive={location.pathname === "/settings/plugins"}
                   label="Plugins"
                   to="/settings/plugins"
+                />
+              )}
+              {canViewConfig && (
+                <NavItem
+                  icon={<ScrollText className="h-4 w-4" />}
+                  isActive={location.pathname === "/settings/logs"}
+                  label="Logs"
+                  to="/settings/logs"
                 />
               )}
             </nav>

--- a/app/components/pages/AdminLogs.tsx
+++ b/app/components/pages/AdminLogs.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import LoadingSpinner from "@/components/library/LoadingSpinner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useLogs, type LogEntry } from "@/hooks/queries/logs";
+import { usePageTitle } from "@/hooks/usePageTitle";
+
+const INITIAL_LIMIT = 200;
+
+const levelColors: Record<string, string> = {
+  debug: "bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400",
+  info: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  warn: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  error: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  fatal: "bg-red-200 text-red-900 dark:bg-red-900/50 dark:text-red-300",
+};
+
+const formatTimestamp = (ts: string): string => {
+  try {
+    const d = new Date(ts);
+    return d.toLocaleTimeString("en-US", {
+      hour12: false,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return ts;
+  }
+};
+
+interface LogRowProps {
+  entry: LogEntry;
+}
+
+const LogRow = ({ entry }: LogRowProps) => {
+  const [expanded, setExpanded] = useState(false);
+  const hasExtra =
+    (entry.data && Object.keys(entry.data).length > 0) || entry.error;
+
+  return (
+    <div
+      className={`px-3 py-1.5 font-mono text-xs hover:bg-muted/50 transition-colors ${hasExtra ? "cursor-pointer" : ""}`}
+      onClick={hasExtra ? () => setExpanded(!expanded) : undefined}
+    >
+      <div className="flex items-start gap-2">
+        <span className="text-muted-foreground shrink-0 tabular-nums">
+          {formatTimestamp(entry.timestamp)}
+        </span>
+        <Badge
+          className={`${levelColors[entry.level] ?? levelColors.info} text-[10px] px-1.5 py-0 shrink-0 font-mono uppercase`}
+          variant="secondary"
+        >
+          {entry.level.slice(0, 3)}
+        </Badge>
+        <span className="text-foreground break-all">{entry.message}</span>
+      </div>
+      {expanded && (
+        <div className="mt-1 ml-[7.5rem] space-y-1">
+          {entry.error && (
+            <div className="text-red-500 dark:text-red-400">
+              error: {entry.error}
+            </div>
+          )}
+          {entry.data && Object.keys(entry.data).length > 0 && (
+            <pre className="text-muted-foreground whitespace-pre-wrap break-all">
+              {JSON.stringify(entry.data, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const AdminLogs = () => {
+  usePageTitle("Server Logs");
+
+  const [level, setLevel] = useState<string>("");
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const prevEntriesRef = useRef<LogEntry[]>([]);
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput), 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const { data, isLoading } = useLogs({
+    level: level || undefined,
+    search: search || undefined,
+    limit: INITIAL_LIMIT,
+  });
+
+  const entries = useMemo(() => data?.entries ?? [], [data]);
+
+  // Auto-scroll to bottom when new entries arrive (if user is at the bottom)
+  useEffect(() => {
+    if (autoScroll && scrollRef.current && entries.length > 0) {
+      if (entries !== prevEntriesRef.current) {
+        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        prevEntriesRef.current = entries;
+      }
+    }
+  }, [entries, autoScroll]);
+
+  const handleScroll = useCallback(() => {
+    if (!scrollRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+    setAutoScroll(scrollHeight - scrollTop - clientHeight < 50);
+  }, []);
+
+  const jumpToLatest = useCallback(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      setAutoScroll(true);
+    }
+  }, []);
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-12rem)]">
+      <div className="mb-4">
+        <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
+          Server Logs
+        </h1>
+        <p className="text-sm md:text-base text-muted-foreground">
+          Real-time server logs from the current session.
+        </p>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex items-center gap-3 mb-4">
+        <Select
+          onValueChange={(v) => setLevel(v === "all" ? "" : v)}
+          value={level || "all"}
+        >
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="All levels" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All levels</SelectItem>
+            <SelectItem value="debug">Debug</SelectItem>
+            <SelectItem value="info">Info</SelectItem>
+            <SelectItem value="warn">Warn</SelectItem>
+            <SelectItem value="error">Error</SelectItem>
+          </SelectContent>
+        </Select>
+        <Input
+          className="max-w-xs"
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Search messages..."
+          value={searchInput}
+        />
+      </div>
+
+      {/* Log list */}
+      <div className="relative flex-1 min-h-0">
+        <div
+          className="absolute inset-0 overflow-y-auto border border-border rounded-md bg-muted/20 dark:bg-neutral-950/50"
+          onScroll={handleScroll}
+          ref={scrollRef}
+        >
+          {entries.length === 0 ? (
+            <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+              {search || level ? "No logs matching filters." : "No logs yet."}
+            </div>
+          ) : (
+            <div className="divide-y divide-border/50">
+              {entries.map((entry) => (
+                <LogRow entry={entry} key={entry.id} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Jump to latest button */}
+        {!autoScroll && entries.length > 0 && (
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+            <Button
+              className="shadow-lg"
+              onClick={jumpToLatest}
+              size="sm"
+              variant="secondary"
+            >
+              Jump to latest
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminLogs;

--- a/app/components/pages/AdminLogs.tsx
+++ b/app/components/pages/AdminLogs.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import LoadingSpinner from "@/components/library/LoadingSpinner";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import LogViewer, { type LogViewerEntry } from "@/components/library/LogViewer";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -11,76 +10,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useLogs, type LogEntry } from "@/hooks/queries/logs";
+import { useLogs } from "@/hooks/queries/logs";
 import { usePageTitle } from "@/hooks/usePageTitle";
 
 const INITIAL_LIMIT = 200;
-
-const levelColors: Record<string, string> = {
-  debug: "bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400",
-  info: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
-  warn: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
-  error: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
-  fatal: "bg-red-200 text-red-900 dark:bg-red-900/50 dark:text-red-300",
-};
-
-const formatTimestamp = (ts: string): string => {
-  try {
-    const d = new Date(ts);
-    return d.toLocaleTimeString("en-US", {
-      hour12: false,
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-  } catch {
-    return ts;
-  }
-};
-
-interface LogRowProps {
-  entry: LogEntry;
-}
-
-const LogRow = ({ entry }: LogRowProps) => {
-  const [expanded, setExpanded] = useState(false);
-  const hasExtra =
-    (entry.data && Object.keys(entry.data).length > 0) || entry.error;
-
-  return (
-    <div
-      className={`px-3 py-1.5 font-mono text-xs hover:bg-muted/50 transition-colors ${hasExtra ? "cursor-pointer" : ""}`}
-      onClick={hasExtra ? () => setExpanded(!expanded) : undefined}
-    >
-      <div className="flex items-start gap-2">
-        <span className="text-muted-foreground shrink-0 tabular-nums">
-          {formatTimestamp(entry.timestamp)}
-        </span>
-        <Badge
-          className={`${levelColors[entry.level] ?? levelColors.info} text-[10px] px-1.5 py-0 shrink-0 font-mono uppercase`}
-          variant="secondary"
-        >
-          {entry.level.slice(0, 3)}
-        </Badge>
-        <span className="text-foreground break-all">{entry.message}</span>
-      </div>
-      {expanded && (
-        <div className="mt-1 ml-[7.5rem] space-y-1">
-          {entry.error && (
-            <div className="text-red-500 dark:text-red-400">
-              error: {entry.error}
-            </div>
-          )}
-          {entry.data && Object.keys(entry.data).length > 0 && (
-            <pre className="text-muted-foreground whitespace-pre-wrap break-all">
-              {JSON.stringify(entry.data, null, 2)}
-            </pre>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
 
 const AdminLogs = () => {
   usePageTitle("Server Logs");
@@ -88,9 +21,6 @@ const AdminLogs = () => {
   const [level, setLevel] = useState<string>("");
   const [searchInput, setSearchInput] = useState("");
   const [search, setSearch] = useState("");
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [autoScroll, setAutoScroll] = useState(true);
-  const prevEntriesRef = useRef<LogEntry[]>([]);
 
   // Debounce search input
   useEffect(() => {
@@ -104,30 +34,19 @@ const AdminLogs = () => {
     limit: INITIAL_LIMIT,
   });
 
-  const entries = useMemo(() => data?.entries ?? [], [data]);
-
-  // Auto-scroll to bottom when new entries arrive (if user is at the bottom)
-  useEffect(() => {
-    if (autoScroll && scrollRef.current && entries.length > 0) {
-      if (entries !== prevEntriesRef.current) {
-        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-        prevEntriesRef.current = entries;
-      }
-    }
-  }, [entries, autoScroll]);
-
-  const handleScroll = useCallback(() => {
-    if (!scrollRef.current) return;
-    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
-    setAutoScroll(scrollHeight - scrollTop - clientHeight < 50);
-  }, []);
-
-  const jumpToLatest = useCallback(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-      setAutoScroll(true);
-    }
-  }, []);
+  const entries: LogViewerEntry[] = useMemo(
+    () =>
+      (data?.entries ?? []).map((e) => ({
+        id: e.id,
+        level: e.level,
+        timestamp: e.timestamp,
+        message: e.message,
+        data: e.data ?? null,
+        error: e.error ?? null,
+        stackTrace: null,
+      })),
+    [data],
+  );
 
   if (isLoading) {
     return <LoadingSpinner />;
@@ -169,40 +88,15 @@ const AdminLogs = () => {
         />
       </div>
 
-      {/* Log list */}
-      <div className="relative flex-1 min-h-0">
-        <div
-          className="absolute inset-0 overflow-y-auto border border-border rounded-md bg-muted/20 dark:bg-neutral-950/50"
-          onScroll={handleScroll}
-          ref={scrollRef}
-        >
-          {entries.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-              {search || level ? "No logs matching filters." : "No logs yet."}
-            </div>
-          ) : (
-            <div className="divide-y divide-border/50">
-              {entries.map((entry) => (
-                <LogRow entry={entry} key={entry.id} />
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Jump to latest button */}
-        {!autoScroll && entries.length > 0 && (
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
-            <Button
-              className="shadow-lg"
-              onClick={jumpToLatest}
-              size="sm"
-              variant="secondary"
-            >
-              Jump to latest
-            </Button>
-          </div>
-        )}
-      </div>
+      {/* Log viewer */}
+      <LogViewer
+        className="flex-1"
+        emptyMessage={
+          search || level ? "No logs matching filters." : "No logs yet."
+        }
+        entries={entries}
+        searchTerm={search}
+      />
     </div>
   );
 };

--- a/app/components/pages/JobDetail.tsx
+++ b/app/components/pages/JobDetail.tsx
@@ -1,12 +1,12 @@
 import { formatDistanceToNow } from "date-fns";
-import { ArrowLeft, ChevronDown, ChevronRight } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ArrowLeft } from "lucide-react";
+import { useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import LoadingSpinner from "@/components/library/LoadingSpinner";
+import LogViewer from "@/components/library/LogViewer";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -23,7 +23,6 @@ import {
   JobLogLevelInfo,
   JobLogLevelWarn,
   JobStatusInProgress,
-  type JobLog,
 } from "@/types";
 
 const getLevelColor = (level: string) => {
@@ -73,102 +72,6 @@ const formatDuration = (start: string, end?: string | null): string => {
   return `${minutes}m ${remainingSeconds}s`;
 };
 
-interface LogEntryProps {
-  log: JobLog;
-  searchTerm: string;
-}
-
-const LogEntry = ({ log, searchTerm }: LogEntryProps) => {
-  const [expanded, setExpanded] = useState(false);
-  const hasExpandableContent = log.data || log.stack_trace;
-
-  const date = new Date(log.created_at);
-  const timestamp = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")} ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}:${String(date.getSeconds()).padStart(2, "0")}.${String(date.getMilliseconds()).padStart(3, "0")}`;
-
-  // Parse data if present
-  let parsedData: Record<string, unknown> | null = null;
-  if (log.data) {
-    try {
-      parsedData = JSON.parse(log.data);
-    } catch {
-      parsedData = null;
-    }
-  }
-
-  // Create data preview
-  const dataPreview = parsedData
-    ? Object.entries(parsedData)
-        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
-        .join(" ")
-    : null;
-
-  // Highlight search term in message
-  const highlightText = (text: string) => {
-    if (!searchTerm) return text;
-    const regex = new RegExp(`(${searchTerm})`, "gi");
-    const parts = text.split(regex);
-    return parts.map((part, i) =>
-      regex.test(part) ? (
-        <mark className="bg-yellow-300 dark:bg-yellow-700" key={i}>
-          {part}
-        </mark>
-      ) : (
-        part
-      ),
-    );
-  };
-
-  return (
-    <div className="py-2 border-b border-border last:border-b-0 font-mono text-sm">
-      <div
-        className={`flex items-center gap-2 overflow-hidden ${hasExpandableContent ? "cursor-pointer" : ""}`}
-        onClick={() => hasExpandableContent && setExpanded(!expanded)}
-      >
-        {hasExpandableContent ? (
-          expanded ? (
-            <ChevronDown className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-          ) : (
-            <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-          )
-        ) : (
-          <div className="w-4 flex-shrink-0" />
-        )}
-        <span className="text-muted-foreground flex-shrink-0 whitespace-nowrap">
-          {timestamp}
-        </span>
-        <Badge
-          className={`${getLevelColor(log.level)} flex-shrink-0`}
-          variant="secondary"
-        >
-          {log.level}
-        </Badge>
-        <span className="text-foreground flex-shrink-0 whitespace-nowrap">
-          {highlightText(log.message)}
-        </span>
-        {dataPreview && !expanded && (
-          <span className="text-muted-foreground truncate min-w-0">
-            {highlightText(dataPreview)}
-          </span>
-        )}
-      </div>
-      {expanded && (
-        <div className="ml-6 mt-2 space-y-2">
-          {parsedData && (
-            <pre className="bg-muted p-2 rounded text-xs overflow-x-auto whitespace-pre-wrap">
-              {highlightText(JSON.stringify(parsedData, null, 2))}
-            </pre>
-          )}
-          {log.stack_trace && (
-            <pre className="bg-red-950/20 p-2 rounded text-xs overflow-x-auto text-red-400 whitespace-pre-wrap">
-              {highlightText(log.stack_trace)}
-            </pre>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
-
 const JobDetail = () => {
   const { id } = useParams<{ id: string }>();
 
@@ -177,9 +80,6 @@ const JobDetail = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [levelFilter, setLevelFilter] = useState<string[]>([]);
   const [pluginFilter, setPluginFilter] = useState<string>("");
-  const [autoScroll, setAutoScroll] = useState(true);
-  const logContainerRef = useRef<HTMLDivElement>(null);
-  const lastLogIdRef = useRef<number | undefined>(undefined);
 
   const { data, isLoading, error } = useJobLogs(id, {
     level: levelFilter.length > 0 ? levelFilter : undefined,
@@ -220,29 +120,6 @@ const JobDetail = () => {
     }
     return true;
   });
-
-  // Auto-scroll to bottom when new logs arrive
-  useEffect(() => {
-    if (autoScroll && logContainerRef.current && filteredLogs.length > 0) {
-      const lastLog = filteredLogs[filteredLogs.length - 1];
-      if (lastLog.id !== lastLogIdRef.current) {
-        lastLogIdRef.current = lastLog.id;
-        logContainerRef.current.scrollTop =
-          logContainerRef.current.scrollHeight;
-      }
-    }
-  }, [filteredLogs, autoScroll]);
-
-  // Disable auto-scroll when user scrolls up
-  const handleScroll = useCallback(() => {
-    if (logContainerRef.current) {
-      const { scrollTop, scrollHeight, clientHeight } = logContainerRef.current;
-      const isAtBottom = scrollHeight - scrollTop - clientHeight < 50;
-      if (!isAtBottom && autoScroll) {
-        setAutoScroll(false);
-      }
-    }
-  }, [autoScroll]);
 
   const toggleLevelFilter = (level: string) => {
     setLevelFilter((prev) =>
@@ -355,42 +232,30 @@ const JobDetail = () => {
         )}
       </div>
 
-      {/* Log container */}
-      <div
-        className="border border-border rounded-md bg-background overflow-y-auto max-h-[500px]"
-        onScroll={handleScroll}
-        ref={logContainerRef}
-      >
-        <div className="p-4">
-          {filteredLogs.length === 0 ? (
-            <p className="text-muted-foreground text-center py-8">
-              No logs found.
-            </p>
-          ) : (
-            filteredLogs.map((log) => (
-              <LogEntry key={log.id} log={log} searchTerm={searchTerm} />
-            ))
-          )}
-        </div>
-      </div>
-
-      {/* Auto-scroll checkbox */}
-      <div className="flex items-center gap-2 mt-4">
-        <Checkbox
-          checked={autoScroll}
-          id="autoscroll"
-          onCheckedChange={(checked) => {
-            setAutoScroll(checked as boolean);
-            if (checked && logContainerRef.current) {
-              logContainerRef.current.scrollTop =
-                logContainerRef.current.scrollHeight;
+      {/* Log viewer */}
+      <LogViewer
+        emptyMessage="No logs found."
+        entries={filteredLogs.map((log) => {
+          let parsedData: Record<string, unknown> | null = null;
+          if (log.data) {
+            try {
+              parsedData = JSON.parse(log.data);
+            } catch {
+              parsedData = null;
             }
-          }}
-        />
-        <label className="text-sm text-muted-foreground" htmlFor="autoscroll">
-          Auto-scroll to new logs
-        </label>
-      </div>
+          }
+          return {
+            id: log.id,
+            level: log.level,
+            timestamp: log.created_at,
+            message: log.message,
+            data: parsedData,
+            error: null,
+            stackTrace: log.stack_trace ?? null,
+          };
+        })}
+        searchTerm={searchTerm}
+      />
     </div>
   );
 };

--- a/app/components/pages/JobDetail.tsx
+++ b/app/components/pages/JobDetail.tsx
@@ -107,19 +107,42 @@ const JobDetail = () => {
     return Array.from(names).sort();
   }, [logs]);
 
-  // Filter logs by search term (client-side)
-  const filteredLogs = logs.filter((log) => {
-    if (searchTerm) {
-      const searchLower = searchTerm.toLowerCase();
-      if (
-        !log.message.toLowerCase().includes(searchLower) &&
-        !log.data?.toLowerCase().includes(searchLower)
-      ) {
-        return false;
-      }
-    }
-    return true;
-  });
+  // Filter and map logs to LogViewerEntry format (memoized to avoid
+  // re-parsing JSON on every render).
+  const viewerEntries = useMemo(() => {
+    const searchLower = searchTerm.toLowerCase();
+    return logs
+      .filter((log) => {
+        if (searchTerm) {
+          if (
+            !log.message.toLowerCase().includes(searchLower) &&
+            !log.data?.toLowerCase().includes(searchLower)
+          ) {
+            return false;
+          }
+        }
+        return true;
+      })
+      .map((log) => {
+        let parsedData: Record<string, unknown> | null = null;
+        if (log.data) {
+          try {
+            parsedData = JSON.parse(log.data);
+          } catch {
+            parsedData = null;
+          }
+        }
+        return {
+          id: log.id,
+          level: log.level,
+          timestamp: log.created_at,
+          message: log.message,
+          data: parsedData,
+          error: null,
+          stackTrace: log.stack_trace ?? null,
+        };
+      });
+  }, [logs, searchTerm]);
 
   const toggleLevelFilter = (level: string) => {
     setLevelFilter((prev) =>
@@ -235,25 +258,7 @@ const JobDetail = () => {
       {/* Log viewer */}
       <LogViewer
         emptyMessage="No logs found."
-        entries={filteredLogs.map((log) => {
-          let parsedData: Record<string, unknown> | null = null;
-          if (log.data) {
-            try {
-              parsedData = JSON.parse(log.data);
-            } catch {
-              parsedData = null;
-            }
-          }
-          return {
-            id: log.id,
-            level: log.level,
-            timestamp: log.created_at,
-            message: log.message,
-            data: parsedData,
-            error: null,
-            stackTrace: log.stack_trace ?? null,
-          };
-        })}
+        entries={viewerEntries}
         searchTerm={searchTerm}
       />
     </div>

--- a/app/hooks/queries/logs.ts
+++ b/app/hooks/queries/logs.ts
@@ -1,0 +1,56 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+
+import { API, ShishoAPIError } from "@/libraries/api";
+
+export enum QueryKey {
+  ListLogs = "ListLogs",
+}
+
+export interface LogEntry {
+  id: number;
+  level: string;
+  timestamp: string;
+  message: string;
+  data?: Record<string, unknown>;
+  error?: string;
+}
+
+interface ListLogsData {
+  entries: LogEntry[];
+}
+
+interface UseLogsOptions {
+  level?: string;
+  search?: string;
+  limit?: number;
+  afterId?: number;
+}
+
+export const useLogs = (
+  options: UseLogsOptions = {},
+  queryOptions: Omit<
+    UseQueryOptions<ListLogsData, ShishoAPIError>,
+    "queryKey" | "queryFn"
+  > = {},
+) => {
+  return useQuery<ListLogsData, ShishoAPIError>({
+    ...queryOptions,
+    queryKey: [QueryKey.ListLogs, options],
+    queryFn: ({ signal }) => {
+      const params: Record<string, string> = {};
+      if (options.level) {
+        params.level = options.level;
+      }
+      if (options.search) {
+        params.search = options.search;
+      }
+      if (options.limit !== undefined) {
+        params.limit = String(options.limit);
+      }
+      if (options.afterId !== undefined) {
+        params.after_id = String(options.afterId);
+      }
+      return API.request("GET", "/logs", null, params, signal);
+    },
+  });
+};

--- a/app/hooks/useSSE.ts
+++ b/app/hooks/useSSE.ts
@@ -8,6 +8,7 @@ import {
 import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
 import { QueryKey as JobsQueryKey } from "@/hooks/queries/jobs";
 import { QueryKey as LibrariesQueryKey } from "@/hooks/queries/libraries";
+import { QueryKey as LogsQueryKey } from "@/hooks/queries/logs";
 import { useAuth } from "@/hooks/useAuth";
 
 export function useSSE() {
@@ -99,9 +100,14 @@ export function useSSE() {
       }
     };
 
+    const handleLogEntry = () => {
+      queryClient.invalidateQueries({ queryKey: [LogsQueryKey.ListLogs] });
+    };
+
     es.addEventListener("job.created", handleJobCreated);
     es.addEventListener("job.status_changed", handleJobStatusChanged);
     es.addEventListener("bulk_download.progress", handleBulkDownloadProgress);
+    es.addEventListener("log.entry", handleLogEntry);
 
     return () => {
       es.removeEventListener("job.created", handleJobCreated);
@@ -110,6 +116,7 @@ export function useSSE() {
         "bulk_download.progress",
         handleBulkDownloadProgress,
       );
+      es.removeEventListener("log.entry", handleLogEntry);
       es.close();
     };
   }, [isAuthenticated, queryClient]);

--- a/app/hooks/useSSE.ts
+++ b/app/hooks/useSSE.ts
@@ -100,8 +100,12 @@ export function useSSE() {
       }
     };
 
+    let logInvalidateTimeout: ReturnType<typeof setTimeout> | undefined;
     const handleLogEntry = () => {
-      queryClient.invalidateQueries({ queryKey: [LogsQueryKey.ListLogs] });
+      clearTimeout(logInvalidateTimeout);
+      logInvalidateTimeout = setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: [LogsQueryKey.ListLogs] });
+      }, 500);
     };
 
     es.addEventListener("job.created", handleJobCreated);
@@ -110,6 +114,7 @@ export function useSSE() {
     es.addEventListener("log.entry", handleLogEntry);
 
     return () => {
+      clearTimeout(logInvalidateTimeout);
       es.removeEventListener("job.created", handleJobCreated);
       es.removeEventListener("job.status_changed", handleJobStatusChanged);
       es.removeEventListener(

--- a/app/router.tsx
+++ b/app/router.tsx
@@ -4,6 +4,7 @@ import ProtectedRoute from "@/components/library/ProtectedRoute";
 import AdminJobs from "@/components/pages/AdminJobs";
 import AdminLayout from "@/components/pages/AdminLayout";
 import AdminLibraries from "@/components/pages/AdminLibraries";
+import AdminLogs from "@/components/pages/AdminLogs";
 import AdminPlugins from "@/components/pages/AdminPlugins";
 import AdminSettings from "@/components/pages/AdminSettings";
 import AdminUsers from "@/components/pages/AdminUsers";
@@ -143,6 +144,16 @@ export const router = createBrowserRouter([
             requiredPermission={{ resource: "config", operation: "read" }}
           >
             <AdminPlugins />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "logs",
+        element: (
+          <ProtectedRoute
+            requiredPermission={{ resource: "config", operation: "read" }}
+          >
+            <AdminLogs />
           </ProtectedRoute>
         ),
       },

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/database"
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/events"
+	"github.com/shishobooks/shisho/pkg/logs"
 	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/plugins"
 	"github.com/shishobooks/shisho/pkg/server"
@@ -25,6 +27,10 @@ import (
 
 func main() {
 	ctx := context.Background()
+
+	broker := events.NewBroker()
+	logBuffer := logs.NewRingBuffer(10_000, broker)
+	logger.SetOutput(io.MultiWriter(logger.Output(), logBuffer))
 	log := logger.New()
 
 	log.Info("starting shisho", logger.Data{"version": version.Version})
@@ -68,13 +74,11 @@ func main() {
 		log.Warn("plugin load errors occurred", logger.Data{"error": err.Error()})
 	}
 
-	broker := events.NewBroker()
-
 	dlCache := downloadcache.NewCache(filepath.Join(cfg.CacheDir, "downloads"), cfg.DownloadCacheMaxSizeBytes())
 
 	wrkr := worker.New(cfg, db, pluginManager, broker, dlCache)
 
-	srv, err := server.New(cfg, db, wrkr, pluginManager, broker, dlCache)
+	srv, err := server.New(cfg, db, wrkr, pluginManager, broker, dlCache, logBuffer)
 	if err != nil {
 		log.Err(err).Fatal("server error")
 	}

--- a/docs/superpowers/plans/2026-04-17-logging-refinement.md
+++ b/docs/superpowers/plans/2026-04-17-logging-refinement.md
@@ -1,0 +1,1122 @@
+# Logging Refinement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> Check the project's root CLAUDE.md and any relevant subdirectory CLAUDE.md files for rules that apply to your work. These contain critical project conventions, gotchas, and requirements (e.g., docs update requirements, testing conventions, naming rules). Violations of these rules are review failures.
+
+**Goal:** Disable Caddy access logs by default (re-enable via env var) and add an in-memory log viewer to the admin UI backed by a ring buffer with live SSE tail.
+
+**Architecture:** A new `pkg/logs` package provides a `RingBuffer` that implements `io.Writer`, receiving JSON bytes from zerolog via `io.MultiWriter`. It parses entries into a circular slice, exposes them via a `GET /logs` endpoint, and publishes `log.entry` SSE events through the existing broker. The frontend adds a `/settings/logs` page with filtering and live tail.
+
+**Tech Stack:** Go (zerolog, Echo), React (Tanstack Query, SSE EventSource), TailwindCSS
+
+**Spec:** `docs/superpowers/specs/2026-04-17-logging-refinement-design.md`
+
+---
+
+### Task 1: Disable Caddy Access Logs by Default
+
+**Files:**
+- Modify: `Caddyfile:7`
+- Modify: `website/docs/configuration.md` (add Docker/Caddy env vars section)
+
+- [ ] **Step 1: Update Caddyfile**
+
+In `Caddyfile`, change line 7 from:
+```
+        output stdout
+```
+to:
+```
+        output {$CADDY_ACCESS_LOG_OUTPUT:discard}
+```
+
+- [ ] **Step 2: Document in website docs**
+
+In `website/docs/configuration.md`, add a new section before the "Authentication" section (before line 97). Add:
+
+```markdown
+### Docker / Caddy
+
+These environment variables are only relevant when running Shisho in Docker, where Caddy serves as the reverse proxy.
+
+| Env Variable | Default | Description |
+|-------------|---------|-------------|
+| `CADDY_ACCESS_LOG_OUTPUT` | `discard` | Caddy access log output. Set to `stdout` to enable access logs. Logs are disabled by default to reduce noise |
+| `PUID` | `1000` | User ID for the Shisho process inside the container |
+| `PGID` | `1000` | Group ID for the Shisho process inside the container |
+| `STARTUP_TIMEOUT_SECONDS` | `120` | Seconds to wait for the backend to start before giving up. Increase for slow storage (e.g., NAS devices) |
+| `LOG_FORMAT` | `console` | Log output format. Set to `json` for structured JSON logs (useful for log aggregation) |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Caddyfile website/docs/configuration.md
+git commit -m "[Backend] Disable Caddy access logs by default"
+```
+
+---
+
+### Task 2: Ring Buffer — Core Data Structure
+
+**Files:**
+- Create: `pkg/logs/ring_buffer.go`
+- Create: `pkg/logs/ring_buffer_test.go`
+
+- [ ] **Step 1: Write the failing test for RingBuffer.Write and Query**
+
+Create `pkg/logs/ring_buffer_test.go`:
+
+```go
+package logs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRingBuffer_WriteAndQuery(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	// Write a zerolog-formatted JSON line
+	line := `{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"starting shisho","data":{"version":"0.0.31"}}` + "\n"
+	n, err := rb.Write([]byte(line))
+	require.NoError(t, err)
+	assert.Equal(t, len(line), n)
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "info", entries[0].Level)
+	assert.Equal(t, "starting shisho", entries[0].Message)
+	assert.Equal(t, uint64(1), entries[0].ID)
+	assert.Equal(t, "0.0.31", entries[0].Data["version"])
+	assert.Nil(t, entries[0].Error)
+}
+
+func TestRingBuffer_ErrorField(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	line := `{"level":"error","timestamp":"2026-04-17T10:30:00Z","message":"db failed","error":"connection refused"}` + "\n"
+	_, err := rb.Write([]byte(line))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "error", entries[0].Level)
+	require.NotNil(t, entries[0].Error)
+	assert.Equal(t, "connection refused", *entries[0].Error)
+}
+
+func TestRingBuffer_Wrapping(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(3, nil)
+
+	for i := 1; i <= 5; i++ {
+		line := fmt.Sprintf(`{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"msg %d"}`, i) + "\n"
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 3)
+	// Should contain the 3 most recent entries (3, 4, 5)
+	assert.Equal(t, "msg 3", entries[0].Message)
+	assert.Equal(t, "msg 4", entries[1].Message)
+	assert.Equal(t, "msg 5", entries[2].Message)
+	// IDs should be 3, 4, 5
+	assert.Equal(t, uint64(3), entries[0].ID)
+	assert.Equal(t, uint64(5), entries[2].ID)
+}
+
+func TestRingBuffer_QueryAfterID(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	for i := 1; i <= 5; i++ {
+		line := fmt.Sprintf(`{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"msg %d"}`, i) + "\n"
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	// Get entries after ID 3 — should return msg 4 and msg 5
+	entries := rb.Query("", "", 100, 3)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "msg 4", entries[0].Message)
+	assert.Equal(t, "msg 5", entries[1].Message)
+}
+
+func TestRingBuffer_QueryLevelFilter(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	lines := []string{
+		`{"level":"debug","timestamp":"2026-04-17T10:30:00Z","message":"debug msg"}` + "\n",
+		`{"level":"info","timestamp":"2026-04-17T10:30:01Z","message":"info msg"}` + "\n",
+		`{"level":"warn","timestamp":"2026-04-17T10:30:02Z","message":"warn msg"}` + "\n",
+		`{"level":"error","timestamp":"2026-04-17T10:30:03Z","message":"error msg"}` + "\n",
+	}
+	for _, line := range lines {
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	// Filter by "warn" — should return warn and error
+	entries := rb.Query("warn", "", 100, 0)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "warn msg", entries[0].Message)
+	assert.Equal(t, "error msg", entries[1].Message)
+}
+
+func TestRingBuffer_QuerySearchFilter(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	lines := []string{
+		`{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"starting shisho"}` + "\n",
+		`{"level":"info","timestamp":"2026-04-17T10:30:01Z","message":"database connected"}` + "\n",
+		`{"level":"info","timestamp":"2026-04-17T10:30:02Z","message":"server started"}` + "\n",
+	}
+	for _, line := range lines {
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	// Case-insensitive search
+	entries := rb.Query("", "DATABASE", 100, 0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "database connected", entries[0].Message)
+}
+
+func TestRingBuffer_QueryLimit(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	for i := 1; i <= 10; i++ {
+		line := fmt.Sprintf(`{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"msg %d"}`, i) + "\n"
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	// Limit to 3 — should return the 3 most recent
+	entries := rb.Query("", "", 3, 0)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "msg 8", entries[0].Message)
+	assert.Equal(t, "msg 10", entries[2].Message)
+}
+
+func TestRingBuffer_MultiLineWrite(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	// zerolog can batch multiple lines in a single Write call
+	batch := `{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"first"}` + "\n" +
+		`{"level":"info","timestamp":"2026-04-17T10:30:01Z","message":"second"}` + "\n"
+	_, err := rb.Write([]byte(batch))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "first", entries[0].Message)
+	assert.Equal(t, "second", entries[1].Message)
+}
+
+func TestRingBuffer_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	// Invalid JSON should be silently dropped
+	_, err := rb.Write([]byte("not json\n"))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	assert.Len(t, entries, 0)
+}
+
+func TestRingBuffer_EmptyBufferQuery(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	entries := rb.Query("", "", 100, 0)
+	assert.Len(t, entries, 0)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/logging && go test ./pkg/logs/... -v`
+Expected: FAIL — package does not exist yet.
+
+- [ ] **Step 3: Implement RingBuffer**
+
+Create `pkg/logs/ring_buffer.go`:
+
+```go
+package logs
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/segmentio/encoding/json"
+	"github.com/shishobooks/shisho/pkg/events"
+)
+
+// LogEntry represents a parsed log entry stored in the ring buffer.
+type LogEntry struct {
+	ID        uint64         `json:"id"`
+	Level     string         `json:"level"`
+	Timestamp time.Time      `json:"timestamp"`
+	Message   string         `json:"message"`
+	Data      map[string]any `json:"data,omitempty"`
+	Error     *string        `json:"error,omitempty"`
+}
+
+// levelSeverity maps level strings to numeric severity for filtering.
+var levelSeverity = map[string]int{
+	"debug": 0,
+	"info":  1,
+	"warn":  2,
+	"error": 3,
+	"fatal": 4,
+}
+
+// RingBuffer captures zerolog JSON output into a fixed-size circular buffer.
+// It implements io.Writer so it can be used with io.MultiWriter.
+type RingBuffer struct {
+	mu       sync.RWMutex
+	entries  []LogEntry
+	capacity int
+	head     int // next write position
+	count    int // number of entries currently stored
+	nextID   atomic.Uint64
+	broker   *events.Broker
+}
+
+// NewRingBuffer creates a ring buffer that stores up to capacity log entries.
+// If broker is non-nil, each new entry is published as a "log.entry" SSE event.
+func NewRingBuffer(capacity int, broker *events.Broker) *RingBuffer {
+	return &RingBuffer{
+		entries:  make([]LogEntry, capacity),
+		capacity: capacity,
+		broker:   broker,
+	}
+}
+
+// Write implements io.Writer. It receives raw JSON bytes from zerolog,
+// splits by newline, parses each line into a LogEntry, and stores it.
+func (rb *RingBuffer) Write(p []byte) (int, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(p))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		entry, ok := parseLogLine(line)
+		if !ok {
+			continue
+		}
+
+		entry.ID = rb.nextID.Add(1)
+
+		rb.mu.Lock()
+		rb.entries[rb.head] = entry
+		rb.head = (rb.head + 1) % rb.capacity
+		if rb.count < rb.capacity {
+			rb.count++
+		}
+		rb.mu.Unlock()
+
+		if rb.broker != nil {
+			data, err := json.Marshal(entry)
+			if err == nil {
+				rb.broker.Publish(events.Event{Type: "log.entry", Data: string(data)})
+			}
+		}
+	}
+	return len(p), nil
+}
+
+// Query returns log entries matching the given filters.
+// level: minimum severity ("debug", "info", "warn", "error"). Empty = all.
+// search: case-insensitive substring match on message. Empty = all.
+// limit: max entries to return. 0 = no limit.
+// afterID: return entries with ID > afterID. 0 = all.
+func (rb *RingBuffer) Query(level, search string, limit int, afterID uint64) []LogEntry {
+	minSeverity := -1
+	if level != "" {
+		if s, ok := levelSeverity[level]; ok {
+			minSeverity = s
+		}
+	}
+	searchLower := strings.ToLower(search)
+
+	rb.mu.RLock()
+	defer rb.mu.RUnlock()
+
+	if rb.count == 0 {
+		return []LogEntry{}
+	}
+
+	// Collect matching entries
+	var matched []LogEntry
+	start := (rb.head - rb.count + rb.capacity) % rb.capacity
+
+	for i := 0; i < rb.count; i++ {
+		idx := (start + i) % rb.capacity
+		entry := rb.entries[idx]
+
+		if entry.ID <= afterID {
+			continue
+		}
+		if minSeverity >= 0 {
+			if s, ok := levelSeverity[entry.Level]; !ok || s < minSeverity {
+				continue
+			}
+		}
+		if searchLower != "" && !strings.Contains(strings.ToLower(entry.Message), searchLower) {
+			continue
+		}
+		matched = append(matched, entry)
+	}
+
+	// Apply limit — return the most recent entries
+	if limit > 0 && len(matched) > limit {
+		matched = matched[len(matched)-limit:]
+	}
+
+	return matched
+}
+
+// rawLogEntry is the intermediate struct for parsing zerolog JSON.
+type rawLogEntry struct {
+	Level     string         `json:"level"`
+	Timestamp string         `json:"timestamp"`
+	Message   string         `json:"message"`
+	Data      map[string]any `json:"data,omitempty"`
+	Error     *string        `json:"error,omitempty"`
+}
+
+func parseLogLine(line []byte) (LogEntry, bool) {
+	var raw rawLogEntry
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return LogEntry{}, false
+	}
+	if raw.Message == "" && raw.Level == "" {
+		return LogEntry{}, false
+	}
+
+	ts, _ := time.Parse(time.RFC3339, raw.Timestamp)
+
+	return LogEntry{
+		Level:     raw.Level,
+		Timestamp: ts,
+		Message:   raw.Message,
+		Data:      raw.Data,
+		Error:     raw.Error,
+	}, true
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/logging && go test ./pkg/logs/... -v`
+Expected: All 9 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/logs/ring_buffer.go pkg/logs/ring_buffer_test.go
+git commit -m "[Backend] Add in-memory log ring buffer"
+```
+
+---
+
+### Task 3: API Endpoint and Route Registration
+
+**Files:**
+- Create: `pkg/logs/handlers.go`
+- Create: `pkg/logs/validators.go`
+- Create: `pkg/logs/routes.go`
+- Modify: `pkg/server/server.go` (add logs route registration)
+
+- [ ] **Step 1: Create validators**
+
+Create `pkg/logs/validators.go`:
+
+```go
+package logs
+
+// ListLogsQuery defines query parameters for GET /logs.
+type ListLogsQuery struct {
+	Level   *string `query:"level" json:"level,omitempty" validate:"omitempty,oneof=debug info warn error"`
+	Search  *string `query:"search" json:"search,omitempty"`
+	Limit   *int    `query:"limit" json:"limit,omitempty" validate:"omitempty,min=1,max=1000"`
+	AfterID *uint64 `query:"after_id" json:"after_id,omitempty"`
+}
+```
+
+- [ ] **Step 2: Create handler**
+
+Create `pkg/logs/handlers.go`:
+
+```go
+package logs
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+)
+
+type handler struct {
+	buffer *RingBuffer
+}
+
+func (h *handler) listLogs(c echo.Context) error {
+	params := ListLogsQuery{}
+	if err := c.Bind(&params); err != nil {
+		return errors.WithStack(err)
+	}
+
+	level := ""
+	if params.Level != nil {
+		level = *params.Level
+	}
+	search := ""
+	if params.Search != nil {
+		search = *params.Search
+	}
+	limit := 100
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	var afterID uint64
+	if params.AfterID != nil {
+		afterID = *params.AfterID
+	}
+
+	entries := h.buffer.Query(level, search, limit, afterID)
+
+	resp := struct {
+		Entries []LogEntry `json:"entries"`
+	}{Entries: entries}
+
+	return errors.WithStack(c.JSON(http.StatusOK, resp))
+}
+```
+
+- [ ] **Step 3: Create routes**
+
+Create `pkg/logs/routes.go`:
+
+```go
+package logs
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// RegisterRoutes registers the log viewer endpoint.
+func RegisterRoutes(e *echo.Echo, buffer *RingBuffer, authMiddleware *auth.Middleware) {
+	h := &handler{buffer: buffer}
+	e.GET("/logs", h.listLogs,
+		authMiddleware.Authenticate,
+		authMiddleware.RequirePermission(models.ResourceConfig, models.OperationRead),
+	)
+}
+```
+
+- [ ] **Step 4: Wire into server.go**
+
+In `pkg/server/server.go`, add the `logs` import and pass the ring buffer through.
+
+Add import:
+```go
+"github.com/shishobooks/shisho/pkg/logs"
+```
+
+Update the `New` function signature from:
+```go
+func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) (*http.Server, error) {
+```
+to:
+```go
+func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache, logBuffer *logs.RingBuffer) (*http.Server, error) {
+```
+
+Add route registration after the SSE event stream registration (after line 104):
+```go
+	// Log viewer endpoint (admin only)
+	logs.RegisterRoutes(e, logBuffer, authMiddleware)
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/logs/handlers.go pkg/logs/validators.go pkg/logs/routes.go pkg/server/server.go
+git commit -m "[Backend] Add GET /logs endpoint with filtering"
+```
+
+---
+
+### Task 4: Wire Ring Buffer in main.go and Update golib
+
+**Files:**
+- Modify: `cmd/api/main.go`
+- Modify: `go.mod` / `go.sum` (update golib)
+
+- [ ] **Step 1: Update golib dependency**
+
+```bash
+cd /Users/robinjoseph/.worktrees/shisho/logging
+go get github.com/robinjoseph08/golib@v0.5.2
+go mod tidy
+```
+
+- [ ] **Step 2: Wire the ring buffer in main.go**
+
+In `cmd/api/main.go`, add import:
+```go
+"io"
+"github.com/shishobooks/shisho/pkg/logs"
+```
+
+The broker is created on line 71 (`broker := events.NewBroker()`). Add the ring buffer setup immediately after the broker creation, and move `log := logger.New()` after the ring buffer setup. The beginning of `main()` changes from:
+
+```go
+func main() {
+	ctx := context.Background()
+	log := logger.New()
+
+	log.Info("starting shisho", logger.Data{"version": version.Version})
+
+	cfg, err := config.New()
+	// ... lines through broker creation ...
+	broker := events.NewBroker()
+```
+
+to:
+
+```go
+func main() {
+	ctx := context.Background()
+
+	broker := events.NewBroker()
+	logBuffer := logs.NewRingBuffer(10_000, broker)
+	logger.SetOutput(io.MultiWriter(logger.Output(), logBuffer))
+	log := logger.New()
+
+	log.Info("starting shisho", logger.Data{"version": version.Version})
+
+	cfg, err := config.New()
+	// ... lines that previously created broker now removed from here ...
+```
+
+This requires moving the `broker` creation to before `logger.New()` — it was previously on line 71 after config, DB, and plugin setup. The broker has no dependencies (it's just `events.NewBroker()`), so it's safe to move to the top.
+
+Also update the `server.New` call to pass `logBuffer`:
+
+```go
+srv, err := server.New(cfg, db, wrkr, pluginManager, broker, dlCache, logBuffer)
+```
+
+- [ ] **Step 3: Verify the project builds**
+
+```bash
+cd /Users/robinjoseph/.worktrees/shisho/logging
+go build ./...
+```
+
+- [ ] **Step 4: Run Go tests**
+
+```bash
+mise test
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/api/main.go go.mod go.sum
+git commit -m "[Backend] Wire log ring buffer into main startup"
+```
+
+---
+
+### Task 5: Frontend — Query Hook and SSE Listener
+
+**Files:**
+- Create: `app/hooks/queries/logs.ts`
+- Modify: `app/hooks/useSSE.ts` (add `log.entry` listener)
+
+- [ ] **Step 1: Create the logs query hook**
+
+Create `app/hooks/queries/logs.ts`:
+
+```typescript
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+
+import { API, ShishoAPIError } from "@/libraries/api";
+
+export enum QueryKey {
+  ListLogs = "ListLogs",
+}
+
+export interface LogEntry {
+  id: number;
+  level: string;
+  timestamp: string;
+  message: string;
+  data?: Record<string, unknown>;
+  error?: string;
+}
+
+interface ListLogsData {
+  entries: LogEntry[];
+}
+
+interface UseLogsOptions {
+  level?: string;
+  search?: string;
+  limit?: number;
+  afterId?: number;
+}
+
+export const useLogs = (
+  options: UseLogsOptions = {},
+  queryOptions: Omit<
+    UseQueryOptions<ListLogsData, ShishoAPIError>,
+    "queryKey" | "queryFn"
+  > = {},
+) => {
+  return useQuery<ListLogsData, ShishoAPIError>({
+    ...queryOptions,
+    queryKey: [QueryKey.ListLogs, options],
+    queryFn: ({ signal }) => {
+      const params: Record<string, string> = {};
+      if (options.level) {
+        params.level = options.level;
+      }
+      if (options.search) {
+        params.search = options.search;
+      }
+      if (options.limit !== undefined) {
+        params.limit = String(options.limit);
+      }
+      if (options.afterId !== undefined) {
+        params.after_id = String(options.afterId);
+      }
+      return API.request("GET", "/logs", null, params, signal);
+    },
+  });
+};
+```
+
+- [ ] **Step 2: Add log.entry SSE listener**
+
+In `app/hooks/useSSE.ts`, the `log.entry` event is broadcast to all authenticated SSE connections but only needs to be consumed by the logs page. The existing `useSSE` hook handles job events globally. For logs, the page will listen directly since it needs local state management (appending to a list). No changes to `useSSE.ts` are needed — the log page will add its own `addEventListener` on the shared `EventSource`. 
+
+Actually, since the current `useSSE` creates the `EventSource` inside the hook and doesn't expose it, the logs page will consume `log.entry` events by invalidating the query cache. Add a listener in `useSSE.ts`:
+
+After the `handleBulkDownloadProgress` listener (line 104), add:
+
+```typescript
+    const handleLogEntry = () => {
+      queryClient.invalidateQueries({ queryKey: [LogsQueryKey.ListLogs] });
+    };
+
+    es.addEventListener("log.entry", handleLogEntry);
+```
+
+Add the import at the top:
+```typescript
+import { QueryKey as LogsQueryKey } from "@/hooks/queries/logs";
+```
+
+And add cleanup in the return function:
+```typescript
+      es.removeEventListener("log.entry", handleLogEntry);
+```
+
+**NOTE:** This approach is simple but means every log event triggers a refetch. Given the logs page will debounce queries or the user won't always be on the logs page, this is acceptable. The query won't actually fire unless there's an active `useLogs` query mounted.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/hooks/queries/logs.ts app/hooks/useSSE.ts
+git commit -m "[Frontend] Add logs query hook and SSE listener"
+```
+
+---
+
+### Task 6: Frontend — Admin Logs Page
+
+**Files:**
+- Create: `app/components/pages/AdminLogs.tsx`
+- Modify: `app/router.tsx` (add route)
+- Modify: `app/components/pages/AdminLayout.tsx` (add sidebar item)
+
+- [ ] **Step 1: Create the AdminLogs page**
+
+Create `app/components/pages/AdminLogs.tsx`:
+
+```tsx
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import LoadingSpinner from "@/components/library/LoadingSpinner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { type LogEntry, useLogs } from "@/hooks/queries/logs";
+import { usePageTitle } from "@/hooks/usePageTitle";
+
+const INITIAL_LIMIT = 200;
+
+const levelColors: Record<string, string> = {
+  debug:
+    "bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400",
+  info: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+  warn: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
+  error: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  fatal: "bg-red-200 text-red-900 dark:bg-red-900/50 dark:text-red-300",
+};
+
+const formatTimestamp = (ts: string): string => {
+  try {
+    const d = new Date(ts);
+    return d.toLocaleTimeString("en-US", {
+      hour12: false,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return ts;
+  }
+};
+
+interface LogRowProps {
+  entry: LogEntry;
+}
+
+const LogRow = ({ entry }: LogRowProps) => {
+  const [expanded, setExpanded] = useState(false);
+  const hasExtra = (entry.data && Object.keys(entry.data).length > 0) || entry.error;
+
+  return (
+    <div
+      className={`px-3 py-1.5 font-mono text-xs hover:bg-muted/50 transition-colors ${hasExtra ? "cursor-pointer" : ""}`}
+      onClick={hasExtra ? () => setExpanded(!expanded) : undefined}
+    >
+      <div className="flex items-start gap-2">
+        <span className="text-muted-foreground shrink-0 tabular-nums">
+          {formatTimestamp(entry.timestamp)}
+        </span>
+        <Badge
+          className={`${levelColors[entry.level] ?? levelColors.info} text-[10px] px-1.5 py-0 shrink-0 font-mono uppercase`}
+          variant="secondary"
+        >
+          {entry.level.slice(0, 3)}
+        </Badge>
+        <span className="text-foreground break-all">{entry.message}</span>
+      </div>
+      {expanded && (
+        <div className="mt-1 ml-[7.5rem] space-y-1">
+          {entry.error && (
+            <div className="text-red-500 dark:text-red-400">
+              error: {entry.error}
+            </div>
+          )}
+          {entry.data && Object.keys(entry.data).length > 0 && (
+            <pre className="text-muted-foreground whitespace-pre-wrap break-all">
+              {JSON.stringify(entry.data, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const AdminLogs = () => {
+  usePageTitle("Server Logs");
+
+  const [level, setLevel] = useState<string>("");
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+  const prevEntriesRef = useRef<LogEntry[]>([]);
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput), 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const { data, isLoading } = useLogs({
+    level: level || undefined,
+    search: search || undefined,
+    limit: INITIAL_LIMIT,
+  });
+
+  const entries = useMemo(() => data?.entries ?? [], [data]);
+
+  // Auto-scroll to bottom when new entries arrive (if user is at the bottom)
+  useEffect(() => {
+    if (autoScroll && scrollRef.current && entries.length > 0) {
+      // Only scroll if entries actually changed
+      if (entries !== prevEntriesRef.current) {
+        scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+        prevEntriesRef.current = entries;
+      }
+    }
+  }, [entries, autoScroll]);
+
+  const handleScroll = useCallback(() => {
+    if (!scrollRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+    // Consider "at bottom" if within 50px of the bottom
+    setAutoScroll(scrollHeight - scrollTop - clientHeight < 50);
+  }, []);
+
+  const jumpToLatest = useCallback(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+      setAutoScroll(true);
+    }
+  }, []);
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-12rem)]">
+      <div className="mb-4">
+        <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
+          Server Logs
+        </h1>
+        <p className="text-sm md:text-base text-muted-foreground">
+          Real-time server logs from the current session.
+        </p>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex items-center gap-3 mb-4">
+        <Select onValueChange={(v) => setLevel(v === "all" ? "" : v)} value={level || "all"}>
+          <SelectTrigger className="w-32">
+            <SelectValue placeholder="All levels" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All levels</SelectItem>
+            <SelectItem value="debug">Debug</SelectItem>
+            <SelectItem value="info">Info</SelectItem>
+            <SelectItem value="warn">Warn</SelectItem>
+            <SelectItem value="error">Error</SelectItem>
+          </SelectContent>
+        </Select>
+        <Input
+          className="max-w-xs"
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder="Search messages..."
+          value={searchInput}
+        />
+      </div>
+
+      {/* Log list */}
+      <div className="relative flex-1 min-h-0">
+        <div
+          className="absolute inset-0 overflow-y-auto border border-border rounded-md bg-muted/20 dark:bg-neutral-950/50"
+          onScroll={handleScroll}
+          ref={scrollRef}
+        >
+          {entries.length === 0 ? (
+            <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+              {search || level ? "No logs matching filters." : "No logs yet."}
+            </div>
+          ) : (
+            <div className="divide-y divide-border/50">
+              {entries.map((entry) => (
+                <LogRow entry={entry} key={entry.id} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Jump to latest button */}
+        {!autoScroll && entries.length > 0 && (
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2">
+            <Button
+              className="shadow-lg"
+              onClick={jumpToLatest}
+              size="sm"
+              variant="secondary"
+            >
+              Jump to latest
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AdminLogs;
+```
+
+- [ ] **Step 2: Add route in router.tsx**
+
+In `app/router.tsx`, add import:
+```typescript
+import AdminLogs from "@/components/pages/AdminLogs";
+```
+
+Add the route inside the `/settings` children array, after the plugins route (after line 148):
+```typescript
+      {
+        path: "logs",
+        element: (
+          <ProtectedRoute
+            requiredPermission={{ resource: "config", operation: "read" }}
+          >
+            <AdminLogs />
+          </ProtectedRoute>
+        ),
+      },
+```
+
+- [ ] **Step 3: Add sidebar item in AdminLayout.tsx**
+
+In `app/components/pages/AdminLayout.tsx`, add the `ScrollText` import:
+```typescript
+import {
+  Briefcase,
+  Cog,
+  Library,
+  LogOut,
+  Menu,
+  Puzzle,
+  ScrollText,
+  Users,
+} from "lucide-react";
+```
+
+Add the "Logs" nav item to the `mobileNavItems` array, after the Plugins entry (after line 178):
+```typescript
+    {
+      to: "/settings/logs",
+      icon: <ScrollText className="h-4 w-4" />,
+      label: "Logs",
+      isActive: location.pathname === "/settings/logs",
+      show: canViewConfig,
+    },
+```
+
+Add the desktop sidebar `NavItem` after the Plugins NavItem (after line 248):
+```tsx
+              {canViewConfig && (
+                <NavItem
+                  icon={<ScrollText className="h-4 w-4" />}
+                  isActive={location.pathname === "/settings/logs"}
+                  label="Logs"
+                  to="/settings/logs"
+                />
+              )}
+```
+
+- [ ] **Step 4: Verify frontend builds**
+
+```bash
+cd /Users/robinjoseph/.worktrees/shisho/logging
+pnpm build
+```
+
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/pages/AdminLogs.tsx app/router.tsx app/components/pages/AdminLayout.tsx
+git commit -m "[Frontend] Add server logs page with live tail and filtering"
+```
+
+---
+
+### Task 7: Manual Verification
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+cd /Users/robinjoseph/.worktrees/shisho/logging
+mise start
+```
+
+- [ ] **Step 2: Verify Caddy log suppression (Docker only)**
+
+If testing in Docker, verify no access logs appear on stdout by default. Set `CADDY_ACCESS_LOG_OUTPUT=stdout` and verify access logs return.
+
+- [ ] **Step 3: Verify logs page**
+
+1. Log in as admin
+2. Navigate to Settings > Logs
+3. Verify log entries appear (startup logs should be visible)
+4. Trigger a library scan to generate more log entries
+5. Verify new entries appear in real-time via SSE
+6. Verify level filter works (select "Error" — only error/fatal entries shown)
+7. Verify search filter works (type "shisho" — only matching entries shown)
+8. Scroll up — verify auto-scroll pauses and "Jump to latest" button appears
+9. Click "Jump to latest" — verify scroll jumps to bottom and auto-scroll resumes
+
+- [ ] **Step 4: Verify non-admin access is denied**
+
+1. Log in as a viewer role user
+2. Navigate to `/settings/logs` directly
+3. Verify access is denied (403 or redirect)
+4. Verify the "Logs" nav item is not visible in the sidebar
+
+- [ ] **Step 5: Run full checks**
+
+```bash
+mise check:quiet
+```
+
+Expected: All checks pass.
+
+- [ ] **Step 6: Commit any fixes from testing**
+
+If any issues were found and fixed during manual testing, commit them.

--- a/docs/superpowers/specs/2026-04-17-logging-refinement-design.md
+++ b/docs/superpowers/specs/2026-04-17-logging-refinement-design.md
@@ -1,0 +1,151 @@
+# Logging Refinement Design
+
+## Overview
+
+Two changes to Shisho's logging:
+1. **Disable Caddy access logs by default** with an env var to re-enable
+2. **In-memory log viewer** — backend captures its own logs in a ring buffer, exposed via API + SSE for a live-tail UI in admin settings
+
+## 1. Caddy Log Suppression
+
+### Change
+
+In `Caddyfile`, replace:
+```
+output stdout
+```
+with:
+```
+output {$CADDY_ACCESS_LOG_OUTPUT:discard}
+```
+
+Caddy's `discard` writer silently drops all access log entries. Users set `CADDY_ACCESS_LOG_OUTPUT=stdout` in their Docker compose to re-enable.
+
+### Documentation
+
+`CADDY_ACCESS_LOG_OUTPUT` must be documented in `website/docs/configuration.md` alongside other environment variables. This is a Docker/Caddy-only env var — it does not touch Go config.
+
+## 2. Ring Buffer (`pkg/logs`)
+
+### golib Dependency
+
+Requires `github.com/robinjoseph08/golib` v0.5.2+ which exports `logger.SetOutput()` and `logger.Output()`.
+
+### RingBuffer
+
+A new `pkg/logs` package with a `RingBuffer` type that:
+- Implements `io.Writer`
+- Receives raw JSON bytes from zerolog (via `io.MultiWriter`)
+- Parses each JSON line into a `LogEntry`
+- Stores entries in a fixed-size circular slice (10,000 entries)
+- Thread-safe via `sync.RWMutex`
+- Publishes `log.entry` SSE events via the event broker on each write
+
+### LogEntry
+
+```go
+type LogEntry struct {
+    ID        uint64         `json:"id"`         // monotonically increasing sequence number
+    Level     string         `json:"level"`      // "debug", "info", "warn", "error", "fatal"
+    Timestamp time.Time      `json:"timestamp"`
+    Message   string         `json:"message"`
+    Data      map[string]any `json:"data"`       // nested data field from zerolog
+    Error     *string        `json:"error"`      // error string if present
+}
+```
+
+`ID` is a monotonically increasing uint64 assigned on write. Used as a cursor for SSE catch-up and pagination.
+
+### Query Method
+
+```go
+func (rb *RingBuffer) Query(level, search string, limit int, afterID uint64) []LogEntry
+```
+
+- `level` — minimum severity filter
+- `search` — case-insensitive substring match on message
+- `limit` — max entries to return
+- `afterID` — return only entries with ID > afterID
+
+**Performance optimization:** Since entries are ordered by ID, `afterID` filtering uses ring position arithmetic to jump directly to the right slot rather than scanning from the start. The common case (SSE catch-up with a recent afterID) only scans the handful of new entries. Full-buffer scans (initial page load with no afterID) are still sub-millisecond for 10k entries.
+
+### Constructor
+
+```go
+func NewRingBuffer(capacity int, broker *events.Broker) *RingBuffer
+```
+
+The broker is used to publish `log.entry` SSE events on each write.
+
+## 3. Wiring in `main.go`
+
+Three lines before `logger.New()`:
+
+```go
+logBuffer := logs.NewRingBuffer(10_000, broker)
+logger.SetOutput(io.MultiWriter(logger.Output(), logBuffer))
+log := logger.New()
+```
+
+`logBuffer` is passed to `server.New()` alongside existing parameters.
+
+## 4. API Endpoint
+
+### `GET /logs`
+
+Registered in `pkg/logs/routes.go`. Protected with `Authenticate` + `RequirePermission(config, read)`.
+
+**Query params:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `level` | string | (all) | Minimum severity: "debug", "info", "warn", "error" |
+| `search` | string | (none) | Case-insensitive substring match on message |
+| `limit` | int | 100 | Max entries to return (max 1000) |
+| `after_id` | uint64 | 0 | Return entries with ID > this value |
+
+**Response:**
+```json
+{
+  "entries": [
+    {
+      "id": 42,
+      "level": "info",
+      "timestamp": "2026-04-17T10:30:00Z",
+      "message": "starting shisho",
+      "data": {"version": "0.0.31"},
+      "error": null
+    }
+  ]
+}
+```
+
+### SSE Event
+
+`log.entry` events are published to the existing broker on every `Write()` call. Event data is the same JSON shape as a single entry. The frontend uses the last seen `id` as a cursor for catch-up on reconnect.
+
+## 5. Frontend — Admin Logs Page
+
+### Route
+
+`/settings/logs` with `config:read` permission, following existing admin page patterns in `app/router.tsx`.
+
+### Sidebar
+
+New "Logs" nav item in `AdminLayout.tsx` with a lucide icon (e.g. `ScrollText`), placed after "Jobs" in nav order. Gated behind `canViewConfig`.
+
+### Page (`AdminLogs.tsx`)
+
+- **Page title:** "Server Logs" via `usePageTitle`
+- **Header:** Title and description ("Real-time server logs from the current session")
+- **Filter bar:** Level dropdown (All / Debug / Info / Warn / Error) + search text input, side by side
+- **Log list:** Scrollable container with monospace text. Each entry shows:
+  - Timestamp (compact format)
+  - Colored level badge
+  - Message
+  - Expandable data/error if present
+- **Auto-tail:** Subscribes to `log.entry` SSE events via the existing `EventSource` at `/api/events`. New entries append to the bottom. Auto-scroll follows the tail if the user is at the bottom; pauses if the user scrolls up (with a "Jump to latest" button).
+- **Initial load:** `GET /api/logs?limit=200` with current filters to populate history. Subsequent entries arrive via SSE.
+- **Filter changes:** Re-fetch from the HTTP endpoint with new filters. SSE entries are filtered client-side to match current filters.
+
+No unsaved changes protection needed — read-only page.

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/pdfcpu/pdfcpu v0.11.1
 	github.com/pkg/errors v0.9.1
-	github.com/robinjoseph08/golib v0.5.1
+	github.com/robinjoseph08/golib v0.5.2
 	github.com/segmentio/encoding v0.5.4
 	github.com/stretchr/testify v1.11.1
 	github.com/uptrace/bun v1.2.18

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++
 github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-github.com/robinjoseph08/golib v0.5.1 h1:ZUH8AkuH0gOaT/FQ4+jqdiLHaMa2yGRCU7hN18ExX7M=
-github.com/robinjoseph08/golib v0.5.1/go.mod h1:4igWuz+AzFHszJdlLeh0prE+dWrDSXIDYUzoY4usPcI=
+github.com/robinjoseph08/golib v0.5.2 h1:+6fHQ84Aa/hDrfjh9bE2zWwSRMMz6JVs5MfgH6A88Mg=
+github.com/robinjoseph08/golib v0.5.2/go.mod h1:4igWuz+AzFHszJdlLeh0prE+dWrDSXIDYUzoY4usPcI=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=

--- a/pkg/logs/handlers.go
+++ b/pkg/logs/handlers.go
@@ -1,0 +1,44 @@
+package logs
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+)
+
+type handler struct {
+	buffer *RingBuffer
+}
+
+func (h *handler) listLogs(c echo.Context) error {
+	params := ListLogsQuery{}
+	if err := c.Bind(&params); err != nil {
+		return errors.WithStack(err)
+	}
+
+	level := ""
+	if params.Level != nil {
+		level = *params.Level
+	}
+	search := ""
+	if params.Search != nil {
+		search = *params.Search
+	}
+	limit := 100
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	var afterID uint64
+	if params.AfterID != nil {
+		afterID = *params.AfterID
+	}
+
+	entries := h.buffer.Query(level, search, limit, afterID)
+
+	resp := struct {
+		Entries []LogEntry `json:"entries"`
+	}{Entries: entries}
+
+	return errors.WithStack(c.JSON(http.StatusOK, resp))
+}

--- a/pkg/logs/ring_buffer.go
+++ b/pkg/logs/ring_buffer.go
@@ -139,31 +139,69 @@ func (rb *RingBuffer) Query(level, search string, limit int, afterID uint64) []L
 	return matched
 }
 
-// rawLogEntry is the intermediate struct for parsing zerolog JSON.
-type rawLogEntry struct {
-	Level     string         `json:"level"`
-	Timestamp string         `json:"timestamp"`
-	Message   string         `json:"message"`
-	Data      map[string]any `json:"data,omitempty"`
-	Error     *string        `json:"error,omitempty"`
+// knownFields are top-level zerolog fields that are extracted into dedicated
+// LogEntry fields (or intentionally excluded like hostname). Everything else
+// is merged into Data so root-level fields from log.Root() are visible.
+var knownFields = map[string]bool{
+	"level": true, "timestamp": true, "message": true,
+	"data": true, "error": true, "hostname": true, "stack": true,
+}
+
+// skipRoutes are API routes whose "request handled" entries are excluded
+// from the ring buffer to prevent feedback loops (e.g. the logs page
+// fetching /logs generates a log entry that triggers an SSE event that
+// causes another fetch).
+var skipRoutes = map[string]bool{
+	"/logs":   true,
+	"/events": true,
 }
 
 func parseLogLine(line []byte) (LogEntry, bool) {
-	var raw rawLogEntry
+	var raw map[string]any
 	if err := json.Unmarshal(line, &raw); err != nil {
 		return LogEntry{}, false
 	}
-	if raw.Message == "" && raw.Level == "" {
+
+	level, _ := raw["level"].(string)
+	message, _ := raw["message"].(string)
+	if level == "" && message == "" {
 		return LogEntry{}, false
 	}
 
-	ts, _ := time.Parse(time.RFC3339, raw.Timestamp)
+	// Skip log viewer and SSE routes to prevent feedback loops.
+	if route, ok := raw["route"].(string); ok && skipRoutes[route] {
+		return LogEntry{}, false
+	}
+
+	timestampStr, _ := raw["timestamp"].(string)
+	ts, _ := time.Parse(time.RFC3339, timestampStr)
+
+	var errStr *string
+	if e, ok := raw["error"].(string); ok {
+		errStr = &e
+	}
+
+	// Build data from nested "data" object + root-level extras.
+	data := make(map[string]any)
+	if nested, ok := raw["data"].(map[string]any); ok {
+		for k, v := range nested {
+			data[k] = v
+		}
+	}
+	for k, v := range raw {
+		if !knownFields[k] {
+			data[k] = v
+		}
+	}
+	if len(data) == 0 {
+		data = nil
+	}
 
 	return LogEntry{
-		Level:     raw.Level,
+		Level:     level,
 		Timestamp: ts,
-		Message:   raw.Message,
-		Data:      raw.Data,
-		Error:     raw.Error,
+		Message:   message,
+		Data:      data,
+		Error:     errStr,
 	}, true
 }

--- a/pkg/logs/ring_buffer.go
+++ b/pkg/logs/ring_buffer.go
@@ -110,7 +110,7 @@ func (rb *RingBuffer) Query(level, search string, limit int, afterID uint64) []L
 	}
 
 	// Collect matching entries in chronological order
-	var matched []LogEntry
+	matched := []LogEntry{}
 	start := (rb.head - rb.count + rb.capacity) % rb.capacity
 
 	for i := 0; i < rb.count; i++ {

--- a/pkg/logs/ring_buffer.go
+++ b/pkg/logs/ring_buffer.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -125,7 +126,7 @@ func (rb *RingBuffer) Query(level, search string, limit int, afterID uint64) []L
 				continue
 			}
 		}
-		if searchLower != "" && !strings.Contains(strings.ToLower(entry.Message), searchLower) {
+		if searchLower != "" && !entryMatchesSearch(entry, searchLower) {
 			continue
 		}
 		matched = append(matched, entry)
@@ -137,6 +138,22 @@ func (rb *RingBuffer) Query(level, search string, limit int, afterID uint64) []L
 	}
 
 	return matched
+}
+
+// entryMatchesSearch checks if the search term appears in the message or any data value.
+func entryMatchesSearch(entry LogEntry, searchLower string) bool {
+	if strings.Contains(strings.ToLower(entry.Message), searchLower) {
+		return true
+	}
+	for k, v := range entry.Data {
+		if strings.Contains(strings.ToLower(k), searchLower) {
+			return true
+		}
+		if strings.Contains(strings.ToLower(fmt.Sprint(v)), searchLower) {
+			return true
+		}
+	}
+	return false
 }
 
 // knownFields are top-level zerolog fields that are extracted into dedicated
@@ -154,6 +171,7 @@ var knownFields = map[string]bool{
 var skipRoutes = map[string]bool{
 	"/logs":   true,
 	"/events": true,
+	"/health": true,
 }
 
 func parseLogLine(line []byte) (LogEntry, bool) {

--- a/pkg/logs/ring_buffer.go
+++ b/pkg/logs/ring_buffer.go
@@ -1,0 +1,169 @@
+package logs
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/segmentio/encoding/json"
+	"github.com/shishobooks/shisho/pkg/events"
+)
+
+// LogEntry represents a parsed log entry stored in the ring buffer.
+type LogEntry struct {
+	ID        uint64         `json:"id"`
+	Level     string         `json:"level"`
+	Timestamp time.Time      `json:"timestamp"`
+	Message   string         `json:"message"`
+	Data      map[string]any `json:"data,omitempty"`
+	Error     *string        `json:"error,omitempty"`
+}
+
+// levelSeverity maps level strings to numeric severity for filtering.
+var levelSeverity = map[string]int{
+	"debug": 0,
+	"info":  1,
+	"warn":  2,
+	"error": 3,
+	"fatal": 4,
+}
+
+// RingBuffer captures zerolog JSON output into a fixed-size circular buffer.
+// It implements io.Writer so it can be used with io.MultiWriter.
+type RingBuffer struct {
+	mu       sync.RWMutex
+	entries  []LogEntry
+	capacity int
+	head     int // next write position
+	count    int // number of entries currently stored
+	nextID   atomic.Uint64
+	broker   *events.Broker
+}
+
+// NewRingBuffer creates a ring buffer that stores up to capacity log entries.
+// If broker is non-nil, each new entry is published as a "log.entry" SSE event.
+func NewRingBuffer(capacity int, broker *events.Broker) *RingBuffer {
+	return &RingBuffer{
+		entries:  make([]LogEntry, capacity),
+		capacity: capacity,
+		broker:   broker,
+	}
+}
+
+// Write implements io.Writer. It receives raw JSON bytes from zerolog,
+// splits by newline, parses each line into a LogEntry, and stores it.
+func (rb *RingBuffer) Write(p []byte) (int, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(p))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		entry, ok := parseLogLine(line)
+		if !ok {
+			continue
+		}
+
+		entry.ID = rb.nextID.Add(1)
+
+		rb.mu.Lock()
+		rb.entries[rb.head] = entry
+		rb.head = (rb.head + 1) % rb.capacity
+		if rb.count < rb.capacity {
+			rb.count++
+		}
+		rb.mu.Unlock()
+
+		if rb.broker != nil {
+			data, err := json.Marshal(entry)
+			if err == nil {
+				rb.broker.Publish(events.Event{Type: "log.entry", Data: string(data)})
+			}
+		}
+	}
+	return len(p), nil
+}
+
+// Query returns log entries matching the given filters.
+// level: minimum severity ("debug", "info", "warn", "error"). Empty = all.
+// search: case-insensitive substring match on message. Empty = all.
+// limit: max entries to return. 0 = no limit.
+// afterID: return entries with ID > afterID. 0 = all.
+func (rb *RingBuffer) Query(level, search string, limit int, afterID uint64) []LogEntry {
+	minSeverity := -1
+	if level != "" {
+		if s, ok := levelSeverity[level]; ok {
+			minSeverity = s
+		}
+	}
+	searchLower := strings.ToLower(search)
+
+	rb.mu.RLock()
+	defer rb.mu.RUnlock()
+
+	if rb.count == 0 {
+		return []LogEntry{}
+	}
+
+	// Collect matching entries in chronological order
+	var matched []LogEntry
+	start := (rb.head - rb.count + rb.capacity) % rb.capacity
+
+	for i := 0; i < rb.count; i++ {
+		idx := (start + i) % rb.capacity
+		entry := rb.entries[idx]
+
+		if entry.ID <= afterID {
+			continue
+		}
+		if minSeverity >= 0 {
+			if s, ok := levelSeverity[entry.Level]; !ok || s < minSeverity {
+				continue
+			}
+		}
+		if searchLower != "" && !strings.Contains(strings.ToLower(entry.Message), searchLower) {
+			continue
+		}
+		matched = append(matched, entry)
+	}
+
+	// Apply limit — return the most recent entries
+	if limit > 0 && len(matched) > limit {
+		matched = matched[len(matched)-limit:]
+	}
+
+	return matched
+}
+
+// rawLogEntry is the intermediate struct for parsing zerolog JSON.
+type rawLogEntry struct {
+	Level     string         `json:"level"`
+	Timestamp string         `json:"timestamp"`
+	Message   string         `json:"message"`
+	Data      map[string]any `json:"data,omitempty"`
+	Error     *string        `json:"error,omitempty"`
+}
+
+func parseLogLine(line []byte) (LogEntry, bool) {
+	var raw rawLogEntry
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return LogEntry{}, false
+	}
+	if raw.Message == "" && raw.Level == "" {
+		return LogEntry{}, false
+	}
+
+	ts, _ := time.Parse(time.RFC3339, raw.Timestamp)
+
+	return LogEntry{
+		Level:     raw.Level,
+		Timestamp: ts,
+		Message:   raw.Message,
+		Data:      raw.Data,
+		Error:     raw.Error,
+	}, true
+}

--- a/pkg/logs/ring_buffer_test.go
+++ b/pkg/logs/ring_buffer_test.go
@@ -175,3 +175,72 @@ func TestRingBuffer_EmptyBufferQuery(t *testing.T) {
 	entries := rb.Query("", "", 100, 0)
 	assert.Empty(t, entries)
 }
+
+func TestRingBuffer_RootLevelFields(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	// Zerolog puts Root() fields at the JSON root level, not under "data"
+	line := `{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"request handled","method":"GET","path":"/books","route":"/books","status_code":200,"duration":"1.234","hostname":"myhost"}` + "\n"
+	_, err := rb.Write([]byte(line))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "request handled", entries[0].Message)
+	// Root-level fields should appear in Data (except known fields like hostname)
+	assert.Equal(t, "GET", entries[0].Data["method"])
+	assert.Equal(t, "/books", entries[0].Data["path"])
+	assert.Equal(t, "/books", entries[0].Data["route"])
+	assert.Equal(t, float64(200), entries[0].Data["status_code"])
+	assert.Equal(t, "1.234", entries[0].Data["duration"])
+	// hostname is excluded
+	assert.Nil(t, entries[0].Data["hostname"])
+}
+
+func TestRingBuffer_RootAndNestedDataMerged(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	// Both nested "data" and root-level fields should appear in Data
+	line := `{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"starting","data":{"version":"0.0.31"},"id":"abc-123"}` + "\n"
+	_, err := rb.Write([]byte(line))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 1)
+	// Nested data
+	assert.Equal(t, "0.0.31", entries[0].Data["version"])
+	// Root-level field
+	assert.Equal(t, "abc-123", entries[0].Data["id"])
+}
+
+func TestRingBuffer_SkipLogsRoute(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	// Requests to /logs should be skipped to prevent feedback loops
+	line := `{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"request handled","route":"/logs","method":"GET","status_code":200}` + "\n"
+	_, err := rb.Write([]byte(line))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	assert.Empty(t, entries)
+}
+
+func TestRingBuffer_SkipEventsRoute(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	// SSE endpoint should also be skipped
+	line := `{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"request handled","route":"/events","method":"GET"}` + "\n"
+	_, err := rb.Write([]byte(line))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	assert.Empty(t, entries)
+}

--- a/pkg/logs/ring_buffer_test.go
+++ b/pkg/logs/ring_buffer_test.go
@@ -244,3 +244,45 @@ func TestRingBuffer_SkipEventsRoute(t *testing.T) {
 	entries := rb.Query("", "", 100, 0)
 	assert.Empty(t, entries)
 }
+
+func TestRingBuffer_SkipHealthRoute(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	line := `{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"request handled","route":"/health","method":"GET","status_code":200}` + "\n"
+	_, err := rb.Write([]byte(line))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	assert.Empty(t, entries)
+}
+
+func TestRingBuffer_SearchMatchesDataFields(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	lines := []string{
+		`{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"request handled","method":"GET","path":"/books","duration":"1.234"}` + "\n",
+		`{"level":"info","timestamp":"2026-04-17T10:30:01Z","message":"request handled","method":"POST","path":"/jobs","duration":"5.678"}` + "\n",
+		`{"level":"info","timestamp":"2026-04-17T10:30:02Z","message":"starting shisho","data":{"version":"0.0.31"}}` + "\n",
+	}
+	for _, line := range lines {
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	// Search by data field value
+	entries := rb.Query("", "/books", 100, 0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "/books", entries[0].Data["path"])
+
+	// Search by data field key
+	entries = rb.Query("", "duration", 100, 0)
+	require.Len(t, entries, 2)
+
+	// Search by nested data value
+	entries = rb.Query("", "0.0.31", 100, 0)
+	require.Len(t, entries, 1)
+}

--- a/pkg/logs/ring_buffer_test.go
+++ b/pkg/logs/ring_buffer_test.go
@@ -1,0 +1,177 @@
+package logs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRingBuffer_WriteAndQuery(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	line := `{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"starting shisho","data":{"version":"0.0.31"}}` + "\n"
+	n, err := rb.Write([]byte(line))
+	require.NoError(t, err)
+	assert.Equal(t, len(line), n)
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "info", entries[0].Level)
+	assert.Equal(t, "starting shisho", entries[0].Message)
+	assert.Equal(t, uint64(1), entries[0].ID)
+	assert.Equal(t, "0.0.31", entries[0].Data["version"])
+	assert.Nil(t, entries[0].Error)
+}
+
+func TestRingBuffer_ErrorField(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	line := `{"level":"error","timestamp":"2026-04-17T10:30:00Z","message":"db failed","error":"connection refused"}` + "\n"
+	_, err := rb.Write([]byte(line))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "error", entries[0].Level)
+	require.NotNil(t, entries[0].Error)
+	assert.Equal(t, "connection refused", *entries[0].Error)
+}
+
+func TestRingBuffer_Wrapping(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(3, nil)
+
+	for i := 1; i <= 5; i++ {
+		line := fmt.Sprintf(`{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"msg %d"}`, i) + "\n"
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "msg 3", entries[0].Message)
+	assert.Equal(t, "msg 4", entries[1].Message)
+	assert.Equal(t, "msg 5", entries[2].Message)
+	assert.Equal(t, uint64(3), entries[0].ID)
+	assert.Equal(t, uint64(5), entries[2].ID)
+}
+
+func TestRingBuffer_QueryAfterID(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	for i := 1; i <= 5; i++ {
+		line := fmt.Sprintf(`{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"msg %d"}`, i) + "\n"
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	entries := rb.Query("", "", 100, 3)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "msg 4", entries[0].Message)
+	assert.Equal(t, "msg 5", entries[1].Message)
+}
+
+func TestRingBuffer_QueryLevelFilter(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	lines := []string{
+		`{"level":"debug","timestamp":"2026-04-17T10:30:00Z","message":"debug msg"}` + "\n",
+		`{"level":"info","timestamp":"2026-04-17T10:30:01Z","message":"info msg"}` + "\n",
+		`{"level":"warn","timestamp":"2026-04-17T10:30:02Z","message":"warn msg"}` + "\n",
+		`{"level":"error","timestamp":"2026-04-17T10:30:03Z","message":"error msg"}` + "\n",
+	}
+	for _, line := range lines {
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	entries := rb.Query("warn", "", 100, 0)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "warn msg", entries[0].Message)
+	assert.Equal(t, "error msg", entries[1].Message)
+}
+
+func TestRingBuffer_QuerySearchFilter(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	lines := []string{
+		`{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"starting shisho"}` + "\n",
+		`{"level":"info","timestamp":"2026-04-17T10:30:01Z","message":"database connected"}` + "\n",
+		`{"level":"info","timestamp":"2026-04-17T10:30:02Z","message":"server started"}` + "\n",
+	}
+	for _, line := range lines {
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	entries := rb.Query("", "DATABASE", 100, 0)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "database connected", entries[0].Message)
+}
+
+func TestRingBuffer_QueryLimit(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	for i := 1; i <= 10; i++ {
+		line := fmt.Sprintf(`{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"msg %d"}`, i) + "\n"
+		_, err := rb.Write([]byte(line))
+		require.NoError(t, err)
+	}
+
+	entries := rb.Query("", "", 3, 0)
+	require.Len(t, entries, 3)
+	assert.Equal(t, "msg 8", entries[0].Message)
+	assert.Equal(t, "msg 10", entries[2].Message)
+}
+
+func TestRingBuffer_MultiLineWrite(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	batch := `{"level":"info","timestamp":"2026-04-17T10:30:00Z","message":"first"}` + "\n" +
+		`{"level":"info","timestamp":"2026-04-17T10:30:01Z","message":"second"}` + "\n"
+	_, err := rb.Write([]byte(batch))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	require.Len(t, entries, 2)
+	assert.Equal(t, "first", entries[0].Message)
+	assert.Equal(t, "second", entries[1].Message)
+}
+
+func TestRingBuffer_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	_, err := rb.Write([]byte("not json\n"))
+	require.NoError(t, err)
+
+	entries := rb.Query("", "", 100, 0)
+	assert.Len(t, entries, 0)
+}
+
+func TestRingBuffer_EmptyBufferQuery(t *testing.T) {
+	t.Parallel()
+
+	rb := NewRingBuffer(100, nil)
+
+	entries := rb.Query("", "", 100, 0)
+	assert.Len(t, entries, 0)
+}

--- a/pkg/logs/ring_buffer_test.go
+++ b/pkg/logs/ring_buffer_test.go
@@ -193,7 +193,7 @@ func TestRingBuffer_RootLevelFields(t *testing.T) {
 	assert.Equal(t, "GET", entries[0].Data["method"])
 	assert.Equal(t, "/books", entries[0].Data["path"])
 	assert.Equal(t, "/books", entries[0].Data["route"])
-	assert.Equal(t, float64(200), entries[0].Data["status_code"])
+	assert.EqualValues(t, 200, entries[0].Data["status_code"])
 	assert.Equal(t, "1.234", entries[0].Data["duration"])
 	// hostname is excluded
 	assert.Nil(t, entries[0].Data["hostname"])

--- a/pkg/logs/ring_buffer_test.go
+++ b/pkg/logs/ring_buffer_test.go
@@ -164,7 +164,7 @@ func TestRingBuffer_InvalidJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := rb.Query("", "", 100, 0)
-	assert.Len(t, entries, 0)
+	assert.Empty(t, entries)
 }
 
 func TestRingBuffer_EmptyBufferQuery(t *testing.T) {
@@ -173,5 +173,5 @@ func TestRingBuffer_EmptyBufferQuery(t *testing.T) {
 	rb := NewRingBuffer(100, nil)
 
 	entries := rb.Query("", "", 100, 0)
-	assert.Len(t, entries, 0)
+	assert.Empty(t, entries)
 }

--- a/pkg/logs/routes.go
+++ b/pkg/logs/routes.go
@@ -1,0 +1,16 @@
+package logs
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// RegisterRoutes registers the log viewer endpoint.
+func RegisterRoutes(e *echo.Echo, buffer *RingBuffer, authMiddleware *auth.Middleware) {
+	h := &handler{buffer: buffer}
+	e.GET("/logs", h.listLogs,
+		authMiddleware.Authenticate,
+		authMiddleware.RequirePermission(models.ResourceConfig, models.OperationRead),
+	)
+}

--- a/pkg/logs/validators.go
+++ b/pkg/logs/validators.go
@@ -1,0 +1,9 @@
+package logs
+
+// ListLogsQuery defines query parameters for GET /logs.
+type ListLogsQuery struct {
+	Level   *string `query:"level" json:"level,omitempty" validate:"omitempty,oneof=debug info warn error"`
+	Search  *string `query:"search" json:"search,omitempty"`
+	Limit   *int    `query:"limit" json:"limit,omitempty" validate:"omitempty,min=1,max=1000"`
+	AfterID *uint64 `query:"after_id" json:"after_id,omitempty"`
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/kobo"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/lists"
+	"github.com/shishobooks/shisho/pkg/logs"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/opds"
 	"github.com/shishobooks/shisho/pkg/people"
@@ -46,7 +47,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) (*http.Server, error) {
+func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache, logBuffer *logs.RingBuffer) (*http.Server, error) {
 	e := echo.New()
 
 	b, err := binder.New()
@@ -102,6 +103,9 @@ func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, 
 
 	// SSE event stream
 	events.RegisterRoutes(e, broker, authMiddleware)
+
+	// Log viewer endpoint (admin only)
+	logs.RegisterRoutes(e, logBuffer, authMiddleware)
 
 	echo.NotFoundHandler = notFoundHandler
 	e.HTTPErrorHandler = errcodes.NewHandler().Handle

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -94,6 +94,18 @@ macOS (FSEvents) and Docker containers typically don't need this adjustment.
 |---------|-------------|---------|-------------|
 | `supplement_exclude_patterns` | `SUPPLEMENT_EXCLUDE_PATTERNS` | `[".*", ".DS_Store", "Thumbs.db", "desktop.ini"]` | Glob patterns to exclude from [supplement file](./supplement-files) discovery. Env var accepts comma-separated values |
 
+### Docker / Caddy
+
+These environment variables are only relevant when running Shisho in Docker, where Caddy serves as the reverse proxy.
+
+| Env Variable | Default | Description |
+|-------------|---------|-------------|
+| `CADDY_ACCESS_LOG_OUTPUT` | `discard` | Caddy access log output. Set to `stdout` to enable access logs. Logs are disabled by default to reduce noise |
+| `PUID` | `1000` | User ID for the Shisho process inside the container |
+| `PGID` | `1000` | Group ID for the Shisho process inside the container |
+| `STARTUP_TIMEOUT_SECONDS` | `120` | Seconds to wait for the backend to start before giving up. Increase for slow storage (e.g., NAS devices) |
+| `LOG_FORMAT` | `console` | Log output format. Set to `json` for structured JSON logs (useful for log aggregation) |
+
 ### Authentication
 
 | Setting | Env Variable | Default | Description |


### PR DESCRIPTION
## Summary
- Disable Caddy access logs by default (re-enable via `CADDY_ACCESS_LOG_OUTPUT=stdout` env var), documented in configuration docs
- Add an in-memory ring buffer (`pkg/logs`) that captures zerolog output via `io.MultiWriter`, storing the last 10,000 entries with monotonic IDs for cursor-based pagination
- Expose `GET /logs` API endpoint (admin only, `config:read`) with level, search, limit, and after_id filters. Search matches both message text and data field keys/values. Log entries for `/logs`, `/events`, and `/health` routes are excluded to prevent feedback loops
- Publish `log.entry` SSE events for real-time updates via the existing event broker
- Add `/settings/logs` admin page with level dropdown, debounced search, auto-scroll with "Jump to latest", and expandable rows showing data/error/stack trace
- Extract shared `LogViewer` component used by both the new server logs page and the existing job detail page for visual consistency

## Test plan
- Navigate to Settings > Logs as admin — startup logs should be visible with data previews
- Trigger a library scan and verify new log entries appear in real-time via SSE
- Test level filter (select Error — only error/fatal entries shown)
- Test search filter (type a data field name like "duration" — matching entries shown)
- Scroll up — auto-scroll pauses, "Jump to latest" button appears
- Click "Jump to latest" — scroll jumps to bottom and auto-scroll resumes
- Verify `/logs` requests don't appear in the log viewer (feedback loop prevention)
- Log in as viewer role — verify Logs nav item is hidden and `/settings/logs` returns 403
- Verify job detail page (`/settings/jobs/:id`) still displays logs correctly with the shared component
- Run `mise check:quiet` — all checks pass