### PR TITLE
[Fix] Align sort default across surfaces and fix per-author pagination

### DIFF
--- a/app/components/library/SortSheet.tsx
+++ b/app/components/library/SortSheet.tsx
@@ -57,6 +57,22 @@ import {
   type SortLevel,
 } from "@/libraries/sortSpec";
 
+/*
+ * SortSheet is intentionally controlled — it holds NO local state for
+ * the levels list. Every edit (add/remove/reorder/toggle) is bubbled
+ * up via `onChange` to the parent (typically Home.tsx), which writes
+ * the serialized spec into the URL `?sort=` param. The next render
+ * flows the new levels back in through `levels`.
+ *
+ * This keeps a single source of truth (the URL), makes sorts shareable
+ * via link, and avoids divergence between sheet state and the gallery.
+ *
+ * Field-uniqueness invariant: the dnd-kit `SortableContext` and
+ * `useSortable` calls below key rows by `level.field`. Parent-level
+ * logic in Home.tsx + the available-fields filter inside SortLevelRow
+ * must keep `levels` free of duplicate fields, otherwise dnd-kit will
+ * reuse the same node id for two rows and reorder/animations break.
+ */
 interface SortSheetProps {
   levels: readonly SortLevel[];
   onChange: (levels: SortLevel[]) => void;

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -106,8 +106,12 @@ const HomeContent = () => {
   const libraryIdNum = libraryId ? parseInt(libraryId, 10) : undefined;
   const languagesQuery = useLibraryLanguages(libraryIdNum);
 
-  // Fetch per-library sort preference. The query is auto-disabled when
-  // libraryIdNum is undefined (via Boolean(0) guard in useLibrarySettings).
+  // Fetch per-library sort preference. Hooks can't be called conditionally,
+  // so we pass a 0 placeholder when libraryIdNum is undefined. Both hooks
+  // are safe under that placeholder:
+  //   - useLibrarySettings auto-disables the query via a Boolean(libraryId) gate.
+  //   - useUpdateLibrarySettings rejects mutate() calls when libraryId is 0,
+  //     and handleSaveSortAsDefault below also early-returns before calling it.
   const librarySettingsQuery = useLibrarySettings(libraryIdNum ?? 0);
   const updateLibrarySettings = useUpdateLibrarySettings(libraryIdNum ?? 0);
 

--- a/app/hooks/queries/librarySettings.ts
+++ b/app/hooks/queries/librarySettings.ts
@@ -52,6 +52,16 @@ export const useUpdateLibrarySettings = (libraryId: number) => {
     UpdateLibrarySettingsPayload
   >({
     mutationFn: (payload) => {
+      // Defensive guard: callers may construct this hook with a 0
+      // placeholder when the route's libraryId param is missing (hooks
+      // can't be called conditionally). Refuse to fire the request
+      // rather than PUT /settings/libraries/0, which would 404 server
+      // side and confuse the user.
+      if (!libraryId) {
+        return Promise.reject(
+          new Error("useUpdateLibrarySettings called without a library id"),
+        );
+      }
       return API.request(
         "PUT",
         `/settings/libraries/${libraryId}`,
@@ -60,7 +70,20 @@ export const useUpdateLibrarySettings = (libraryId: number) => {
       );
     },
     onSuccess: (data) => {
+      // Optimistically write the freshly-saved settings into the cache so
+      // dependent components (Home gallery's effective-sort logic, the
+      // SortSheet's "dirty" indicator) re-render immediately without
+      // waiting for a refetch.
       queryClient.setQueryData([QueryKey.LibrarySettings, libraryId], data);
+      // Then invalidate to mark the entry stale and trigger a background
+      // refetch. This is belt-and-suspenders: setQueryData already covers
+      // the active query, but if another mount/component subscribes to
+      // this key (e.g., a settings page open in another tab) we want it
+      // to re-fetch and converge on the server's view of the row,
+      // including server-set fields (updated_at).
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.LibrarySettings, libraryId],
+      });
       // Gallery ordering may change, so invalidate the list cache.
       // RetrieveBook is intentionally not invalidated — sort preferences
       // don't change individual book data.

--- a/app/libraries/sortSpec.ts
+++ b/app/libraries/sortSpec.ts
@@ -45,7 +45,15 @@ export const SORT_FIELD_LABELS: Record<SortField, string> = {
 /** Hard cap matching pkg/sortspec.MaxLevels. */
 export const MAX_SORT_LEVELS = 10;
 
-/** Builtin default when the URL has no sort and the DB has no saved default. */
+/**
+ * Builtin default when the URL has no sort and the DB has no saved default.
+ *
+ * Mirrors `sortspec.BuiltinDefault()` in pkg/sortspec/spec.go (Go).
+ * Keep both sides in sync — the OPDS and eReader handlers fall back to
+ * the Go side when no preference is stored, so a drift here would mean
+ * the gallery, OPDS feeds, and eReader UI list the same library in
+ * different orders for users who have not saved a default.
+ */
 export const BUILTIN_DEFAULT_SORT: readonly SortLevel[] = [
   { field: "date_added", direction: "desc" },
 ];
@@ -94,7 +102,15 @@ export function parseSortSpec(s: string): SortLevel[] | null {
   return levels;
 }
 
-/** Serialize a spec back into the URL-param form. */
+/**
+ * Serialize a spec back into the URL-param form.
+ *
+ * Returns "" for an empty array — callers MUST treat empty output as
+ * "no sort" and either omit the URL param entirely or skip sending a
+ * `sort` query param to the API. Setting `?sort=` with an empty value
+ * would round-trip through parseSortSpec as null (no sort) but pollutes
+ * the URL with a meaningless empty key.
+ */
 export function serializeSortSpec(levels: readonly SortLevel[]): string {
   return levels.map((l) => `${l.field}:${l.direction}`).join(",");
 }

--- a/pkg/books/handlers_list_test.go
+++ b/pkg/books/handlers_list_test.go
@@ -97,10 +97,11 @@ func TestListHandler_ExplicitSortWins(t *testing.T) {
 }
 
 // TestListHandler_StoredPreferenceUsed verifies that when no URL sort is
-// provided, the stored preference drives ordering. Books are chosen so the
-// default sort_title ASC (apple, banana) disagrees with date_added:desc
-// (banana, apple) — this asymmetry is what makes the test actually prove
-// the resolver fired.
+// provided, the stored preference drives ordering. Books are chosen so
+// the builtin default (date_added:desc → banana, apple) disagrees with
+// the stored title:asc (apple, banana) — this asymmetry is what makes
+// the test actually prove the resolver fired rather than silently
+// inheriting the builtin default.
 func TestListHandler_StoredPreferenceUsed(t *testing.T) {
 	t.Parallel()
 
@@ -113,7 +114,7 @@ func TestListHandler_StoredPreferenceUsed(t *testing.T) {
 	banana := seedBook(t, db, lib, "Banana", "Banana", now)                // newer
 
 	settingsSvc := settings.NewService(db)
-	stored := "date_added:desc"
+	stored := "title:asc"
 	_, err := settingsSvc.UpsertLibrarySort(context.Background(), user.ID, lib.ID, &stored)
 	require.NoError(t, err)
 
@@ -132,10 +133,11 @@ func TestListHandler_StoredPreferenceUsed(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Len(t, resp.Books, 2)
-	// date_added:desc → banana (newer) before apple (older).
-	// If the resolver hadn't fired, default sort_title ASC would invert this.
-	assert.Equal(t, banana.ID, resp.Books[0].ID)
-	assert.Equal(t, apple.ID, resp.Books[1].ID)
+	// title:asc → apple (alphabetical) before banana. If the resolver
+	// hadn't fired, the builtin default (date_added:desc) would return
+	// banana (newer) first and the assertion would fail.
+	assert.Equal(t, apple.ID, resp.Books[0].ID)
+	assert.Equal(t, banana.ID, resp.Books[1].ID)
 }
 
 // TestListHandler_InvalidSortReturns400 verifies sort validation.
@@ -176,11 +178,14 @@ func TestListHandler_NoLibraryIDSkipsStoredLookup(t *testing.T) {
 	cheese := seedBook(t, db, lib, "Cheese", "Cheese", now)
 	apple := seedBook(t, db, lib, "Apple", "Apple", now.Add(-time.Hour))
 
-	// Stored preference would produce date_added:desc → cheese first,
-	// but without library_id the resolver is skipped and the default
-	// sort_title ASC → apple first applies.
+	// Stored preference title:asc would produce Apple first; the builtin
+	// default (date_added:desc, applied by the books service when Sort is
+	// nil) produces Cheese first. Picking stored-vs-default pairs that
+	// order differently is what makes this test actually prove the
+	// resolver was skipped — if both produced the same order we couldn't
+	// tell whether the resolver ran.
 	settingsSvc := settings.NewService(db)
-	stored := "date_added:desc"
+	stored := "title:asc"
 	_, err := settingsSvc.UpsertLibrarySort(context.Background(), user.ID, lib.ID, &stored)
 	require.NoError(t, err)
 
@@ -199,6 +204,9 @@ func TestListHandler_NoLibraryIDSkipsStoredLookup(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Len(t, resp.Books, 2)
-	assert.Equal(t, apple.ID, resp.Books[0].ID) // alphabetical default
-	assert.Equal(t, cheese.ID, resp.Books[1].ID)
+	// Without library_id the resolver is skipped, so the stored title:asc
+	// preference is ignored and the builtin default (date_added:desc) wins
+	// → Cheese (newer) before Apple (older).
+	assert.Equal(t, cheese.ID, resp.Books[0].ID)
+	assert.Equal(t, apple.ID, resp.Books[1].ID)
 }

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -33,6 +33,7 @@ type ListBooksOptions struct {
 	LibraryID  *int
 	LibraryIDs []int // Filter by multiple library IDs (for access control)
 	SeriesID   *int
+	PersonID   *int     // Filter to books authored by this person (joins through authors)
 	FileTypes  []string // Filter by file types (e.g., ["epub", "cbz"])
 	GenreIDs   []int    // Filter by genre IDs
 	TagIDs     []int    // Filter by tag IDs
@@ -316,7 +317,7 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 
 	case len(opts.Sort) > 0:
 		for _, clause := range sortspec.OrderClauses(opts.Sort) {
-			q = q.OrderExpr(clause.Expression, clause.Args...)
+			q = q.OrderExpr(clause.Expression)
 		}
 		// Stable tiebreaker: ensures deterministic pagination when the
 		// user-specified sort levels have ties. Without this, SQLite's
@@ -348,6 +349,17 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 	// Filter by specific book IDs
 	if len(opts.IDs) > 0 {
 		q = q.Where("b.id IN (?)", bun.List(opts.IDs))
+	}
+
+	// Filter by author (person). Subquery rather than JOIN so it composes
+	// cleanly with the user-specified Sort — joining `authors` into the
+	// outer query would require disambiguating ORDER BY references and
+	// risks duplicate rows when a person appears multiple times on the
+	// same book (already deduped at the authors table by UNIQUE
+	// (book_id, person_id, role), but a future role-aware schema could
+	// reintroduce the issue).
+	if opts.PersonID != nil {
+		q = q.Where("b.id IN (SELECT DISTINCT book_id FROM authors WHERE person_id = ?)", *opts.PersonID)
 	}
 
 	// Filter by file types

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -41,9 +41,11 @@ type ListBooksOptions struct {
 	IDs        []int    // Filter by specific book IDs
 	Search     *string  // Search query for title/author
 
-	// Sort overrides the default ordering. When nil, the legacy default
-	// (sort_title ASC, or series_number ASC + sort_title ASC when
-	// filtering by series) is preserved.
+	// Sort overrides the default ordering. When nil and SeriesID is set,
+	// books are ordered by series_number ASC + sort_title ASC. When nil
+	// and SeriesID is not set, the service falls back to
+	// sortspec.BuiltinDefault (date_added DESC) so all surfaces (REST,
+	// OPDS, eReader, gallery) share the same "newest first" default.
 	Sort []sortspec.SortLevel
 
 	includeTotal  bool
@@ -310,7 +312,8 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 	}
 
 	// Apply ordering.
-	// Precedence: orderByRecent (internal flag) > explicit Sort > legacy default.
+	// Precedence: orderByRecent (internal flag) > explicit Sort >
+	// series-number (when SeriesID is set) > sortspec.BuiltinDefault.
 	switch {
 	case opts.orderByRecent:
 		q = q.Order("b.updated_at DESC")
@@ -326,11 +329,24 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 		q = q.Order("b.id ASC")
 
 	case opts.SeriesID != nil:
-		// When filtering by series, order by series_number then sort_title
+		// When filtering by series, order by series_number then sort_title.
+		// Series listings are a distinct use case from the general "newest
+		// first" fallback — readers of a series expect #1, #2, #3 order,
+		// not most-recently-added.
 		q = q.Order("bs_filter.series_number ASC", "b.sort_title ASC")
 
 	default:
-		q = q.Order("b.sort_title ASC")
+		// No explicit caller Sort, not a series listing, not the internal
+		// recent-flag path — fall back to the builtin default ("date_added
+		// DESC"). Applying it here means the /books REST handler, OPDS
+		// feeds, and the eReader browser all show the same "newest first"
+		// ordering when neither the URL nor a stored preference overrides
+		// it. Keep a stable id tiebreaker for the same pagination reason
+		// as the explicit-sort branch.
+		for _, clause := range sortspec.OrderClauses(sortspec.BuiltinDefault()) {
+			q = q.OrderExpr(clause.Expression)
+		}
+		q = q.Order("b.id ASC")
 	}
 
 	if opts.Limit != nil {

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -355,9 +355,11 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 	// cleanly with the user-specified Sort — joining `authors` into the
 	// outer query would require disambiguating ORDER BY references and
 	// risks duplicate rows when a person appears multiple times on the
-	// same book (already deduped at the authors table by UNIQUE
-	// (book_id, person_id, role), but a future role-aware schema could
-	// reintroduce the issue).
+	// same book. The `authors` UNIQUE index is on
+	// (book_id, person_id, role), so a single person CAN legitimately
+	// appear on one book under multiple roles (e.g., writer + inker on
+	// a comic). The `SELECT DISTINCT book_id` — not the UNIQUE index —
+	// is what guarantees each book appears at most once in the result.
 	if opts.PersonID != nil {
 		q = q.Where("b.id IN (SELECT DISTINCT book_id FROM authors WHERE person_id = ?)", *opts.PersonID)
 	}

--- a/pkg/books/service_filter_test.go
+++ b/pkg/books/service_filter_test.go
@@ -1,0 +1,118 @@
+package books
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/sortspec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// seedPerson + seedAuthor are scoped to filter tests; the existing
+// seed helpers in service_sort_test.go don't touch authors because
+// sort tests don't need them.
+func seedPerson(t *testing.T, db *bun.DB, lib *models.Library, name string) *models.Person {
+	t.Helper()
+	p := &models.Person{
+		LibraryID:      lib.ID,
+		Name:           name,
+		SortName:       name,
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err := db.NewInsert().Model(p).Exec(context.Background())
+	require.NoError(t, err)
+	return p
+}
+
+func seedAuthor(t *testing.T, db *bun.DB, book *models.Book, person *models.Person) {
+	t.Helper()
+	// authors.sort_order is NOT NULL with no default; the model uses
+	// `nullzero` which would strip a 0 from the INSERT, so seed with
+	// 1 rather than the natural 0-index.
+	a := &models.Author{
+		BookID:    book.ID,
+		PersonID:  person.ID,
+		SortOrder: 1,
+	}
+	_, err := db.NewInsert().Model(a).Exec(context.Background())
+	require.NoError(t, err)
+}
+
+// TestListBooks_PersonIDFilter confirms PersonID restricts results to
+// books authored by that person, with the user-supplied Sort applied.
+//
+// This is the seam the eReader AuthorBooks handler relies on — the old
+// implementation called peopleService.GetAuthoredBooks (which orders by
+// title only and ignores library scope), then filtered in Go. Routing
+// through the books service with PersonID + Sort fixes both: the SQL
+// applies the user's sort preference, and the LibraryID filter scopes
+// to a single library before the Person join.
+func TestListBooks_PersonIDFilter(t *testing.T) {
+	t.Parallel()
+
+	db := setupBooksTestDB(t)
+	svc := NewService(db)
+	lib := seedLibrary(t, db, "Books")
+
+	now := time.Now()
+	// Two books by Alice, one by Bob — proves Bob's book is excluded.
+	apple := seedBook(t, db, lib, "Apple", "Apple", now.Add(-2*time.Hour))
+	cheese := seedBook(t, db, lib, "Cheese", "Cheese", now)
+	bobsBook := seedBook(t, db, lib, "BobsBook", "BobsBook", now.Add(-time.Hour))
+
+	alice := seedPerson(t, db, lib, "Alice")
+	bob := seedPerson(t, db, lib, "Bob")
+	seedAuthor(t, db, apple, alice)
+	seedAuthor(t, db, cheese, alice)
+	seedAuthor(t, db, bobsBook, bob)
+
+	// Filter to Alice + sort by date_added DESC.
+	got, total, err := svc.ListBooksWithTotal(context.Background(), ListBooksOptions{
+		LibraryID: &lib.ID,
+		PersonID:  &alice.ID,
+		Sort:      []sortspec.SortLevel{{Field: sortspec.FieldDateAdded, Direction: sortspec.DirDesc}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, total, "PersonID filter excludes Bob's book")
+	require.Len(t, got, 2)
+	// date_added DESC → cheese (now) before apple (now-2h).
+	assert.Equal(t, cheese.ID, got[0].ID)
+	assert.Equal(t, apple.ID, got[1].ID)
+}
+
+// TestListBooks_PersonIDFilter_ScopesToLibrary confirms PersonID
+// composes with LibraryID — the same person can author books in
+// multiple libraries (the persons table is library-scoped, but in
+// practice users can have the same name across libraries via separate
+// Person rows). The bigger guarantee is that LibraryID still narrows
+// the result set when both are set, so the eReader's per-library view
+// doesn't leak books from sibling libraries.
+func TestListBooks_PersonIDFilter_ScopesToLibrary(t *testing.T) {
+	t.Parallel()
+
+	db := setupBooksTestDB(t)
+	svc := NewService(db)
+	libA := seedLibrary(t, db, "LibA")
+	libB := seedLibrary(t, db, "LibB")
+
+	now := time.Now()
+	bookInA := seedBook(t, db, libA, "BookA", "BookA", now)
+	bookInB := seedBook(t, db, libB, "BookB", "BookB", now)
+	// Same person row authoring books across two libraries — contrived,
+	// but the SQL filter shouldn't care about the person's home library.
+	alice := seedPerson(t, db, libA, "Alice")
+	seedAuthor(t, db, bookInA, alice)
+	seedAuthor(t, db, bookInB, alice)
+
+	got, _, err := svc.ListBooksWithTotal(context.Background(), ListBooksOptions{
+		LibraryID: &libA.ID,
+		PersonID:  &alice.ID,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1, "LibraryID restricts to libA only")
+	assert.Equal(t, bookInA.ID, got[0].ID)
+}

--- a/pkg/books/service_sort_test.go
+++ b/pkg/books/service_sort_test.go
@@ -68,7 +68,7 @@ func seedBook(t *testing.T, db *bun.DB, lib *models.Library, title, sortTitle st
 }
 
 // TestListBooks_SortByTitleAsc confirms an explicit Sort overrides the
-// default sort_title ASC ordering.
+// service's builtin default (date_added:desc) and orders by title.
 func TestListBooks_SortByTitleAsc(t *testing.T) {
 	t.Parallel()
 
@@ -152,14 +152,25 @@ func TestListBooks_SortByTiesFallsBackToID(t *testing.T) {
 	assert.Equal(t, b3.ID, got[2].ID)
 }
 
-// TestListBooks_NilSortUsesDefault preserves backward compatibility.
-func TestListBooks_NilSortUsesDefault(t *testing.T) {
+// TestListBooks_NilSortUsesBuiltinDefault confirms callers that pass no
+// explicit sort (e.g., the /books REST handler when no ?sort= is set)
+// inherit sortspec.BuiltinDefault — currently "date_added DESC".
+//
+// Pushing the builtin default into the service keeps all surfaces (the
+// React gallery, OPDS, eReader browser, and third-party REST consumers)
+// aligned on the same "newest first" fallback unless the caller or the
+// user has asked for something else.
+func TestListBooks_NilSortUsesBuiltinDefault(t *testing.T) {
 	t.Parallel()
 
 	db := setupBooksTestDB(t)
 	svc := NewService(db)
 	lib := seedLibrary(t, db, "Books")
 
+	// "Cheese" is newer than "Apple" — sort_title ASC would surface
+	// Apple first, date_added DESC surfaces Cheese first. Picking
+	// non-alphabetic-vs-chronological titles makes the assertion
+	// unambiguous.
 	now := time.Now()
 	cheese := seedBook(t, db, lib, "Cheese", "Cheese", now)
 	apple := seedBook(t, db, lib, "Apple", "Apple", now.Add(-time.Hour))
@@ -170,7 +181,7 @@ func TestListBooks_NilSortUsesDefault(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, got, 2)
-	// Default is sort_title ASC → Apple before Cheese.
-	assert.Equal(t, apple.ID, got[0].ID)
-	assert.Equal(t, cheese.ID, got[1].ID)
+	// Builtin default is date_added DESC → newer (Cheese) before older (Apple).
+	assert.Equal(t, cheese.ID, got[0].ID)
+	assert.Equal(t, apple.ID, got[1].ID)
 }

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -84,10 +84,12 @@ func (h *handler) getUserLibraryIDs(ctx echo.Context, userID int) ([]int, error)
 // sort input — the stored preference (or builtin default) is the only
 // input.
 //
-// Falling back to BuiltinDefault (rather than nil + the books service's
-// hard-coded `sort_title ASC`) keeps the eReader UI consistent with the
-// React gallery and OPDS feeds: the same library lists the same way
-// across all surfaces unless the user has saved a different default.
+// The books service also falls back to BuiltinDefault when Sort is nil,
+// so returning BuiltinDefault here is belt-and-suspenders: it keeps the
+// eReader surface explicit about what sort it applies and insulates the
+// eReader UI from a future change to the service's default. It also
+// guarantees this function never returns nil, so callers can rely on
+// the result without guarding.
 func (h *handler) resolveSort(ctx context.Context, apiKey *apikeys.APIKey, libraryID int) []sortspec.SortLevel {
 	if apiKey == nil {
 		return sortspec.BuiltinDefault()

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -79,14 +79,24 @@ func (h *handler) getUserLibraryIDs(ctx echo.Context, userID int) ([]int, error)
 }
 
 // resolveSort returns the stored user-library sort preference for the
-// API-key-authenticated caller, or nil when no preference is set. The
-// eReader browser has no explicit URL sort input — the stored default
-// is the only input.
+// API-key-authenticated caller, falling back to sortspec.BuiltinDefault
+// when no preference is set. The eReader browser has no explicit URL
+// sort input — the stored preference (or builtin default) is the only
+// input.
+//
+// Falling back to BuiltinDefault (rather than nil + the books service's
+// hard-coded `sort_title ASC`) keeps the eReader UI consistent with the
+// React gallery and OPDS feeds: the same library lists the same way
+// across all surfaces unless the user has saved a different default.
 func (h *handler) resolveSort(ctx context.Context, apiKey *apikeys.APIKey, libraryID int) []sortspec.SortLevel {
 	if apiKey == nil {
-		return nil
+		return sortspec.BuiltinDefault()
 	}
-	return sortspec.ResolveForLibrary(ctx, h.settingsService, apiKey.UserID, libraryID, nil)
+	resolved := sortspec.ResolveForLibrary(ctx, h.settingsService, apiKey.UserID, libraryID, nil)
+	if resolved == nil {
+		return sortspec.BuiltinDefault()
+	}
+	return resolved
 }
 
 // Libraries lists all libraries the user has access to.
@@ -447,21 +457,26 @@ func (h *handler) AuthorBooks(c echo.Context) error {
 		return errcodes.NotFound("Author")
 	}
 
-	// Get books by author
-	authorBooks, err := h.peopleService.GetAuthoredBooks(ctx, authorIDInt)
+	// Resolve sort once (so the type-filter branch and the SQL query use
+	// the same ordering) and fetch books for this author + library via
+	// the books service. Going through the books service applies the
+	// user's stored sort preference and lets SQL do the library/author
+	// filtering — the previous code fetched all books for the author
+	// across every library and filtered in Go, which both ignored sort
+	// and scanned more rows than necessary.
+	sort := h.resolveSort(ctx, apiKey, libraryIDInt)
+	booksInLibrary, _, err := h.bookService.ListBooksWithTotal(ctx, books.ListBooksOptions{
+		LibraryID: &libraryIDInt,
+		PersonID:  &authorIDInt,
+		Sort:      sort,
+	})
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	// Filter books to only those in the current library
-	var booksInLibrary []*models.Book
-	for _, book := range authorBooks {
-		if book.LibraryID == libraryIDInt {
-			booksInLibrary = append(booksInLibrary, book)
-		}
-	}
-
-	// Apply type filter
+	// Apply type filter (in-memory, matches LibraryAllBooks behavior —
+	// books service's FileTypes filter is "any file matches", but the
+	// eReader UI shows the dominant per-book type via getBookFileType).
 	booksInLibrary = filterBooksByType(booksInLibrary, typesFilter)
 
 	var content strings.Builder

--- a/pkg/ereader/handlers_sort_test.go
+++ b/pkg/ereader/handlers_sort_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shishobooks/shisho/pkg/apikeys"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -125,9 +126,61 @@ func TestStoredSortFlowsThroughBooksService(t *testing.T) {
 	assert.Equal(t, apple.ID, got[1].ID)
 }
 
-// TestNoStoredSortResolvesToNil confirms that without a
-// stored preference, ResolveForLibrary returns nil and the handler falls
-// through to its existing default ordering.
+// TestHandlerResolveSort_FallsBackToBuiltinDefault confirms the handler's
+// resolveSort layers sortspec.BuiltinDefault on top of ResolveForLibrary.
+// Without this layering an eReader user with no saved preference would
+// see books in `b.sort_title ASC` order (the books service's hard-coded
+// fallback) while the React gallery shows the same library in
+// `date_added:desc` order — the inconsistency the M6 review caught.
+func TestHandlerResolveSort_FallsBackToBuiltinDefault(t *testing.T) {
+	t.Parallel()
+
+	db := setupEReaderDB(t)
+	lib := &models.Library{
+		Name:                     "Books",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(context.Background())
+	require.NoError(t, err)
+
+	user := &models.User{Username: "alice", PasswordHash: "x", RoleID: 1, IsActive: true}
+	_, err = db.NewInsert().Model(user).Exec(context.Background())
+	require.NoError(t, err)
+
+	settingsSvc := settings.NewService(db)
+	// Other deps are unused by resolveSort; nil keeps the test focused.
+	h := newHandler(db, nil, nil, nil, nil, nil, settingsSvc)
+
+	apiKey := &apikeys.APIKey{UserID: user.ID}
+	got := h.resolveSort(context.Background(), apiKey, lib.ID)
+
+	assert.Equal(t, sortspec.BuiltinDefault(), got,
+		"no stored preference → handler falls back to BuiltinDefault")
+}
+
+// TestHandlerResolveSort_NilApiKeyFallsBackToBuiltinDefault is a
+// belt-and-suspenders check: the handler's other call sites already
+// short-circuit on missing API keys with an Unauthorized response, but
+// resolveSort is independently safe — it never returns nil, so callers
+// don't have to guard.
+func TestHandlerResolveSort_NilApiKeyFallsBackToBuiltinDefault(t *testing.T) {
+	t.Parallel()
+
+	db := setupEReaderDB(t)
+	settingsSvc := settings.NewService(db)
+	h := newHandler(db, nil, nil, nil, nil, nil, settingsSvc)
+
+	got := h.resolveSort(context.Background(), nil, 1)
+
+	assert.Equal(t, sortspec.BuiltinDefault(), got)
+}
+
+// TestNoStoredSortResolvesToNil pins the lower-level
+// ResolveForLibrary contract: without a stored preference, it returns
+// nil. The eReader handler then layers BuiltinDefault on top — see
+// TestHandlerResolveSort_FallsBackToBuiltinDefault above for the
+// handler-level behavior.
 func TestNoStoredSortResolvesToNil(t *testing.T) {
 	t.Parallel()
 
@@ -148,5 +201,100 @@ func TestNoStoredSortResolvesToNil(t *testing.T) {
 	resolved := sortspec.ResolveForLibrary(
 		context.Background(), settingsSvc, user.ID, lib.ID, nil,
 	)
-	assert.Nil(t, resolved, "no stored preference → nil (handler uses its default)")
+	assert.Nil(t, resolved, "no stored preference → nil (handler layers BuiltinDefault on top)")
+}
+
+// TestAuthorBooks_PersonIDAndSortFlow exercises the seam the AuthorBooks
+// handler uses after the M8 refactor: instead of fetching every book by
+// the author across all libraries (peopleService.GetAuthoredBooks) and
+// filtering in Go, the handler now calls bookService.ListBooksWithTotal
+// with LibraryID + PersonID + the resolved sort. This test pins that
+// composition: PersonID restricts to one author's books inside the
+// chosen library, and the user's stored sort preference flips the order
+// from the legacy default.
+func TestAuthorBooks_PersonIDAndSortFlow(t *testing.T) {
+	t.Parallel()
+
+	db := setupEReaderDB(t)
+	ctx := context.Background()
+
+	lib := &models.Library{
+		Name:                     "Books",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(ctx)
+	require.NoError(t, err)
+
+	now := time.Now()
+	apple := &models.Book{
+		LibraryID: lib.ID, Title: "Apple", TitleSource: models.DataSourceFilepath,
+		SortTitle: "Apple", SortTitleSource: models.DataSourceFilepath,
+		AuthorSource: models.DataSourceFilepath,
+		Filepath:     "/a", CreatedAt: now.Add(-2 * time.Hour),
+	}
+	cheese := &models.Book{
+		LibraryID: lib.ID, Title: "Cheese", TitleSource: models.DataSourceFilepath,
+		SortTitle: "Cheese", SortTitleSource: models.DataSourceFilepath,
+		AuthorSource: models.DataSourceFilepath,
+		Filepath:     "/c", CreatedAt: now,
+	}
+	other := &models.Book{
+		LibraryID: lib.ID, Title: "BobsOnly", TitleSource: models.DataSourceFilepath,
+		SortTitle: "BobsOnly", SortTitleSource: models.DataSourceFilepath,
+		AuthorSource: models.DataSourceFilepath,
+		Filepath:     "/o", CreatedAt: now.Add(-time.Hour),
+	}
+	for _, b := range []*models.Book{apple, cheese, other} {
+		_, err = db.NewInsert().Model(b).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	alice := &models.Person{
+		LibraryID: lib.ID, Name: "Alice", SortName: "Alice",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	bob := &models.Person{
+		LibraryID: lib.ID, Name: "Bob", SortName: "Bob",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(alice).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(bob).Exec(ctx)
+	require.NoError(t, err)
+
+	// authors.sort_order is NOT NULL; nullzero would strip a 0, so use 1.
+	for _, link := range []*models.Author{
+		{BookID: apple.ID, PersonID: alice.ID, SortOrder: 1},
+		{BookID: cheese.ID, PersonID: alice.ID, SortOrder: 1},
+		{BookID: other.ID, PersonID: bob.ID, SortOrder: 1},
+	} {
+		_, err = db.NewInsert().Model(link).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	user := &models.User{Username: "alice", PasswordHash: "x", RoleID: 1, IsActive: true}
+	_, err = db.NewInsert().Model(user).Exec(ctx)
+	require.NoError(t, err)
+
+	settingsSvc := settings.NewService(db)
+	stored := "date_added:desc"
+	_, err = settingsSvc.UpsertLibrarySort(ctx, user.ID, lib.ID, &stored)
+	require.NoError(t, err)
+
+	resolved := sortspec.ResolveForLibrary(ctx, settingsSvc, user.ID, lib.ID, nil)
+	require.NotNil(t, resolved)
+
+	bookSvc := books.NewService(db)
+	got, total, err := bookSvc.ListBooksWithTotal(ctx, books.ListBooksOptions{
+		LibraryID: &lib.ID,
+		PersonID:  &alice.ID,
+		Sort:      resolved,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, total, "PersonID excludes Bob's book")
+	require.Len(t, got, 2)
+	// date_added:desc → cheese (newer) before apple (older).
+	assert.Equal(t, cheese.ID, got[0].ID)
+	assert.Equal(t, apple.ID, got[1].ID)
 }

--- a/pkg/ereader/handlers_sort_test.go
+++ b/pkg/ereader/handlers_sort_test.go
@@ -127,11 +127,12 @@ func TestStoredSortFlowsThroughBooksService(t *testing.T) {
 }
 
 // TestHandlerResolveSort_FallsBackToBuiltinDefault confirms the handler's
-// resolveSort layers sortspec.BuiltinDefault on top of ResolveForLibrary.
-// Without this layering an eReader user with no saved preference would
-// see books in `b.sort_title ASC` order (the books service's hard-coded
-// fallback) while the React gallery shows the same library in
-// `date_added:desc` order — the inconsistency the M6 review caught.
+// resolveSort returns sortspec.BuiltinDefault when ResolveForLibrary
+// finds no stored preference. The books service also applies
+// BuiltinDefault when Sort is nil, so this is belt-and-suspenders — it
+// keeps the eReader surface explicit about the sort it applies and
+// ensures the function never returns nil for callers that depend on a
+// non-nil slice.
 func TestHandlerResolveSort_FallsBackToBuiltinDefault(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/models/user_library_settings.go
+++ b/pkg/models/user_library_settings.go
@@ -6,13 +6,18 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// UserLibrarySettings is intentionally not exposed over JSON or
+// generated as a TS type (`tstype:"-"`). Handlers transform it into
+// LibrarySettingsResponse (in pkg/settings) so the wire shape can
+// evolve independently of the storage row, and tygo skips it. The
+// struct therefore carries no `json:"..."` tags.
 type UserLibrarySettings struct {
 	bun.BaseModel `bun:"table:user_library_settings,alias:uls" tstype:"-"`
 
-	ID        int       `bun:",pk,autoincrement"                            json:"id"`
-	CreatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"created_at"`
-	UpdatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"updated_at"`
-	UserID    int       `bun:",notnull"                                     json:"user_id"`
-	LibraryID int       `bun:",notnull"                                     json:"library_id"`
-	SortSpec  *string   `bun:",nullzero"                                    json:"sort_spec"`
+	ID        int       `bun:",pk,autoincrement"`
+	CreatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp"`
+	UpdatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp"`
+	UserID    int       `bun:",notnull"`
+	LibraryID int       `bun:",notnull"`
+	SortSpec  *string   `bun:",nullzero"`
 }

--- a/pkg/opds/handlers.go
+++ b/pkg/opds/handlers.go
@@ -33,15 +33,25 @@ type handler struct {
 }
 
 // resolveSort resolves the stored user-library sort preference for the
-// current request, or returns nil so the service's legacy default
-// ordering applies. OPDS is read-only; there's no explicit ?sort=
+// current request, falling back to sortspec.BuiltinDefault when no
+// preference exists. OPDS is read-only; there's no explicit ?sort=
 // input, so we pass explicit=nil to ResolveForLibrary.
+//
+// Falling back to BuiltinDefault (rather than returning nil and
+// inheriting the books service's hard-coded `sort_title ASC`) keeps
+// OPDS clients aligned with the gallery — the eReader on a Kobo and
+// the React frontend in a browser show the same library in the same
+// order when neither the user nor the URL has overridden it.
 func (h *handler) resolveSort(c echo.Context, libraryID int) []sortspec.SortLevel {
 	user, ok := c.Get("user").(*models.User)
 	if !ok {
-		return nil
+		return sortspec.BuiltinDefault()
 	}
-	return sortspec.ResolveForLibrary(c.Request().Context(), h.settingsService, user.ID, libraryID, nil)
+	resolved := sortspec.ResolveForLibrary(c.Request().Context(), h.settingsService, user.ID, libraryID, nil)
+	if resolved == nil {
+		return sortspec.BuiltinDefault()
+	}
+	return resolved
 }
 
 // getBaseURL returns the base URL for OPDS feeds.

--- a/pkg/opds/handlers.go
+++ b/pkg/opds/handlers.go
@@ -37,11 +37,12 @@ type handler struct {
 // preference exists. OPDS is read-only; there's no explicit ?sort=
 // input, so we pass explicit=nil to ResolveForLibrary.
 //
-// Falling back to BuiltinDefault (rather than returning nil and
-// inheriting the books service's hard-coded `sort_title ASC`) keeps
-// OPDS clients aligned with the gallery — the eReader on a Kobo and
-// the React frontend in a browser show the same library in the same
-// order when neither the user nor the URL has overridden it.
+// The books service also falls back to BuiltinDefault when Sort is nil,
+// so returning BuiltinDefault here is belt-and-suspenders: it keeps the
+// OPDS surface explicit about what sort it applies (useful when
+// tracing requests) and insulates OPDS from a future change to the
+// service's default. Returning the resolved slice directly also lets
+// callers log or cache it without re-resolving.
 func (h *handler) resolveSort(c echo.Context, libraryID int) []sortspec.SortLevel {
 	user, ok := c.Get("user").(*models.User)
 	if !ok {

--- a/pkg/opds/handlers_sort_test.go
+++ b/pkg/opds/handlers_sort_test.go
@@ -46,10 +46,10 @@ func mustParseSortSpec(t *testing.T, s string) []sortspec.SortLevel {
 
 // TestLibraryAllBooksFeed_HonorsStoredSort confirms the OPDS "all books"
 // feed applies the user's stored library sort preference. Apple has the
-// older created_at but the alphabetically-earlier title, so the default
-// (sort_title ASC) would return Apple, Cheese. The stored date_added:desc
-// inverts that, returning Cheese, Apple — which only holds if the sort
-// parameter was actually threaded through.
+// older created_at but the alphabetically-earlier title, so the builtin
+// default (date_added DESC) would return Cheese, Apple. The stored
+// title:asc inverts that, returning Apple, Cheese — which only holds if
+// the sort parameter was actually threaded through.
 func TestLibraryAllBooksFeed_HonorsStoredSort(t *testing.T) {
 	t.Parallel()
 
@@ -94,7 +94,12 @@ func TestLibraryAllBooksFeed_HonorsStoredSort(t *testing.T) {
 	require.NoError(t, err)
 
 	settingsSvc := settings.NewService(db)
-	stored := "date_added:desc"
+	// Pick a stored preference that orders DIFFERENTLY from the builtin
+	// default (date_added DESC). title:asc → Apple, Cheese; default →
+	// Cheese, Apple. The distinct orderings are what makes the assertion
+	// prove the sort was threaded through rather than silently falling
+	// back to the builtin default.
+	stored := "title:asc"
 	_, err = settingsSvc.UpsertLibrarySort(context.Background(), user.ID, lib.ID, &stored)
 	require.NoError(t, err)
 
@@ -119,15 +124,19 @@ func TestLibraryAllBooksFeed_HonorsStoredSort(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, feed.Entries, 2)
-	// date_added:desc → cheese (newer) first, apple (older) second.
-	// Under the default sort_title ASC this would be reversed, so this
-	// assertion proves the sort param was threaded through.
-	assert.Contains(t, feed.Entries[0].Title, "Cheese")
-	assert.Contains(t, feed.Entries[1].Title, "Apple")
+	// title:asc → Apple first, Cheese second. Under the builtin default
+	// (date_added DESC) this would be reversed, so this assertion proves
+	// the sort param was threaded through.
+	assert.Contains(t, feed.Entries[0].Title, "Apple")
+	assert.Contains(t, feed.Entries[1].Title, "Cheese")
 }
 
-// TestLibraryAllBooksFeed_NilSortUsesDefault preserves backward compat.
-func TestLibraryAllBooksFeed_NilSortUsesDefault(t *testing.T) {
+// TestLibraryAllBooksFeed_NilSortUsesBuiltinDefault confirms that when
+// a caller passes no explicit sort (e.g., the resolver returned nil), the
+// books service falls back to sortspec.BuiltinDefault — date_added DESC.
+// This keeps OPDS consistent with the /books REST endpoint and the
+// gallery for callers that haven't layered BuiltinDefault themselves.
+func TestLibraryAllBooksFeed_NilSortUsesBuiltinDefault(t *testing.T) {
 	t.Parallel()
 
 	db := setupOPDSDB(t)
@@ -181,17 +190,18 @@ func TestLibraryAllBooksFeed_NilSortUsesDefault(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Len(t, feed.Entries, 2)
-	// Default sort_title ASC → Apple, Cheese.
-	assert.Contains(t, feed.Entries[0].Title, "Apple")
-	assert.Contains(t, feed.Entries[1].Title, "Cheese")
+	// Builtin default is date_added DESC → Cheese (newer) before Apple.
+	assert.Contains(t, feed.Entries[0].Title, "Cheese")
+	assert.Contains(t, feed.Entries[1].Title, "Apple")
 }
 
 // TestHandlerResolveSort_FallsBackToBuiltinDefault confirms the OPDS
-// handler's resolveSort layers sortspec.BuiltinDefault on top of
-// ResolveForLibrary. Without this, an OPDS client whose user has no
-// saved preference would get books in `b.sort_title ASC` order while
-// the React gallery shows them in `date_added:desc` — the M6 review
-// inconsistency.
+// handler's resolveSort returns sortspec.BuiltinDefault when
+// ResolveForLibrary finds no stored preference. The books service also
+// applies BuiltinDefault when Sort is nil, so this is belt-and-
+// suspenders — it keeps the OPDS surface explicit about the sort it
+// applies and insulates OPDS from a future change to the service's
+// default.
 func TestHandlerResolveSort_FallsBackToBuiltinDefault(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/opds/handlers_sort_test.go
+++ b/pkg/opds/handlers_sort_test.go
@@ -3,9 +3,12 @@ package opds
 import (
 	"context"
 	"database/sql"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/settings"
@@ -181,4 +184,58 @@ func TestLibraryAllBooksFeed_NilSortUsesDefault(t *testing.T) {
 	// Default sort_title ASC → Apple, Cheese.
 	assert.Contains(t, feed.Entries[0].Title, "Apple")
 	assert.Contains(t, feed.Entries[1].Title, "Cheese")
+}
+
+// TestHandlerResolveSort_FallsBackToBuiltinDefault confirms the OPDS
+// handler's resolveSort layers sortspec.BuiltinDefault on top of
+// ResolveForLibrary. Without this, an OPDS client whose user has no
+// saved preference would get books in `b.sort_title ASC` order while
+// the React gallery shows them in `date_added:desc` — the M6 review
+// inconsistency.
+func TestHandlerResolveSort_FallsBackToBuiltinDefault(t *testing.T) {
+	t.Parallel()
+
+	db := setupOPDSDB(t)
+	user := &models.User{Username: "alice", PasswordHash: "x", RoleID: 1, IsActive: true}
+	_, err := db.NewInsert().Model(user).Exec(context.Background())
+	require.NoError(t, err)
+
+	settingsSvc := settings.NewService(db)
+	h := &handler{settingsService: settingsSvc}
+
+	// Build an echo.Context carrying the authenticated user, mirroring
+	// what the auth middleware sets in production.
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/opds/v1/library/1/all", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	got := h.resolveSort(c, 1)
+
+	assert.Equal(t, sortspec.BuiltinDefault(), got,
+		"no stored preference → handler falls back to BuiltinDefault")
+}
+
+// TestHandlerResolveSort_MissingUserFallsBackToBuiltinDefault is a
+// belt-and-suspenders check: in production the auth middleware ensures
+// "user" is set before the handler runs, but resolveSort is independently
+// safe — it never returns nil, so callers don't have to guard.
+func TestHandlerResolveSort_MissingUserFallsBackToBuiltinDefault(t *testing.T) {
+	t.Parallel()
+
+	db := setupOPDSDB(t)
+	settingsSvc := settings.NewService(db)
+	h := &handler{settingsService: settingsSvc}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/opds/v1/library/1/all", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	// Intentionally NOT calling c.Set("user", ...) — simulates a code
+	// path where middleware didn't run.
+
+	got := h.resolveSort(c, 1)
+
+	assert.Equal(t, sortspec.BuiltinDefault(), got)
 }

--- a/pkg/opds/service.go
+++ b/pkg/opds/service.go
@@ -7,9 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/people"
 	"github.com/shishobooks/shisho/pkg/series"
 	"github.com/shishobooks/shisho/pkg/sortspec"
 	"github.com/uptrace/bun"
@@ -21,6 +24,7 @@ type Service struct {
 	bookService    *books.Service
 	libraryService *libraries.Service
 	seriesService  *series.Service
+	peopleService  *people.Service
 }
 
 // NewService creates a new OPDS service.
@@ -30,6 +34,7 @@ func NewService(db *bun.DB) *Service {
 		bookService:    books.NewService(db),
 		libraryService: libraries.NewService(db),
 		seriesService:  series.NewService(db),
+		peopleService:  people.NewService(db),
 	}
 }
 
@@ -450,68 +455,39 @@ func (svc *Service) BuildLibraryAuthorsListFeed(ctx context.Context, baseURL, fi
 }
 
 // ListBooksByAuthor lists books by a specific author in a library.
+//
+// Implementation note: the original version queried for unsorted book
+// IDs, paginated those IDs in Go, then fetched the entire library's
+// books with sort applied and filtered down to the paginated IDs. That
+// pattern broke pagination (page 1 wasn't "first N in sort order") and
+// scaled poorly. We now look up the person row (case-insensitive,
+// library-scoped, matching peopleService semantics) and delegate to
+// the books service's PersonID filter, which lets SQL apply the sort,
+// limit, and offset together.
 func (svc *Service) ListBooksByAuthor(ctx context.Context, libraryID int, authorName string, fileTypes []string, limit, offset int, sort []sortspec.SortLevel) ([]*models.Book, int, error) {
-	var bookIDs []int
-
-	// Get book IDs for this author using persons and authors tables
-	q := svc.db.NewSelect().
-		TableExpr("authors a").
-		ColumnExpr("DISTINCT a.book_id").
-		Join("INNER JOIN persons p ON p.id = a.person_id").
-		Join("INNER JOIN books b ON b.id = a.book_id").
-		Where("b.library_id = ? AND p.name = ?", libraryID, authorName)
-
-	if len(fileTypes) > 0 {
-		q = q.Where("b.id IN (SELECT DISTINCT book_id FROM files WHERE file_type IN (?))", bun.List(fileTypes))
-	}
-
-	err := q.Scan(ctx, &bookIDs)
+	person, err := svc.peopleService.RetrievePerson(ctx, people.RetrievePersonOptions{
+		Name:      &authorName,
+		LibraryID: &libraryID,
+	})
 	if err != nil {
+		// "No such author in this library" yields an empty acquisition
+		// feed rather than a 404 — preserves the previous behavior of
+		// the unsorted-ID query, which returned empty when nothing
+		// joined.
+		if errors.Is(err, errcodes.NotFound("Person")) {
+			return []*models.Book{}, 0, nil
+		}
 		return nil, 0, err
 	}
 
-	if len(bookIDs) == 0 {
-		return []*models.Book{}, 0, nil
-	}
-
-	// Get books with pagination
-	total := len(bookIDs)
-
-	// Apply pagination to book IDs
-	start := offset
-	if start >= len(bookIDs) {
-		return []*models.Book{}, total, nil
-	}
-	end := start + limit
-	if end > len(bookIDs) {
-		end = len(bookIDs)
-	}
-	paginatedIDs := bookIDs[start:end]
-
-	// Fetch full book details
-	booksResult, err := svc.bookService.ListBooks(ctx, books.ListBooksOptions{
+	return svc.bookService.ListBooksWithTotal(ctx, books.ListBooksOptions{
+		Limit:     &limit,
+		Offset:    &offset,
 		LibraryID: &libraryID,
+		PersonID:  &person.ID,
 		FileTypes: fileTypes,
 		Sort:      sort,
 	})
-	if err != nil {
-		return nil, 0, err
-	}
-
-	// Filter to only include books in paginatedIDs
-	idSet := make(map[int]bool)
-	for _, id := range paginatedIDs {
-		idSet[id] = true
-	}
-
-	var filtered []*models.Book
-	for _, book := range booksResult {
-		if idSet[book.ID] {
-			filtered = append(filtered, book)
-		}
-	}
-
-	return filtered, total, nil
 }
 
 // BuildLibraryAuthorBooksFeed builds an acquisition feed with books by an author.

--- a/pkg/opds/service.go
+++ b/pkg/opds/service.go
@@ -460,10 +460,21 @@ func (svc *Service) BuildLibraryAuthorsListFeed(ctx context.Context, baseURL, fi
 // IDs, paginated those IDs in Go, then fetched the entire library's
 // books with sort applied and filtered down to the paginated IDs. That
 // pattern broke pagination (page 1 wasn't "first N in sort order") and
-// scaled poorly. We now look up the person row (case-insensitive,
-// library-scoped, matching peopleService semantics) and delegate to
-// the books service's PersonID filter, which lets SQL apply the sort,
-// limit, and offset together.
+// scaled poorly. We now look up the person row (library-scoped via
+// peopleService.RetrievePerson) and delegate to the books service's
+// PersonID filter, which lets SQL apply the sort, limit, and offset
+// together.
+//
+// Name-match semantics change: the old implementation used `p.name = ?`
+// (case-sensitive under SQLite's default BINARY collation), whereas
+// peopleService.RetrievePerson uses `LOWER(p.name) = LOWER(?)`. This
+// aligns with the creation-side invariant — `persons` has a UNIQUE
+// index on (name COLLATE NOCASE, library_id), so there's at most one
+// person per (library, name) regardless of case, and the canonical
+// casing is whatever was first inserted. Any author URL Shisho
+// generates itself is already canonical; the change only affects OPDS
+// clients that hand-craft URLs with non-canonical casing — those now
+// resolve instead of 404ing.
 func (svc *Service) ListBooksByAuthor(ctx context.Context, libraryID int, authorName string, fileTypes []string, limit, offset int, sort []sortspec.SortLevel) ([]*models.Book, int, error) {
 	person, err := svc.peopleService.RetrievePerson(ctx, people.RetrievePersonOptions{
 		Name:      &authorName,

--- a/pkg/opds/service_author_test.go
+++ b/pkg/opds/service_author_test.go
@@ -109,10 +109,11 @@ func seedAuthorTestData(t *testing.T, db *bun.DB) authorTestSeeds {
 
 // TestListBooksByAuthor_HonorsSort confirms M14: the per-author ID
 // query now applies the user's sort. Apple has the older created_at
-// but the alphabetically-earlier title, so default `sort_title ASC`
-// would return Apple, Cheese. The explicit date_added:desc inverts
-// that — proving the sort is threaded into the filtered query rather
-// than being applied to a different (broader) result set as before.
+// but the alphabetically-earlier title. The builtin default is
+// date_added:desc (Cheese first, Apple second). The explicit title:asc
+// inverts that to Apple, Cheese — proving the sort is threaded into the
+// filtered query rather than silently falling back to the builtin
+// default.
 func TestListBooksByAuthor_HonorsSort(t *testing.T) {
 	t.Parallel()
 
@@ -127,13 +128,13 @@ func TestListBooksByAuthor_HonorsSort(t *testing.T) {
 		nil, // no file-type filter
 		10,
 		0,
-		[]sortspec.SortLevel{{Field: sortspec.FieldDateAdded, Direction: sortspec.DirDesc}},
+		[]sortspec.SortLevel{{Field: sortspec.FieldTitle, Direction: sortspec.DirAsc}},
 	)
 	require.NoError(t, err)
 	require.Equal(t, 2, total, "alice has two books, bob's book filtered out")
 	require.Len(t, got, 2)
-	assert.Equal(t, seeds.cheese.ID, got[0].ID, "date_added DESC: cheese first")
-	assert.Equal(t, seeds.apple.ID, got[1].ID, "date_added DESC: apple second")
+	assert.Equal(t, seeds.apple.ID, got[0].ID, "title:asc: apple first")
+	assert.Equal(t, seeds.cheese.ID, got[1].ID, "title:asc: cheese second")
 }
 
 // TestListBooksByAuthor_RespectsLimitOffset confirms pagination is

--- a/pkg/opds/service_author_test.go
+++ b/pkg/opds/service_author_test.go
@@ -1,0 +1,204 @@
+package opds
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/sortspec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// authorTestSeeds packages the DB rows shared across the
+// ListBooksByAuthor tests so each test reads cleanly.
+type authorTestSeeds struct {
+	library *models.Library
+	apple   *models.Book
+	cheese  *models.Book
+	other   *models.Book // by a different author — proves the filter works
+	alice   *models.Person
+}
+
+func seedAuthorTestData(t *testing.T, db *bun.DB) authorTestSeeds {
+	t.Helper()
+	ctx := context.Background()
+
+	lib := &models.Library{
+		Name:                     "Library A",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(ctx)
+	require.NoError(t, err)
+
+	now := time.Now()
+	apple := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Apple",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Apple",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        "/tmp/apple",
+		CreatedAt:       now.Add(-2 * time.Hour),
+	}
+	cheese := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Cheese",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Cheese",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        "/tmp/cheese",
+		CreatedAt:       now,
+	}
+	other := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "OtherAuthorBook",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "OtherAuthorBook",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        "/tmp/other",
+		CreatedAt:       now.Add(-time.Hour),
+	}
+	for _, b := range []*models.Book{apple, cheese, other} {
+		_, err = db.NewInsert().Model(b).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	alice := &models.Person{
+		LibraryID:      lib.ID,
+		Name:           "Alice",
+		SortName:       "Alice",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	bob := &models.Person{
+		LibraryID:      lib.ID,
+		Name:           "Bob",
+		SortName:       "Bob",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(alice).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(bob).Exec(ctx)
+	require.NoError(t, err)
+
+	// authors.sort_order is NOT NULL with no default; nullzero would
+	// strip a 0, so seed all rows with 1.
+	for _, link := range []*models.Author{
+		{BookID: apple.ID, PersonID: alice.ID, SortOrder: 1},
+		{BookID: cheese.ID, PersonID: alice.ID, SortOrder: 1},
+		{BookID: other.ID, PersonID: bob.ID, SortOrder: 1},
+	} {
+		_, err = db.NewInsert().Model(link).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	return authorTestSeeds{
+		library: lib,
+		apple:   apple,
+		cheese:  cheese,
+		other:   other,
+		alice:   alice,
+	}
+}
+
+// TestListBooksByAuthor_HonorsSort confirms M14: the per-author ID
+// query now applies the user's sort. Apple has the older created_at
+// but the alphabetically-earlier title, so default `sort_title ASC`
+// would return Apple, Cheese. The explicit date_added:desc inverts
+// that — proving the sort is threaded into the filtered query rather
+// than being applied to a different (broader) result set as before.
+func TestListBooksByAuthor_HonorsSort(t *testing.T) {
+	t.Parallel()
+
+	db := setupOPDSDB(t)
+	seeds := seedAuthorTestData(t, db)
+
+	svc := NewService(db)
+	got, total, err := svc.ListBooksByAuthor(
+		context.Background(),
+		seeds.library.ID,
+		seeds.alice.Name,
+		nil, // no file-type filter
+		10,
+		0,
+		[]sortspec.SortLevel{{Field: sortspec.FieldDateAdded, Direction: sortspec.DirDesc}},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, total, "alice has two books, bob's book filtered out")
+	require.Len(t, got, 2)
+	assert.Equal(t, seeds.cheese.ID, got[0].ID, "date_added DESC: cheese first")
+	assert.Equal(t, seeds.apple.ID, got[1].ID, "date_added DESC: apple second")
+}
+
+// TestListBooksByAuthor_RespectsLimitOffset confirms pagination is
+// SQL-driven and ordering-aware. The previous implementation paginated
+// an unsorted ID slice before applying the sort, so page 1 wasn't
+// guaranteed to contain the "first N in sort order".
+func TestListBooksByAuthor_RespectsLimitOffset(t *testing.T) {
+	t.Parallel()
+
+	db := setupOPDSDB(t)
+	seeds := seedAuthorTestData(t, db)
+
+	svc := NewService(db)
+
+	// limit=1, offset=0 with date_added DESC → just cheese.
+	page1, total, err := svc.ListBooksByAuthor(
+		context.Background(),
+		seeds.library.ID,
+		seeds.alice.Name,
+		nil,
+		1,
+		0,
+		[]sortspec.SortLevel{{Field: sortspec.FieldDateAdded, Direction: sortspec.DirDesc}},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, total, "total still reports the full filtered count")
+	require.Len(t, page1, 1)
+	assert.Equal(t, seeds.cheese.ID, page1[0].ID)
+
+	// limit=1, offset=1 → just apple.
+	page2, _, err := svc.ListBooksByAuthor(
+		context.Background(),
+		seeds.library.ID,
+		seeds.alice.Name,
+		nil,
+		1,
+		1,
+		[]sortspec.SortLevel{{Field: sortspec.FieldDateAdded, Direction: sortspec.DirDesc}},
+	)
+	require.NoError(t, err)
+	require.Len(t, page2, 1)
+	assert.Equal(t, seeds.apple.ID, page2[0].ID)
+}
+
+// TestListBooksByAuthor_UnknownAuthor confirms the "no such person in
+// this library" branch returns an empty result rather than bubbling up
+// a 404 — preserving the previous behavior where the unsorted-ID
+// query returned an empty slice when nothing joined.
+func TestListBooksByAuthor_UnknownAuthor(t *testing.T) {
+	t.Parallel()
+
+	db := setupOPDSDB(t)
+	seeds := seedAuthorTestData(t, db)
+
+	svc := NewService(db)
+	got, total, err := svc.ListBooksByAuthor(
+		context.Background(),
+		seeds.library.ID,
+		"Nobody",
+		nil,
+		10,
+		0,
+		nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 0, total)
+	assert.Empty(t, got)
+}

--- a/pkg/settings/validators.go
+++ b/pkg/settings/validators.go
@@ -34,8 +34,14 @@ func IsValidFitMode(mode string) bool {
 // SortSpec is a pointer so the client can distinguish "unset" (omit field
 // from JSON) from "clear the saved default" (send null). A null body
 // clears the saved sort; omitting the field leaves it untouched.
+//
+// max=200 caps the input length defensively at bind time. The longest
+// possible legitimate spec — every field at the longest direction —
+// fits comfortably under 200 chars (sortspec.MaxLevels=10), so 200 is
+// a generous upper bound that still rejects pathological input before
+// it reaches sortspec.Parse.
 type UpdateLibrarySettingsPayload struct {
-	SortSpec *string `json:"sort_spec"`
+	SortSpec *string `json:"sort_spec" validate:"omitempty,max=200"`
 }
 
 // LibrarySettingsResponse is the response for GET/PUT /settings/libraries/:library_id.

--- a/pkg/sortspec/resolve.go
+++ b/pkg/sortspec/resolve.go
@@ -6,11 +6,22 @@ import (
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
-// LibrarySettingsReader is the narrow read interface this package
-// needs from the settings service. Declared here (not in pkg/settings)
-// so ResolveForLibrary can be called without importing settings —
-// avoiding an import cycle because pkg/settings imports pkg/sortspec
-// to validate sort_spec at write time.
+// LibrarySettingsReader is the dependency-injection seam ResolveForLibrary
+// uses to read a user's stored sort preference for a library. In
+// production it is satisfied by *pkg/settings.Service; tests pass a
+// fake.
+//
+// It exists here (not in pkg/settings) to break what would otherwise
+// be a circular import: pkg/settings already imports pkg/sortspec to
+// validate sort_spec strings at write time, so pkg/sortspec cannot
+// turn around and import pkg/settings to read them back. Defining the
+// narrow read contract on this side of the boundary lets the resolver
+// stay in pkg/sortspec without dragging in the rest of the settings
+// service surface.
+//
+// Implementations MUST return (nil, nil) — not an error — when no row
+// exists for (userID, libraryID); ResolveForLibrary treats that as
+// "no stored preference" and falls back to the builtin default.
 type LibrarySettingsReader interface {
 	GetLibrarySettings(ctx context.Context, userID, libraryID int) (*models.UserLibrarySettings, error)
 }

--- a/pkg/sortspec/spec.go
+++ b/pkg/sortspec/spec.go
@@ -34,11 +34,15 @@ type SortLevel struct {
 // Returns a fresh slice each call so callers can mutate the result
 // without surprising other consumers.
 //
-// Surfaces that should fall back here include OPDS feeds and the
-// eReader browser UI, which have no explicit sort input. The books
-// REST handler intentionally does NOT apply this default — its
-// callers (the gallery, third-party API consumers) carry their own
-// expectations and the gallery already supplies an explicit sort.
+// The books service (pkg/books/service.go ListBooksWithTotal) applies
+// this default when Sort is nil and no series filter is active, so all
+// surfaces that hit the books service — the /books REST endpoint, OPDS
+// feeds, the eReader browser, and the React gallery — share the same
+// "newest first" fallback. OPDS and the eReader browser still resolve
+// to this default explicitly in their handlers so a stored preference
+// takes priority over the builtin; the books service default is the
+// safety net for callers that pass Sort=nil with no stored preference
+// (e.g. third-party API consumers).
 func BuiltinDefault() []SortLevel {
 	return []SortLevel{
 		{Field: FieldDateAdded, Direction: DirDesc},

--- a/pkg/sortspec/spec.go
+++ b/pkg/sortspec/spec.go
@@ -26,6 +26,25 @@ type SortLevel struct {
 	Direction Direction
 }
 
+// BuiltinDefault is the fallback sort applied when neither an explicit
+// URL sort nor a stored per-(user, library) preference exists. It is
+// the same default the React frontend's app/libraries/sortSpec.ts
+// exposes as `BUILTIN_DEFAULT_SORT` — keep both in sync.
+//
+// Returns a fresh slice each call so callers can mutate the result
+// without surprising other consumers.
+//
+// Surfaces that should fall back here include OPDS feeds and the
+// eReader browser UI, which have no explicit sort input. The books
+// REST handler intentionally does NOT apply this default — its
+// callers (the gallery, third-party API consumers) carry their own
+// expectations and the gallery already supplies an explicit sort.
+func BuiltinDefault() []SortLevel {
+	return []SortLevel{
+		{Field: FieldDateAdded, Direction: DirDesc},
+	}
+}
+
 // Parse reads a serialized spec string (e.g. "author:asc,series:desc") into
 // a slice of SortLevel. It rejects unknown fields, bad directions, duplicates,
 // empty pairs, stray whitespace, and specs longer than MaxLevels.

--- a/pkg/sortspec/spec_test.go
+++ b/pkg/sortspec/spec_test.go
@@ -89,6 +89,28 @@ func TestSerialize(t *testing.T) {
 	assert.Empty(t, Serialize(nil))
 }
 
+func TestBuiltinDefault(t *testing.T) {
+	t.Parallel()
+
+	got := BuiltinDefault()
+
+	// The exact default is intentionally pinned: OPDS, the eReader UI,
+	// and the React frontend all read this. Drift here without an
+	// equivalent change to app/libraries/sortSpec.ts BUILTIN_DEFAULT_SORT
+	// would cause inconsistent ordering across surfaces.
+	assert.Equal(t, []SortLevel{
+		{Field: FieldDateAdded, Direction: DirDesc},
+	}, got)
+
+	// Each call must return a fresh slice — callers (e.g. handlers
+	// composing sort options) may append or otherwise mutate without
+	// poisoning subsequent calls.
+	a := BuiltinDefault()
+	a[0].Direction = DirAsc
+	b := BuiltinDefault()
+	assert.Equal(t, DirDesc, b[0].Direction, "BuiltinDefault must return a fresh slice")
+}
+
 func TestParseSerialize_RoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/sortspec/sql.go
+++ b/pkg/sortspec/sql.go
@@ -6,14 +6,17 @@ import (
 )
 
 // OrderClause is one unit of ordering for a Bun query, ready to pass
-// to q.OrderExpr(clause.Expression, clause.Args...).
+// to q.OrderExpr(clause.Expression).
 //
 // Each user-visible sort level produces ONE OrderClause, except the
 // series level which expands to two (series sort name, then series
 // number ASC).
+//
+// Expressions are built from the whitelisted field branches in
+// OrderClauses and never embed user input, so no parameter args are
+// needed — callers pass Expression directly to OrderExpr.
 type OrderClause struct {
 	Expression string
-	Args       []any
 }
 
 // OrderClauses maps a parsed sort spec to the SQL ORDER BY clauses

--- a/pkg/sortspec/sql_test.go
+++ b/pkg/sortspec/sql_test.go
@@ -17,7 +17,6 @@ func TestOrderClauses_SingleLevel(t *testing.T) {
 	// leading "IS NULL" term.
 	assert.Len(t, got, 1)
 	assert.Equal(t, "b.sort_title IS NULL, b.sort_title ASC", got[0].Expression)
-	assert.Nil(t, got[0].Args)
 }
 
 func TestOrderClauses_DescDirection(t *testing.T) {

--- a/pkg/sortspec/whitelist.go
+++ b/pkg/sortspec/whitelist.go
@@ -6,7 +6,7 @@ package sortspec
 //   - Update AllFields() below (order matters — it's pinned in tests).
 //   - Add an SQL case to OrderClauses in sql.go.
 //   - Update the TS whitelist in app/libraries/sortSpec.ts (it mirrors this file).
-//   - Document semantics in docs/plans/2026-04-19-gallery-sort-design.md.
+//   - Document semantics in website/docs/gallery-sort.md (the user-facing reference).
 const (
 	FieldTitle        = "title"
 	FieldAuthor       = "author"

--- a/website/docs/ereader-browser.md
+++ b/website/docs/ereader-browser.md
@@ -63,4 +63,4 @@ Each device gets its own API key. The key is embedded in the URL, so there's no 
 
 ## Sort order
 
-The eReader browser's book listings (library index, author, series, genre pages) apply the authenticated user's saved default sort for the relevant library. See [Gallery sort](./gallery-sort.md) for how to set a default.
+The eReader browser's book listings (library index, author, series, genre pages) apply the authenticated user's saved default sort for the relevant library. If no default has been saved, the browser falls back to the builtin default: **Date added, newest first**. See [Gallery sort](./gallery-sort.md) for how to save a different default for a library.

--- a/website/docs/gallery-sort.md
+++ b/website/docs/gallery-sort.md
@@ -23,7 +23,7 @@ A dot on the Sort button means your current sort differs from your saved default
 |-------|----------|
 | Title | Book title |
 | Author | Primary author's name (books with no author sort to the end) |
-| Series | Primary series name, then series number within each series |
+| Series | Primary series name, then series number within each series (the within-series order is always ascending — "Stormlight #1 before #2" — even when you pick **Series, descending**, which only flips the series-name ordering) |
 | Date added | When the book was first scanned into the library |
 | Date released | Release date from the primary file's metadata |
 | Page count | Page count from the primary file |

--- a/website/docs/opds.md
+++ b/website/docs/opds.md
@@ -75,6 +75,6 @@ The feed respects your user's [library permissions](./users-and-permissions#libr
 
 ## Sort order
 
-Book-listing feeds (library, series, author, genre, tag, all-books, recently-added) apply the authenticated user's saved default sort for the relevant library. See [Gallery sort](./gallery-sort.md) for how to set a default.
+Book-listing feeds (library, series, author, genre, tag, all-books, recently-added) apply the authenticated user's saved default sort for the relevant library. If no default has been saved, the feed falls back to the builtin default: **Date added, newest first**. See [Gallery sort](./gallery-sort.md) for how to save a different default for a library.
 
-When a feed is not scoped to a single library (for example, the all-books root feed across a user's libraries), Shisho falls back to its builtin default order — `user_library_settings` is per-library by design.
+When a feed is not scoped to a single library (for example, the all-books root feed across a user's libraries), Shisho uses the same builtin default — **Date added, newest first** — because `user_library_settings` is per-library by design.


### PR DESCRIPTION
## Summary

Follow-up improvements after #108 (gallery sort).

- **Sort consistency across surfaces.** New `sortspec.BuiltinDefault()` is the single source of truth for the fallback sort (`date_added:desc`), mirrored in the frontend's `BUILTIN_DEFAULT_SORT`. OPDS and eReader handlers now layer it on top of `ResolveForLibrary` instead of returning `nil` and inheriting the books service's hard-coded `sort_title ASC` — so a user with no saved preference sees the same library in the same order on the gallery, OPDS clients, and Kobo's eReader browser.
- **Per-author listing correctness.** `books.ListBooksOptions.PersonID` is a new composable filter that stacks cleanly with `Sort`. `opds.ListBooksByAuthor` used to paginate an unsorted ID slice then re-sort — page 1 wasn't guaranteed to contain the first N books in sort order. It now delegates to the books service with `LibraryID+PersonID+Sort` so SQL applies limit/offset in sort order. `ereader.AuthorBooks` dropped the `peopleService.GetAuthoredBooks` + in-Go library filter in favor of the same path.
- **Hardening + polish.** Stable `b.id` tiebreaker on custom sort; `max=200` validator on `SortSpec`; drop JSON tags from `UserLibrarySettings` (it's `tstype:"-"` and transformed to `LibrarySettingsResponse` by handlers — the tags were unused and invited accidental leakage); defensive guard in `useUpdateLibrarySettings` against a `libraryId=0` placeholder; `setQueryData` + `invalidateQueries` on save so dependent components re-render immediately; dropped unused `Args` field from `sortspec.OrderClause`; within-series ordering wording clarified in `website/docs/gallery-sort.md`.

## Test plan

- `mise check:quiet` passes (Go tests + race + js tests + js+go lint).
- New tests pin the behaviors above:
  - `pkg/sortspec.TestBuiltinDefault` — value and fresh-slice contract.
  - `pkg/books.TestListBooks_PersonIDFilter` and `TestListBooks_PersonIDFilter_ScopesToLibrary` — PersonID composes with sort and library scope.
  - `pkg/opds.TestListBooksByAuthor_HonorsSort`, `_RespectsLimitOffset`, `_UnknownAuthor` — sort is threaded through the filtered query, pagination is SQL-driven, unknown author returns empty (not 404).
  - `pkg/ereader.TestHandlerResolveSort_FallsBackToBuiltinDefault`, `_NilApiKeyFallsBackToBuiltinDefault`, `TestAuthorBooks_PersonIDAndSortFlow` — handler-level consistency.
  - `pkg/opds.TestHandlerResolveSort_FallsBackToBuiltinDefault`, `_MissingUserFallsBackToBuiltinDefault` — same for OPDS.
- Manual verification on a running server:
  - Fresh user (no saved default) hits `/libraries/:id` and `/opds/v1/library/:id/all` and `/ereader/key/:apiKey/library/:id/all` — all three list the same library in `date_added:desc` order.
  - OPDS: `/opds/v1/library/:id/authors/:name?limit=1&offset=0` then `&offset=1` returns the two expected books in date-added order; a non-existent author returns an empty feed rather than 404.
  - Home page: save a default via the sort sheet; the sort sheet's "dirty" dot disappears without a refetch; the gallery reorders immediately.