### PR TITLE
[Frontend] Sort relative imports last via prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,6 @@
     "prettier-plugin-tailwindcss",
     "@ianvs/prettier-plugin-sort-imports"
   ],
-  "importOrder": ["<BUILTIN_MODULES>", "", "<THIRD_PARTY_MODULES>", "", "^@/"],
+  "importOrder": ["<BUILTIN_MODULES>", "", "<THIRD_PARTY_MODULES>", "", "^@/", "", "^[./]"],
   "importOrderTypeScriptVersion": "5.7.3"
 }

--- a/app/components/common/SortNameInput.test.tsx
+++ b/app/components/common/SortNameInput.test.tsx
@@ -1,7 +1,8 @@
-import { SortNameInput } from "./SortNameInput";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
+import { SortNameInput } from "./SortNameInput";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/components/contexts/Auth/AuthProvider.tsx
+++ b/app/components/contexts/Auth/AuthProvider.tsx
@@ -1,7 +1,8 @@
-import { AuthContext, type AuthUser } from "./context";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 
 import { API } from "@/libraries/api";
+
+import { AuthContext, type AuthUser } from "./context";
 
 interface AuthProviderProps {
   children: ReactNode;

--- a/app/components/files/ChapterRow.test.tsx
+++ b/app/components/files/ChapterRow.test.tsx
@@ -1,10 +1,11 @@
-import ChapterRow from "./ChapterRow";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import { FileTypeCBZ, FileTypeM4B, type Chapter } from "@/types";
+
+import ChapterRow from "./ChapterRow";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/components/files/ChapterRow.tsx
+++ b/app/components/files/ChapterRow.tsx
@@ -1,11 +1,4 @@
 import {
-  countDescendants,
-  formatTimestampMs,
-  parseTimestampMs,
-} from "./chapterUtils";
-import PagePicker from "./PagePicker";
-import PagePreview from "./PagePreview";
-import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
@@ -42,6 +35,14 @@ import {
   type Chapter,
   type FileType,
 } from "@/types";
+
+import {
+  countDescendants,
+  formatTimestampMs,
+  parseTimestampMs,
+} from "./chapterUtils";
+import PagePicker from "./PagePicker";
+import PagePreview from "./PagePreview";
 
 /** Pixels of indentation per depth level for EPUB hierarchy */
 const INDENT_PX_PER_LEVEL = 24;

--- a/app/components/files/FileChaptersTab.test.tsx
+++ b/app/components/files/FileChaptersTab.test.tsx
@@ -1,4 +1,3 @@
-import FileChaptersTab from "./FileChaptersTab";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -7,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useFileChapters } from "@/hooks/queries/chapters";
 import { FileTypeM4B, FileTypePDF, type Chapter, type File } from "@/types";
+
+import FileChaptersTab from "./FileChaptersTab";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/components/files/chapterUtils.test.ts
+++ b/app/components/files/chapterUtils.test.ts
@@ -1,9 +1,3 @@
-import {
-  formatTimestampMs,
-  getNextChapterTitle,
-  normalizeChapterOrder,
-  parseTimestampMs,
-} from "./chapterUtils";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -13,6 +7,13 @@ import {
   FileTypePDF,
   type ChapterInput,
 } from "@/types";
