### PR TITLE
[Feature] Let plugins set cover_page for CBZ/PDF files

### DIFF
--- a/app/components/library/FileEditDialog.test.tsx
+++ b/app/components/library/FileEditDialog.test.tsx
@@ -262,6 +262,9 @@ describe("FileEditDialog", () => {
   });
 
   describe("cover page change race condition", () => {
+    // Bumped timeout: the test chains many waitFor + React Query + FormDialog
+    // settle steps, and the default 5s tips over under parallel E2E + coverage
+    // load in `mise check:quiet`. Runs in ~1s in isolation.
     it("should reset pendingCoverPage after successful save so hasChanges becomes false", async () => {
       // This test reproduces the bug:
       // 1. User opens dialog
@@ -321,7 +324,7 @@ describe("FileEditDialog", () => {
       await waitFor(() => {
         expect(onOpenChange).toHaveBeenCalledWith(false);
       });
-    });
+    }, 15_000);
   });
 
   describe("memory management", () => {

--- a/app/components/library/FileEditDialog.test.tsx
+++ b/app/components/library/FileEditDialog.test.tsx
@@ -14,8 +14,16 @@ import {
 
 import { FileRoleMain, FileTypeCBZ, type File } from "@/types";
 
+// delay:null skips userEvent's default 10ms-per-event pause so chained
+// clicks don't rely on fake-timer advancement under CPU contention — this
+// is the root-cause fix for the parallel E2E + coverage flakiness that the
+// "cover page save race" test hit (the test chains 5 waitFor + React Query
+// + FormDialog settle steps, each of which accumulates delay otherwise).
 const createUser = () =>
-  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  userEvent.setup({
+    advanceTimers: vi.advanceTimersByTime,
+    delay: null,
+  });
 
 // Define global that's normally set by Vite
 beforeAll(() => {
@@ -262,9 +270,6 @@ describe("FileEditDialog", () => {
   });
 
   describe("cover page change race condition", () => {
-    // Bumped timeout: the test chains many waitFor + React Query + FormDialog
-    // settle steps, and the default 5s tips over under parallel E2E + coverage
-    // load in `mise check:quiet`. Runs in ~1s in isolation.
     it("should reset pendingCoverPage after successful save so hasChanges becomes false", async () => {
       // This test reproduces the bug:
       // 1. User opens dialog
@@ -324,7 +329,7 @@ describe("FileEditDialog", () => {
       await waitFor(() => {
         expect(onOpenChange).toHaveBeenCalledWith(false);
       });
-    }, 15_000);
+    });
   });
 
   describe("memory management", () => {

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -430,8 +430,14 @@ export function IdentifyBookDialog({
                           }
                           const previewFileId =
                             selectedFileId ?? selectedFile?.id;
-                          if (
+                          const previewPageCount = selectedFile?.page_count;
+                          const coverPageInRange =
                             result.cover_page != null &&
+                            result.cover_page >= 0 &&
+                            (previewPageCount == null ||
+                              result.cover_page < previewPageCount);
+                          if (
+                            coverPageInRange &&
                             previewFileId &&
                             (selectedFileType === "cbz" ||
                               selectedFileType === "pdf")

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -428,9 +428,11 @@ export function IdentifyBookDialog({
                               />
                             );
                           }
+                          const previewFileId =
+                            selectedFileId ?? selectedFile?.id;
                           if (
                             result.cover_page != null &&
-                            selectedFileId &&
+                            previewFileId &&
                             (selectedFileType === "cbz" ||
                               selectedFileType === "pdf")
                           ) {
@@ -438,7 +440,7 @@ export function IdentifyBookDialog({
                               <img
                                 alt=""
                                 className={thumbClass}
-                                src={`/api/books/files/${selectedFileId}/page/${result.cover_page}`}
+                                src={`/api/books/files/${previewFileId}/page/${result.cover_page}`}
                               />
                             );
                           }

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -414,25 +414,45 @@ export function IdentifyBookDialog({
                     >
                       <div className="flex gap-3">
                         {/* Cover thumbnail */}
-                        {result.cover_url ? (
-                          <img
-                            alt=""
-                            className={cn(
-                              "w-16 object-cover rounded shrink-0 bg-muted",
-                              isAudiobook ? "h-16" : "h-24",
-                            )}
-                            src={result.cover_url}
-                          />
-                        ) : (
-                          <div
-                            className={cn(
-                              "w-16 rounded shrink-0 bg-muted flex items-center justify-center text-muted-foreground text-xs",
-                              isAudiobook ? "h-16" : "h-24",
-                            )}
-                          >
-                            No cover
-                          </div>
-                        )}
+                        {(() => {
+                          const thumbClass = cn(
+                            "w-16 object-cover rounded shrink-0 bg-muted",
+                            isAudiobook ? "h-16" : "h-24",
+                          );
+                          if (result.cover_url) {
+                            return (
+                              <img
+                                alt=""
+                                className={thumbClass}
+                                src={result.cover_url}
+                              />
+                            );
+                          }
+                          if (
+                            result.cover_page != null &&
+                            selectedFileId &&
+                            (selectedFileType === "cbz" ||
+                              selectedFileType === "pdf")
+                          ) {
+                            return (
+                              <img
+                                alt=""
+                                className={thumbClass}
+                                src={`/api/books/files/${selectedFileId}/page/${result.cover_page}`}
+                              />
+                            );
+                          }
+                          return (
+                            <div
+                              className={cn(
+                                "w-16 rounded shrink-0 bg-muted flex items-center justify-center text-muted-foreground text-xs",
+                                isAudiobook ? "h-16" : "h-24",
+                              )}
+                            >
+                              No cover
+                            </div>
+                          );
+                        })()}
 
                         {/* Details */}
                         <div className="flex-1 min-w-0">

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -589,20 +589,29 @@ export function IdentifyReviewForm({
     defaults.identifiers.value,
   );
 
-  // Cover state — page-based formats (CBZ, PDF) derive covers from page
-  // content and shouldn't be overwritten by plugin images.
-  const coverEditable = !isPageBasedFileType(file?.file_type);
+  // Cover state — for page-based formats (CBZ, PDF) the cover is a page of
+  // the file itself, so plugin cover *image* data (cover_url/cover_data) is
+  // ignored, but a plugin-supplied `cover_page` can still change the cover.
+  const isFilePageBased = isPageBasedFileType(file?.file_type);
   const isAudiobook = file?.file_type === "m4b";
-  const newCoverUrl = result.cover_url;
+  const newCoverUrl = !isFilePageBased ? result.cover_url : undefined;
+  const newCoverPage = isFilePageBased ? result.cover_page : undefined;
+  // The preview URL shown for the "new" option. For page-based files with a
+  // plugin-supplied cover_page, render the page via the file's page endpoint.
+  const newCoverPreviewUrl =
+    newCoverUrl ??
+    (file && newCoverPage != null
+      ? `/api/books/files/${file.id}/page/${newCoverPage}`
+      : undefined);
   const currentCoverUrl = file?.cover_image_filename
     ? `/api/books/files/${file.id}/cover?t=${new Date(file.updated_at).getTime()}`
     : undefined;
-  const hasCoverChoice = !!newCoverUrl && coverEditable;
+  const hasCoverChoice = !!newCoverPreviewUrl;
   const [coverSelection, setCoverSelection] = useState<"current" | "new">(
-    newCoverUrl && !isDisabled("cover") ? "new" : "current",
+    hasCoverChoice && !isDisabled("cover") ? "new" : "current",
   );
   const currentCoverDims = useImageDimensions(currentCoverUrl);
-  const newCoverDims = useImageDimensions(newCoverUrl);
+  const newCoverDims = useImageDimensions(newCoverPreviewUrl);
 
   // Prefer keeping the current cover when it's at least as high-resolution
   // as the plugin cover (by pixel count) — avoids unnecessary writes/churn.
@@ -637,7 +646,7 @@ export function IdentifyReviewForm({
       abridged !== defaults.abridged.value ||
       !equal(identifiers, defaults.identifiers.value) ||
       coverSelection !==
-        (newCoverUrl && !disabledFields.has("cover") && !preferCurrentCover
+        (hasCoverChoice && !disabledFields.has("cover") && !preferCurrentCover
           ? "new"
           : "current")
     );
@@ -660,7 +669,7 @@ export function IdentifyReviewForm({
     identifiers,
     coverSelection,
     defaults,
-    newCoverUrl,
+    hasCoverChoice,
     disabledFields,
     preferCurrentCover,
   ]);
@@ -695,8 +704,12 @@ export function IdentifyReviewForm({
       })),
     };
 
-    if (coverSelection === "new" && newCoverUrl) {
-      fields.cover_url = newCoverUrl;
+    if (coverSelection === "new") {
+      if (newCoverUrl) {
+        fields.cover_url = newCoverUrl;
+      } else if (newCoverPage != null) {
+        fields.cover_page = newCoverPage;
+      }
     }
 
     try {
@@ -806,7 +819,7 @@ export function IdentifyReviewForm({
                   "w-24 object-cover bg-muted",
                   isAudiobook ? "h-24" : "h-36",
                 )}
-                src={newCoverUrl}
+                src={newCoverPreviewUrl}
               />
               <span className="absolute bottom-0 inset-x-0 bg-black/60 text-white text-[0.6rem] text-center py-0.5">
                 Use new

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -595,7 +595,16 @@ export function IdentifyReviewForm({
   const isFilePageBased = isPageBasedFileType(file?.file_type);
   const isAudiobook = file?.file_type === "m4b";
   const newCoverUrl = !isFilePageBased ? result.cover_url : undefined;
-  const newCoverPage = isFilePageBased ? result.cover_page : undefined;
+  // Only treat coverPage as usable when it's a non-negative integer within
+  // the file's page range. A plugin returning out-of-range values would
+  // otherwise render a broken preview and get silently dropped at apply time.
+  const newCoverPage =
+    isFilePageBased &&
+    result.cover_page != null &&
+    result.cover_page >= 0 &&
+    (file?.page_count == null || result.cover_page < file.page_count)
+      ? result.cover_page
+      : undefined;
   // The preview URL shown for the "new" option. For page-based files with a
   // plugin-supplied cover_page, render the page via the file's page endpoint.
   const newCoverPreviewUrl =

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -560,6 +560,7 @@ export interface PluginSearchResult {
   language?: string;
   abridged?: boolean;
   cover_url?: string;
+  cover_page?: number;
   plugin_scope: string;
   plugin_id: string;
   disabled_fields?: string[];

--- a/docs/superpowers/plans/2026-04-19-plugin-cover-page.md
+++ b/docs/superpowers/plans/2026-04-19-plugin-cover-page.md
@@ -1,0 +1,922 @@
+# Plugin-Settable Cover Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let plugins set `coverPage` for CBZ/PDF files (under the existing `cover` capability) so enrichers can choose a non-first page as the cover without manual intervention.
+
+**Architecture:** (1) Wire `coverPage` through the two JS→Go parsers that don't already handle it; `parseParsedMetadata` already does. (2) Extract the manual UI handler's page-to-cover-image logic into a shared `ExtractCoverPageToFile` function in `pkg/books`. (3) Inject a `PageExtractor` dependency into `plugins.EnrichDeps` and update `persistMetadata` to apply `md.CoverPage` for page-based files, silently ignoring `coverData`/`coverUrl` for those formats (strict file-type-gated precedence). Out-of-range pages are skipped with a warning.
+
+**Tech Stack:** Go, Bun ORM, Goja, existing `pkg/cbzpages` and `pkg/pdfpages` caches for page rendering.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-plugin-cover-page-design.md`
+
+---
+
+## Background notes
+
+- `ParsedMetadata.CoverPage *int` already exists (`pkg/mediafile/mediafile.go:50`).
+- `coverPage?: number` already declared in SDK (`packages/plugin-sdk/metadata.d.ts:66`).
+- **`parseParsedMetadata` already parses `coverPage`** (`pkg/plugins/hooks.go:552-557`) — no change needed.
+- `models.File.CoverPage *int` already exists and `IsPageBasedFileType` returns true for CBZ and PDF (`pkg/models/file.go:86`).
+- `files.cover_page` column already exists — no migration.
+- The manual UI handler `updateFileCoverPage` (`pkg/books/handlers_cover_page.go:26-135`) is the reference implementation for applying a cover page.
+- Existing persist-metadata test pattern lives in `pkg/plugins/handler_persist_metadata_test.go` — use the same stub-based setup.
+- `EnrichDeps` is constructed once in `pkg/server/server.go:200` and passed to both `RegisterIdentifyRoutes` and `RegisterRoutesWithGroup`. Add a new field there.
+
+---
+
+## Task 1: Parse `coverPage` in `parseSearchResponse`
+
+**Files:**
+- Modify: `pkg/plugins/hooks.go:390-401` (add `coverPage` parsing inside the per-result loop)
+- Test: `pkg/plugins/hooks_search_result_test.go` (existing file for `parseSearchResponse` tests)
+
+- [ ] **Step 1: Read the existing test file to match style**
+
+Run: `cat pkg/plugins/hooks_search_result_test.go | head -60` so your new test matches the existing test setup (VM creation, JS eval, `parseSearchResponse` call, `results[0]` assertions).
+
+- [ ] **Step 2: Add a failing test for `coverPage` in search results**
+
+Append to `pkg/plugins/hooks_search_result_test.go`:
+
+```go
+func TestParseSearchResponse_CoverPage(t *testing.T) {
+	t.Parallel()
+	vm := goja.New()
+	val, err := vm.RunString(`({ results: [{ title: "x", coverPage: 3 }] })`)
+	require.NoError(t, err)
+
+	resp := parseSearchResponse(vm, val, "test", "plugin-id")
+
+	require.Len(t, resp.Results, 1)
+	require.NotNil(t, resp.Results[0].CoverPage)
+	assert.Equal(t, 3, *resp.Results[0].CoverPage)
+}
+
+func TestParseSearchResponse_CoverPage_MissingOrNull(t *testing.T) {
+	t.Parallel()
+	vm := goja.New()
+	val, err := vm.RunString(`({ results: [{ title: "a" }, { title: "b", coverPage: null }] })`)
+	require.NoError(t, err)
+
+	resp := parseSearchResponse(vm, val, "test", "plugin-id")
+
+	require.Len(t, resp.Results, 2)
+	assert.Nil(t, resp.Results[0].CoverPage)
+	assert.Nil(t, resp.Results[1].CoverPage)
+}
+```
+
+If `goja` is not already imported by the test file, add `"github.com/dop251/goja"` to the imports.
+
+- [ ] **Step 3: Run tests and confirm they fail**
+
+Run: `go test ./pkg/plugins/ -run TestParseSearchResponse_CoverPage -v`
+
+Expected: FAIL. Likely `Expected: not <nil>` because `CoverPage` is never set.
+
+- [ ] **Step 4: Add the parsing block to `parseSearchResponse`**
+
+In `pkg/plugins/hooks.go`, immediately after the `confidence` block (near line 427), add:
+
+```go
+// coverPage -> *int
+coverPageVal := itemObj.Get("coverPage")
+if coverPageVal != nil && !goja.IsUndefined(coverPageVal) && !goja.IsNull(coverPageVal) {
+	cp := int(coverPageVal.ToInteger())
+	md.CoverPage = &cp
+}
+```
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run: `go test ./pkg/plugins/ -run TestParseSearchResponse_CoverPage -v`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full plugins test package to catch regressions**
+
+Run: `go test ./pkg/plugins/ -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/plugins/hooks.go pkg/plugins/hooks_search_result_test.go
+git commit -m "[Backend] Parse coverPage from metadata enricher search results"
+```
+
+---
+
+## Task 2: Parse `cover_page` in `convertFieldsToMetadata`
+
+**Files:**
+- Modify: `pkg/plugins/handler.go:1929-1970` (the `convertFieldsToMetadata` function)
+- Test: `pkg/plugins/handler_convert_test.go` (existing)
+
+- [ ] **Step 1: Add a failing test**
+
+Append to `pkg/plugins/handler_convert_test.go`:
+
+```go
+func TestConvertFieldsToMetadata_CoverPage(t *testing.T) {
+	t.Parallel()
+	fields := map[string]any{
+		"cover_page": float64(4), // JSON numbers decode to float64
+	}
+
+	md := convertFieldsToMetadata(fields)
+
+	require.NotNil(t, md.CoverPage)
+	assert.Equal(t, 4, *md.CoverPage)
+}
+
+func TestConvertFieldsToMetadata_CoverPage_Missing(t *testing.T) {
+	t.Parallel()
+	md := convertFieldsToMetadata(map[string]any{})
+	assert.Nil(t, md.CoverPage)
+}
+```
+
+- [ ] **Step 2: Run and confirm they fail**
+
+Run: `go test ./pkg/plugins/ -run TestConvertFieldsToMetadata_CoverPage -v`
+
+Expected: FAIL. `md.CoverPage` is nil.
+
+- [ ] **Step 3: Add the parsing block**
+
+In `pkg/plugins/handler.go`, inside `convertFieldsToMetadata`, after the `series_number` block (near line 1960), add:
+
+```go
+// Cover page (0-indexed page number for CBZ/PDF)
+if v, ok := fields["cover_page"].(float64); ok {
+	cp := int(v)
+	md.CoverPage = &cp
+}
+```
+
+- [ ] **Step 4: Run and confirm they pass**
+
+Run: `go test ./pkg/plugins/ -run TestConvertFieldsToMetadata_CoverPage -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/plugins/handler.go pkg/plugins/handler_convert_test.go
+git commit -m "[Backend] Parse cover_page in manual identify apply payload"
+```
+
+---
+
+## Task 3: Extract shared `ExtractCoverPageToFile` helper
+
+This is a pure refactor: move the page extraction + cover file write logic from `updateFileCoverPage` into a new exported function so `persistMetadata` can reuse it. Existing tests in `handlers_cover_page_test.go` validate behavior is unchanged.
+
+**Files:**
+- Create: `pkg/books/coverpage_extract.go`
+- Modify: `pkg/books/handlers_cover_page.go` (swap in the helper)
+- Test: no new test — existing `handlers_cover_page_test.go` is the regression suite
+
+- [ ] **Step 1: Create the helper file**
+
+Create `pkg/books/coverpage_extract.go`:
+
+```go
+package books
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/cbzpages"
+	"github.com/shishobooks/shisho/pkg/fileutils"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/pdfpages"
+)
+
+// ExtractCoverPageToFile renders `page` from the given page-based file (CBZ or
+// PDF) via the appropriate page cache and writes the rendered image as the
+// cover file alongside the book. Returns the cover filename (not path) and
+// MIME type. Any existing cover image with the same base name is removed first
+// regardless of extension.
+//
+// Callers are responsible for updating the file's CoverPage, CoverImageFilename,
+// CoverMimeType, and CoverSource fields on the model and persisting them.
+func ExtractCoverPageToFile(
+	file *models.File,
+	bookFilepath string,
+	page int,
+	cbzCache *cbzpages.Cache,
+	pdfCache *pdfpages.Cache,
+	log logger.Logger,
+) (filename string, mimeType string, err error) {
+	var cachedPath string
+	switch file.FileType {
+	case models.FileTypeCBZ:
+		cachedPath, mimeType, err = cbzCache.GetPage(file.Filepath, file.ID, page)
+	case models.FileTypePDF:
+		cachedPath, mimeType, err = pdfCache.GetPage(file.Filepath, file.ID, page)
+	default:
+		return "", "", errors.Errorf("file type %q does not support page-based covers", file.FileType)
+	}
+	if err != nil {
+		return "", "", errors.Wrap(err, "failed to extract cover page")
+	}
+
+	coverDir := fileutils.ResolveCoverDir(bookFilepath)
+	coverBaseName := filepath.Base(file.Filepath) + ".cover"
+
+	ext := getExtensionFromMimeType(mimeType)
+	if ext == "" {
+		ext = filepath.Ext(cachedPath)
+	}
+
+	// Delete any existing cover with this base name (regardless of extension).
+	for _, existingExt := range fileutils.CoverImageExtensions {
+		existingPath := filepath.Join(coverDir, coverBaseName+existingExt)
+		if _, err := os.Stat(existingPath); err == nil {
+			if err := os.Remove(existingPath); err != nil {
+				log.Warn("failed to remove existing cover", logger.Data{"path": existingPath, "error": err.Error()})
+			}
+		}
+	}
+
+	coverFilename := coverBaseName + ext
+	coverFilepath := filepath.Join(coverDir, coverFilename)
+	if err := copyFile(cachedPath, coverFilepath); err != nil {
+		return "", "", errors.Wrap(err, "failed to save cover image")
+	}
+
+	return coverFilename, mimeType, nil
+}
+```
+
+Note: `copyFile` and `getExtensionFromMimeType` are already package-private helpers in `pkg/books/handlers_cover_page.go` and `handlers.go` — the new file references them directly.
+
+- [ ] **Step 2: Replace the inline logic in `updateFileCoverPage`**
+
+In `pkg/books/handlers_cover_page.go`, replace lines 65-107 (from `// Extract the page image using the appropriate page cache` through the `copyFile` call) with:
+
+```go
+	coverFilename, mimeType, err := ExtractCoverPageToFile(
+		file,
+		file.Book.Filepath,
+		payload.Page,
+		h.pageCache,
+		h.pdfPageCache,
+		log,
+	)
+	if err != nil {
+		log.Error("failed to extract cover page", logger.Data{"error": err.Error(), "page": payload.Page, "file_type": file.FileType})
+		return errcodes.ValidationError("Failed to extract page from file")
+	}
+
+	log.Info("set cover page", logger.Data{
+		"file_id":   file.ID,
+		"page":      payload.Page,
+		"cover":     coverFilename,
+		"mime_type": mimeType,
+	})
+```
+
+Then update the field-setting block (existing lines 117-121) to use `coverFilename` directly instead of reconstructing it:
+
+```go
+	file.CoverPage = &payload.Page
+	file.CoverMimeType = &mimeType
+	file.CoverSource = strPtr(models.DataSourceManual)
+	file.CoverImageFilename = &coverFilename
+```
+
+Remove now-unused imports if any (`io`, `net/http` are still used for `copyFile` / response). Run `goimports -w pkg/books/handlers_cover_page.go`.
+
+- [ ] **Step 3: Run the existing cover-page handler tests**
+
+Run: `go test ./pkg/books/ -run TestUpdateFileCoverPage -v -count=1`
+
+Expected: PASS (all existing tests — this is a pure refactor).
+
+- [ ] **Step 4: Run the broader books test suite**
+
+Run: `go test ./pkg/books/ -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/books/coverpage_extract.go pkg/books/handlers_cover_page.go
+git commit -m "[Backend] Extract shared ExtractCoverPageToFile helper"
+```
+
+---
+
+## Task 4: Wire `PageExtractor` dependency through `EnrichDeps`
+
+**Files:**
+- Modify: `pkg/plugins/handler.go` (add `pageExtractor` interface + field)
+- Modify: `pkg/plugins/routes.go` (add `PageExtractor` field to public `EnrichDeps`, copy into private `enrichDeps`)
+- Create: `pkg/books/plugin_page_extractor.go` (wrapper type implementing the interface)
+- Modify: `pkg/server/server.go` (construct and wire the extractor)
+
+- [ ] **Step 1: Define the interface in the plugins package**
+
+In `pkg/plugins/handler.go`, add this interface definition near the other dep interfaces (around line 107, after `searchIndexer`):
+
+```go
+// pageExtractor renders a page from a page-based file (CBZ/PDF) and writes
+// it as that file's cover image. Returns the cover filename (not a full path)
+// and the MIME type of the extracted image.
+type pageExtractor interface {
+	ExtractCoverPage(file *models.File, bookFilepath string, page int) (filename, mimeType string, err error)
+}
+```
+
+And add the field to `enrichDeps` (`pkg/plugins/handler.go:39`):
+
+```go
+type enrichDeps struct {
+	bookStore       bookStore
+	relStore        relationStore
+	identStore      identifierStore
+	personFinder    personFinder
+	genreFinder     genreFinder
+	tagFinder       tagFinder
+	publisherFinder publisherFinder
+	imprintFinder   imprintFinder
+	searchIndexer   searchIndexer
+	pageExtractor   pageExtractor
+}
+```
+
+- [ ] **Step 2: Add the public field on `EnrichDeps` and copy it in both registration sites**
+
+In `pkg/plugins/routes.go`:
+
+Add to `EnrichDeps` (line 12):
+
+```go
+type EnrichDeps struct {
+	BookStore       bookStore
+	RelStore        relationStore
+	IdentStore      identifierStore
+	PersonFinder    personFinder
+	GenreFinder     genreFinder
+	TagFinder       tagFinder
+	PublisherFinder publisherFinder
+	ImprintFinder   imprintFinder
+	SearchIndexer   searchIndexer
+	PageExtractor   pageExtractor
+}
+```
+
+In both `RegisterRoutesWithGroup` (line 28-39) and `RegisterIdentifyRoutes` (line 70-81), add `pageExtractor: ed.PageExtractor,` at the end of the `enrichDeps{...}` literal.
+
+- [ ] **Step 3: Create the wrapper type in the books package**
+
+Create `pkg/books/plugin_page_extractor.go`:
+
+```go
+package books
+
+import (
+	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/cbzpages"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/pdfpages"
+)
+
+// PluginPageExtractor adapts ExtractCoverPageToFile to the plugins package's
+// pageExtractor interface so plugin-provided cover_page values can be applied
+// without the plugins package needing to depend on books or the page caches
+// directly.
+type PluginPageExtractor struct {
+	cbzCache *cbzpages.Cache
+	pdfCache *pdfpages.Cache
+	log      logger.Logger
+}
+
+// NewPluginPageExtractor constructs a page extractor backed by its own
+// cbzpages and pdfpages caches. Multiple instances pointing at the same
+// cache directory are safe; the page cache writes are idempotent.
+func NewPluginPageExtractor(cbzCache *cbzpages.Cache, pdfCache *pdfpages.Cache) *PluginPageExtractor {
+	return &PluginPageExtractor{
+		cbzCache: cbzCache,
+		pdfCache: pdfCache,
+		log:      logger.New(),
+	}
+}
+
+// ExtractCoverPage satisfies the plugins.pageExtractor interface.
+func (p *PluginPageExtractor) ExtractCoverPage(file *models.File, bookFilepath string, page int) (string, string, error) {
+	return ExtractCoverPageToFile(file, bookFilepath, page, p.cbzCache, p.pdfCache, p.log)
+}
+```
+
+The codebase uses `logger.New()` (no arguments) — see `pkg/plugins/hooks.go:776` for an example.
+
+- [ ] **Step 4: Wire it in `pkg/server/server.go`**
+
+In `pkg/server/server.go`, before `enrichDeps := &plugins.EnrichDeps{...}` (around line 200), construct the page caches and the extractor. The caches need to be created here so the server owns their lifetime (the books handler already creates its own inside `RegisterRoutesWithGroup`; a second instance here pointing at the same `cfg.CacheDir` is safe). Add:
+
+```go
+	cbzCache := cbzpages.NewCache(cfg.CacheDir)
+	pdfCache := pdfpages.NewCache(cfg.CacheDir, cfg.PDFRenderDPI, cfg.PDFRenderQuality)
+	pageExtractor := books.NewPluginPageExtractor(cbzCache, pdfCache)
+```
+
+Then add `PageExtractor: pageExtractor,` to the `plugins.EnrichDeps{...}` literal (after `SearchIndexer`).
+
+Add the imports `"github.com/shishobooks/shisho/pkg/cbzpages"` and `"github.com/shishobooks/shisho/pkg/pdfpages"` at the top of `server.go` if not already present.
+
+- [ ] **Step 5: Build the whole module to catch wiring errors**
+
+Run: `go build ./...`
+
+Expected: no output (clean build). If there are errors about unresolved references or unused imports, resolve them.
+
+- [ ] **Step 6: Run plugins tests to confirm the new field doesn't break existing tests**
+
+Run: `go test ./pkg/plugins/ -count=1`
+
+Expected: PASS (existing tests should be unaffected — they construct `enrichDeps` without the new field, which defaults to nil).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/plugins/handler.go pkg/plugins/routes.go pkg/books/plugin_page_extractor.go pkg/server/server.go
+git commit -m "[Backend] Wire PageExtractor dependency through plugin EnrichDeps"
+```
+
+---
+
+## Task 5: Apply `coverPage` in `persistMetadata` — CBZ happy path
+
+**Files:**
+- Modify: `pkg/plugins/handler.go:1870-1896` (replace the current cover-data block with a file-type-gated branch)
+- Test: `pkg/plugins/handler_persist_metadata_test.go` (add new test cases + stub extractor)
+
+- [ ] **Step 1: Add a stub `PageExtractor` for tests**
+
+Append to `pkg/plugins/handler_persist_metadata_test.go` (top level, near the existing `stubBookStoreForPersist`):
+
+```go
+// stubPageExtractor records calls and returns a fixed (filename, mimeType).
+// Set `wantErr` to simulate a failed extraction.
+type stubPageExtractor struct {
+	calls    []stubPageExtractorCall
+	filename string
+	mimeType string
+	wantErr  error
+}
+
+type stubPageExtractorCall struct {
+	FileID       int
+	BookFilepath string
+	Page         int
+}
+
+func (s *stubPageExtractor) ExtractCoverPage(file *models.File, bookFilepath string, page int) (string, string, error) {
+	s.calls = append(s.calls, stubPageExtractorCall{FileID: file.ID, BookFilepath: bookFilepath, Page: page})
+	if s.wantErr != nil {
+		return "", "", s.wantErr
+	}
+	return s.filename, s.mimeType, nil
+}
+```
+
+- [ ] **Step 2: Write a failing test for CBZ `coverPage` happy path**
+
+Append to `pkg/plugins/handler_persist_metadata_test.go`:
+
+```go
+func TestPersistMetadata_CoverPage_CBZ_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "comic.cbz")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake cbz"), 0600))
+
+	pageCount := 10
+	file := &models.File{
+		ID:        1,
+		BookID:    1,
+		Filepath:  filePath,
+		FileType:  models.FileTypeCBZ,
+		PageCount: &pageCount,
+	}
+	book := &models.Book{
+		ID:        1,
+		LibraryID: 1,
+		Filepath:  libraryDir,
+		Files:     []*models.File{file},
+	}
+
+	extractor := &stubPageExtractor{filename: "comic.cbz.cover.jpg", mimeType: "image/jpeg"}
+
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			pageExtractor: extractor,
+		},
+	}
+
+	page := 3
+	md := &mediafile.ParsedMetadata{CoverPage: &page}
+
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	require.Len(t, extractor.calls, 1)
+	assert.Equal(t, 1, extractor.calls[0].FileID)
+	assert.Equal(t, 3, extractor.calls[0].Page)
+
+	require.NotNil(t, file.CoverPage)
+	assert.Equal(t, 3, *file.CoverPage)
+	require.NotNil(t, file.CoverImageFilename)
+	assert.Equal(t, "comic.cbz.cover.jpg", *file.CoverImageFilename)
+	require.NotNil(t, file.CoverMimeType)
+	assert.Equal(t, "image/jpeg", *file.CoverMimeType)
+	require.NotNil(t, file.CoverSource)
+	assert.Equal(t, models.PluginDataSource("test", "plugin-id"), *file.CoverSource)
+}
+```
+
+- [ ] **Step 3: Run and confirm it fails**
+
+Run: `go test ./pkg/plugins/ -run TestPersistMetadata_CoverPage_CBZ_HappyPath -v`
+
+Expected: FAIL. `CoverPage` and `CoverImageFilename` will still be nil — `persistMetadata` doesn't handle `md.CoverPage` yet.
+
+- [ ] **Step 4: Update `persistMetadata` to handle `coverPage` for page-based files**
+
+In `pkg/plugins/handler.go`, replace the current block at lines 1870-1896 (`// Apply cover data ...` through the closing brace) with a file-type-gated branch:
+
+```go
+	// Apply cover data. Precedence is strict: page-based files (CBZ, PDF)
+	// only accept coverPage; other formats only accept coverData / coverUrl.
+	if targetFile != nil {
+		if models.IsPageBasedFileType(targetFile.FileType) {
+			// Page-based: apply coverPage, silently ignore coverData/coverUrl.
+			if md.CoverPage != nil {
+				page := *md.CoverPage
+				switch {
+				case page < 0:
+					log.Warn("plugin-provided coverPage is negative, skipping", logger.Data{"file_id": targetFile.ID, "cover_page": page})
+				case targetFile.PageCount == nil:
+					log.Warn("plugin-provided coverPage skipped: page count unknown", logger.Data{"file_id": targetFile.ID, "cover_page": page})
+				case page >= *targetFile.PageCount:
+					log.Warn("plugin-provided coverPage is out of range, skipping", logger.Data{"file_id": targetFile.ID, "cover_page": page, "page_count": *targetFile.PageCount})
+				case h.enrich.pageExtractor == nil:
+					log.Warn("plugin-provided coverPage skipped: no page extractor configured", logger.Data{"file_id": targetFile.ID})
+				default:
+					coverFilename, mimeType, extractErr := h.enrich.pageExtractor.ExtractCoverPage(targetFile, book.Filepath, page)
+					if extractErr != nil {
+						log.Warn("failed to extract plugin-provided cover page", logger.Data{"file_id": targetFile.ID, "cover_page": page, "error": extractErr.Error()})
+					} else {
+						targetFile.CoverPage = &page
+						targetFile.CoverImageFilename = &coverFilename
+						targetFile.CoverMimeType = &mimeType
+						source := models.PluginDataSource(pluginScope, pluginID)
+						targetFile.CoverSource = &source
+						fileColumns = append(fileColumns, "cover_page", "cover_image_filename", "cover_mime_type", "cover_source")
+					}
+				}
+			}
+		} else {
+			// Non-page-based: existing coverData write path.
+			if len(md.CoverData) > 0 {
+				coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, targetFile.Filepath)
+				coverBaseName := filepath.Base(targetFile.Filepath) + ".cover"
+
+				normalizedData, normalizedMime, _ := fileutils.NormalizeImage(md.CoverData, md.CoverMimeType)
+				coverExt := ".png"
+				if normalizedMime == md.CoverMimeType {
+					coverExt = md.CoverExtension()
+				}
+
+				coverFilename := coverBaseName + coverExt
+				coverFilepath := filepath.Join(coverDir, coverFilename)
+
+				if err := os.WriteFile(coverFilepath, normalizedData, 0600); err != nil {
+					log.Warn("failed to write cover file", logger.Data{"error": err.Error()})
+				} else {
+					targetFile.CoverImageFilename = &coverFilename
+					fileColumns = append(fileColumns, "cover_image_filename")
+				}
+			}
+		}
+	}
+```
+
+Confirm imports still include `os`, `path/filepath`, `fileutils`, and `logger` (they should already be there).
+
+`models.PluginDataSource(scope, id)` is defined at `pkg/models/data-source.go:46` and returns a string like `"plugin:scope/id"`.
+
+- [ ] **Step 5: Run the new test to confirm it passes**
+
+Run: `go test ./pkg/plugins/ -run TestPersistMetadata_CoverPage_CBZ_HappyPath -v`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full `handler_persist_metadata_test.go` to confirm no regression**
+
+Run: `go test ./pkg/plugins/ -run TestPersistMetadata -v -count=1`
+
+Expected: PASS (including the existing `TestPersistMetadata_CoverWrite_RootLevelFile_SyntheticBookPath`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/plugins/handler.go pkg/plugins/handler_persist_metadata_test.go
+git commit -m "[Backend] Apply plugin-provided coverPage to CBZ/PDF files"
+```
+
+---
+
+## Task 6: Add remaining persist tests (PDF, bounds, precedence)
+
+All of these should pass against the implementation from Task 5 — they exercise different paths through the new branch.
+
+**Files:**
+- Test: `pkg/plugins/handler_persist_metadata_test.go`
+
+- [ ] **Step 1: Add PDF happy path test**
+
+Append to `pkg/plugins/handler_persist_metadata_test.go`:
+
+```go
+func TestPersistMetadata_CoverPage_PDF_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "book.pdf")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake pdf"), 0600))
+
+	pageCount := 100
+	file := &models.File{
+		ID: 2, BookID: 2, Filepath: filePath, FileType: models.FileTypePDF, PageCount: &pageCount,
+	}
+	book := &models.Book{ID: 2, LibraryID: 1, Filepath: libraryDir, Files: []*models.File{file}}
+
+	extractor := &stubPageExtractor{filename: "book.pdf.cover.jpg", mimeType: "image/jpeg"}
+	h := &handler{enrich: &enrichDeps{bookStore: &stubBookStoreForPersist{book: book}, pageExtractor: extractor}}
+
+	page := 7
+	md := &mediafile.ParsedMetadata{CoverPage: &page}
+
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	require.Len(t, extractor.calls, 1)
+	assert.Equal(t, 7, extractor.calls[0].Page)
+	require.NotNil(t, file.CoverPage)
+	assert.Equal(t, 7, *file.CoverPage)
+}
+```
+
+- [ ] **Step 2: Add out-of-bounds tests**
+
+```go
+func TestPersistMetadata_CoverPage_OutOfBounds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		pageCount *int
+		page      int
+	}{
+		{"negative", intPtr(10), -1},
+		{"page equals count", intPtr(5), 5},
+		{"page above count", intPtr(5), 99},
+		{"page count unknown", nil, 3},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			libraryDir := t.TempDir()
+			filePath := filepath.Join(libraryDir, "comic.cbz")
+			require.NoError(t, os.WriteFile(filePath, []byte("fake cbz"), 0600))
+
+			file := &models.File{
+				ID: 1, BookID: 1, Filepath: filePath, FileType: models.FileTypeCBZ, PageCount: tc.pageCount,
+			}
+			book := &models.Book{ID: 1, LibraryID: 1, Filepath: libraryDir, Files: []*models.File{file}}
+			extractor := &stubPageExtractor{filename: "x", mimeType: "image/jpeg"}
+			h := &handler{enrich: &enrichDeps{bookStore: &stubBookStoreForPersist{book: book}, pageExtractor: extractor}}
+
+			md := &mediafile.ParsedMetadata{CoverPage: &tc.page}
+
+			err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+			require.NoError(t, err)
+
+			assert.Empty(t, extractor.calls, "extractor should not be called for invalid page")
+			assert.Nil(t, file.CoverPage, "file.CoverPage should remain unchanged")
+			assert.Nil(t, file.CoverImageFilename, "file.CoverImageFilename should remain unchanged")
+		})
+	}
+}
+
+func intPtr(v int) *int { return &v }
+```
+
+If `intPtr` is already defined in the test package, drop the helper definition. (Check with `grep -n "func intPtr" pkg/plugins`.)
+
+- [ ] **Step 3: Add precedence tests**
+
+```go
+// Plugin returns both coverPage and coverData for a CBZ file — coverPage wins,
+// coverData is silently ignored.
+func TestPersistMetadata_CoverPage_CBZ_BeatsCoverData(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "comic.cbz")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake cbz"), 0600))
+
+	pageCount := 10
+	file := &models.File{
+		ID: 1, BookID: 1, Filepath: filePath, FileType: models.FileTypeCBZ, PageCount: &pageCount,
+	}
+	book := &models.Book{ID: 1, LibraryID: 1, Filepath: libraryDir, Files: []*models.File{file}}
+	extractor := &stubPageExtractor{filename: "comic.cbz.cover.jpg", mimeType: "image/jpeg"}
+	h := &handler{enrich: &enrichDeps{bookStore: &stubBookStoreForPersist{book: book}, pageExtractor: extractor}}
+
+	page := 2
+	md := &mediafile.ParsedMetadata{
+		CoverPage:     &page,
+		CoverData:     makePersistTestJPEG(400, 600),
+		CoverMimeType: "image/jpeg",
+	}
+
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	// coverPage path taken
+	require.Len(t, extractor.calls, 1)
+	require.NotNil(t, file.CoverPage)
+	assert.Equal(t, 2, *file.CoverPage)
+
+	// coverData file must NOT have been written alongside the file
+	_, err = os.Stat(filepath.Join(libraryDir, "comic.cbz.cover.png"))
+	assert.True(t, os.IsNotExist(err), "coverData should not have been written for a page-based file")
+}
+
+// Plugin returns coverPage for a non-page-based format (EPUB) — coverPage is
+// silently ignored, coverData (if provided) is applied.
+func TestPersistMetadata_CoverPage_EPUB_Ignored(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "book.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0600))
+
+	file := &models.File{
+		ID: 1, BookID: 1, Filepath: filePath, FileType: models.FileTypeEPUB,
+	}
+	book := &models.Book{ID: 1, LibraryID: 1, Filepath: libraryDir, Files: []*models.File{file}}
+	extractor := &stubPageExtractor{filename: "x", mimeType: "image/jpeg"}
+	h := &handler{enrich: &enrichDeps{bookStore: &stubBookStoreForPersist{book: book}, pageExtractor: extractor}}
+
+	page := 3
+	md := &mediafile.ParsedMetadata{
+		CoverPage:     &page,
+		CoverData:     makePersistTestJPEG(400, 600),
+		CoverMimeType: "image/jpeg",
+	}
+
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	// Extractor must not be called for non-page-based files
+	assert.Empty(t, extractor.calls)
+	// file.CoverPage must remain unchanged
+	assert.Nil(t, file.CoverPage)
+	// coverData write path ran — CoverImageFilename is set
+	require.NotNil(t, file.CoverImageFilename)
+	assert.Equal(t, "book.epub.cover.jpg", *file.CoverImageFilename)
+}
+```
+
+- [ ] **Step 4: Run all new tests**
+
+Run: `go test ./pkg/plugins/ -run TestPersistMetadata_CoverPage -v -count=1`
+
+Expected: PASS for all cases.
+
+- [ ] **Step 5: Run the whole plugins + books packages**
+
+Run: `go test ./pkg/plugins/ ./pkg/books/ -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/plugins/handler_persist_metadata_test.go
+git commit -m "[Backend] Test cover_page persist: PDF, bounds, precedence"
+```
+
+---
+
+## Task 7: Update docs
+
+**Files:**
+- Modify: `website/docs/plugins/development.md`
+- Modify: `pkg/plugins/CLAUDE.md`
+
+- [ ] **Step 1: Read the current plugin dev docs cover section**
+
+Run: `grep -n "coverPage\|coverData\|coverUrl" website/docs/plugins/development.md` and read the surrounding section to find the right spot.
+
+- [ ] **Step 2: Add the cover_page rules to `website/docs/plugins/development.md`**
+
+Under the `cover` field group description (wherever `coverData`, `coverMimeType`, `coverPage`, `coverUrl` are documented), add a subsection:
+
+```markdown
+### Cover page selection (CBZ and PDF only)
+
+For page-based file formats — CBZ and PDF — the cover is derived from a page
+of the file itself, not from an arbitrary image. Plugins can tell Shisho which
+page to use by returning `coverPage` (a 0-indexed page number).
+
+**Precedence (strict, file-type-gated):**
+
+- **CBZ/PDF:** Only `coverPage` is applied. `coverData` and `coverUrl` are
+  silently ignored for these formats. A plugin that returns only `coverData`
+  for a CBZ/PDF will not change the cover.
+- **EPUB/M4B and other formats:** Only `coverData` / `coverUrl` are applied.
+  `coverPage` is silently ignored.
+
+**Bounds:** If `coverPage` is negative, greater than or equal to the file's
+page count, or the page count is unknown, the value is skipped with a warning
+in the server logs — Shisho will not fall through to `coverData`.
+
+**Cover source:** When `coverPage` is applied, the rendered page is saved as
+the file's cover image on disk, and `cover_source` is set to
+`plugin:<scope>/<id>`. This mirrors the behavior of the manual page-picker UI
+(which uses `manual` as the source).
+
+Example search result from a metadata enricher:
+
+```javascript
+return {
+  results: [{
+    title: "Saga #1",
+    authors: [{ name: "Brian K. Vaughan", role: "writer" }],
+    coverPage: 3, // The cover image is on page 3 of this CBZ, not page 0.
+    confidence: 0.95
+  }]
+};
+```
+```
+
+- [ ] **Step 3: Add a note to `pkg/plugins/CLAUDE.md`**
+
+Find the fileParser example near line 150 (the block that mentions `coverPage: 0`) and add a one-liner beneath that field:
+
+```markdown
+      coverPage: 0,                           // CBZ/PDF only; silently ignored for other formats, skipped with warning when out of range
+```
+
+Also find the "Logical field groupings" section (already says `cover` controls `coverData`, `coverMimeType`, `coverPage`, `coverUrl`) and append after that list item:
+
+```markdown
+- **`coverPage` precedence:** For CBZ/PDF, only `coverPage` is applied (`coverData`/`coverUrl` ignored). For other formats, only `coverData`/`coverUrl` are applied (`coverPage` ignored). Out-of-range pages are skipped with a warning.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/docs/plugins/development.md pkg/plugins/CLAUDE.md
+git commit -m "[Docs] Document plugin-settable cover_page for CBZ/PDF"
+```
+
+---
+
+## Task 8: Final validation
+
+- [ ] **Step 1: Run the project-wide check**
+
+Run: `mise check:quiet`
+
+Expected: one-line pass summary. If any step fails, address the specific issue and re-run.
+
+- [ ] **Step 2: Verify `mise tygo` isn't flagging new type drift**
+
+Run: `mise tygo`
+
+Expected: "skipping, outputs are up-to-date" — no Go type changes were made that affect the generated TypeScript. If output is generated, inspect whether the changes are expected; if not, something unrelated changed.
+
+- [ ] **Step 3: Push to remote (only if the user asks you to)**
+
+Stop here. Do not push, rebase, or open a PR unless the user explicitly requests it.

--- a/docs/superpowers/specs/2026-04-19-plugin-cover-page-design.md
+++ b/docs/superpowers/specs/2026-04-19-plugin-cover-page-design.md
@@ -1,0 +1,115 @@
+# Plugin-Settable Cover Page
+
+## Summary
+
+Allow plugins to set `coverPage` for page-based files (CBZ, PDF). Currently plugins can return `coverData`/`coverUrl` for non-page-based files, but for CBZ/PDF these are silently ignored because covers come from page content, not arbitrary images. Plugins — particularly metadata enrichers — often know that a comic's cover isn't the first page; this change lets them tell Shisho which page to use. `coverPage` falls under the existing `cover` capability; no new capability is added.
+
+## Background
+
+- `ParsedMetadata.CoverPage *int` already exists in Go (`pkg/mediafile/mediafile.go:50`).
+- `coverPage?: number` already exists in the plugin SDK (`packages/plugin-sdk/metadata.d.ts:66`).
+- The `cover` manifest field is already documented as controlling `coverData`, `coverMimeType`, `coverPage`, and `coverUrl` (`pkg/plugins/CLAUDE.md`).
+- `models.File.CoverPage *int` already exists with a column in the schema.
+- `IsPageBasedFileType` returns true only for CBZ and PDF (`pkg/models/file.go:86`).
+- The manual UI handler `updateFileCoverPage` (`pkg/books/handlers_cover_page.go`) is the reference implementation for applying a cover page: bounds-check, extract the page via the appropriate page cache, write the rendered image as the cover file, update file fields, write sidecar.
+
+What's missing is wiring: parsing `coverPage` out of JS results, applying it during `persistMetadata`, and sharing the page-extraction logic between the UI handler and the plugin path.
+
+## Design Decisions
+
+1. **Scope: all three plugin paths** — `fileParser`, `metadataEnricher`, and the manual identify apply all support `coverPage`. Keeps the three parsers symmetric. In practice `metadataEnricher` is the primary use case; `fileParser` is limited (reserved extensions can't be claimed) but including it costs nothing.
+2. **Precedence: file-type-gated (strict)** — For CBZ/PDF, `coverPage` is used and `coverData`/`coverUrl` are ignored. For EPUB/M4B, `coverData`/`coverUrl` is used and `coverPage` is ignored. This matches the existing invariant in `persistMetadata` that page-based formats never accept external cover images. No fallback between the two branches.
+3. **Invalid `coverPage` handling: skip with warning** — Out-of-range, negative, or `PageCount`-unknown cases log a warning and leave the existing cover alone. No clamping, no fallback to `coverData`. A plugin returning page 5 for a 3-page file is a bug worth surfacing.
+4. **Cover extraction mirrors the manual handler** — When `coverPage` is applied, extract the page via the appropriate page cache and write it as the cover image file, just like the UI flow. Otherwise the cover wouldn't actually appear.
+5. **`CoverSource` is `plugin:scope/id`** — Follows existing data source convention. The manual UI handler continues to write `manual`.
+
+## Changes
+
+### Shared helper
+
+New exported function, implemented in the `books` package (which already owns the caches and the existing logic):
+
+```go
+// ExtractCoverPageToFile renders `page` from `file`, writes it as the cover
+// image alongside the book, and returns (filename, mimeType). Deletes any
+// existing cover image with the same base name first.
+func ExtractCoverPageToFile(
+    file *models.File,
+    bookFilepath string,
+    page int,
+    cbzCache *cbzpages.Cache,
+    pdfCache *pdfpages.Cache,
+) (filename, mimeType string, err error)
+```
+
+The body is the existing `handlers_cover_page.go:65-107` logic, unchanged behaviorally. `updateFileCoverPage` becomes a thin wrapper: bounds-check, call the helper, update fields, write sidecar.
+
+### JS → Go parsing
+
+Each parser gets a small `coverPage` block next to existing cover fields. Only populate `md.CoverPage` when the value is a finite non-negative integer; ignore `undefined`, `null`, `NaN`, and negative values at parse time. The real bounds check happens at apply time when `PageCount` is known.
+
+- `pkg/plugins/hooks.go` `parseParsedMetadata` (fileParser) — near line 495.
+- `pkg/plugins/hooks.go` `parseSearchResponse` (metadataEnricher) — near line 398.
+- `pkg/plugins/handler.go` `convertFieldsToMetadata` (manual identify apply) — near line 1953, key is `cover_page`, value is `float64`.
+
+### Apply (`persistMetadata`)
+
+Replace the current block at `pkg/plugins/handler.go:1870-1896`. Instead of unconditionally skipping cover data when `targetFile.CoverPage != nil`, branch on file type:
+
+```
+if targetFile is CBZ/PDF:
+    if md.CoverPage != nil:
+        if invalid (negative, >= PageCount, PageCount unknown):
+            log warning, skip
+        else:
+            call pageExtractor.ExtractCoverPage(file, book.Filepath, *md.CoverPage)
+            set CoverPage, CoverImageFilename, CoverMimeType, CoverSource (plugin:scope/id)
+            append the four columns to fileColumns
+    // coverData / coverUrl are ignored for page-based files (unchanged)
+else:
+    // existing coverData write path, unchanged
+```
+
+### Dependency injection
+
+Add a new interface to `enrichDeps` (`pkg/plugins/handler.go:39`):
+
+```go
+type pageExtractor interface {
+    ExtractCoverPage(file *models.File, bookFilepath string, page int) (filename, mimeType string, err error)
+}
+```
+
+Implementation lives in the `books` package as a small wrapper that captures the two caches and delegates to `ExtractCoverPageToFile`. Wired in `pkg/plugins/routes.go` at both construction sites (lines 28 and 70).
+
+## Testing
+
+All new tests use `t.Parallel()`.
+
+**Parser unit tests** (`pkg/plugins/hooks_test.go`): one new case per parser asserting `coverPage: 3` produces `md.CoverPage == &3`, and one case per parser asserting invalid values (negative, `NaN`, missing) produce `nil`.
+
+**Persist integration tests** (new `pkg/worker/scan_cover_page_test.go` or extension of `scan_enricher_test.go`):
+
+- CBZ with 5 pages, enricher returns `coverPage: 2` → `file.CoverPage == 2`, cover file exists on disk, `CoverSource == "plugin:<scope>/<id>"`.
+- PDF equivalent.
+- Out-of-bounds (`coverPage: 99`) → `CoverPage` unchanged, warning logged, no cover file written.
+- `coverPage` for an EPUB → silently ignored, existing cover untouched.
+- CBZ with both `coverPage` and `coverData` → `coverPage` wins, no `coverData` write.
+- EPUB with both → `coverData` wins, `coverPage` ignored.
+
+**Manual handler regression** (`pkg/books/handlers_cover_page_test.go`): existing tests continue to pass against the refactored helper — `CoverSource` remains `manual`, cover file is still extracted.
+
+## Docs
+
+- **`website/docs/plugins/development.md`**: under the `cover` field group, document that `coverPage` only applies to CBZ/PDF files, takes precedence over `coverData`/`coverUrl` for those formats, is silently ignored otherwise, and out-of-range values are skipped with a warning.
+- **`pkg/plugins/CLAUDE.md`**: one-line note under the fileParser metadata example clarifying CBZ/PDF-only behavior for `coverPage`.
+- No versioned docs updates (they're snapshots).
+- No `configuration.md`, sidecar, or `metadata.md` updates — no new config, no schema change, no new user-visible metadata field.
+
+## Non-goals
+
+- No new plugin capability (still under `cover`).
+- No schema migration (`files.cover_page` already exists).
+- No frontend changes (the existing `FileEditDialog` already handles files with `cover_page` set).
+- No changes to how covers are served for page-based files.
+- No new SDK changes (`coverPage` already in `metadata.d.ts`).

--- a/pkg/books/coverpage_extract.go
+++ b/pkg/books/coverpage_extract.go
@@ -1,0 +1,69 @@
+package books
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/cbzpages"
+	"github.com/shishobooks/shisho/pkg/fileutils"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/pdfpages"
+)
+
+// ExtractCoverPageToFile renders `page` from the given page-based file (CBZ or
+// PDF) via the appropriate page cache and writes the rendered image as the
+// cover file alongside the book. Returns the cover filename (not path) and
+// MIME type. Any existing cover image with the same base name is removed first
+// regardless of extension.
+//
+// Callers are responsible for updating the file's CoverPage, CoverImageFilename,
+// CoverMimeType, and CoverSource fields on the model and persisting them.
+func ExtractCoverPageToFile(
+	file *models.File,
+	bookFilepath string,
+	page int,
+	cbzCache *cbzpages.Cache,
+	pdfCache *pdfpages.Cache,
+	log logger.Logger,
+) (filename string, mimeType string, err error) {
+	var cachedPath string
+	switch file.FileType {
+	case models.FileTypeCBZ:
+		cachedPath, mimeType, err = cbzCache.GetPage(file.Filepath, file.ID, page)
+	case models.FileTypePDF:
+		cachedPath, mimeType, err = pdfCache.GetPage(file.Filepath, file.ID, page)
+	default:
+		return "", "", errors.Errorf("file type %q does not support page-based covers", file.FileType)
+	}
+	if err != nil {
+		return "", "", errors.Wrap(err, "failed to extract cover page")
+	}
+
+	coverDir := fileutils.ResolveCoverDir(bookFilepath)
+	coverBaseName := filepath.Base(file.Filepath) + ".cover"
+
+	ext := getExtensionFromMimeType(mimeType)
+	if ext == "" {
+		ext = filepath.Ext(cachedPath)
+	}
+
+	// Delete any existing cover with this base name (regardless of extension).
+	for _, existingExt := range fileutils.CoverImageExtensions {
+		existingPath := filepath.Join(coverDir, coverBaseName+existingExt)
+		if _, err := os.Stat(existingPath); err == nil {
+			if err := os.Remove(existingPath); err != nil {
+				log.Warn("failed to remove existing cover", logger.Data{"path": existingPath, "error": err.Error()})
+			}
+		}
+	}
+
+	coverFilename := coverBaseName + ext
+	coverFilepath := filepath.Join(coverDir, coverFilename)
+	if err := copyFile(cachedPath, coverFilepath); err != nil {
+		return "", "", errors.Wrap(err, "failed to save cover image")
+	}
+
+	return coverFilename, mimeType, nil
+}

--- a/pkg/books/coverpage_extract.go
+++ b/pkg/books/coverpage_extract.go
@@ -41,7 +41,10 @@ func ExtractCoverPageToFile(
 		return "", "", errors.Wrap(err, "failed to extract cover page")
 	}
 
-	coverDir := fileutils.ResolveCoverDir(bookFilepath)
+	// Use the write-side resolver so root-level files (whose bookFilepath may
+	// be a synthetic organized-folder path that doesn't yet exist on disk)
+	// land the cover next to the file instead of failing on a stale path.
+	coverDir := fileutils.ResolveCoverDirForWrite(bookFilepath, file.Filepath)
 	coverBaseName := filepath.Base(file.Filepath) + ".cover"
 
 	ext := getExtensionFromMimeType(mimeType)

--- a/pkg/books/handlers_cover_page.go
+++ b/pkg/books/handlers_cover_page.go
@@ -4,14 +4,12 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/errcodes"
-	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/sidecar"
 )
@@ -62,59 +60,27 @@ func (h *handler) updateFileCoverPage(c echo.Context) error {
 		return errcodes.ValidationError("Page number is out of bounds")
 	}
 
-	// Extract the page image using the appropriate page cache
-	var cachedPath, mimeType string
-	switch file.FileType {
-	case models.FileTypeCBZ:
-		cachedPath, mimeType, err = h.pageCache.GetPage(file.Filepath, file.ID, payload.Page)
-	case models.FileTypePDF:
-		cachedPath, mimeType, err = h.pdfPageCache.GetPage(file.Filepath, file.ID, payload.Page)
-	default:
-		return errcodes.ValidationError("This file does not support page-based covers")
-	}
+	coverFilename, mimeType, err := ExtractCoverPageToFile(
+		file,
+		file.Book.Filepath,
+		payload.Page,
+		h.pageCache,
+		h.pdfPageCache,
+		log,
+	)
 	if err != nil {
 		log.Error("failed to extract cover page", logger.Data{"error": err.Error(), "page": payload.Page, "file_type": file.FileType})
 		return errcodes.ValidationError("Failed to extract page from file")
 	}
 
-	coverDir := fileutils.ResolveCoverDir(file.Book.Filepath)
-
-	// Generate the cover filename: {filename}.cover.{ext}
-	filename := filepath.Base(file.Filepath)
-	coverBaseName := filename + ".cover"
-
-	// Get extension from mime type
-	ext := getExtensionFromMimeType(mimeType)
-	if ext == "" {
-		ext = filepath.Ext(cachedPath)
-	}
-
-	// Delete any existing cover with this base name (regardless of extension)
-	for _, existingExt := range fileutils.CoverImageExtensions {
-		existingPath := filepath.Join(coverDir, coverBaseName+existingExt)
-		if _, err := os.Stat(existingPath); err == nil {
-			if err := os.Remove(existingPath); err != nil {
-				log.Warn("failed to remove existing cover", logger.Data{"path": existingPath, "error": err.Error()})
-			}
-		}
-	}
-
-	// Copy the extracted page to the cover location
-	coverFilePath := filepath.Join(coverDir, coverBaseName+ext)
-	if err := copyFile(cachedPath, coverFilePath); err != nil {
-		log.Error("failed to copy cover image", logger.Data{"error": err.Error()})
-		return errcodes.ValidationError("Failed to save cover image")
-	}
-
 	log.Info("set cover page", logger.Data{
-		"file_id":    file.ID,
-		"page":       payload.Page,
-		"cover_path": coverFilePath,
-		"mime_type":  mimeType,
+		"file_id":   file.ID,
+		"page":      payload.Page,
+		"cover":     coverFilename,
+		"mime_type": mimeType,
 	})
 
 	// Update file's cover metadata
-	coverFilename := coverBaseName + ext
 	file.CoverPage = &payload.Page
 	file.CoverMimeType = &mimeType
 	file.CoverSource = strPtr(models.DataSourceManual)

--- a/pkg/books/plugin_page_extractor.go
+++ b/pkg/books/plugin_page_extractor.go
@@ -1,0 +1,33 @@
+package books
+
+import (
+	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/cbzpages"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/pdfpages"
+)
+
+// PluginPageExtractor adapts ExtractCoverPageToFile to the plugins package's
+// pageExtractor interface so plugin-provided cover_page values can be applied
+// without the plugins package needing to depend on the page caches directly.
+type PluginPageExtractor struct {
+	cbzCache *cbzpages.Cache
+	pdfCache *pdfpages.Cache
+	log      logger.Logger
+}
+
+// NewPluginPageExtractor constructs a page extractor backed by the given
+// cbzpages and pdfpages caches.
+func NewPluginPageExtractor(cbzCache *cbzpages.Cache, pdfCache *pdfpages.Cache) *PluginPageExtractor {
+	return &PluginPageExtractor{
+		cbzCache: cbzCache,
+		pdfCache: pdfCache,
+		log:      logger.New(),
+	}
+}
+
+// ExtractCoverPage satisfies the plugins.pageExtractor interface by
+// delegating to ExtractCoverPageToFile.
+func (p *PluginPageExtractor) ExtractCoverPage(file *models.File, bookFilepath string, page int) (string, string, error) {
+	return ExtractCoverPageToFile(file, bookFilepath, page, p.cbzCache, p.pdfCache, p.log)
+}

--- a/pkg/books/plugin_page_extractor.go
+++ b/pkg/books/plugin_page_extractor.go
@@ -13,7 +13,6 @@ import (
 type PluginPageExtractor struct {
 	cbzCache *cbzpages.Cache
 	pdfCache *pdfpages.Cache
-	log      logger.Logger
 }
 
 // NewPluginPageExtractor constructs a page extractor backed by the given
@@ -22,12 +21,11 @@ func NewPluginPageExtractor(cbzCache *cbzpages.Cache, pdfCache *pdfpages.Cache) 
 	return &PluginPageExtractor{
 		cbzCache: cbzCache,
 		pdfCache: pdfCache,
-		log:      logger.New(),
 	}
 }
 
 // ExtractCoverPage satisfies the plugins.pageExtractor interface by
 // delegating to ExtractCoverPageToFile.
-func (p *PluginPageExtractor) ExtractCoverPage(file *models.File, bookFilepath string, page int) (string, string, error) {
-	return ExtractCoverPageToFile(file, bookFilepath, page, p.cbzCache, p.pdfCache, p.log)
+func (p *PluginPageExtractor) ExtractCoverPage(file *models.File, bookFilepath string, page int, log logger.Logger) (string, string, error) {
+	return ExtractCoverPageToFile(file, bookFilepath, page, p.cbzCache, p.pdfCache, log)
 }

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -104,6 +104,8 @@ shisho/goodreads-metadata/
 - `cover` → controls `coverData`, `coverMimeType`, `coverPage`, and `coverUrl`
 - `series` → controls both `series` (name) and `seriesNumber`
 
+**`coverPage` precedence:** For CBZ/PDF, only `coverPage` is applied (`coverData`/`coverUrl` ignored). For other formats, only `coverData`/`coverUrl` are applied (`coverPage` ignored). Out-of-range pages are skipped with a warning.
+
 ## main.js Pattern
 
 All plugins use IIFE to define the `plugin` global:
@@ -167,7 +169,7 @@ fileParser: {
       releaseDate: "2023-06-15T00:00:00Z",  // ISO 8601
       coverMimeType: "image/jpeg",
       coverData: arrayBuffer,                 // ArrayBuffer
-      coverPage: 0,
+      coverPage: 0,                           // CBZ/PDF only; silently ignored for other formats, skipped with warning when out of range
       duration: 3661.5,                       // seconds (float)
       bitrateBps: 128000,
       pageCount: 42,

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -46,6 +46,7 @@ type enrichDeps struct {
 	publisherFinder publisherFinder
 	imprintFinder   imprintFinder
 	searchIndexer   searchIndexer
+	pageExtractor   pageExtractor
 }
 
 // bookStore provides core book and file CRUD operations.
@@ -105,6 +106,13 @@ type imprintFinder interface {
 // searchIndexer updates the search index after metadata changes.
 type searchIndexer interface {
 	IndexBook(ctx context.Context, book *models.Book) error
+}
+
+// pageExtractor renders a page from a page-based file (CBZ/PDF) and writes
+// it as that file's cover image. Returns the cover filename (not a full path)
+// and the MIME type of the extracted image.
+type pageExtractor interface {
+	ExtractCoverPage(file *models.File, bookFilepath string, page int) (filename, mimeType string, err error)
 }
 
 type handler struct {

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1959,6 +1959,12 @@ func convertFieldsToMetadata(fields map[string]any) *mediafile.ParsedMetadata {
 		md.SeriesNumber = &v
 	}
 
+	// Cover page (0-indexed page number for CBZ/PDF)
+	if v, ok := fields["cover_page"].(float64); ok {
+		cp := int(v)
+		md.CoverPage = &cp
+	}
+
 	// Release date
 	if v, ok := fields["release_date"].(string); ok && v != "" {
 		t, err := time.Parse("2006-01-02", v)

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -1994,10 +1995,14 @@ func convertFieldsToMetadata(fields map[string]any) *mediafile.ParsedMetadata {
 		md.SeriesNumber = &v
 	}
 
-	// Cover page (0-indexed page number for CBZ/PDF)
+	// Cover page (0-indexed page number for CBZ/PDF). Only accept finite
+	// non-negative integers; reject negative, NaN, and Infinity so they
+	// don't propagate to the apply path.
 	if v, ok := fields["cover_page"].(float64); ok {
-		cp := int(v)
-		md.CoverPage = &cp
+		if !math.IsNaN(v) && !math.IsInf(v, 0) && v >= 0 {
+			cp := int(v)
+			md.CoverPage = &cp
+		}
 	}
 
 	// Release date

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -112,7 +112,7 @@ type searchIndexer interface {
 // it as that file's cover image. Returns the cover filename (not a full path)
 // and the MIME type of the extracted image.
 type pageExtractor interface {
-	ExtractCoverPage(file *models.File, bookFilepath string, page int) (filename, mimeType string, err error)
+	ExtractCoverPage(file *models.File, bookFilepath string, page int, log logger.Logger) (filename, mimeType string, err error)
 }
 
 type handler struct {

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1875,31 +1875,58 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 		}
 	}
 
-	// Apply cover data (caller is responsible for downloading cover URLs before calling persistMetadata).
-	// Skip for files with cover_page — their covers are derived from page content (CBZ, PDF).
-	if len(md.CoverData) > 0 && targetFile != nil && targetFile.CoverPage == nil {
-		// Use the write-side helper so root-level files (whose book.Filepath
-		// may be a synthetic organized-folder path that does not yet exist
-		// on disk) land their cover next to the file instead of silently
-		// failing on os.WriteFile.
-		coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, targetFile.Filepath)
-		coverBaseName := filepath.Base(targetFile.Filepath) + ".cover"
-
-		// Normalize the cover image
-		normalizedData, normalizedMime, _ := fileutils.NormalizeImage(md.CoverData, md.CoverMimeType)
-		coverExt := ".png"
-		if normalizedMime == md.CoverMimeType {
-			coverExt = md.CoverExtension()
-		}
-
-		coverFilename := coverBaseName + coverExt
-		coverFilepath := filepath.Join(coverDir, coverFilename)
-
-		if err := os.WriteFile(coverFilepath, normalizedData, 0600); err != nil {
-			log.Warn("failed to write cover file", logger.Data{"error": err.Error()})
+	// Apply cover data. Precedence is strict: page-based files (CBZ, PDF)
+	// only accept coverPage; other formats only accept coverData / coverUrl.
+	if targetFile != nil {
+		if models.IsPageBasedFileType(targetFile.FileType) {
+			// Page-based: apply coverPage, silently ignore coverData/coverUrl.
+			if md.CoverPage != nil {
+				page := *md.CoverPage
+				switch {
+				case page < 0:
+					log.Warn("plugin-provided coverPage is negative, skipping", logger.Data{"file_id": targetFile.ID, "cover_page": page})
+				case targetFile.PageCount == nil:
+					log.Warn("plugin-provided coverPage skipped: page count unknown", logger.Data{"file_id": targetFile.ID, "cover_page": page})
+				case page >= *targetFile.PageCount:
+					log.Warn("plugin-provided coverPage is out of range, skipping", logger.Data{"file_id": targetFile.ID, "cover_page": page, "page_count": *targetFile.PageCount})
+				case h.enrich.pageExtractor == nil:
+					log.Warn("plugin-provided coverPage skipped: no page extractor configured", logger.Data{"file_id": targetFile.ID})
+				default:
+					coverFilename, mimeType, extractErr := h.enrich.pageExtractor.ExtractCoverPage(targetFile, book.Filepath, page, log)
+					if extractErr != nil {
+						log.Warn("failed to extract plugin-provided cover page", logger.Data{"file_id": targetFile.ID, "cover_page": page, "error": extractErr.Error()})
+					} else {
+						targetFile.CoverPage = &page
+						targetFile.CoverImageFilename = &coverFilename
+						targetFile.CoverMimeType = &mimeType
+						source := models.PluginDataSource(pluginScope, pluginID)
+						targetFile.CoverSource = &source
+						fileColumns = append(fileColumns, "cover_page", "cover_image_filename", "cover_mime_type", "cover_source")
+					}
+				}
+			}
 		} else {
-			targetFile.CoverImageFilename = &coverFilename
-			fileColumns = append(fileColumns, "cover_image_filename")
+			// Non-page-based: existing coverData write path.
+			if len(md.CoverData) > 0 {
+				coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, targetFile.Filepath)
+				coverBaseName := filepath.Base(targetFile.Filepath) + ".cover"
+
+				normalizedData, normalizedMime, _ := fileutils.NormalizeImage(md.CoverData, md.CoverMimeType)
+				coverExt := ".png"
+				if normalizedMime == md.CoverMimeType {
+					coverExt = md.CoverExtension()
+				}
+
+				coverFilename := coverBaseName + coverExt
+				coverFilepath := filepath.Join(coverDir, coverFilename)
+
+				if err := os.WriteFile(coverFilepath, normalizedData, 0600); err != nil {
+					log.Warn("failed to write cover file", logger.Data{"error": err.Error()})
+				} else {
+					targetFile.CoverImageFilename = &coverFilename
+					fileColumns = append(fileColumns, "cover_image_filename")
+				}
+			}
 		}
 	}
 

--- a/pkg/plugins/handler_convert_test.go
+++ b/pkg/plugins/handler_convert_test.go
@@ -307,6 +307,24 @@ func TestConvertFieldsToMetadata_AbridgedFalse(t *testing.T) {
 	assert.False(t, *md.Abridged)
 }
 
+func TestConvertFieldsToMetadata_CoverPage(t *testing.T) {
+	t.Parallel()
+	fields := map[string]any{
+		"cover_page": float64(4), // JSON numbers decode to float64
+	}
+
+	md := convertFieldsToMetadata(fields)
+
+	require.NotNil(t, md.CoverPage)
+	assert.Equal(t, 4, *md.CoverPage)
+}
+
+func TestConvertFieldsToMetadata_CoverPage_Missing(t *testing.T) {
+	t.Parallel()
+	md := convertFieldsToMetadata(map[string]any{})
+	assert.Nil(t, md.CoverPage)
+}
+
 func TestConvertFieldsToMetadata_AbridgedMissing(t *testing.T) {
 	t.Parallel()
 	// Absent key should result in nil

--- a/pkg/plugins/handler_convert_test.go
+++ b/pkg/plugins/handler_convert_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -323,6 +324,27 @@ func TestConvertFieldsToMetadata_CoverPage_Missing(t *testing.T) {
 	t.Parallel()
 	md := convertFieldsToMetadata(map[string]any{})
 	assert.Nil(t, md.CoverPage)
+}
+
+func TestConvertFieldsToMetadata_CoverPage_Invalid(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name  string
+		value float64
+	}{
+		{"negative", -1},
+		{"NaN", math.NaN()},
+		{"positive infinity", math.Inf(1)},
+		{"negative infinity", math.Inf(-1)},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			md := convertFieldsToMetadata(map[string]any{"cover_page": tc.value})
+			assert.Nil(t, md.CoverPage, "invalid coverPage %v should be rejected", tc.value)
+		})
+	}
 }
 
 func TestConvertFieldsToMetadata_AbridgedMissing(t *testing.T) {

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -202,4 +203,178 @@ func TestPersistMetadata_CoverPage_CBZ_HappyPath(t *testing.T) {
 	assert.Equal(t, "image/jpeg", *file.CoverMimeType)
 	require.NotNil(t, file.CoverSource)
 	assert.Equal(t, models.PluginDataSource("test", "plugin-id"), *file.CoverSource)
+}
+
+func TestPersistMetadata_CoverPage_PDF_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "book.pdf")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake pdf"), 0600))
+
+	pageCount := 100
+	file := &models.File{
+		ID: 2, BookID: 2, Filepath: filePath, FileType: models.FileTypePDF, PageCount: &pageCount,
+	}
+	book := &models.Book{ID: 2, LibraryID: 1, Filepath: libraryDir, Files: []*models.File{file}}
+
+	extractor := &stubPageExtractor{filename: "book.pdf.cover.jpg", mimeType: "image/jpeg"}
+	h := &handler{enrich: &enrichDeps{bookStore: &stubBookStoreForPersist{book: book}, pageExtractor: extractor}}
+
+	page := 7
+	md := &mediafile.ParsedMetadata{CoverPage: &page}
+
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	require.Len(t, extractor.calls, 1)
+	assert.Equal(t, 7, extractor.calls[0].Page)
+	require.NotNil(t, file.CoverPage)
+	assert.Equal(t, 7, *file.CoverPage)
+}
+
+func TestPersistMetadata_CoverPage_OutOfBounds(t *testing.T) {
+	t.Parallel()
+
+	intPointer := func(v int) *int { return &v }
+
+	cases := []struct {
+		name      string
+		pageCount *int
+		page      int
+	}{
+		{"negative", intPointer(10), -1},
+		{"page equals count", intPointer(5), 5},
+		{"page above count", intPointer(5), 99},
+		{"page count unknown", nil, 3},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			libraryDir := t.TempDir()
+			filePath := filepath.Join(libraryDir, "comic.cbz")
+			require.NoError(t, os.WriteFile(filePath, []byte("fake cbz"), 0600))
+
+			file := &models.File{
+				ID: 1, BookID: 1, Filepath: filePath, FileType: models.FileTypeCBZ, PageCount: tc.pageCount,
+			}
+			book := &models.Book{ID: 1, LibraryID: 1, Filepath: libraryDir, Files: []*models.File{file}}
+			extractor := &stubPageExtractor{filename: "x", mimeType: "image/jpeg"}
+			h := &handler{enrich: &enrichDeps{bookStore: &stubBookStoreForPersist{book: book}, pageExtractor: extractor}}
+
+			md := &mediafile.ParsedMetadata{CoverPage: &tc.page}
+
+			err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+			require.NoError(t, err)
+
+			assert.Empty(t, extractor.calls, "extractor should not be called for invalid page")
+			assert.Nil(t, file.CoverPage, "file.CoverPage should remain unchanged")
+			assert.Nil(t, file.CoverImageFilename, "file.CoverImageFilename should remain unchanged")
+		})
+	}
+}
+
+func TestPersistMetadata_CoverPage_ExtractorError(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "comic.cbz")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake cbz"), 0600))
+
+	pageCount := 10
+	file := &models.File{
+		ID: 1, BookID: 1, Filepath: filePath, FileType: models.FileTypeCBZ, PageCount: &pageCount,
+	}
+	book := &models.Book{ID: 1, LibraryID: 1, Filepath: libraryDir, Files: []*models.File{file}}
+
+	extractor := &stubPageExtractor{wantErr: errors.New("extraction failed")}
+	h := &handler{enrich: &enrichDeps{bookStore: &stubBookStoreForPersist{book: book}, pageExtractor: extractor}}
+
+	page := 3
+	md := &mediafile.ParsedMetadata{CoverPage: &page}
+
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err, "extractor errors should be logged, not returned")
+
+	require.Len(t, extractor.calls, 1, "extractor should still be called once")
+	assert.Nil(t, file.CoverPage, "file.CoverPage should remain unchanged")
+	assert.Nil(t, file.CoverImageFilename, "file.CoverImageFilename should remain unchanged")
+	assert.Nil(t, file.CoverSource, "file.CoverSource should remain unchanged")
+}
+
+// Plugin returns both coverPage and coverData for a CBZ file — coverPage wins,
+// coverData is silently ignored (no .cover file written via the data path).
+func TestPersistMetadata_CoverPage_CBZ_BeatsCoverData(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "comic.cbz")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake cbz"), 0600))
+
+	pageCount := 10
+	file := &models.File{
+		ID: 1, BookID: 1, Filepath: filePath, FileType: models.FileTypeCBZ, PageCount: &pageCount,
+	}
+	book := &models.Book{ID: 1, LibraryID: 1, Filepath: libraryDir, Files: []*models.File{file}}
+	extractor := &stubPageExtractor{filename: "comic.cbz.cover.jpg", mimeType: "image/jpeg"}
+	h := &handler{enrich: &enrichDeps{bookStore: &stubBookStoreForPersist{book: book}, pageExtractor: extractor}}
+
+	page := 2
+	md := &mediafile.ParsedMetadata{
+		CoverPage:     &page,
+		CoverData:     makePersistTestJPEG(400, 600),
+		CoverMimeType: "image/jpeg",
+	}
+
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	// coverPage path taken
+	require.Len(t, extractor.calls, 1)
+	require.NotNil(t, file.CoverPage)
+	assert.Equal(t, 2, *file.CoverPage)
+
+	// coverData file must NOT have been written alongside the file
+	_, err = os.Stat(filepath.Join(libraryDir, "comic.cbz.cover.png"))
+	assert.True(t, os.IsNotExist(err), "coverData should not have been written for a page-based file")
+	_, err = os.Stat(filepath.Join(libraryDir, "comic.cbz.cover.jpg"))
+	assert.True(t, os.IsNotExist(err), "coverData should not have been written for a page-based file (jpg path)")
+}
+
+// Plugin returns coverPage for a non-page-based format (EPUB) — coverPage is
+// silently ignored, coverData (if provided) is applied.
+func TestPersistMetadata_CoverPage_EPUB_Ignored(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "book.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0600))
+
+	file := &models.File{
+		ID: 1, BookID: 1, Filepath: filePath, FileType: models.FileTypeEPUB,
+	}
+	book := &models.Book{ID: 1, LibraryID: 1, Filepath: libraryDir, Files: []*models.File{file}}
+	extractor := &stubPageExtractor{filename: "x", mimeType: "image/jpeg"}
+	h := &handler{enrich: &enrichDeps{bookStore: &stubBookStoreForPersist{book: book}, pageExtractor: extractor}}
+
+	page := 3
+	md := &mediafile.ParsedMetadata{
+		CoverPage:     &page,
+		CoverData:     makePersistTestJPEG(400, 600),
+		CoverMimeType: "image/jpeg",
+	}
+
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	// Extractor must not be called for non-page-based files
+	assert.Empty(t, extractor.calls)
+	// file.CoverPage must remain unchanged
+	assert.Nil(t, file.CoverPage)
+	// coverData write path ran — CoverImageFilename is set
+	require.NotNil(t, file.CoverImageFilename)
+	assert.Equal(t, "book.epub.cover.jpg", *file.CoverImageFilename)
 }

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
@@ -127,4 +128,78 @@ func TestPersistMetadata_CoverWrite_RootLevelFile_SyntheticBookPath(t *testing.T
 	// CoverImageFilename should be set (to the filename only, not a full path).
 	require.NotNil(t, file.CoverImageFilename, "CoverImageFilename should be set on the file")
 	assert.Equal(t, "book.epub.cover.jpg", *file.CoverImageFilename)
+}
+
+// stubPageExtractor records calls and returns a fixed (filename, mimeType).
+// Set `wantErr` to simulate a failed extraction.
+type stubPageExtractor struct {
+	calls    []stubPageExtractorCall
+	filename string
+	mimeType string
+	wantErr  error
+}
+
+type stubPageExtractorCall struct {
+	FileID       int
+	BookFilepath string
+	Page         int
+}
+
+func (s *stubPageExtractor) ExtractCoverPage(file *models.File, bookFilepath string, page int, _ logger.Logger) (string, string, error) {
+	s.calls = append(s.calls, stubPageExtractorCall{FileID: file.ID, BookFilepath: bookFilepath, Page: page})
+	if s.wantErr != nil {
+		return "", "", s.wantErr
+	}
+	return s.filename, s.mimeType, nil
+}
+
+func TestPersistMetadata_CoverPage_CBZ_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "comic.cbz")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake cbz"), 0600))
+
+	pageCount := 10
+	file := &models.File{
+		ID:        1,
+		BookID:    1,
+		Filepath:  filePath,
+		FileType:  models.FileTypeCBZ,
+		PageCount: &pageCount,
+	}
+	book := &models.Book{
+		ID:        1,
+		LibraryID: 1,
+		Filepath:  libraryDir,
+		Files:     []*models.File{file},
+	}
+
+	extractor := &stubPageExtractor{filename: "comic.cbz.cover.jpg", mimeType: "image/jpeg"}
+
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			pageExtractor: extractor,
+		},
+	}
+
+	page := 3
+	md := &mediafile.ParsedMetadata{CoverPage: &page}
+
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	require.Len(t, extractor.calls, 1)
+	assert.Equal(t, 1, extractor.calls[0].FileID)
+	assert.Equal(t, 3, extractor.calls[0].Page)
+
+	require.NotNil(t, file.CoverPage)
+	assert.Equal(t, 3, *file.CoverPage)
+	require.NotNil(t, file.CoverImageFilename)
+	assert.Equal(t, "comic.cbz.cover.jpg", *file.CoverImageFilename)
+	require.NotNil(t, file.CoverMimeType)
+	assert.Equal(t, "image/jpeg", *file.CoverMimeType)
+	require.NotNil(t, file.CoverSource)
+	assert.Equal(t, models.PluginDataSource("test", "plugin-id"), *file.CoverSource)
 }

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -426,6 +426,13 @@ func parseSearchResponse(vm *goja.Runtime, val goja.Value, pluginScope, pluginID
 			md.Confidence = &c
 		}
 
+		// coverPage -> *int
+		coverPageVal := itemObj.Get("coverPage")
+		if coverPageVal != nil && !goja.IsUndefined(coverPageVal) && !goja.IsNull(coverPageVal) {
+			cp := int(coverPageVal.ToInteger())
+			md.CoverPage = &cp
+		}
+
 		// genres -> []string
 		genresVal := itemObj.Get("genres")
 		if genresVal != nil && !goja.IsUndefined(genresVal) && !goja.IsNull(genresVal) {

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"math"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -426,11 +427,15 @@ func parseSearchResponse(vm *goja.Runtime, val goja.Value, pluginScope, pluginID
 			md.Confidence = &c
 		}
 
-		// coverPage -> *int
+		// coverPage -> *int (only accept finite non-negative integers; reject
+		// negative, NaN, and Infinity to avoid broken previews downstream)
 		coverPageVal := itemObj.Get("coverPage")
 		if coverPageVal != nil && !goja.IsUndefined(coverPageVal) && !goja.IsNull(coverPageVal) {
-			cp := int(coverPageVal.ToInteger())
-			md.CoverPage = &cp
+			f := coverPageVal.ToFloat()
+			if !math.IsNaN(f) && !math.IsInf(f, 0) && f >= 0 {
+				cp := int(f)
+				md.CoverPage = &cp
+			}
 		}
 
 		// genres -> []string
@@ -556,11 +561,15 @@ func parseParsedMetadata(vm *goja.Runtime, val goja.Value) (*mediafile.ParsedMet
 		md.CoverData = parseByteData(coverDataVal)
 	}
 
-	// coverPage -> *int
+	// coverPage -> *int (only accept finite non-negative integers; reject
+	// negative, NaN, and Infinity to avoid broken previews downstream)
 	coverPageVal := obj.Get("coverPage")
 	if coverPageVal != nil && !goja.IsUndefined(coverPageVal) && !goja.IsNull(coverPageVal) {
-		cp := int(coverPageVal.ToInteger())
-		md.CoverPage = &cp
+		f := coverPageVal.ToFloat()
+		if !math.IsNaN(f) && !math.IsInf(f, 0) && f >= 0 {
+			cp := int(f)
+			md.CoverPage = &cp
+		}
 	}
 
 	// duration -> time.Duration (from seconds float)

--- a/pkg/plugins/hooks_search_result_test.go
+++ b/pkg/plugins/hooks_search_result_test.go
@@ -303,3 +303,26 @@ func TestParseSearchResponse_CoverPage_MissingOrNull(t *testing.T) {
 	assert.Nil(t, resp.Results[0].CoverPage)
 	assert.Nil(t, resp.Results[1].CoverPage)
 }
+
+func TestParseSearchResponse_CoverPage_Invalid(t *testing.T) {
+	t.Parallel()
+	vm := goja.New()
+	// Negative, NaN, and Infinity values must be rejected at parse time so
+	// they don't propagate to the apply path and cause broken previews.
+	val, err := vm.RunString(`({ results: [
+		{ title: "neg", coverPage: -1 },
+		{ title: "nan", coverPage: NaN },
+		{ title: "inf", coverPage: Infinity },
+		{ title: "zero", coverPage: 0 },
+	] })`)
+	require.NoError(t, err)
+
+	resp := parseSearchResponse(vm, val, "test", "plugin-id")
+
+	require.Len(t, resp.Results, 4)
+	assert.Nil(t, resp.Results[0].CoverPage, "negative coverPage should be rejected")
+	assert.Nil(t, resp.Results[1].CoverPage, "NaN coverPage should be rejected")
+	assert.Nil(t, resp.Results[2].CoverPage, "Infinity coverPage should be rejected")
+	require.NotNil(t, resp.Results[3].CoverPage, "0 is a valid coverPage")
+	assert.Equal(t, 0, *resp.Results[3].CoverPage)
+}

--- a/pkg/plugins/hooks_search_result_test.go
+++ b/pkg/plugins/hooks_search_result_test.go
@@ -277,3 +277,29 @@ func TestParseSearchResponse_NilInput(t *testing.T) {
 	resp = parseSearchResponse(vm, val, "s", "p")
 	assert.Empty(t, resp.Results)
 }
+
+func TestParseSearchResponse_CoverPage(t *testing.T) {
+	t.Parallel()
+	vm := goja.New()
+	val, err := vm.RunString(`({ results: [{ title: "x", coverPage: 3 }] })`)
+	require.NoError(t, err)
+
+	resp := parseSearchResponse(vm, val, "test", "plugin-id")
+
+	require.Len(t, resp.Results, 1)
+	require.NotNil(t, resp.Results[0].CoverPage)
+	assert.Equal(t, 3, *resp.Results[0].CoverPage)
+}
+
+func TestParseSearchResponse_CoverPage_MissingOrNull(t *testing.T) {
+	t.Parallel()
+	vm := goja.New()
+	val, err := vm.RunString(`({ results: [{ title: "a" }, { title: "b", coverPage: null }] })`)
+	require.NoError(t, err)
+
+	resp := parseSearchResponse(vm, val, "test", "plugin-id")
+
+	require.Len(t, resp.Results, 2)
+	assert.Nil(t, resp.Results[0].CoverPage)
+	assert.Nil(t, resp.Results[1].CoverPage)
+}

--- a/pkg/plugins/routes.go
+++ b/pkg/plugins/routes.go
@@ -19,6 +19,7 @@ type EnrichDeps struct {
 	PublisherFinder publisherFinder
 	ImprintFinder   imprintFinder
 	SearchIndexer   searchIndexer
+	PageExtractor   pageExtractor
 }
 
 // RegisterRoutesWithGroup registers plugin management API routes.
@@ -35,6 +36,7 @@ func RegisterRoutesWithGroup(g *echo.Group, service *Service, manager *Manager, 
 			publisherFinder: ed.PublisherFinder,
 			imprintFinder:   ed.ImprintFinder,
 			searchIndexer:   ed.SearchIndexer,
+			pageExtractor:   ed.PageExtractor,
 		}
 	}
 
@@ -77,6 +79,7 @@ func RegisterIdentifyRoutes(g *echo.Group, service *Service, manager *Manager, e
 			publisherFinder: ed.PublisherFinder,
 			imprintFinder:   ed.ImprintFinder,
 			searchIndexer:   ed.SearchIndexer,
+			pageExtractor:   ed.PageExtractor,
 		}
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/binder"
 	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/cbzpages"
 	"github.com/shishobooks/shisho/pkg/chapters"
 	"github.com/shishobooks/shisho/pkg/config"
 	"github.com/shishobooks/shisho/pkg/downloadcache"
@@ -33,6 +34,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/logs"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/opds"
+	"github.com/shishobooks/shisho/pkg/pdfpages"
 	"github.com/shishobooks/shisho/pkg/people"
 	"github.com/shishobooks/shisho/pkg/plugins"
 	"github.com/shishobooks/shisho/pkg/publishers"
@@ -197,6 +199,9 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 	pluginService := plugins.NewService(db)
 	bookSvc := books.NewService(db)
 	bookAdapter := &bookUpdaterAdapter{svc: bookSvc}
+	cbzCache := cbzpages.NewCache(cfg.CacheDir)
+	pdfCache := pdfpages.NewCache(cfg.CacheDir, cfg.PDFRenderDPI, cfg.PDFRenderQuality)
+	pageExtractor := books.NewPluginPageExtractor(cbzCache, pdfCache)
 	enrichDeps := &plugins.EnrichDeps{
 		BookStore:       bookAdapter,
 		RelStore:        bookAdapter,
@@ -207,6 +212,7 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 		PublisherFinder: publishers.NewService(db),
 		ImprintFinder:   imprints.NewService(db),
 		SearchIndexer:   search.NewService(db),
+		PageExtractor:   pageExtractor,
 	}
 	pluginIdentifyGroup := e.Group("/plugins")
 	pluginIdentifyGroup.Use(authMiddleware.Authenticate)

--- a/pkg/worker/scan_enricher_test.go
+++ b/pkg/worker/scan_enricher_test.go
@@ -480,21 +480,166 @@ func TestCoverPageProtection_EnricherCannotOverridePageCover(t *testing.T) {
 	require.NotNil(t, enrichedMeta.CoverPage)
 	assert.Equal(t, 0, *enrichedMeta.CoverPage)
 
-	// 3. Apply page-based file type protection (as runMetadataEnrichers does)
+	// 3. Apply page-based file type protection (as runMetadataEnrichers does).
+	// The reset only touches image data; CoverPage is intentionally left alone
+	// since the merge already handled "enricher wins if set, file parser fills
+	// in otherwise". Since the enricher did NOT set CoverPage here, the
+	// "cover" source is restored to the file parser.
 	fileType := models.FileTypeCBZ
 	if models.IsPageBasedFileType(fileType) {
 		enrichedMeta.CoverData = fileMetadata.CoverData
 		enrichedMeta.CoverMimeType = fileMetadata.CoverMimeType
-		enrichedMeta.CoverPage = fileMetadata.CoverPage
 		enrichedMeta.FieldDataSources["cover"] = fileMetadata.SourceForField("cover")
 	}
 
-	// File parser's cover should be restored
+	// File parser's image data should be restored; CoverPage came from file
+	// parser via merge (enricher didn't set one) and stays there.
 	assert.Equal(t, []byte("page-derived cover"), enrichedMeta.CoverData)
 	assert.Equal(t, "image/jpeg", enrichedMeta.CoverMimeType)
 	require.NotNil(t, enrichedMeta.CoverPage)
 	assert.Equal(t, 0, *enrichedMeta.CoverPage)
 	assert.Equal(t, fileSource, enrichedMeta.FieldDataSources["cover"])
+}
+
+// TestMergeFileParserFallback_EnricherCoverPagePreserved is a regression test
+// for a bug where the page-based file protection block unconditionally reset
+// CoverPage to the file parser's value, silently discarding an enricher-
+// provided coverPage. The feature spec requires enrichers on CBZ/PDF to be
+// able to set coverPage — this test exercises mergeFileParserFallback
+// directly so the production code path is under test.
+func TestMergeFileParserFallback_EnricherCoverPagePreserved(t *testing.T) {
+	t.Parallel()
+
+	fileCoverPage := 0
+	fileSource := "cbz_metadata"
+
+	// File parser provides cover page 0 (default)
+	fileMetadata := &mediafile.ParsedMetadata{
+		Title:         "My CBZ Book",
+		CoverData:     []byte("page-derived cover"),
+		CoverMimeType: "image/jpeg",
+		CoverPage:     &fileCoverPage,
+		DataSource:    fileSource,
+		FieldDataSources: map[string]string{
+			"cover": fileSource,
+		},
+	}
+
+	// Enricher tells Shisho to use page 3 for the cover.
+	enricherCoverPage := 3
+	enricherSource := "plugin:test/enricher"
+	enricherResult := &mediafile.ParsedMetadata{
+		CoverPage: &enricherCoverPage,
+	}
+
+	// 1. Enricher merges into empty target (simulates runMetadataEnrichers).
+	var enrichedMeta mediafile.ParsedMetadata
+	mergeEnrichedMetadata(&enrichedMeta, enricherResult, enricherSource)
+
+	// 2. File parser fallback + page-based protection (production code path).
+	mergeFileParserFallback(&enrichedMeta, fileMetadata, models.FileTypeCBZ)
+
+	// Enricher's CoverPage must be preserved — this is the whole point of the
+	// coverPage feature for page-based formats.
+	require.NotNil(t, enrichedMeta.CoverPage)
+	assert.Equal(t, 3, *enrichedMeta.CoverPage, "enricher coverPage must not be overwritten by file parser")
+	assert.Equal(t, enricherSource, enrichedMeta.FieldDataSources["cover"], "source should reflect enricher, not file parser")
+
+	// File parser's image data should still be restored (enricher image data,
+	// if any, is rejected for page-based formats).
+	assert.Equal(t, []byte("page-derived cover"), enrichedMeta.CoverData)
+	assert.Equal(t, "image/jpeg", enrichedMeta.CoverMimeType)
+}
+
+// TestMergeFileParserFallback_PDFEnricherCoverPagePreserved covers the PDF
+// variant of the regression fix — same behavior as CBZ.
+func TestMergeFileParserFallback_PDFEnricherCoverPagePreserved(t *testing.T) {
+	t.Parallel()
+
+	fileCoverPage := 0
+	fileSource := "pdf_metadata"
+	fileMetadata := &mediafile.ParsedMetadata{
+		Title:      "My PDF",
+		CoverPage:  &fileCoverPage,
+		DataSource: fileSource,
+	}
+
+	enricherCoverPage := 5
+	enricherSource := "plugin:test/enricher"
+	enricherResult := &mediafile.ParsedMetadata{
+		CoverPage: &enricherCoverPage,
+	}
+
+	var enrichedMeta mediafile.ParsedMetadata
+	mergeEnrichedMetadata(&enrichedMeta, enricherResult, enricherSource)
+	mergeFileParserFallback(&enrichedMeta, fileMetadata, models.FileTypePDF)
+
+	require.NotNil(t, enrichedMeta.CoverPage)
+	assert.Equal(t, 5, *enrichedMeta.CoverPage)
+	assert.Equal(t, enricherSource, enrichedMeta.FieldDataSources["cover"])
+}
+
+// TestMergeFileParserFallback_NoEnricherCoverPage_FileParserUsed verifies
+// that when no enricher provides a CoverPage, the file parser's value is
+// used and the source tracks the file parser.
+func TestMergeFileParserFallback_NoEnricherCoverPage_FileParserUsed(t *testing.T) {
+	t.Parallel()
+
+	fileCoverPage := 0
+	fileSource := "cbz_metadata"
+	fileMetadata := &mediafile.ParsedMetadata{
+		CoverData:     []byte("page-derived cover"),
+		CoverMimeType: "image/jpeg",
+		CoverPage:     &fileCoverPage,
+		DataSource:    fileSource,
+	}
+
+	// Enricher provides only downloaded image data (no CoverPage).
+	enricherSource := "plugin:test/enricher"
+	enricherResult := &mediafile.ParsedMetadata{
+		CoverData:     []byte("enricher-downloaded cover"),
+		CoverMimeType: "image/png",
+	}
+
+	var enrichedMeta mediafile.ParsedMetadata
+	mergeEnrichedMetadata(&enrichedMeta, enricherResult, enricherSource)
+	mergeFileParserFallback(&enrichedMeta, fileMetadata, models.FileTypeCBZ)
+
+	// Enricher image data is rejected; file parser's cover applied.
+	assert.Equal(t, []byte("page-derived cover"), enrichedMeta.CoverData)
+	assert.Equal(t, "image/jpeg", enrichedMeta.CoverMimeType)
+	require.NotNil(t, enrichedMeta.CoverPage)
+	assert.Equal(t, 0, *enrichedMeta.CoverPage)
+	assert.Equal(t, fileSource, enrichedMeta.FieldDataSources["cover"])
+}
+
+// TestMergeFileParserFallback_NonPageBased_EnricherCoverPreserved verifies
+// that EPUB/M4B (non-page-based) files keep the enricher's cover data.
+func TestMergeFileParserFallback_NonPageBased_EnricherCoverPreserved(t *testing.T) {
+	t.Parallel()
+
+	fileSource := "epub_metadata"
+	fileMetadata := &mediafile.ParsedMetadata{
+		CoverData:     []byte("epub-embedded cover"),
+		CoverMimeType: "image/jpeg",
+		DataSource:    fileSource,
+	}
+
+	enricherSource := "plugin:test/enricher"
+	enricherResult := &mediafile.ParsedMetadata{
+		CoverData:     []byte("enricher high-res cover"),
+		CoverMimeType: "image/png",
+	}
+
+	var enrichedMeta mediafile.ParsedMetadata
+	mergeEnrichedMetadata(&enrichedMeta, enricherResult, enricherSource)
+	mergeFileParserFallback(&enrichedMeta, fileMetadata, models.FileTypeEPUB)
+
+	// Enricher cover preserved (EPUB is not page-based).
+	assert.Equal(t, []byte("enricher high-res cover"), enrichedMeta.CoverData)
+	assert.Equal(t, "image/png", enrichedMeta.CoverMimeType)
+	assert.Nil(t, enrichedMeta.CoverPage)
+	assert.Equal(t, enricherSource, enrichedMeta.FieldDataSources["cover"])
 }
 
 // TestCoverPageProtection_NoCoverPage_EnricherCoverPreserved verifies that when
@@ -530,8 +675,6 @@ func TestCoverPageProtection_NoCoverPage_EnricherCoverPreserved(t *testing.T) {
 	if models.IsPageBasedFileType(fileType) {
 		enrichedMeta.CoverData = fileMetadata.CoverData
 		enrichedMeta.CoverMimeType = fileMetadata.CoverMimeType
-		enrichedMeta.CoverPage = fileMetadata.CoverPage
-		enrichedMeta.FieldDataSources["cover"] = fileMetadata.SourceForField("cover")
 	}
 
 	// Enricher's cover should be preserved

--- a/pkg/worker/scan_plugins_test.go
+++ b/pkg/worker/scan_plugins_test.go
@@ -1,7 +1,10 @@
 package worker
 
 import (
+	"bytes"
 	"context"
+	"image"
+	"image/color"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1998,4 +2001,87 @@ func TestScanWithPluginMetadataEnricher_PerLibraryFieldOverride(t *testing.T) {
 
 	// Description should NOT be present due to per-library override
 	assert.Nil(t, book.Description, "description should be filtered due to per-library override")
+}
+
+// TestScanWithEnricher_CoverPageForCBZ verifies that when a metadata enricher
+// returns coverPage for a CBZ file during an automated scan, Shisho writes the
+// selected page back to file.CoverPage, re-extracts that page as the on-disk
+// cover image, and records the enricher as the cover source.
+func TestScanWithEnricher_CoverPageForCBZ(t *testing.T) {
+	t.Parallel()
+	pluginDir := t.TempDir()
+	tc := newTestContextWithPlugins(t, pluginDir)
+
+	enricherManifest := `{
+  "manifestVersion": 1,
+  "id": "cover-page-enricher",
+  "name": "Cover Page Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "description": "Picks page 2 as the cover",
+      "fileTypes": ["cbz"],
+      "fields": ["cover"]
+    }
+  }
+}`
+	enricherMainJS := `var plugin = (function() {
+  return {
+    metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, coverPage: 2 }] };
+      }
+    }
+  };
+})();`
+
+	installTestPlugin(t, tc, pluginDir, "cover-page-enricher", enricherManifest, enricherMainJS)
+
+	pluginService := plugins.NewService(tc.db)
+	err := pluginService.AppendToOrder(context.Background(), models.PluginHookMetadataEnricher, "test", "cover-page-enricher")
+	require.NoError(t, err)
+
+	err = tc.worker.pluginManager.LoadAll(context.Background())
+	require.NoError(t, err)
+
+	libraryPath := t.TempDir()
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := filepath.Join(libraryPath, "Page Picker Comic")
+	err = os.MkdirAll(bookDir, 0755)
+	require.NoError(t, err)
+
+	cbzPath := filepath.Join(bookDir, "comic.cbz")
+	writeCBZWithColoredPages(t, cbzPath, []color.RGBA{
+		{R: 255, G: 0, B: 0, A: 255},   // page 0: red (file parser default)
+		{R: 0, G: 255, B: 0, A: 255},   // page 1: green
+		{R: 30, G: 40, B: 250, A: 255}, // page 2: blue (enricher's choice)
+	})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	file := files[0]
+
+	// The enricher's coverPage must land in the DB.
+	require.NotNil(t, file.CoverPage, "file.CoverPage should be set from enricher")
+	assert.Equal(t, 2, *file.CoverPage)
+
+	// The cover source must reflect the enricher.
+	require.NotNil(t, file.CoverSource)
+	assert.Equal(t, "plugin:test/cover-page-enricher", *file.CoverSource)
+
+	// The on-disk cover image must be page 2 (blue), not page 0 (red).
+	require.NotNil(t, file.CoverImageFilename)
+	coverPath := filepath.Join(bookDir, *file.CoverImageFilename)
+	coverBytes, err := os.ReadFile(coverPath)
+	require.NoError(t, err)
+	img, _, err := image.Decode(bytes.NewReader(coverBytes))
+	require.NoError(t, err)
+	bounds := img.Bounds()
+	r, g, b, _ := img.At((bounds.Min.X+bounds.Max.X)/2, (bounds.Min.Y+bounds.Max.Y)/2).RGBA()
+	assert.Less(t, int(r>>8), 80, "red channel should be low (page 2 is blue)")
+	assert.Less(t, int(g>>8), 80, "green channel should be low (page 2 is blue)")
+	assert.Greater(t, int(b>>8), 150, "blue channel should be high (page 2 is blue)")
 }

--- a/pkg/worker/scan_plugins_test.go
+++ b/pkg/worker/scan_plugins_test.go
@@ -2085,3 +2085,86 @@ func TestScanWithEnricher_CoverPageForCBZ(t *testing.T) {
 	assert.Less(t, int(g>>8), 80, "green channel should be low (page 2 is blue)")
 	assert.Greater(t, int(b>>8), 150, "blue channel should be high (page 2 is blue)")
 }
+
+// TestScanWithEnricher_CoverPageOutOfBounds verifies that an enricher
+// returning an out-of-range coverPage is skipped with a warning during
+// auto-scan: file.CoverPage stays on the file parser's default (page 0),
+// and the on-disk cover is page 0 (red), not page 99.
+func TestScanWithEnricher_CoverPageOutOfBounds(t *testing.T) {
+	t.Parallel()
+	pluginDir := t.TempDir()
+	tc := newTestContextWithPlugins(t, pluginDir)
+
+	enricherManifest := `{
+  "manifestVersion": 1,
+  "id": "oob-enricher",
+  "name": "Out-Of-Bounds Cover Page Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "description": "Returns an out-of-range page",
+      "fileTypes": ["cbz"],
+      "fields": ["cover"]
+    }
+  }
+}`
+	enricherMainJS := `var plugin = (function() {
+  return {
+    metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{ title: ctx.query, coverPage: 99 }] };
+      }
+    }
+  };
+})();`
+
+	installTestPlugin(t, tc, pluginDir, "oob-enricher", enricherManifest, enricherMainJS)
+
+	pluginService := plugins.NewService(tc.db)
+	err := pluginService.AppendToOrder(context.Background(), models.PluginHookMetadataEnricher, "test", "oob-enricher")
+	require.NoError(t, err)
+
+	err = tc.worker.pluginManager.LoadAll(context.Background())
+	require.NoError(t, err)
+
+	libraryPath := t.TempDir()
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := filepath.Join(libraryPath, "Out Of Bounds Comic")
+	err = os.MkdirAll(bookDir, 0755)
+	require.NoError(t, err)
+
+	cbzPath := filepath.Join(bookDir, "comic.cbz")
+	writeCBZWithColoredPages(t, cbzPath, []color.RGBA{
+		{R: 255, G: 0, B: 0, A: 255},   // page 0: red
+		{R: 0, G: 255, B: 0, A: 255},   // page 1: green
+		{R: 30, G: 40, B: 250, A: 255}, // page 2: blue
+	})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	file := files[0]
+
+	// Enricher's out-of-range page is rejected; file parser's default (page 0) stands.
+	require.NotNil(t, file.CoverPage)
+	assert.Equal(t, 0, *file.CoverPage, "out-of-range coverPage should be skipped")
+
+	// Cover source must NOT be the enricher.
+	require.NotNil(t, file.CoverSource)
+	assert.NotEqual(t, "plugin:test/oob-enricher", *file.CoverSource)
+
+	// On-disk cover must be page 0 (red), not page 99.
+	require.NotNil(t, file.CoverImageFilename)
+	coverPath := filepath.Join(bookDir, *file.CoverImageFilename)
+	coverBytes, err := os.ReadFile(coverPath)
+	require.NoError(t, err)
+	img, _, err := image.Decode(bytes.NewReader(coverBytes))
+	require.NoError(t, err)
+	bounds := img.Bounds()
+	r, g, b, _ := img.At((bounds.Min.X+bounds.Max.X)/2, (bounds.Min.Y+bounds.Max.Y)/2).RGBA()
+	assert.Greater(t, int(r>>8), 200, "red channel should be high (page 0 is red)")
+	assert.Less(t, int(g>>8), 80, "green channel should be low (page 0 is red)")
+	assert.Less(t, int(b>>8), 80, "blue channel should be low (page 0 is red)")
+}

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2035,46 +2035,22 @@ func (w *Worker) scanFileCore(
 		isDifferent := file.CoverPage == nil || *file.CoverPage != *fileSidecarData.CoverPage
 
 		if shouldApply && isDifferent {
-			// book.Filepath may be a synthetic organized-folder path that
-			// does not yet exist for root-level new files, so use the
-			// write-side helper that falls back to the file's parent dir.
-			coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, file.Filepath)
-
-			// Generate cover filename
-			filename := filepath.Base(file.Filepath)
-			coverBaseName := filename + ".cover"
-
-			// Extract the cover page from the source file.
-			var coverFilename, coverMimeType string
-			switch file.FileType {
-			case models.FileTypePDF:
-				coverFilename, coverMimeType, err = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, *fileSidecarData.CoverPage)
-			case models.FileTypeCBZ:
-				coverFilename, coverMimeType, err = extractCBZPageCover(file.Filepath, coverDir, coverBaseName, *fileSidecarData.CoverPage)
-			default:
-				err = errors.Errorf("unsupported page-based file type for cover extraction: %s", file.FileType)
-			}
-			if err != nil {
+			fromPage := file.CoverPage
+			page := *fileSidecarData.CoverPage
+			extractErr, updateErr := w.applyPageCover(ctx, file, book, page, sidecarSource)
+			switch {
+			case extractErr != nil:
 				logWarn("failed to extract cover page from sidecar", logger.Data{
-					"error":      err.Error(),
-					"cover_page": *fileSidecarData.CoverPage,
+					"error":      extractErr.Error(),
+					"cover_page": page,
 				})
-			} else {
+			case updateErr != nil:
+				return nil, errors.Wrap(updateErr, "failed to update cover page from sidecar")
+			default:
 				logInfo("updating cover page from sidecar", logger.Data{
-					"from_page": file.CoverPage,
-					"to_page":   *fileSidecarData.CoverPage,
+					"from_page": fromPage,
+					"to_page":   page,
 				})
-
-				file.CoverPage = fileSidecarData.CoverPage
-				file.CoverImageFilename = &coverFilename
-				file.CoverMimeType = &coverMimeType
-				file.CoverSource = &sidecarSource
-
-				if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
-					Columns: []string{"cover_page", "cover_image_filename", "cover_mime_type", "cover_source"},
-				}); err != nil {
-					return nil, errors.Wrap(err, "failed to update cover page from sidecar")
-				}
 			}
 		}
 	}
@@ -2129,39 +2105,23 @@ func (w *Worker) scanFileCore(
 					"source":     metadataCoverSource,
 				})
 			default:
-				coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, file.Filepath)
-				coverBaseName := filepath.Base(file.Filepath) + ".cover"
-
-				var coverFilename, coverMimeType string
-				switch file.FileType {
-				case models.FileTypePDF:
-					coverFilename, coverMimeType, err = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, page)
-				case models.FileTypeCBZ:
-					coverFilename, coverMimeType, err = extractCBZPageCover(file.Filepath, coverDir, coverBaseName, page)
-				}
-				if err != nil {
+				fromPage := file.CoverPage
+				extractErr, updateErr := w.applyPageCover(ctx, file, book, page, metadataCoverSource)
+				switch {
+				case extractErr != nil:
 					logWarn("failed to extract cover page from metadata", logger.Data{
-						"error":      err.Error(),
+						"error":      extractErr.Error(),
 						"cover_page": page,
 						"source":     metadataCoverSource,
 					})
-				} else {
+				case updateErr != nil:
+					return nil, errors.Wrap(updateErr, "failed to update cover page from metadata")
+				default:
 					logInfo("updating cover page from metadata", logger.Data{
-						"from_page": file.CoverPage,
+						"from_page": fromPage,
 						"to_page":   page,
 						"source":    metadataCoverSource,
 					})
-
-					file.CoverPage = &page
-					file.CoverImageFilename = &coverFilename
-					file.CoverMimeType = &coverMimeType
-					file.CoverSource = &metadataCoverSource
-
-					if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
-						Columns: []string{"cover_page", "cover_image_filename", "cover_mime_type", "cover_source"},
-					}); err != nil {
-						return nil, errors.Wrap(err, "failed to update cover page from metadata")
-					}
 				}
 			}
 		}
@@ -3690,6 +3650,39 @@ func (w *Worker) recoverMissingCover(ctx context.Context, file *models.File, job
 	}
 
 	return nil
+}
+
+// applyPageCover renders `page` from the page-based file, writes it as the
+// cover image next to the book, and persists the cover_page /
+// cover_image_filename / cover_mime_type / cover_source update to the DB.
+// Returns (extractErr, updateErr). Callers typically treat extract errors as
+// non-fatal warnings and surface update errors.
+func (w *Worker) applyPageCover(ctx context.Context, file *models.File, book *models.Book, page int, source string) (extractErr, updateErr error) {
+	coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, file.Filepath)
+	coverBaseName := filepath.Base(file.Filepath) + ".cover"
+
+	var coverFilename, coverMimeType string
+	switch file.FileType {
+	case models.FileTypePDF:
+		coverFilename, coverMimeType, extractErr = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, page)
+	case models.FileTypeCBZ:
+		coverFilename, coverMimeType, extractErr = extractCBZPageCover(file.Filepath, coverDir, coverBaseName, page)
+	default:
+		extractErr = errors.Errorf("unsupported page-based file type for cover extraction: %s", file.FileType)
+	}
+	if extractErr != nil {
+		return extractErr, nil
+	}
+
+	file.CoverPage = &page
+	file.CoverImageFilename = &coverFilename
+	file.CoverMimeType = &coverMimeType
+	file.CoverSource = &source
+
+	updateErr = w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
+		Columns: []string{"cover_page", "cover_image_filename", "cover_mime_type", "cover_source"},
+	})
+	return nil, updateErr
 }
 
 // extractCBZPageCover extracts a specific page from a CBZ file and saves it as the cover.

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2079,6 +2079,66 @@ func (w *Worker) scanFileCore(
 		}
 	}
 
+	// Update cover page (from enricher-supplied metadata) for page-based formats.
+	// Plugin enrichers can identify a cover page that isn't the file parser's
+	// default (typically page 0); apply their value when the source priority
+	// allows. The file parser's own metadata.CoverPage is also handled here —
+	// scanFileCreateNew already wrote it during the initial insert, so the
+	// isDifferent guard makes this a no-op for that path.
+	if metadata.CoverPage != nil && models.IsPageBasedFileType(file.FileType) {
+		metadataCoverSource := metadata.SourceForField("cover")
+		existingCoverSource := ""
+		if file.CoverSource != nil {
+			existingCoverSource = *file.CoverSource
+		}
+
+		metadataPriority := models.GetDataSourcePriority(metadataCoverSource)
+		existingPriority := models.GetDataSourcePriority(existingCoverSource)
+		if existingCoverSource == "" {
+			existingPriority = models.GetDataSourcePriority(models.DataSourceFilepath)
+		}
+
+		shouldApply := forceRefresh || metadataPriority <= existingPriority
+		isDifferent := file.CoverPage == nil || *file.CoverPage != *metadata.CoverPage
+
+		if shouldApply && isDifferent {
+			coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, file.Filepath)
+			coverBaseName := filepath.Base(file.Filepath) + ".cover"
+
+			var coverFilename, coverMimeType string
+			switch file.FileType {
+			case models.FileTypePDF:
+				coverFilename, coverMimeType, err = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, *metadata.CoverPage)
+			case models.FileTypeCBZ:
+				coverFilename, coverMimeType, err = extractCBZPageCover(file.Filepath, coverDir, coverBaseName, *metadata.CoverPage)
+			}
+			if err != nil {
+				logWarn("failed to extract cover page from metadata", logger.Data{
+					"error":      err.Error(),
+					"cover_page": *metadata.CoverPage,
+					"source":     metadataCoverSource,
+				})
+			} else {
+				logInfo("updating cover page from metadata", logger.Data{
+					"from_page": file.CoverPage,
+					"to_page":   *metadata.CoverPage,
+					"source":    metadataCoverSource,
+				})
+
+				file.CoverPage = metadata.CoverPage
+				file.CoverImageFilename = &coverFilename
+				file.CoverMimeType = &coverMimeType
+				file.CoverSource = &metadataCoverSource
+
+				if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
+					Columns: []string{"cover_page", "cover_image_filename", "cover_mime_type", "cover_source"},
+				}); err != nil {
+					return nil, errors.Wrap(err, "failed to update cover page from metadata")
+				}
+			}
+		}
+	}
+
 	// ==========================================================================
 	// Write sidecar files
 	// ==========================================================================

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2079,14 +2079,20 @@ func (w *Worker) scanFileCore(
 		}
 	}
 
-	// Update cover page (from enricher-supplied metadata) for page-based formats.
-	// Plugin enrichers can identify a cover page that isn't the file parser's
-	// default (typically page 0); apply their value when the source priority
-	// allows. The file parser's own metadata.CoverPage is also handled here —
-	// scanFileCreateNew already wrote it during the initial insert, so the
-	// isDifferent guard makes this a no-op for that path.
-	if metadata.CoverPage != nil && models.IsPageBasedFileType(file.FileType) {
-		metadataCoverSource := metadata.SourceForField("cover")
+	// Update cover page (from plugin-supplied metadata) for page-based formats.
+	// Plugin enrichers (and plugin fileParsers) can identify a cover page that
+	// isn't the file parser's default (typically page 0); apply their value
+	// when the source priority allows.
+	//
+	// This branch only fires for plugin-sourced CoverPage. The file parser's
+	// own default (cbz_metadata / pdf_metadata) is already written by
+	// scanFileCreateNew, and re-applying it here would silently revert a
+	// user's page-picker selection on any forced rescan — see
+	// TestRecoverMissingCover_RespectsCoverPage. Sidecar-sourced CoverPage is
+	// handled by the dedicated sidecar branch above.
+	metadataCoverSource := metadata.SourceForField("cover")
+	isPluginCoverSource := strings.HasPrefix(metadataCoverSource, models.DataSourcePluginPrefix)
+	if metadata.CoverPage != nil && models.IsPageBasedFileType(file.FileType) && isPluginCoverSource {
 		existingCoverSource := ""
 		if file.CoverSource != nil {
 			existingCoverSource = *file.CoverSource
@@ -2098,42 +2104,64 @@ func (w *Worker) scanFileCore(
 			existingPriority = models.GetDataSourcePriority(models.DataSourceFilepath)
 		}
 
-		shouldApply := forceRefresh || metadataPriority <= existingPriority
+		shouldApply := metadataPriority <= existingPriority
 		isDifferent := file.CoverPage == nil || *file.CoverPage != *metadata.CoverPage
 
 		if shouldApply && isDifferent {
-			coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, file.Filepath)
-			coverBaseName := filepath.Base(file.Filepath) + ".cover"
-
-			var coverFilename, coverMimeType string
-			switch file.FileType {
-			case models.FileTypePDF:
-				coverFilename, coverMimeType, err = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, *metadata.CoverPage)
-			case models.FileTypeCBZ:
-				coverFilename, coverMimeType, err = extractCBZPageCover(file.Filepath, coverDir, coverBaseName, *metadata.CoverPage)
-			}
-			if err != nil {
-				logWarn("failed to extract cover page from metadata", logger.Data{
-					"error":      err.Error(),
-					"cover_page": *metadata.CoverPage,
+			page := *metadata.CoverPage
+			// Bounds guard — mirrors persistMetadata's handling so scan-path
+			// warnings are just as actionable as the identify-apply path.
+			switch {
+			case page < 0:
+				logWarn("plugin-provided cover page is negative, skipping", logger.Data{
+					"cover_page": page,
 					"source":     metadataCoverSource,
 				})
-			} else {
-				logInfo("updating cover page from metadata", logger.Data{
-					"from_page": file.CoverPage,
-					"to_page":   *metadata.CoverPage,
-					"source":    metadataCoverSource,
+			case file.PageCount == nil:
+				logWarn("cover page skipped: page count unknown", logger.Data{
+					"cover_page": page,
+					"source":     metadataCoverSource,
 				})
+			case page >= *file.PageCount:
+				logWarn("plugin-provided cover page is out of range, skipping", logger.Data{
+					"cover_page": page,
+					"page_count": *file.PageCount,
+					"source":     metadataCoverSource,
+				})
+			default:
+				coverDir := fileutils.ResolveCoverDirForWrite(book.Filepath, file.Filepath)
+				coverBaseName := filepath.Base(file.Filepath) + ".cover"
 
-				file.CoverPage = metadata.CoverPage
-				file.CoverImageFilename = &coverFilename
-				file.CoverMimeType = &coverMimeType
-				file.CoverSource = &metadataCoverSource
+				var coverFilename, coverMimeType string
+				switch file.FileType {
+				case models.FileTypePDF:
+					coverFilename, coverMimeType, err = extractPDFPageCover(file.Filepath, coverDir, coverBaseName, page)
+				case models.FileTypeCBZ:
+					coverFilename, coverMimeType, err = extractCBZPageCover(file.Filepath, coverDir, coverBaseName, page)
+				}
+				if err != nil {
+					logWarn("failed to extract cover page from metadata", logger.Data{
+						"error":      err.Error(),
+						"cover_page": page,
+						"source":     metadataCoverSource,
+					})
+				} else {
+					logInfo("updating cover page from metadata", logger.Data{
+						"from_page": file.CoverPage,
+						"to_page":   page,
+						"source":    metadataCoverSource,
+					})
 
-				if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
-					Columns: []string{"cover_page", "cover_image_filename", "cover_mime_type", "cover_source"},
-				}); err != nil {
-					return nil, errors.Wrap(err, "failed to update cover page from metadata")
+					file.CoverPage = &page
+					file.CoverImageFilename = &coverFilename
+					file.CoverMimeType = &coverMimeType
+					file.CoverSource = &metadataCoverSource
+
+					if err := w.bookService.UpdateFile(ctx, file, books.UpdateFileOptions{
+						Columns: []string{"cover_page", "cover_image_filename", "cover_mime_type", "cover_source"},
+					}); err != nil {
+						return nil, errors.Wrap(err, "failed to update cover page from metadata")
+					}
 				}
 			}
 		}

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -3114,18 +3114,9 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 		modified = true
 	}
 
-	// Merge file-parsed metadata as fallback for fields no enricher provided.
-	// This gives enrichers priority over file metadata (priority 2 > priority 3).
-	mergeEnrichedMetadata(&enrichedMeta, metadata, metadata.DataSource)
-
-	// Page-based formats (CBZ, PDF) derive covers from page content and must
-	// not have them replaced by enricher-downloaded images.
-	if models.IsPageBasedFileType(file.FileType) {
-		enrichedMeta.CoverData = metadata.CoverData
-		enrichedMeta.CoverMimeType = metadata.CoverMimeType
-		enrichedMeta.CoverPage = metadata.CoverPage
-		enrichedMeta.FieldDataSources["cover"] = metadata.SourceForField("cover")
-	}
+	// Merge file-parsed metadata as fallback and apply page-based cover
+	// protection. See mergeFileParserFallback for the full policy.
+	mergeFileParserFallback(&enrichedMeta, metadata, file.FileType)
 
 	// Copy technical fields that enrichers don't provide
 	enrichedMeta.Duration = metadata.Duration
@@ -3139,6 +3130,47 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 	}
 
 	return &enrichedMeta
+}
+
+// mergeFileParserFallback merges file-parsed metadata into target as a
+// fallback for fields no enricher provided, then applies page-based-format
+// cover protection.
+//
+// For page-based formats (CBZ, PDF), plugin-provided image data
+// (coverData/coverUrl) must never replace page-derived covers, so CoverData
+// and CoverMimeType are reset to the file parser's values. Enricher-supplied
+// CoverPage IS honored — the merge already handles "enricher wins if set,
+// file parser fills in otherwise".
+//
+// Source-tracking nuance: FieldDataSources["cover"] is shared between
+// CoverData and CoverPage. The file-parser CoverData merge can overwrite the
+// "cover" source recorded by the enricher for CoverPage, so we capture the
+// pre-merge enricher state and restore it when appropriate.
+func mergeFileParserFallback(target, fileParsed *mediafile.ParsedMetadata, fileType string) {
+	// Capture enricher state before the file-parser merge possibly overwrites
+	// FieldDataSources["cover"] via its CoverData merge.
+	enricherSetCoverPage := target.CoverPage != nil
+	enricherCoverSource := ""
+	if target.FieldDataSources != nil {
+		enricherCoverSource = target.FieldDataSources["cover"]
+	}
+
+	// Merge file-parsed metadata as fallback for fields no enricher provided.
+	// This gives enrichers priority over file metadata (priority 2 > priority 3).
+	mergeEnrichedMetadata(target, fileParsed, fileParsed.DataSource)
+
+	// For page-based formats, reset image data to the file parser's values and
+	// restore the "cover" source to reflect whoever provided the CoverPage we
+	// kept.
+	if models.IsPageBasedFileType(fileType) {
+		target.CoverData = fileParsed.CoverData
+		target.CoverMimeType = fileParsed.CoverMimeType
+		if enricherSetCoverPage {
+			target.FieldDataSources["cover"] = enricherCoverSource
+		} else {
+			target.FieldDataSources["cover"] = fileParsed.SourceForField("cover")
+		}
+	}
 }
 
 // mergeEnrichedMetadata applies fields from enrichment result to the target

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -442,6 +442,32 @@ During automatic scans, enricher-provided covers are subject to additional check
 - **Page-based formats:** CBZ and PDF files derive covers from their page content. Plugin covers are never applied to these formats, even if the plugin declares the `cover` field.
 - **Field settings:** The `cover` field must be enabled in the plugin's per-library field settings for cover enrichment to take effect. If disabled, all cover data from the plugin is silently stripped.
 
+#### Cover page selection (CBZ and PDF only)
+
+For page-based file formats — CBZ and PDF — the cover is derived from a page of the file itself, not from an arbitrary image. Plugins can tell Shisho which page to use by returning `coverPage` (a 0-indexed page number).
+
+**Precedence (strict, file-type-gated):**
+
+- **CBZ/PDF:** Only `coverPage` is applied. `coverData` and `coverUrl` are silently ignored for these formats. A plugin that returns only `coverData` for a CBZ/PDF will not change the cover.
+- **EPUB/M4B and other formats:** Only `coverData` / `coverUrl` are applied. `coverPage` is silently ignored.
+
+**Bounds:** If `coverPage` is negative, greater than or equal to the file's page count, or the page count is unknown, the value is skipped with a warning in the server logs — Shisho will not fall through to `coverData`.
+
+**Cover source:** When `coverPage` is applied, the rendered page is saved as the file's cover image on disk, and `cover_source` is set to `plugin:<scope>/<id>`. This mirrors the behavior of the manual page-picker UI (which uses `manual` as the source).
+
+Example search result from a metadata enricher:
+
+```javascript
+return {
+  results: [{
+    title: "Saga #1",
+    authors: [{ name: "Brian K. Vaughan", role: "writer" }],
+    coverPage: 3, // The cover image is on page 3 of this CBZ, not page 0.
+    confidence: 0.95
+  }]
+};
+```
+
 #### File Hints
 
 The `context.file` object provides read-only metadata about the file being enriched. Use it to narrow your search — for example, filtering audiobook results by duration or distinguishing a comic from a novel by page count:

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -439,7 +439,7 @@ For advanced use cases (file parsers extracting embedded covers, or enrichers th
 During automatic scans, enricher-provided covers are subject to additional checks:
 
 - **Resolution gate:** An enricher cover is only applied if its total resolution (width × height) is strictly greater than the file's current cover. If the file already has a cover of equal or greater resolution, the enricher cover is skipped. This prevents low-resolution external images from replacing high-quality embedded covers.
-- **Page-based formats:** CBZ and PDF files derive covers from their page content. Plugin covers are never applied to these formats, even if the plugin declares the `cover` field.
+- **Page-based formats:** CBZ and PDF files derive covers from their page content. Plugin-supplied _image data_ (`coverData` and `coverUrl`) is never applied for these formats. To set the cover for a CBZ or PDF, a plugin returns `coverPage` — see [Cover page selection (CBZ and PDF only)](#cover-page-selection-cbz-and-pdf-only) below.
 - **Field settings:** The `cover` field must be enabled in the plugin's per-library field settings for cover enrichment to take effect. If disabled, all cover data from the plugin is silently stripped.
 
 #### Cover page selection (CBZ and PDF only)


### PR DESCRIPTION
## Summary

- Plugins can now return `coverPage` (0-indexed page number) for CBZ/PDF files under the existing `cover` capability — no new capability added.
- Precedence is strict and file-type-gated: CBZ/PDF accept only `coverPage` (ignoring `coverData`/`coverUrl`); EPUB/M4B accept only `coverData`/`coverUrl` (ignoring `coverPage`). Out-of-range values skip with a warning.
- When a plugin provides `coverPage`, the rendered page is saved as the file's cover image on disk (mirroring the manual page-picker UI), with `cover_source` set to `plugin:<scope>/<id>`.
- Identify search results now preview the selected page via the existing `/api/books/files/:id/page/:pageNum` endpoint when `cover_url` is absent and the selected file is CBZ/PDF.

## Test plan

- Run `mise check:quiet` to verify all Go/JS tests, lint, and type-checks pass.
- Install a metadata enricher plugin that returns `coverPage: N` (not 0) for a CBZ book. Run `Identify book`, confirm the results row shows a preview of page N. Apply the result; the book cover updates to page N and `file.cover_source` becomes `plugin:<scope>/<id>`.
- Same flow for a PDF.
- Plugin that returns only `coverData` for a CBZ → cover unchanged (image data ignored for page-based formats).
- Plugin returns out-of-range `coverPage` (e.g., page 99 on a 5-page file) → cover unchanged, warning logged.
- Plugin returns `coverPage` for an EPUB → silently ignored, `coverData`/`coverUrl` still apply if present.
- Auto-scan: enricher returning `coverPage` for a CBZ at scan time applies it (regression test for the scan-merge fix in `runMetadataEnrichers`).