### PR TITLE
[Fix] Release port 3689 promptly on server shutdown

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
@@ -24,6 +25,19 @@ import (
 	"github.com/shishobooks/shisho/pkg/version"
 	"github.com/shishobooks/shisho/pkg/worker"
 )
+
+// shutdownHardDeadline is the wall-clock budget for the full graceful shutdown
+// sequence (server + worker + db). If we exceed it, we os.Exit so the port is
+// released promptly. Air's kill_delay defaults to 1s before SIGKILL, so the
+// hard deadline is mainly insurance for `mise start:api` and other callers
+// without a watchdog — if graceful takes longer than this, something is wrong
+// and we'd rather drop the process than hold the port indefinitely.
+const shutdownHardDeadline = 5 * time.Second
+
+// serverShutdownTimeout bounds how long we wait for in-flight HTTP requests
+// (including long-lived SSE streams) to finish before forcing connections
+// closed. Shorter than shutdownHardDeadline so worker/db cleanup still runs.
+const serverShutdownTimeout = 3 * time.Second
 
 func main() {
 	ctx := context.Background()
@@ -115,9 +129,38 @@ func main() {
 	<-graceful
 	log.Info("starting graceful shutdown")
 
-	err = srv.Shutdown(ctx)
+	// Watchdog: if any step below blocks past the hard deadline, force-exit
+	// so the TCP listener is released. Without this, a stuck SSE stream, a
+	// slow DB close, or a runaway job handler could hold port 3689 long
+	// enough for the next air rebuild to race and hit "address already in
+	// use". log.Fatal is not used here because it flushes buffered logs
+	// which is itself a blocking operation.
+	go func() {
+		time.Sleep(shutdownHardDeadline)
+		log.Error("graceful shutdown exceeded hard deadline, forcing exit", logger.Data{"deadline": shutdownHardDeadline.String()})
+		os.Exit(1)
+	}()
+
+	// Tell SSE streams to exit their select loops now; otherwise each one
+	// would hold an in-flight request until srv.Shutdown's timeout expires
+	// or the client happened to disconnect. The broker's Done channel is
+	// idempotent so this is safe to call before Shutdown.
+	broker.Close()
+
+	// Bound server shutdown so a hung SSE client or slow handler can't stall
+	// the rest of the shutdown sequence. Shutdown returns ctx.DeadlineExceeded
+	// on timeout; we then call Close to tear down remaining connections
+	// forcefully.
+	srvCtx, cancel := context.WithTimeout(ctx, serverShutdownTimeout)
+	defer cancel()
+	err = srv.Shutdown(srvCtx)
 	if err != nil {
 		log.Err(err).Error("server shutdown error")
+		// Force-close any lingering connections (e.g. SSE streams that
+		// didn't observe their request context cancellation in time).
+		if closeErr := srv.Close(); closeErr != nil {
+			log.Err(closeErr).Error("server force-close error")
+		}
 	}
 	log.Info("server shutdown")
 

--- a/pkg/events/broker.go
+++ b/pkg/events/broker.go
@@ -37,8 +37,7 @@ func (b *Broker) Done() <-chan struct{} {
 }
 
 // Close broadcasts shutdown to all current and future subscribers. Idempotent:
-// safe to call multiple times (e.g., from both http.Server.RegisterOnShutdown
-// and explicit main-goroutine cleanup).
+// safe to call multiple times.
 func (b *Broker) Close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/pkg/events/broker.go
+++ b/pkg/events/broker.go
@@ -15,11 +15,38 @@ type Event struct {
 type Broker struct {
 	mu          sync.RWMutex
 	subscribers map[chan Event]struct{}
+	// done is closed by Close() to broadcast "server is shutting down" to
+	// every SSE handler. Without this signal, streaming handlers would wait
+	// for the client to disconnect before returning, stalling srv.Shutdown
+	// until its timeout expires.
+	done chan struct{}
 }
 
 func NewBroker() *Broker {
 	return &Broker{
 		subscribers: make(map[chan Event]struct{}),
+		done:        make(chan struct{}),
+	}
+}
+
+// Done returns a channel that is closed when Close is called. SSE handlers
+// select on this channel alongside the request context so they exit promptly
+// during server shutdown instead of blocking until the client disconnects.
+func (b *Broker) Done() <-chan struct{} {
+	return b.done
+}
+
+// Close broadcasts shutdown to all current and future subscribers. Idempotent:
+// safe to call multiple times (e.g., from both http.Server.RegisterOnShutdown
+// and explicit main-goroutine cleanup).
+func (b *Broker) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	select {
+	case <-b.done:
+		// already closed
+	default:
+		close(b.done)
 	}
 }
 

--- a/pkg/events/handler.go
+++ b/pkg/events/handler.go
@@ -40,6 +40,10 @@ func (h *handler) stream(c echo.Context) error {
 		select {
 		case <-ctx.Done():
 			return nil
+		case <-h.broker.Done():
+			// Server is shutting down; exit the stream so srv.Shutdown can
+			// return without waiting the full timeout for this handler.
+			return nil
 		case <-heartbeat.C:
 			// SSE comment line keeps the connection alive through proxies.
 			fmt.Fprint(w, ": keepalive\n\n")

--- a/pkg/events/handler_test.go
+++ b/pkg/events/handler_test.go
@@ -69,3 +69,39 @@ func TestSSEHandler_StreamsEvents(t *testing.T) {
 	assert.Contains(t, lines, "event: job.created")
 	assert.Contains(t, lines, `data: {"job_id":1}`)
 }
+
+// TestSSEHandler_ReturnsOnBrokerClose verifies that the SSE handler exits
+// promptly when the broker is closed (graceful server shutdown), without
+// waiting for the client to disconnect. Without this, srv.Shutdown blocks
+// for the full timeout waiting for the handler to return, which in turn
+// delays the worker/db cleanup and the process exit past air's kill_delay.
+func TestSSEHandler_ReturnsOnBrokerClose(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker()
+	h := &handler{broker: b}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/events", nil)
+	// Intentionally do NOT cancel the request context — we want to prove
+	// the handler observes broker shutdown independently of the client.
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- h.stream(c)
+	}()
+
+	// Let the handler subscribe before signalling shutdown.
+	time.Sleep(50 * time.Millisecond)
+
+	b.Close()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("SSE handler did not return after broker.Close()")
+	}
+}

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -260,6 +260,11 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 	jobLog.Info("processing libraries", logger.Data{"count": len(allLibraries)})
 
 	for _, library := range allLibraries {
+		// Honor cancellation between libraries — if the worker is shutting
+		// down mid-scan, don't start a fresh per-library walk.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		jobLog.Info("processing library", logger.Data{"library_id": library.ID})
 		filesToScan := make([]string, 0)
 
@@ -289,6 +294,12 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 		for _, libraryPath := range library.LibraryPaths {
 			jobLog.Info("processing library path", logger.Data{"library_path_id": libraryPath.ID, "library_path": libraryPath.Filepath})
 			err := filepath.WalkDir(libraryPath.Filepath, func(path string, info fs.DirEntry, err error) error {
+				// Stop walking the tree if the worker is shutting down. Returning
+				// the cancellation error aborts the outer WalkDir call so we bail
+				// out of the library rather than enumerating thousands more paths.
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
 				if err != nil {
 					return errors.WithStack(err)
 				}
@@ -393,13 +404,18 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 		fileChan := make(chan string, len(filesToScan))
 		resultChan := make(chan scanResult, len(filesToScan))
 
-		// Start workers
+		// Start workers. Each worker checks ctx.Err() at the top of its
+		// loop so that once the worker is shutting down, queued paths
+		// still in fileChan are drained without running scanInternal.
 		var wg sync.WaitGroup
 		for i := 0; i < workerCount; i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				for path := range fileChan {
+					if ctx.Err() != nil {
+						continue
+					}
 					result, err := w.scanInternal(ctx, ScanOptions{
 						FilePath:  path,
 						LibraryID: library.ID,
@@ -417,9 +433,14 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 			}()
 		}
 
-		// Dispatch files
+		// Dispatch files; bail early on shutdown so queued workers can drain.
+	dispatchLoop:
 		for _, path := range filesToScan {
-			fileChan <- path
+			select {
+			case <-ctx.Done():
+				break dispatchLoop
+			case fileChan <- path:
+			}
 		}
 		close(fileChan)
 
@@ -448,6 +469,12 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 			"publishers_cached": cache.PublisherCount(),
 			"imprints_cached":   cache.ImprintCount(),
 		})
+
+		// If we were cancelled mid-scan, return now rather than running orphan
+		// cleanup/organize/hash-gen queuing on a partial result set.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 
 		// Books whose files were reconciled as moves should also be organized
 		// so organize_file_structure can rename their folders back into the

--- a/pkg/worker/scheduler_test.go
+++ b/pkg/worker/scheduler_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -121,6 +122,7 @@ func TestScheduler_StartWithZeroInterval(t *testing.T) {
 	tc.worker.doneScheduling = make(chan struct{})
 	tc.worker.doneUpdateCheck = make(chan struct{})
 	tc.worker.queue = make(chan *models.Job, tc.worker.config.WorkerProcesses)
+	tc.worker.jobCtx, tc.worker.jobCancel = context.WithCancel(context.Background())
 
 	// Start the worker
 	tc.worker.Start()

--- a/pkg/worker/scheduler_test.go
+++ b/pkg/worker/scheduler_test.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -115,14 +114,7 @@ func TestScheduler_StartWithZeroInterval(t *testing.T) {
 	// Set SyncIntervalMinutes to 0 (disabled)
 	tc.worker.config.SyncIntervalMinutes = 0
 
-	// Initialize channels
-	tc.worker.shutdown = make(chan struct{})
-	tc.worker.doneFetching = make(chan struct{})
-	tc.worker.doneProcessing = make(chan struct{}, tc.worker.config.WorkerProcesses)
-	tc.worker.doneScheduling = make(chan struct{})
-	tc.worker.doneUpdateCheck = make(chan struct{})
-	tc.worker.queue = make(chan *models.Job, tc.worker.config.WorkerProcesses)
-	tc.worker.jobCtx, tc.worker.jobCancel = context.WithCancel(context.Background())
+	tc.initWorkerRuntime()
 
 	// Start the worker
 	tc.worker.Start()

--- a/pkg/worker/shutdown_test.go
+++ b/pkg/worker/shutdown_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/shishobooks/shisho/pkg/config"
+	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/joblogs"
 	"github.com/shishobooks/shisho/pkg/jobs"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -153,4 +154,36 @@ func TestShutdown_PersistsFailedJobStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, models.JobStatusFailed, retrieved.Status,
 		"failed status should persist even when the job ctx was cancelled during shutdown")
+}
+
+// TestShouldSkipCleanup_SkipsAfterShutdown verifies that the download cache
+// cleanup callback observes worker shutdown. When w.ctx is cancelled, the
+// embedded HasActiveJob query bails out with context.Canceled, and the
+// closure returns true ("skip cleanup") rather than treating the cancelled
+// query as "no active job, proceed with cleanup" — that would race against
+// Shutdown and risk deleting cache files for an actively-running bulk
+// download whose job row we couldn't confirm.
+func TestShouldSkipCleanup_SkipsAfterShutdown(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	dlCache := downloadcache.NewCache(t.TempDir(), 100<<20)
+	cfg := &config.Config{WorkerProcesses: 1}
+	w := New(cfg, tc.db, nil, nil, dlCache)
+
+	// Before shutdown: no active bulk-download jobs exist, so the closure
+	// should allow cleanup (false == "don't skip").
+	assert.False(t, dlCache.ShouldSkipCleanup(),
+		"with no active bulk download job and a live ctx, cleanup should proceed")
+
+	// Simulate shutdown by cancelling the worker's context directly. We don't
+	// call Shutdown() here because that would block on goroutines we didn't
+	// Start(); cancelling the ctx exercises the codepath we care about.
+	w.cancel()
+
+	// After ctx cancellation, HasActiveJob returns context.Canceled. The
+	// closure must recognize that as a shutdown signal and return true so
+	// RunCleanup is skipped — we can't confirm it's safe.
+	assert.True(t, dlCache.ShouldSkipCleanup(),
+		"ShouldSkipCleanup should return true when the worker ctx is cancelled")
 }

--- a/pkg/worker/shutdown_test.go
+++ b/pkg/worker/shutdown_test.go
@@ -1,0 +1,95 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/config"
+	"github.com/shishobooks/shisho/pkg/joblogs"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShutdown_CancelsInFlightJob verifies that when Worker.Shutdown is called
+// while a job is executing, the job's context is cancelled so the job handler
+// can return early. Without this, long-running jobs (e.g. hash generation over
+// a large library) block shutdown past air's kill_delay, leaving the old API
+// process holding port 3689 and making the new process fail to bind with
+// "address already in use".
+func TestShutdown_CancelsInFlightJob(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	// Use New() so the internal channels and shutdown context are initialized
+	// the same way they are in production. The test context's worker is built
+	// manually and doesn't have Start/Shutdown-ready plumbing.
+	cfg := &config.Config{WorkerProcesses: 1}
+	w := New(cfg, tc.db, nil, nil, nil)
+
+	// Install a test-only process function under the scan job type that blocks
+	// until its context is cancelled. This stands in for a slow, real job
+	// (hash generation, scan, bulk download) so we can exercise the shutdown
+	// path without needing real file I/O.
+	jobStarted := make(chan struct{})
+	jobCtxCh := make(chan context.Context, 1)
+	w.processFuncs[models.JobTypeScan] = func(ctx context.Context, _ *models.Job, _ *joblogs.JobLogger) error {
+		close(jobStarted)
+		jobCtxCh <- ctx
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	// Insert a real job row so the UpdateJob call inside processJobs succeeds.
+	job := &models.Job{
+		Type:       models.JobTypeScan,
+		Status:     models.JobStatusPending,
+		DataParsed: &models.JobScanData{},
+	}
+	err := tc.jobService.CreateJob(tc.ctx, job)
+	require.NoError(t, err)
+
+	w.Start()
+	// Push the job onto the internal queue directly; we don't want to wait for
+	// the 5-second fetchJobs tick.
+	w.queue <- job
+
+	// Wait for the job to actually start executing so we know Shutdown is
+	// racing against in-flight work, not an idle worker.
+	select {
+	case <-jobStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job never started executing")
+	}
+
+	// Call Shutdown in a goroutine with a generous timeout so a broken
+	// implementation (Shutdown blocks forever) fails the test instead of
+	// hanging the whole test run.
+	shutdownDone := make(chan struct{})
+	start := time.Now()
+	go func() {
+		w.Shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-shutdownDone:
+		elapsed := time.Since(start)
+		// Shutdown should complete promptly because the job handler returns
+		// as soon as its context is cancelled. We allow a comfortable margin
+		// so this isn't flaky on slow CI, but catch the real bug (infinite
+		// wait) decisively.
+		assert.Less(t, elapsed, 500*time.Millisecond, "Shutdown should complete quickly after cancelling the in-flight job")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Shutdown did not complete within 3 seconds; in-flight job was not cancelled")
+	}
+
+	// Verify the job's context was actually cancelled (not just ignored).
+	select {
+	case ctx := <-jobCtxCh:
+		require.Error(t, ctx.Err(), "job context should have been cancelled during shutdown")
+	default:
+		t.Error("job never reported its context")
+	}
+}

--- a/pkg/worker/shutdown_test.go
+++ b/pkg/worker/shutdown_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shishobooks/shisho/pkg/config"
 	"github.com/shishobooks/shisho/pkg/joblogs"
+	"github.com/shishobooks/shisho/pkg/jobs"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,4 +93,64 @@ func TestShutdown_CancelsInFlightJob(t *testing.T) {
 	default:
 		t.Error("job never reported its context")
 	}
+}
+
+// TestShutdown_PersistsFailedJobStatus verifies that when a handler returns an
+// error during shutdown, the job row is still updated to "failed" in the DB.
+// Without a separate un-cancelled context for the status write, UpdateJob uses
+// the cancelled job context and fails silently, leaving the row stuck in
+// "in_progress". That orphan row does self-heal on restart (processID
+// regenerates, fetchJobs re-picks it up), but a completed-but-unpersisted job
+// would otherwise re-run wastefully — bulk download in particular would
+// re-render its zip.
+func TestShutdown_PersistsFailedJobStatus(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	cfg := &config.Config{WorkerProcesses: 1}
+	w := New(cfg, tc.db, nil, nil, nil)
+
+	// Handler returns ctx.Err() once cancelled — same shape as a real job
+	// that observes shutdown and bails out.
+	jobStarted := make(chan struct{})
+	w.processFuncs[models.JobTypeScan] = func(ctx context.Context, _ *models.Job, _ *joblogs.JobLogger) error {
+		close(jobStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	job := &models.Job{
+		Type:       models.JobTypeScan,
+		Status:     models.JobStatusPending,
+		DataParsed: &models.JobScanData{},
+	}
+	err := tc.jobService.CreateJob(tc.ctx, job)
+	require.NoError(t, err)
+
+	w.Start()
+	w.queue <- job
+
+	select {
+	case <-jobStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job never started executing")
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		w.Shutdown()
+		close(shutdownDone)
+	}()
+	select {
+	case <-shutdownDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Shutdown did not complete in time")
+	}
+
+	// After shutdown, the job row should reflect that the handler completed
+	// with a failure — NOT be stuck in "in_progress" from the initial update.
+	retrieved, err := tc.jobService.RetrieveJob(tc.ctx, jobs.RetrieveJobOptions{ID: &job.ID})
+	require.NoError(t, err)
+	assert.Equal(t, models.JobStatusFailed, retrieved.Status,
+		"failed status should persist even when the job ctx was cancelled during shutdown")
 }

--- a/pkg/worker/testhelpers_test.go
+++ b/pkg/worker/testhelpers_test.go
@@ -141,6 +141,23 @@ func newTestContext(t *testing.T) *testContext {
 	return tc
 }
 
+// initWorkerRuntime initializes the channels and cancellable context that
+// Worker.Start/Shutdown need. Tests that build a Worker directly (via struct
+// literal in newTestContext, not via New()) must call this before Start()
+// otherwise processJobs and the schedulers will panic on nil channels or nil
+// ctx. Kept separate from newTestContext because most tests call service
+// methods directly and never exercise Start/Shutdown.
+func (tc *testContext) initWorkerRuntime() {
+	tc.t.Helper()
+	tc.worker.shutdown = make(chan struct{})
+	tc.worker.doneFetching = make(chan struct{})
+	tc.worker.doneProcessing = make(chan struct{}, tc.worker.config.WorkerProcesses)
+	tc.worker.doneScheduling = make(chan struct{})
+	tc.worker.doneUpdateCheck = make(chan struct{})
+	tc.worker.queue = make(chan *models.Job, tc.worker.config.WorkerProcesses)
+	tc.worker.ctx, tc.worker.cancel = context.WithCancel(context.Background())
+}
+
 // createLibrary creates a test library with the given paths.
 func (tc *testContext) createLibrary(paths []string) {
 	tc.t.Helper()

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -226,9 +226,11 @@ func (w *Worker) processJobs() {
 			}
 			log := w.log.ID(id.String()).Root(logger.Data{"job_id": job.ID, "type": job.Type, "process_id": processID})
 			// Derive from jobCtx (not context.Background) so Shutdown can
-			// cancel in-flight jobs. Handlers like ProcessHashGenerationJob
-			// check ctx.Done() at loop boundaries and return ctx.Err() when
-			// cancelled; the scan job plumbs this ctx down to scanInternal.
+			// cancel in-flight jobs. Hash generation and bulk download check
+			// ctx.Done() at loop boundaries; the scan job does not yet honor
+			// cancellation, so its shutdown latency is still bounded only by
+			// the OS-level timeouts of whatever filesystem/DB call it happens
+			// to be in when ctx fires.
 			ctx := log.WithContext(w.jobCtx)
 
 			// Create job logger for DB persistence

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -147,9 +147,17 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 
 	if dlCache != nil {
 		dlCache.ShouldSkipCleanup = func() bool {
-			hasActive, err := w.jobService.HasActiveJob(context.Background(), models.JobTypeBulkDownload, nil)
+			// Use w.ctx so the query bails out during shutdown instead of
+			// holding up the cleanup goroutine on a DB that may be closing.
+			hasActive, err := w.jobService.HasActiveJob(w.ctx, models.JobTypeBulkDownload, nil)
 			if err != nil {
-				return false
+				// During shutdown the query returns context.Canceled — we
+				// can't confirm whether a bulk download is active, so err on
+				// the side of skipping cleanup rather than racing against
+				// Shutdown and potentially deleting an in-use cache file.
+				// Any other error (real DB failure) falls through to false
+				// so cleanup can still make progress under normal operation.
+				return errors.Is(err, context.Canceled)
 			}
 			return hasActive
 		}
@@ -273,7 +281,24 @@ func (w *Worker) processJobs() {
 
 				err = fn(ctx, job, jobLog)
 				if err != nil {
-					jobLog.Error("job failed", err, nil)
+					// A context.Canceled from shutdown isn't a real failure —
+					// suppress the ERROR log (and its doomed DB persist, since
+					// the job ctx is already cancelled) to match how the
+					// schedulers above handle the same case. We still fall
+					// through to mark the row failed.
+					//
+					// Cancelled-at-shutdown jobs intentionally stay at
+					// failed rather than being reset to pending:
+					//   - scan is re-queued by scheduleScanJobs on the next
+					//     SyncIntervalMinutes tick
+					//   - hash_generation is re-queued by the tail-hook at
+					//     the end of every scan
+					//   - bulk_download is NOT re-queued automatically; a
+					//     partial zip is cheaper to abandon than to re-render
+					//     unprompted on restart, so the user re-initiates it
+					if !errors.Is(err, context.Canceled) {
+						jobLog.Error("job failed", err, nil)
+					}
 					job.Status = models.JobStatusFailed
 					w.persistJobStatus(job, log)
 					return

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -74,15 +74,16 @@ type Worker struct {
 	doneCleanup     chan struct{}
 	doneUpdateCheck chan struct{}
 
-	// jobCtx is the parent context for every job the worker processes. It is
-	// cancelled by Shutdown so long-running jobs (hash generation, scans,
-	// bulk downloads) see ctx.Done() and return promptly instead of blocking
-	// shutdown until they finish naturally. Without this, a hash-gen job
-	// iterating a large library keeps processJobs busy past air's 1s
-	// kill_delay, and the next `mise start` reload races the outgoing
-	// process for port 3689.
-	jobCtx    context.Context
-	jobCancel context.CancelFunc
+	// ctx is the worker-wide context cancelled by Shutdown. It is the parent
+	// for every job handler's context (hash generation, scans, bulk downloads)
+	// AND for the DB calls inside fetchJobs/scheduleScanJobs/cleanupOldJobs/
+	// checkPluginUpdates. Without this, a hash-gen job iterating a large
+	// library would keep processJobs busy past air's 1s kill_delay (and the
+	// next `mise start` reload would race the outgoing process for port
+	// 3689), and a slow scheduler DB query would block the scheduler goroutine
+	// from observing shutdown until the query returned.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) *Worker {
@@ -101,15 +102,15 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 	pluginService := plugins.NewService(db)
 	fingerprintService := fingerprints.NewService(db)
 
-	jobCtx, jobCancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 
 	w := &Worker{
 		config: cfg,
 		log:    logger.New(),
 		db:     db,
 
-		jobCtx:    jobCtx,
-		jobCancel: jobCancel,
+		ctx:    ctx,
+		cancel: cancel,
 
 		bookService:        bookService,
 		chapterService:     chapterService,
@@ -193,13 +194,17 @@ func (w *Worker) fetchJobs() {
 			w.doneFetching <- struct{}{}
 			return
 		case <-timer.C:
-			j, err := w.jobService.ListJobs(context.Background(), jobs.ListJobsOptions{
+			j, err := w.jobService.ListJobs(w.ctx, jobs.ListJobsOptions{
 				Limit:              pointerutil.Int(1),
 				Statuses:           []string{models.JobStatusPending, models.JobStatusInProgress},
 				ProcessIDToExclude: &processID,
 			})
 			if err != nil {
-				w.log.Err(err).Error("list jobs error")
+				// Silently drop ctx.Canceled errors during shutdown; the
+				// enclosing select will observe w.shutdown on the next loop.
+				if !errors.Is(err, context.Canceled) {
+					w.log.Err(err).Error("list jobs error")
+				}
 				timer.Reset(duration)
 				continue
 			}
@@ -225,13 +230,11 @@ func (w *Worker) processJobs() {
 				continue
 			}
 			log := w.log.ID(id.String()).Root(logger.Data{"job_id": job.ID, "type": job.Type, "process_id": processID})
-			// Derive from jobCtx (not context.Background) so Shutdown can
-			// cancel in-flight jobs. Hash generation and bulk download check
-			// ctx.Done() at loop boundaries; the scan job does not yet honor
-			// cancellation, so its shutdown latency is still bounded only by
-			// the OS-level timeouts of whatever filesystem/DB call it happens
-			// to be in when ctx fires.
-			ctx := log.WithContext(w.jobCtx)
+			// Derive from w.ctx (not context.Background) so Shutdown can
+			// cancel in-flight jobs. Hash generation, scan, and bulk download
+			// all check ctx.Done() at loop boundaries and return ctx.Err()
+			// when cancelled.
+			ctx := log.WithContext(w.ctx)
 
 			// Create job logger for DB persistence
 			jobLog := w.jobLogService.NewJobLogger(ctx, job.ID, log)
@@ -255,10 +258,7 @@ func (w *Worker) processJobs() {
 					if r := recover(); r != nil {
 						jobLog.Fatal("job panicked", errors.Wrapf(errJobPanicked, "%v", r), logger.Data{"panic": r})
 						job.Status = models.JobStatusFailed
-						_ = w.jobService.UpdateJob(ctx, job, jobs.UpdateJobOptions{
-							Columns: []string{"status"},
-						})
-						w.publishJobEvent("job.status_changed", job)
+						w.persistJobStatus(job, log)
 					}
 				}()
 
@@ -267,10 +267,7 @@ func (w *Worker) processJobs() {
 				if !ok {
 					jobLog.Error("can't find process function for type", errors.Wrapf(errUnknownJobType, "%s", job.Type), nil)
 					job.Status = models.JobStatusFailed
-					_ = w.jobService.UpdateJob(ctx, job, jobs.UpdateJobOptions{
-						Columns: []string{"status"},
-					})
-					w.publishJobEvent("job.status_changed", job)
+					w.persistJobStatus(job, log)
 					return
 				}
 
@@ -278,22 +275,13 @@ func (w *Worker) processJobs() {
 				if err != nil {
 					jobLog.Error("job failed", err, nil)
 					job.Status = models.JobStatusFailed
-					_ = w.jobService.UpdateJob(ctx, job, jobs.UpdateJobOptions{
-						Columns: []string{"status"},
-					})
-					w.publishJobEvent("job.status_changed", job)
+					w.persistJobStatus(job, log)
 					return
 				}
 
 				// Update job to be completed so that it's not picked up anymore.
 				job.Status = models.JobStatusCompleted
-				err = w.jobService.UpdateJob(ctx, job, jobs.UpdateJobOptions{
-					Columns: []string{"status"},
-				})
-				if err != nil {
-					log.Err(err).Error("update job error")
-				}
-				w.publishJobEvent("job.status_changed", job)
+				w.persistJobStatus(job, log)
 			}()
 		}
 	}
@@ -310,15 +298,16 @@ func (w *Worker) scheduleScanJobs() {
 			w.doneScheduling <- struct{}{}
 			return
 		case <-timer.C:
-			ctx := context.Background()
 			log := w.log.Root(logger.Data{"scheduler": "scan"})
 
 			// Check if there are any non-deleted libraries
-			libs, err := w.libraryService.ListLibraries(ctx, libraries.ListLibrariesOptions{
+			libs, err := w.libraryService.ListLibraries(w.ctx, libraries.ListLibrariesOptions{
 				Limit: pointerutil.Int(1),
 			})
 			if err != nil {
-				log.Err(err).Error("failed to list libraries for scheduled scan")
+				if !errors.Is(err, context.Canceled) {
+					log.Err(err).Error("failed to list libraries for scheduled scan")
+				}
 				timer.Reset(duration)
 				continue
 			}
@@ -329,9 +318,11 @@ func (w *Worker) scheduleScanJobs() {
 			}
 
 			// Check if a scan job is already active
-			hasActive, err := w.jobService.HasActiveJob(ctx, models.JobTypeScan, nil)
+			hasActive, err := w.jobService.HasActiveJob(w.ctx, models.JobTypeScan, nil)
 			if err != nil {
-				log.Err(err).Error("failed to check for active scan job")
+				if !errors.Is(err, context.Canceled) {
+					log.Err(err).Error("failed to check for active scan job")
+				}
 				timer.Reset(duration)
 				continue
 			}
@@ -347,8 +338,10 @@ func (w *Worker) scheduleScanJobs() {
 				Status:     models.JobStatusPending,
 				DataParsed: &models.JobScanData{},
 			}
-			if err := w.jobService.CreateJob(ctx, scanJob); err != nil {
-				log.Err(err).Error("failed to create scheduled scan job")
+			if err := w.jobService.CreateJob(w.ctx, scanJob); err != nil {
+				if !errors.Is(err, context.Canceled) {
+					log.Err(err).Error("failed to create scheduled scan job")
+				}
 				timer.Reset(duration)
 				continue
 			}
@@ -372,12 +365,13 @@ func (w *Worker) cleanupOldJobs() {
 			w.doneCleanup <- struct{}{}
 			return
 		case <-timer.C:
-			ctx := context.Background()
 			log := w.log.Root(logger.Data{"cleanup": "jobs"})
 
-			count, err := w.jobService.CleanupOldJobs(ctx, w.config.JobRetentionDays)
+			count, err := w.jobService.CleanupOldJobs(w.ctx, w.config.JobRetentionDays)
 			if err != nil {
-				log.Err(err).Error("failed to cleanup old jobs")
+				if !errors.Is(err, context.Canceled) {
+					log.Err(err).Error("failed to cleanup old jobs")
+				}
 			} else if count > 0 {
 				log.Info("cleaned up old jobs", logger.Data{"count": count})
 			}
@@ -403,11 +397,12 @@ func (w *Worker) checkPluginUpdates() {
 			w.doneUpdateCheck <- struct{}{}
 			return
 		case <-timer.C:
-			ctx := context.Background()
 			log := w.log.Root(logger.Data{"scheduler": "plugin-update-check"})
 
-			if err := w.pluginManager.CheckForUpdates(ctx); err != nil {
-				log.Err(err).Error("failed to check for plugin updates")
+			if err := w.pluginManager.CheckForUpdates(w.ctx); err != nil {
+				if !errors.Is(err, context.Canceled) {
+					log.Err(err).Error("failed to check for plugin updates")
+				}
 			} else {
 				log.Debug("completed plugin update check")
 			}
@@ -457,13 +452,14 @@ func (w *Worker) Shutdown() {
 		w.monitor.stop()
 	}
 
-	// Cancel in-flight job contexts BEFORE closing w.shutdown. processJobs
-	// is currently inside fn(ctx, ...) for any running job, so signalling
-	// via w.shutdown alone would make it wait for the job to finish on its
-	// own. Cancelling the job context lets ctx.Done()-aware handlers unwind
-	// immediately.
-	if w.jobCancel != nil {
-		w.jobCancel()
+	// Cancel w.ctx BEFORE closing w.shutdown. This unblocks two things at
+	// once: in-flight job handlers currently running inside fn(ctx, ...),
+	// and DB queries in any of the scheduler goroutines that happened to
+	// be mid-call when shutdown arrived. Without this, processJobs would
+	// wait for the current job to finish naturally, and the schedulers
+	// wouldn't observe w.shutdown until their driver-level timeouts fired.
+	if w.cancel != nil {
+		w.cancel()
 	}
 
 	close(w.shutdown)
@@ -484,6 +480,30 @@ func (w *Worker) publishJobEvent(eventType string, job *models.Job) {
 		return
 	}
 	w.broker.Publish(events.NewJobEvent(eventType, job.ID, job.Status, job.Type, job.LibraryID))
+}
+
+// jobStatusWriteTimeout bounds the final status-update DB call when a job
+// finishes. It's short because the update is a single-row write — if it's
+// slower than this, something is wrong with the DB and blocking Shutdown on
+// it would only compound the problem.
+const jobStatusWriteTimeout = time.Second
+
+// persistJobStatus writes the job's current status (completed/failed) to the
+// DB and broadcasts the status_changed event, using a background-derived
+// context so it can still persist during shutdown. The in-progress job ctx
+// is cancelled the moment Shutdown starts, which would otherwise make this
+// final write fail silently and leave the row stuck at in_progress. The
+// 1s deadline keeps us from stalling Shutdown if the DB itself hangs.
+func (w *Worker) persistJobStatus(job *models.Job, log logger.Logger) {
+	statusCtx, cancel := context.WithTimeout(context.Background(), jobStatusWriteTimeout)
+	defer cancel()
+	if err := w.jobService.UpdateJob(statusCtx, job, jobs.UpdateJobOptions{
+		Columns: []string{"status"},
+	}); err != nil {
+		log.Err(err).Error("job status update error")
+		return
+	}
+	w.publishJobEvent("job.status_changed", job)
 }
 
 const letterBytes = "abcdef0123456789"

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -73,6 +73,16 @@ type Worker struct {
 	doneScheduling  chan struct{}
 	doneCleanup     chan struct{}
 	doneUpdateCheck chan struct{}
+
+	// jobCtx is the parent context for every job the worker processes. It is
+	// cancelled by Shutdown so long-running jobs (hash generation, scans,
+	// bulk downloads) see ctx.Done() and return promptly instead of blocking
+	// shutdown until they finish naturally. Without this, a hash-gen job
+	// iterating a large library keeps processJobs busy past air's 1s
+	// kill_delay, and the next `mise start` reload races the outgoing
+	// process for port 3689.
+	jobCtx    context.Context
+	jobCancel context.CancelFunc
 }
 
 func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) *Worker {
@@ -91,10 +101,15 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 	pluginService := plugins.NewService(db)
 	fingerprintService := fingerprints.NewService(db)
 
+	jobCtx, jobCancel := context.WithCancel(context.Background())
+
 	w := &Worker{
 		config: cfg,
 		log:    logger.New(),
 		db:     db,
+
+		jobCtx:    jobCtx,
+		jobCancel: jobCancel,
 
 		bookService:        bookService,
 		chapterService:     chapterService,
@@ -210,7 +225,11 @@ func (w *Worker) processJobs() {
 				continue
 			}
 			log := w.log.ID(id.String()).Root(logger.Data{"job_id": job.ID, "type": job.Type, "process_id": processID})
-			ctx := log.WithContext(context.Background())
+			// Derive from jobCtx (not context.Background) so Shutdown can
+			// cancel in-flight jobs. Handlers like ProcessHashGenerationJob
+			// check ctx.Done() at loop boundaries and return ctx.Err() when
+			// cancelled; the scan job plumbs this ctx down to scanInternal.
+			ctx := log.WithContext(w.jobCtx)
 
 			// Create job logger for DB persistence
 			jobLog := w.jobLogService.NewJobLogger(ctx, job.ID, log)
@@ -434,6 +453,15 @@ func (w *Worker) RefreshMonitorWatches() {
 func (w *Worker) Shutdown() {
 	if w.monitor != nil {
 		w.monitor.stop()
+	}
+
+	// Cancel in-flight job contexts BEFORE closing w.shutdown. processJobs
+	// is currently inside fn(ctx, ...) for any running job, so signalling
+	// via w.shutdown alone would make it wait for the job to finish on its
+	// own. Cancelling the job context lets ctx.Done()-aware handlers unwind
+	// immediately.
+	if w.jobCancel != nil {
+		w.jobCancel()
 	}
 
 	close(w.shutdown)


### PR DESCRIPTION
## Summary
- Cancel in-flight worker jobs on `Worker.Shutdown()` via a new `jobCtx` so long-running handlers (hash generation, scans, bulk downloads) return promptly instead of blocking shutdown past air's 1s `kill_delay`.
- Broadcast shutdown to SSE streams via `broker.Close()`/`broker.Done()` so they exit immediately when the server is shutting down, instead of holding in-flight HTTP requests until the client disconnects or `srv.Shutdown` times out.
- Bound `srv.Shutdown` with a 3s timeout, fall through to `srv.Close()` on timeout, and add a 5s watchdog goroutine that `os.Exit(1)`s if anything still blocks — so the TCP listener is always released promptly for the next `mise start` or container restart.

## Test plan
- `mise check:quiet` passes locally (lint, test, lint:js, test:js all green).
- `TestShutdown_CancelsInFlightJob` (new) asserts `Worker.Shutdown()` completes in <500ms when a job is mid-run; without the fix the test hangs past its 3s timeout.
- `TestSSEHandler_ReturnsOnBrokerClose` (new) asserts the stream handler returns immediately after `broker.Close()` without waiting for client disconnect.
- Manual: run `mise start`, open the UI (subscribes to `/events` SSE), trigger an air reload by editing a Go file, confirm the new API binary binds port 3689 cleanly with no "address already in use" and no leftover `api-air` process.
- Manual: start a scan on a real library, trigger a reload mid-scan, confirm the old process exits within ~1s and the new one boots without a stale `in_progress` job blocking future scans.