+
+import {
+  formatTimestampMs,
+  getNextChapterTitle,
+  normalizeChapterOrder,
+  parseTimestampMs,
+} from "./chapterUtils";
 
 describe("getNextChapterTitle", () => {
   it('detects "Chapter N" pattern', () => {

--- a/app/components/library/AddToListDialog.test.tsx
+++ b/app/components/library/AddToListDialog.test.tsx
@@ -1,10 +1,11 @@
-import { AddToListDialog } from "./AddToListDialog";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { List } from "@/types";
+
+import { AddToListDialog } from "./AddToListDialog";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/components/library/CoverGalleryTabs.test.tsx
+++ b/app/components/library/CoverGalleryTabs.test.tsx
@@ -1,8 +1,9 @@
-import CoverGalleryTabs from "./CoverGalleryTabs";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import type { File } from "@/types";
+
+import CoverGalleryTabs from "./CoverGalleryTabs";
 
 function makeFile(overrides: Partial<File> = {}): File {
   return {

--- a/app/components/library/CoverPlaceholder.test.tsx
+++ b/app/components/library/CoverPlaceholder.test.tsx
@@ -1,6 +1,7 @@
-import CoverPlaceholder from "./CoverPlaceholder";
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+
+import CoverPlaceholder from "./CoverPlaceholder";
 
 describe("CoverPlaceholder", () => {
   it("renders book variant with correct viewBox", () => {

--- a/app/components/library/CreateListDialog.test.tsx
+++ b/app/components/library/CreateListDialog.test.tsx
@@ -1,10 +1,11 @@
-import { CreateListDialog } from "./CreateListDialog";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import type { List } from "@/types";
+
+import { CreateListDialog } from "./CreateListDialog";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/components/library/FileEditDialog.test.tsx
+++ b/app/components/library/FileEditDialog.test.tsx
@@ -1,4 +1,3 @@
-import { FileEditDialog } from "./FileEditDialog";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -13,6 +12,8 @@ import {
 } from "vitest";
 
 import { FileRoleMain, FileTypeCBZ, type File } from "@/types";
+
+import { FileEditDialog } from "./FileEditDialog";
 
 // delay:null skips userEvent's default 10ms-per-event pause so chained
 // clicks don't rely on fake-timer advancement under CPU contention — this

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -1,5 +1,3 @@
-import { computeIdentifyEmptyState } from "./identify-utils";
-import { IdentifyReviewForm } from "./IdentifyReviewForm";
 import { AlertTriangle, ExternalLink, Loader2, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -33,6 +31,9 @@ import {
   getFilename,
 } from "@/utils/format";
 import { getIdentifierUrl } from "@/utils/identifiers";
+
+import { computeIdentifyEmptyState } from "./identify-utils";
+import { IdentifyReviewForm } from "./IdentifyReviewForm";
 
 interface IdentifyBookDialogProps {
   open: boolean;

--- a/app/components/library/IdentifyReviewForm.test.ts
+++ b/app/components/library/IdentifyReviewForm.test.ts
@@ -1,5 +1,6 @@
-import { resolveIdentifiers } from "./identify-utils";
 import { describe, expect, it } from "vitest";
+
+import { resolveIdentifiers } from "./identify-utils";
 
 describe("resolveIdentifiers", () => {
   it("returns unchanged when identifiers are identical", () => {

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -1,9 +1,3 @@
-import {
-  resolveIdentifiers,
-  type FieldStatus,
-  type IdentifierEntry,
-} from "./identify-utils";
-import { LanguageCombobox } from "./LanguageCombobox";
 import equal from "fast-deep-equal";
 import {
   ArrowLeft,
@@ -37,6 +31,13 @@ import { cn, isPageBasedFileType } from "@/libraries/utils";
 import type { Book, File } from "@/types";
 import { getAuthorRoleLabel } from "@/utils/authorRoles";
 import { formatIdentifierType, formatMetadataFieldLabel } from "@/utils/format";
+
+import {
+  resolveIdentifiers,
+  type FieldStatus,
+  type IdentifierEntry,
+} from "./identify-utils";
+import { LanguageCombobox } from "./LanguageCombobox";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/app/components/library/MergeIntoDialog.tsx
+++ b/app/components/library/MergeIntoDialog.tsx
@@ -1,4 +1,3 @@
-import { BookSelectionList } from "./BookSelectionList";
 import { AlertTriangle, GitMerge, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -15,6 +14,8 @@ import {
 import { Label } from "@/components/ui/label";
 import { useMergeBooks } from "@/hooks/queries/books";
 import type { Book, Library } from "@/types";
+
+import { BookSelectionList } from "./BookSelectionList";
 
 interface MergeIntoDialogProps {
   open: boolean;

--- a/app/components/library/MetadataDeleteDialog.tsx
+++ b/app/components/library/MetadataDeleteDialog.tsx
@@ -1,4 +1,3 @@
-import type { EntityType } from "./MetadataEditDialog";
 import { AlertTriangle, Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -10,6 +9,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+
+import type { EntityType } from "./MetadataEditDialog";
 
 interface MetadataDeleteDialogProps {
   open: boolean;

--- a/app/components/library/MetadataEditDialog.test.tsx
+++ b/app/components/library/MetadataEditDialog.test.tsx
@@ -1,8 +1,9 @@
-import { MetadataEditDialog } from "./MetadataEditDialog";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
+import { MetadataEditDialog } from "./MetadataEditDialog";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/components/library/MetadataMergeDialog.tsx
+++ b/app/components/library/MetadataMergeDialog.tsx
@@ -1,4 +1,3 @@
-import type { EntityType } from "./MetadataEditDialog";
 import { Check, ChevronsUpDown, Loader2 } from "lucide-react";
 import { useMemo, useState } from "react";
 
@@ -23,6 +22,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+
+import type { EntityType } from "./MetadataEditDialog";
 
 interface EntityOption {
   id: number;

--- a/app/components/library/MoveFilesDialog.tsx
+++ b/app/components/library/MoveFilesDialog.tsx
@@ -1,4 +1,3 @@
-import { BookSelectionList } from "./BookSelectionList";
 import { AlertTriangle, Info, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -15,6 +14,8 @@ import {
 import { Label } from "@/components/ui/label";
 import { useMoveFiles } from "@/hooks/queries/books";
 import type { Book, File, Library } from "@/types";
+
+import { BookSelectionList } from "./BookSelectionList";
 
 interface MoveFilesDialogProps {
   open: boolean;

--- a/app/components/library/RoleDialog.test.tsx
+++ b/app/components/library/RoleDialog.test.tsx
@@ -1,10 +1,11 @@
-import RoleDialog from "./RoleDialog";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import type { Role } from "@/types";
+
+import RoleDialog from "./RoleDialog";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/components/library/SelectableBookItem.tsx
+++ b/app/components/library/SelectableBookItem.tsx
@@ -1,7 +1,7 @@
-import BookItem from "./BookItem";
-
 import { useBulkSelection } from "@/hooks/useBulkSelection";
 import type { Book } from "@/types";
+
+import BookItem from "./BookItem";
 
 interface SelectableBookItemProps {
   book: Book;

--- a/app/components/library/SortSheet.test.tsx
+++ b/app/components/library/SortSheet.test.tsx
@@ -1,10 +1,11 @@
-import SortSheet from "./SortSheet";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { Button } from "@/components/ui/button";
 import type { SortLevel } from "@/libraries/sortSpec";
+
+import SortSheet from "./SortSheet";
 
 // jsdom does not implement window.matchMedia. Mock it to return matches=true
 // so useMediaQuery("(min-width: 768px)") returns true and the Sheet (Radix

--- a/app/components/library/SortedByChips.test.tsx
+++ b/app/components/library/SortedByChips.test.tsx
@@ -1,9 +1,10 @@
-import SortedByChips from "./SortedByChips";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import type { SortLevel } from "@/libraries/sortSpec";
+
+import SortedByChips from "./SortedByChips";
 
 describe("SortedByChips", () => {
   it("renders a chip per level", () => {

--- a/app/components/library/identify-utils.test.ts
+++ b/app/components/library/identify-utils.test.ts
@@ -1,8 +1,9 @@
+import { describe, expect, it } from "vitest";
+
 import {
   computeIdentifyEmptyState,
   resolveIdentifiers,
 } from "./identify-utils";
-import { describe, expect, it } from "vitest";
 
 describe("computeIdentifyEmptyState", () => {
   const baseInput = {

--- a/app/components/pages/CreateLibrary.test.tsx
+++ b/app/components/pages/CreateLibrary.test.tsx
@@ -1,9 +1,10 @@
-import CreateLibrary from "./CreateLibrary";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import CreateLibrary from "./CreateLibrary";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/components/pages/PluginDetail.test.tsx
+++ b/app/components/pages/PluginDetail.test.tsx
@@ -1,8 +1,9 @@
-import { PluginDetail } from "./PluginDetail";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
+
+import { PluginDetail } from "./PluginDetail";
 
 // Mock the auth hook used by PluginDetail.
 vi.mock("@/hooks/useAuth", () => ({

--- a/app/components/plugins/AdvancedPluginsDialog.test.tsx
+++ b/app/components/plugins/AdvancedPluginsDialog.test.tsx
@@ -1,7 +1,8 @@
-import { AdvancedPluginsDialog } from "./AdvancedPluginsDialog";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
+import { AdvancedPluginsDialog } from "./AdvancedPluginsDialog";
 
 // Mock child sections to keep tests focused on dialog behaviour
 vi.mock("./AdvancedOrderSection", () => ({

--- a/app/components/plugins/AdvancedPluginsDialog.tsx
+++ b/app/components/plugins/AdvancedPluginsDialog.tsx
@@ -1,6 +1,3 @@
-import { AdvancedOrderSection } from "./AdvancedOrderSection";
-import { AdvancedRepositoriesSection } from "./AdvancedRepositoriesSection";
-
 import {
   Dialog,
   DialogContent,
@@ -8,6 +5,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import { AdvancedOrderSection } from "./AdvancedOrderSection";
+import { AdvancedRepositoriesSection } from "./AdvancedRepositoriesSection";
 
 export interface AdvancedPluginsDialogProps {
   defaultSection?: "order" | "repositories";

--- a/app/components/plugins/CapabilitiesWarning.tsx
+++ b/app/components/plugins/CapabilitiesWarning.tsx
@@ -1,6 +1,3 @@
-import { CapabilityRow } from "./CapabilityRow";
-import { CAPABILITY_DEFS, filterDefsByCapabilities } from "./capabilityRows";
-
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -11,6 +8,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { AvailablePlugin } from "@/hooks/queries/plugins";
+
+import { CapabilityRow } from "./CapabilityRow";
+import { CAPABILITY_DEFS, filterDefsByCapabilities } from "./capabilityRows";
 
 interface CapabilitiesWarningProps {
   isPending: boolean;

--- a/app/components/plugins/ChangelogMarkdown.test.tsx
+++ b/app/components/plugins/ChangelogMarkdown.test.tsx
@@ -1,6 +1,7 @@
-import { ChangelogMarkdown } from "./ChangelogMarkdown";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+
+import { ChangelogMarkdown } from "./ChangelogMarkdown";
 
 describe("ChangelogMarkdown", () => {
   it("renders h2/h3 headings and paragraphs", () => {

--- a/app/components/plugins/DiscoverTab.test.tsx
+++ b/app/components/plugins/DiscoverTab.test.tsx
@@ -1,5 +1,3 @@
-import { filterPlugins } from "./discoverFilters";
-import { DiscoverTab } from "./DiscoverTab";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -8,6 +6,9 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AvailablePlugin } from "@/hooks/queries/plugins";
+
+import { filterPlugins } from "./discoverFilters";
+import { DiscoverTab } from "./DiscoverTab";
 
 // --- Mocks ---
 

--- a/app/components/plugins/InstalledTab.tsx
+++ b/app/components/plugins/InstalledTab.tsx
@@ -1,8 +1,3 @@
-import {
-  deriveCapabilityLabels,
-  resolveInstalledPluginCapabilities,
-} from "./pluginCapabilities";
-import { PluginRow } from "./PluginRow";
 import { Download, FolderSearch, Loader2, Package } from "lucide-react";
 import { toast } from "sonner";
 
@@ -18,6 +13,12 @@ import {
 } from "@/hooks/queries/plugins";
 import { useAuth } from "@/hooks/useAuth";
 import type { Plugin } from "@/types/generated/models";
+
+import {
+  deriveCapabilityLabels,
+  resolveInstalledPluginCapabilities,
+} from "./pluginCapabilities";
+import { PluginRow } from "./PluginRow";
 
 export const InstalledTab = () => {
   const { hasPermission } = useAuth();

--- a/app/components/plugins/PluginCapabilitiesSection.tsx
+++ b/app/components/plugins/PluginCapabilitiesSection.tsx
@@ -1,5 +1,3 @@
-import { CapabilityRow } from "./CapabilityRow";
-import { CAPABILITY_DEFS, filterDefsByCapabilities } from "./capabilityRows";
 import { useMemo } from "react";
 
 import type {
@@ -7,6 +5,9 @@ import type {
   PluginCapabilities,
 } from "@/hooks/queries/plugins";
 import type { Plugin } from "@/types/generated/models";
+
+import { CapabilityRow } from "./CapabilityRow";
+import { CAPABILITY_DEFS, filterDefsByCapabilities } from "./capabilityRows";
 
 interface PluginCapabilitiesSectionProps {
   available?: AvailablePlugin;

--- a/app/components/plugins/PluginConfigForm.test.tsx
+++ b/app/components/plugins/PluginConfigForm.test.tsx
@@ -1,8 +1,9 @@
-import { PluginConfigForm } from "./PluginConfigForm";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PluginConfigForm } from "./PluginConfigForm";
 
 const mockSaveConfig = vi.fn();
 const mockSaveFields = vi.fn();

--- a/app/components/plugins/PluginDangerZone.test.tsx
+++ b/app/components/plugins/PluginDangerZone.test.tsx
@@ -1,10 +1,11 @@
-import { PluginDangerZone } from "./PluginDangerZone";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 import { describe, expect, it, vi } from "vitest";
 
 import { PluginStatusActive, type Plugin } from "@/types/generated/models";
+
+import { PluginDangerZone } from "./PluginDangerZone";
 
 const mockUninstallMutate = vi.fn();
 const mockNavigate = vi.fn();

--- a/app/components/plugins/PluginDetailHero.test.tsx
+++ b/app/components/plugins/PluginDetailHero.test.tsx
@@ -1,8 +1,9 @@
-import { PluginDetailHero } from "./PluginDetailHero";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import type { AvailablePlugin } from "@/hooks/queries/plugins";
+
+import { PluginDetailHero } from "./PluginDetailHero";
 
 const baseAvailable: AvailablePlugin = {
   compatible: true,

--- a/app/components/plugins/PluginDetailHero.tsx
+++ b/app/components/plugins/PluginDetailHero.tsx
@@ -1,5 +1,3 @@
-import { PluginHeroActions } from "./PluginHeroActions";
-import { PluginLogo } from "./PluginLogo";
 import { BadgeCheck, ExternalLink } from "lucide-react";
 import { Fragment, type ReactNode } from "react";
 
@@ -9,6 +7,9 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import type { AvailablePlugin } from "@/hooks/queries/plugins";
 import { PluginStatusActive, type Plugin } from "@/types/generated/models";
+
+import { PluginHeroActions } from "./PluginHeroActions";
+import { PluginLogo } from "./PluginLogo";
 
 export interface PluginDetailHeroProps {
   available?: AvailablePlugin;

--- a/app/components/plugins/PluginHeroActions.test.tsx
+++ b/app/components/plugins/PluginHeroActions.test.tsx
@@ -1,4 +1,3 @@
-import { PluginHeroActions } from "./PluginHeroActions";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -7,6 +6,8 @@ import { toast } from "sonner";
 import { describe, expect, it, vi } from "vitest";
 
 import { PluginStatusActive, type Plugin } from "@/types/generated/models";
+
+import { PluginHeroActions } from "./PluginHeroActions";
 
 const mockReloadMutateAsync = vi.fn();
 

--- a/app/components/plugins/PluginHeroActions.tsx
+++ b/app/components/plugins/PluginHeroActions.tsx
@@ -1,4 +1,3 @@
-import { PluginManifestDialog } from "./PluginManifestDialog";
 import { Braces, RotateCw } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -11,6 +10,8 @@ import {
 } from "@/components/ui/tooltip";
 import { useReloadPlugin } from "@/hooks/queries/plugins";
 import type { Plugin } from "@/types/generated/models";
+
+import { PluginManifestDialog } from "./PluginManifestDialog";
 
 export interface PluginHeroActionsProps {
   canWrite: boolean;

--- a/app/components/plugins/PluginHookOrderSection.tsx
+++ b/app/components/plugins/PluginHookOrderSection.tsx
@@ -1,4 +1,3 @@
-import { resolveInstalledPluginCapabilities } from "./pluginCapabilities";
 import { ExternalLink } from "lucide-react";
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
@@ -10,6 +9,8 @@ import {
   type PluginMode,
 } from "@/hooks/queries/plugins";
 import type { Plugin } from "@/types/generated/models";
+
+import { resolveInstalledPluginCapabilities } from "./pluginCapabilities";
 
 interface PluginHookOrderSectionProps {
   installed: Plugin;

--- a/app/components/plugins/PluginLogo.test.tsx
+++ b/app/components/plugins/PluginLogo.test.tsx
@@ -1,6 +1,7 @@
-import { PluginLogo } from "./PluginLogo";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+
+import { PluginLogo } from "./PluginLogo";
 
 describe("PluginLogo", () => {
   it("renders an <img> when imageUrl is provided", () => {

--- a/app/components/plugins/PluginLogo.tsx
+++ b/app/components/plugins/PluginLogo.tsx
@@ -1,7 +1,8 @@
-import { derivePluginInitials, getPluginFallbackColor } from "./logoColor";
 import { useState } from "react";
 
 import { cn } from "@/libraries/utils";
+
+import { derivePluginInitials, getPluginFallbackColor } from "./logoColor";
 
 export interface PluginLogoProps {
   scope: string;

--- a/app/components/plugins/PluginManifestDialog.test.tsx
+++ b/app/components/plugins/PluginManifestDialog.test.tsx
@@ -1,8 +1,9 @@
-import { PluginManifestDialog } from "./PluginManifestDialog";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
+
+import { PluginManifestDialog } from "./PluginManifestDialog";
 
 const mockUsePluginManifest = vi.fn();
 

--- a/app/components/plugins/PluginRow.test.tsx
+++ b/app/components/plugins/PluginRow.test.tsx
@@ -1,8 +1,9 @@
-import { PluginRow } from "./PluginRow";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
+
+import { PluginRow } from "./PluginRow";
 
 const base = {
   scope: "shisho",

--- a/app/components/plugins/PluginRow.tsx
+++ b/app/components/plugins/PluginRow.tsx
@@ -1,10 +1,11 @@
-import { PluginLogo } from "./PluginLogo";
 import { BadgeCheck, ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/libraries/utils";
+
+import { PluginLogo } from "./PluginLogo";
 
 export interface PluginRowProps {
   actions?: ReactNode;

--- a/app/components/plugins/PluginVersionCard.test.tsx
+++ b/app/components/plugins/PluginVersionCard.test.tsx
@@ -1,8 +1,9 @@
-import { PluginVersionCard } from "./PluginVersionCard";
 import { render, screen } from "@testing-library/react";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import type { PluginVersion } from "@/hooks/queries/plugins";
+
+import { PluginVersionCard } from "./PluginVersionCard";
 
 const makeVersion = (
   overrides: Partial<PluginVersion> = {},

--- a/app/components/plugins/PluginVersionCard.tsx
+++ b/app/components/plugins/PluginVersionCard.tsx
@@ -1,9 +1,10 @@
-import { ChangelogMarkdown } from "./ChangelogMarkdown";
 import { ExternalLink } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { PluginVersion } from "@/hooks/queries/plugins";
+
+import { ChangelogMarkdown } from "./ChangelogMarkdown";
 
 export type PluginVersionCardState =
   | "installed"

--- a/app/components/plugins/PluginVersionHistory.test.tsx
+++ b/app/components/plugins/PluginVersionHistory.test.tsx
@@ -1,10 +1,11 @@
-import { PluginVersionHistory } from "./PluginVersionHistory";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it } from "vitest";
 
 import type { AvailablePlugin, PluginVersion } from "@/hooks/queries/plugins";
+
+import { PluginVersionHistory } from "./PluginVersionHistory";
 
 const makeVersion = (
   v: string,

--- a/app/components/plugins/PluginVersionHistory.tsx
+++ b/app/components/plugins/PluginVersionHistory.tsx
@@ -1,4 +1,3 @@
-import { PluginVersionCard } from "./PluginVersionCard";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -8,6 +7,8 @@ import {
   type AvailablePlugin,
 } from "@/hooks/queries/plugins";
 import type { Plugin } from "@/types/generated/models";
+
+import { PluginVersionCard } from "./PluginVersionCard";
 
 const INITIAL_VISIBLE_OLDER = 3;
 

--- a/app/components/plugins/TabUpdatePill.test.tsx
+++ b/app/components/plugins/TabUpdatePill.test.tsx
@@ -1,6 +1,7 @@
-import { TabUpdatePill } from "./TabUpdatePill";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+
+import { TabUpdatePill } from "./TabUpdatePill";
 
 describe("TabUpdatePill", () => {
   it("renders nothing when count is 0", () => {

--- a/app/components/plugins/logoColor.test.ts
+++ b/app/components/plugins/logoColor.test.ts
@@ -1,5 +1,6 @@
-import { derivePluginInitials, getPluginFallbackColor } from "./logoColor";
 import { describe, expect, it } from "vitest";
+
+import { derivePluginInitials, getPluginFallbackColor } from "./logoColor";
 
 describe("derivePluginInitials", () => {
   it("uses first letter + letter after first hyphen when id has a hyphen", () => {

--- a/app/components/plugins/pluginCapabilities.test.ts
+++ b/app/components/plugins/pluginCapabilities.test.ts
@@ -1,7 +1,3 @@
-import {
-  deriveCapabilityLabels,
-  resolveInstalledPluginCapabilities,
-} from "./pluginCapabilities";
 import { describe, expect, it } from "vitest";
 
 import type {
@@ -10,6 +6,11 @@ import type {
   PluginVersion,
 } from "@/hooks/queries/plugins";
 import { PluginStatusActive, type Plugin } from "@/types/generated/models";
+
+import {
+  deriveCapabilityLabels,
+  resolveInstalledPluginCapabilities,
+} from "./pluginCapabilities";
 
 describe("deriveCapabilityLabels", () => {
   it("returns [] for null caps", () => {

--- a/app/components/ui/SortableList.tsx
+++ b/app/components/ui/SortableList.tsx
@@ -1,4 +1,3 @@
-import { SortableItem, type DragHandleProps } from "./SortableItem";
 import {
   closestCenter,
   DndContext,
@@ -15,6 +14,8 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { ReactNode, useCallback } from "react";
+
+import { SortableItem, type DragHandleProps } from "./SortableItem";
 
 export type { DragHandleProps };
 

--- a/app/components/ui/form-dialog.test.tsx
+++ b/app/components/ui/form-dialog.test.tsx
@@ -1,4 +1,3 @@
-import { FormDialog } from "./form-dialog";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +8,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+
+import { FormDialog } from "./form-dialog";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/components/ui/unsaved-changes-dialog.test.tsx
+++ b/app/components/ui/unsaved-changes-dialog.test.tsx
@@ -1,7 +1,8 @@
-import { UnsavedChangesDialog } from "./unsaved-changes-dialog";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
+import { UnsavedChangesDialog } from "./unsaved-changes-dialog";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/constants/languages.test.ts
+++ b/app/constants/languages.test.ts
@@ -1,5 +1,6 @@
-import { getLanguageName, LANGUAGES } from "./languages";
 import { describe, expect, it } from "vitest";
+
+import { getLanguageName, LANGUAGES } from "./languages";
 
 describe("getLanguageName", () => {
   it("returns exact match for a curated tag", () => {

--- a/app/contexts/BulkDownload/BulkDownloadProvider.tsx
+++ b/app/contexts/BulkDownload/BulkDownloadProvider.tsx
@@ -1,9 +1,10 @@
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+
 import {
   BulkDownloadContext,
   type BulkDownloadContextValue,
   type BulkDownloadProgress,
 } from "./context";
-import { useCallback, useMemo, useState, type ReactNode } from "react";
 
 export const BulkDownloadProvider = ({ children }: { children: ReactNode }) => {
   const [activeDownload, setActiveDownload] =

--- a/app/contexts/BulkSelection/BulkSelectionProvider.tsx
+++ b/app/contexts/BulkSelection/BulkSelectionProvider.tsx
@@ -1,8 +1,9 @@
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
+
 import {
   BulkSelectionContext,
   type BulkSelectionContextValue,
 } from "./context";
-import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
 
 interface BulkSelectionProviderProps {
   children: ReactNode;

--- a/app/contexts/MobileNav/useMobileNav.ts
+++ b/app/contexts/MobileNav/useMobileNav.ts
@@ -1,5 +1,6 @@
-import { MobileNavContext } from "./MobileNavContext";
 import { useContext } from "react";
+
+import { MobileNavContext } from "./MobileNavContext";
 
 export const useMobileNav = () => {
   const context = useContext(MobileNavContext);

--- a/app/hooks/queries/books.ts
+++ b/app/hooks/queries/books.ts
@@ -1,5 +1,3 @@
-import { QueryKey as LibrariesQueryKey } from "./libraries";
-import { QueryKey as SearchQueryKey } from "./search";
 import {
   useMutation,
   useQuery,
@@ -23,6 +21,9 @@ import type {
   UpdateBookPayload,
   UpdateFilePayload,
 } from "@/types";
+
+import { QueryKey as LibrariesQueryKey } from "./libraries";
+import { QueryKey as SearchQueryKey } from "./search";
 
 export enum QueryKey {
   RetrieveBook = "RetrieveBook",

--- a/app/hooks/queries/genres.ts
+++ b/app/hooks/queries/genres.ts
@@ -1,4 +1,3 @@
-import { QueryKey as BooksQueryKey } from "./books";
 import {
   useMutation,
   useQuery,
@@ -12,6 +11,8 @@ import type {
   ListGenresQuery,
   UpdateGenrePayload,
 } from "@/types/generated/genres";
+
+import { QueryKey as BooksQueryKey } from "./books";
 
 export enum QueryKey {
   ListGenres = "ListGenres",

--- a/app/hooks/queries/imprints.ts
+++ b/app/hooks/queries/imprints.ts
@@ -1,4 +1,3 @@
-import { QueryKey as BooksQueryKey } from "./books";
 import {
   useMutation,
   useQuery,
@@ -12,6 +11,8 @@ import type {
   ListImprintsQuery,
   UpdateImprintPayload,
 } from "@/types/generated/imprints";
+
+import { QueryKey as BooksQueryKey } from "./books";
 
 export enum QueryKey {
   ListImprints = "ListImprints",

--- a/app/hooks/queries/people.ts
+++ b/app/hooks/queries/people.ts
@@ -1,4 +1,3 @@
-import { QueryKey as BooksQueryKey } from "./books";
 import {
   useMutation,
   useQuery,
@@ -9,6 +8,8 @@ import {
 import { API, ShishoAPIError } from "@/libraries/api";
 import type { Book, File, Person } from "@/types";
 import type { UpdatePersonPayload } from "@/types/generated/people";
+
+import { QueryKey as BooksQueryKey } from "./books";
 
 export enum QueryKey {
   ListPeople = "ListPeople",

--- a/app/hooks/queries/plugins.test.ts
+++ b/app/hooks/queries/plugins.test.ts
@@ -1,8 +1,9 @@
-import { QueryKey, useUninstallPlugin } from "./plugins";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
+
+import { QueryKey, useUninstallPlugin } from "./plugins";
 
 // Mock the API layer so the mutation completes without a real HTTP call.
 vi.mock("@/libraries/api", async () => {

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -1,4 +1,3 @@
-import { QueryKey as BooksQueryKey } from "./books";
 import {
   useMutation,
   useQuery,
@@ -12,6 +11,8 @@ import type {
   ListPublishersQuery,
   UpdatePublisherPayload,
 } from "@/types/generated/publishers";
+
+import { QueryKey as BooksQueryKey } from "./books";
 
 export enum QueryKey {
   ListPublishers = "ListPublishers",

--- a/app/hooks/queries/resync.ts
+++ b/app/hooks/queries/resync.ts
@@ -1,8 +1,9 @@
-import { QueryKey } from "./books";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { API } from "@/libraries/api";
 import { Book, File } from "@/types";
+
+import { QueryKey } from "./books";
 
 export type RescanMode = "scan" | "refresh" | "reset";
 

--- a/app/hooks/queries/series.ts
+++ b/app/hooks/queries/series.ts
@@ -1,4 +1,3 @@
-import { QueryKey as BooksQueryKey } from "./books";
 import {
   useMutation,
   useQuery,
@@ -12,6 +11,8 @@ import type {
   ListSeriesQuery,
   UpdateSeriesPayload,
 } from "@/types/generated/series";
+
+import { QueryKey as BooksQueryKey } from "./books";
 
 export enum QueryKey {
   ListSeries = "ListSeries",

--- a/app/hooks/queries/tags.ts
+++ b/app/hooks/queries/tags.ts
@@ -1,4 +1,3 @@
-import { QueryKey as BooksQueryKey } from "./books";
 import {
   useMutation,
   useQuery,
@@ -9,6 +8,8 @@ import {
 import { API, ShishoAPIError } from "@/libraries/api";
 import type { Book, Tag } from "@/types";
 import type { ListTagsQuery, UpdateTagPayload } from "@/types/generated/tags";
+
+import { QueryKey as BooksQueryKey } from "./books";
 
 export enum QueryKey {
   ListTags = "ListTags",

--- a/app/hooks/useFormDialogClose.test.ts
+++ b/app/hooks/useFormDialogClose.test.ts
@@ -1,6 +1,7 @@
-import { useFormDialogClose } from "./useFormDialogClose";
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+
+import { useFormDialogClose } from "./useFormDialogClose";
 
 describe("useFormDialogClose", () => {
   it("should not close dialog when hasChanges is true", () => {

--- a/app/hooks/useNavigateAfterSave.test.tsx
+++ b/app/hooks/useNavigateAfterSave.test.tsx
@@ -1,9 +1,10 @@
-import { useNavigateAfterSave } from "./useNavigateAfterSave";
 import { act, render, renderHook, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useMemo, useState } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useNavigateAfterSave } from "./useNavigateAfterSave";
 
 const createUser = () =>
   userEvent.setup({ advanceTimers: vi.advanceTimersByTime });

--- a/app/hooks/useSSE.test.ts
+++ b/app/hooks/useSSE.test.ts
@@ -1,4 +1,3 @@
-import { useSSE } from "./useSSE";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
@@ -10,6 +9,8 @@ import {
 } from "@/components/contexts/Auth/context";
 import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
 import { QueryKey as JobsQueryKey } from "@/hooks/queries/jobs";
+
+import { useSSE } from "./useSSE";
 
 // Mock EventSource
 class MockEventSource {

--- a/app/hooks/useUnsavedChanges.test.tsx
+++ b/app/hooks/useUnsavedChanges.test.tsx
@@ -1,8 +1,9 @@
-import { useUnsavedChanges } from "./useUnsavedChanges";
 import { act, render } from "@testing-library/react";
 import { useRef } from "react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useUnsavedChanges } from "./useUnsavedChanges";
 
 describe("useUnsavedChanges", () => {
   // Store original addEventListener/removeEventListener

--- a/app/libraries/query-client.ts
+++ b/app/libraries/query-client.ts
@@ -1,5 +1,6 @@
-import { ShishoAPIError } from "./api";
 import { keepPreviousData, QueryClient } from "@tanstack/react-query";
+
+import { ShishoAPIError } from "./api";
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/app/libraries/sortSpec.test.ts
+++ b/app/libraries/sortSpec.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import {
   BUILTIN_DEFAULT_SORT,
   parseSortSpec,
@@ -6,7 +8,6 @@ import {
   sortSpecsEqual,
   type SortLevel,
 } from "./sortSpec";
-import { describe, expect, it } from "vitest";
 
 describe("parseSortSpec", () => {
   it("parses single level", () => {

--- a/app/utils/authorRoles.test.ts
+++ b/app/utils/authorRoles.test.ts
@@ -1,5 +1,6 @@
-import { getAuthorRoleLabel } from "./authorRoles";
 import { describe, expect, it } from "vitest";
+
+import { getAuthorRoleLabel } from "./authorRoles";
 
 describe("getAuthorRoleLabel", () => {
   it("maps known canonical roles to capitalized labels", () => {

--- a/app/utils/format.test.ts
+++ b/app/utils/format.test.ts
@@ -1,5 +1,6 @@
-import { formatDate, formatDateTime } from "./format";
 import { describe, expect, it } from "vitest";
+
+import { formatDate, formatDateTime } from "./format";
 
 describe("formatDate", () => {
   it("preserves the UTC date regardless of local timezone", () => {

--- a/app/utils/identifiers.test.ts
+++ b/app/utils/identifiers.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import {
   validateASIN,
   validateIdentifier,
@@ -5,7 +7,6 @@ import {
   validateISBN13,
   validateUUID,
 } from "./identifiers";
-import { describe, expect, it } from "vitest";
 
 describe("validateISBN10", () => {
   it("validates correct ISBN-10", () => {

--- a/app/utils/roles.test.ts
+++ b/app/utils/roles.test.ts
@@ -1,7 +1,8 @@
-import { sortRoles } from "./roles";
 import { describe, expect, it } from "vitest";
 
 import type { Role } from "@/types";
+
+import { sortRoles } from "./roles";
 
 const makeRole = (id: number, name: string, is_system = false): Role => ({
   id,

--- a/app/utils/sortname.test.ts
+++ b/app/utils/sortname.test.ts
@@ -1,5 +1,6 @@
-import { forPerson, forTitle } from "./sortname";
 import { describe, expect, it } from "vitest";
+
+import { forPerson, forTitle } from "./sortname";
 
 describe("forTitle", () => {
   it("moves 'The' to end", () => {

--- a/e2e/plugins.spec.ts
+++ b/e2e/plugins.spec.ts
@@ -18,8 +18,9 @@
  *   pnpm test:e2e e2e/plugins.spec.ts    # Run only plugins tests
  */
 
-import { expect, getApiBaseURL, request, test } from "./fixtures";
 import type { Page } from "@playwright/test";
+
+import { expect, getApiBaseURL, request, test } from "./fixtures";
 
 async function loginAsAdmin(page: Page) {
   await page.goto("/login");

--- a/e2e/setup.spec.ts
+++ b/e2e/setup.spec.ts
@@ -9,8 +9,9 @@
  *   pnpm test:e2e e2e/setup.spec.ts  # Run only setup tests
  */
 
-import { expect, getApiBaseURL, request, test } from "./fixtures";
 import type { Page } from "@playwright/test";
+
+import { expect, getApiBaseURL, request, test } from "./fixtures";
 
 async function gotoSetup(page: Page, path = "/setup") {
   await page.goto(path, { waitUntil: "domcontentloaded" });

--- a/packages/plugin-sdk/testing/index.ts
+++ b/packages/plugin-sdk/testing/index.ts
@@ -1,3 +1,6 @@
+import { XMLParser } from "fast-xml-parser";
+import { parseHTML } from "linkedom";
+
 import type {
   FetchResponse,
   HtmlElement,
@@ -12,8 +15,6 @@ import type {
   ShishoXML,
   XMLElement,
 } from "../index";
-import { XMLParser } from "fast-xml-parser";
-import { parseHTML } from "linkedom";
 
 /** Configuration for a mock fetch response. */
 export interface MockFetchResponse {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import { Github } from "../components/GithubIcon";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
@@ -14,6 +13,8 @@ import {
   Users,
 } from "lucide-react";
 import type { ReactNode } from "react";
+
+import { Github } from "../components/GithubIcon";
 
 const workflowSteps = [
   {

--- a/website/src/theme/NavbarItem/DropdownNavbarItem/index.tsx
+++ b/website/src/theme/NavbarItem/DropdownNavbarItem/index.tsx
@@ -1,6 +1,7 @@
-import DropdownNavbarItemDesktop from "./Desktop";
 import DropdownNavbarItemMobile from "@theme-original/NavbarItem/DropdownNavbarItem/Mobile";
 import type { ReactNode } from "react";
+
+import DropdownNavbarItemDesktop from "./Desktop";
 
 interface DropdownNavbarItemProps {
   mobile?: boolean;

--- a/website/src/theme/NavbarItem/NavbarNavLink.tsx
+++ b/website/src/theme/NavbarItem/NavbarNavLink.tsx
@@ -1,4 +1,3 @@
-import { Github } from "../../components/GithubIcon";
 import isInternalUrl from "@docusaurus/isInternalUrl";
 import Link from "@docusaurus/Link";
 import { isRegexpStringMatch } from "@docusaurus/theme-common";
@@ -6,6 +5,8 @@ import useBaseUrl from "@docusaurus/useBaseUrl";
 import IconExternalLink from "@theme/Icon/ExternalLink";
 import { BookOpenText, ChevronDown } from "lucide-react";
 import type { ReactNode } from "react";
+
+import { Github } from "../../components/GithubIcon";
 
 interface NavbarNavLinkProps {
   activeBasePath?: string;


### PR DESCRIPTION
## Summary
- Add a trailing `"^[./]"` group to `.prettierrc` `importOrder` so relative imports sort after `@/` aliases.
- Run `pnpm exec prettier --write .` to reformat 85 files to match the new order.

## Test plan
- `mise check:quiet` passes (lint, tests, lint:js, test:js).
- Spot-check a reformatted file (e.g. `app/components/plugins/DiscoverTab.test.tsx`) — imports now read third-party → `@/` → `./`.