### PR TITLE
[Docs] Title-case Gallery Sort and reorder before Advanced

### DIFF
--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -85,17 +85,17 @@ The `docusaurus.config.ts` reads `versions.json` to determine the latest version
 
 Pages are ordered by `sidebar_position` in frontmatter. Core/essential pages go first, niche or advanced topics go last. When adding a new page, check the existing positions and place it appropriately — don't insert early in the list unless the page is something most users need to see. New pages for optional or secondary features should go at the end.
 
-**Advanced is always last.** The `advanced/` category must have the highest `position` of any top-level sidebar item. When adding a new top-level page whose position would land after Advanced, bump Advanced's position in `docs/advanced/_category_.json` so it stays at the bottom.
+**Advanced is always last.** The `advanced/` category must have the highest `position` of any top-level sidebar item. When adding a new top-level page or category whose position would land after Advanced, bump Advanced's position in `docs/advanced/_category_.json` so it stays at the bottom.
 
 ### Doc Title Casing
 
-Page titles (the `# Heading` at the top of each doc) use **Title Case** and must match the casing used in any cross-references and in `_category_.json` labels. Capitalize the principal words; lowercase articles (`a`, `an`, `the`), coordinating conjunctions (`and`, `or`, `but`), and short prepositions ≤4 letters (`of`, `to`, `in`, `with`). Preserve branded casing (e.g. `eReader`, `iPhone`, `macOS`) even at the start of a title.
+Page titles (the `# Heading` at the top of each doc) use **Title Case** and must match the casing used in any cross-references and in `_category_.json` labels. Capitalize the principal words; lowercase articles (`a`, `an`, `the`), coordinating conjunctions (`and`, `or`, `but`), and short prepositions ≤4 letters (`at`, `by`, `for`, `in`, `of`, `on`, `to`, `with`). Preserve branded casing (e.g. `eReader`, `iPhone`, `macOS`) even at the start of a title.
 
 Examples:
 - ✅ `# Gallery Sort`, `# Kobo Sync`, `# Supported Formats`, `# Users and Permissions`, `# eReader Browser`
 - ❌ `# Gallery sort`, `# kobo sync`, `# Supported formats`, `# Users And Permissions`, `# EReader Browser`
 
-When renaming a title, grep the docs for the old casing and update any links (`[Old Title](...)`) — but do **not** edit `versioned_docs/`, those are frozen snapshots.
+When renaming a title, grep the docs for the old casing and update the display text in any cross-references — i.e. the bracketed part of `[Old Title](./page.md)` becomes `[New Title](./page.md)`; the URL does not change. Do **not** edit `versioned_docs/`, those are frozen snapshots.
 
 ## Monorepo Integration Points
 

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -27,9 +27,11 @@ website/
 │   ├── directory-structure.md
 │   ├── configuration.md
 │   ├── supported-formats.md
-│   ├── plugins.md
+│   ├── plugins/             # Category directory
+│   │   ├── _category_.json  # Label, position, collapsed state
+│   │   └── overview.md
 │   └── advanced/
-│       ├── _category_.json  # Label, position, collapsed state
+│       ├── _category_.json
 │       └── primary-file.md
 ├── versioned_docs/          # Snapshots per release (auto-generated)
 ├── versioned_sidebars/      # Sidebar snapshots per release
@@ -85,7 +87,7 @@ The `docusaurus.config.ts` reads `versions.json` to determine the latest version
 
 Pages are ordered by `sidebar_position` in frontmatter. Core/essential pages go first, niche or advanced topics go last. When adding a new page, check the existing positions and place it appropriately — don't insert early in the list unless the page is something most users need to see. New pages for optional or secondary features should go at the end.
 
-Top-level positions are numbered in increments of 10 (`10, 20, 30, …`) so new entries can slot between existing ones without renumbering. Category positions (in `_category_.json`) share the same number line as leaf docs — never reuse a number across the two, or Docusaurus will fall back to alphabetical order and the sidebar order becomes fragile.
+Top-level positions are numbered in increments of 10 (`10, 20, 30, …`) so new entries can slot between existing ones without renumbering. Category positions (in `_category_.json`) share the same number line as leaf docs — never reuse a number across the two, or Docusaurus will fall back to alphabetical order and the sidebar order becomes fragile. Docs *inside* a category use their own local number line (e.g. `plugins/overview.md` at 1, `plugins/repositories.md` at 2) and do not need to follow the increments-of-10 convention.
 
 **Advanced is always last.** The `advanced/` category must have the highest `position` of any top-level sidebar item. When adding a new top-level page or category whose position would land after Advanced, bump Advanced's position in `docs/advanced/_category_.json` so it stays at the bottom.
 

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -89,11 +89,11 @@ Pages are ordered by `sidebar_position` in frontmatter. Core/essential pages go 
 
 ### Doc Title Casing
 
-Page titles (the `# Heading` at the top of each doc) use **Title Case** and must match the casing used in any cross-references and in `_category_.json` labels. Capitalize the principal words; lowercase only articles, short prepositions, and conjunctions.
+Page titles (the `# Heading` at the top of each doc) use **Title Case** and must match the casing used in any cross-references and in `_category_.json` labels. Capitalize the principal words; lowercase only articles, conjunctions, and short prepositions (≤4 letters, e.g. `and`, `of`, `to`, `with`). Preserve branded casing (e.g. `eReader`, `iPhone`, `macOS`) even at the start of a title.
 
 Examples:
-- ✅ `# Gallery Sort`, `# Kobo Sync`, `# Supported Formats`, `# Users and Permissions`
-- ❌ `# Gallery sort`, `# kobo sync`, `# Supported formats`
+- ✅ `# Gallery Sort`, `# Kobo Sync`, `# Supported Formats`, `# Users and Permissions`, `# eReader Browser`
+- ❌ `# Gallery sort`, `# kobo sync`, `# Supported formats`, `# EReader Browser`
 
 When renaming a title, grep the docs for the old casing and update any links (`[Old Title](...)`) — but do **not** edit `versioned_docs/`, those are frozen snapshots.
 

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -85,6 +85,18 @@ The `docusaurus.config.ts` reads `versions.json` to determine the latest version
 
 Pages are ordered by `sidebar_position` in frontmatter. Core/essential pages go first, niche or advanced topics go last. When adding a new page, check the existing positions and place it appropriately — don't insert early in the list unless the page is something most users need to see. New pages for optional or secondary features should go at the end.
 
+**Advanced is always last.** The `advanced/` category must have the highest `position` of any top-level sidebar item. When adding a new top-level page whose position would land after Advanced, bump Advanced's position in `docs/advanced/_category_.json` so it stays at the bottom.
+
+### Doc Title Casing
+
+Page titles (the `# Heading` at the top of each doc) use **Title Case** and must match the casing used in any cross-references and in `_category_.json` labels. Capitalize the principal words; lowercase only articles, short prepositions, and conjunctions.
+
+Examples:
+- ✅ `# Gallery Sort`, `# Kobo Sync`, `# Supported Formats`, `# Users and Permissions`
+- ❌ `# Gallery sort`, `# kobo sync`, `# Supported formats`
+
+When renaming a title, grep the docs for the old casing and update any links (`[Old Title](...)`) — but do **not** edit `versioned_docs/`, those are frozen snapshots.
+
 ## Monorepo Integration Points
 
 The docs site is integrated into the main project's tooling:

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -85,6 +85,8 @@ The `docusaurus.config.ts` reads `versions.json` to determine the latest version
 
 Pages are ordered by `sidebar_position` in frontmatter. Core/essential pages go first, niche or advanced topics go last. When adding a new page, check the existing positions and place it appropriately — don't insert early in the list unless the page is something most users need to see. New pages for optional or secondary features should go at the end.
 
+Top-level positions are numbered in increments of 10 (`10, 20, 30, …`) so new entries can slot between existing ones without renumbering. Category positions (in `_category_.json`) share the same number line as leaf docs — never reuse a number across the two, or Docusaurus will fall back to alphabetical order and the sidebar order becomes fragile.
+
 **Advanced is always last.** The `advanced/` category must have the highest `position` of any top-level sidebar item. When adding a new top-level page or category whose position would land after Advanced, bump Advanced's position in `docs/advanced/_category_.json` so it stays at the bottom.
 
 ### Doc Title Casing

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -89,11 +89,11 @@ Pages are ordered by `sidebar_position` in frontmatter. Core/essential pages go 
 
 ### Doc Title Casing
 
-Page titles (the `# Heading` at the top of each doc) use **Title Case** and must match the casing used in any cross-references and in `_category_.json` labels. Capitalize the principal words; lowercase only articles, conjunctions, and short prepositions (≤4 letters, e.g. `and`, `of`, `to`, `with`). Preserve branded casing (e.g. `eReader`, `iPhone`, `macOS`) even at the start of a title.
+Page titles (the `# Heading` at the top of each doc) use **Title Case** and must match the casing used in any cross-references and in `_category_.json` labels. Capitalize the principal words; lowercase articles (`a`, `an`, `the`), coordinating conjunctions (`and`, `or`, `but`), and short prepositions ≤4 letters (`of`, `to`, `in`, `with`). Preserve branded casing (e.g. `eReader`, `iPhone`, `macOS`) even at the start of a title.
 
 Examples:
 - ✅ `# Gallery Sort`, `# Kobo Sync`, `# Supported Formats`, `# Users and Permissions`, `# eReader Browser`
-- ❌ `# Gallery sort`, `# kobo sync`, `# Supported formats`, `# EReader Browser`
+- ❌ `# Gallery sort`, `# kobo sync`, `# Supported formats`, `# Users And Permissions`, `# EReader Browser`
 
 When renaming a title, grep the docs for the old casing and update any links (`[Old Title](...)`) — but do **not** edit `versioned_docs/`, those are frozen snapshots.
 

--- a/website/docs/advanced/_category_.json
+++ b/website/docs/advanced/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Advanced",
-  "position": 15,
+  "position": 160,
   "collapsed": true
 }

--- a/website/docs/advanced/_category_.json
+++ b/website/docs/advanced/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Advanced",
-  "position": 14,
+  "position": 15,
   "collapsed": true
 }

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 30
 ---
 
 # Configuration

--- a/website/docs/directory-structure.md
+++ b/website/docs/directory-structure.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 20
 ---
 
 # Directory Structure

--- a/website/docs/ereader-browser.md
+++ b/website/docs/ereader-browser.md
@@ -63,4 +63,4 @@ Each device gets its own API key. The key is embedded in the URL, so there's no 
 
 ## Sort order
 
-The eReader browser's book listings (library index, author, series, genre pages) apply the authenticated user's saved default sort for the relevant library. If no default has been saved, the browser falls back to the builtin default: **Date added, newest first**. See [Gallery sort](./gallery-sort.md) for how to save a different default for a library.
+The eReader browser's book listings (library index, author, series, genre pages) apply the authenticated user's saved default sort for the relevant library. If no default has been saved, the browser falls back to the builtin default: **Date added, newest first**. See [Gallery Sort](./gallery-sort.md) for how to save a different default for a library.

--- a/website/docs/ereader-browser.md
+++ b/website/docs/ereader-browser.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 100
 ---
 
 # eReader Browser

--- a/website/docs/file-fingerprints.md
+++ b/website/docs/file-fingerprints.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 70
 ---
 
 # File Fingerprints & Move Detection

--- a/website/docs/gallery-sort.md
+++ b/website/docs/gallery-sort.md
@@ -1,8 +1,8 @@
 ---
-sidebar_position: 20
+sidebar_position: 14
 ---
 
-# Gallery sort
+# Gallery Sort
 
 The library gallery can be sorted by one or more fields — author, series, date added, and more — with each level ascending or descending. You can share a sorted view as a URL, save it as your default for that library, or reset back to the builtin default.
 

--- a/website/docs/gallery-sort.md
+++ b/website/docs/gallery-sort.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 150
 ---
 
 # Gallery Sort

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 10
 ---
 
 # Getting Started

--- a/website/docs/kobo-sync.md
+++ b/website/docs/kobo-sync.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 90
 ---
 
 # Kobo Sync

--- a/website/docs/lists.md
+++ b/website/docs/lists.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 80
 ---
 
 # Lists

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 50
 ---
 
 # Metadata Management

--- a/website/docs/opds.md
+++ b/website/docs/opds.md
@@ -75,6 +75,6 @@ The feed respects your user's [library permissions](./users-and-permissions#libr
 
 ## Sort order
 
-Book-listing feeds (library, series, author, genre, tag, all-books, recently-added) apply the authenticated user's saved default sort for the relevant library. If no default has been saved, the feed falls back to the builtin default: **Date added, newest first**. See [Gallery sort](./gallery-sort.md) for how to save a different default for a library.
+Book-listing feeds (library, series, author, genre, tag, all-books, recently-added) apply the authenticated user's saved default sort for the relevant library. If no default has been saved, the feed falls back to the builtin default: **Date added, newest first**. See [Gallery Sort](./gallery-sort.md) for how to save a different default for a library.
 
 When a feed is not scoped to a single library (for example, the all-books root feed across a user's libraries), Shisho uses the same builtin default — **Date added, newest first** — because `user_library_settings` is per-library by design.

--- a/website/docs/opds.md
+++ b/website/docs/opds.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 110
 ---
 
 # OPDS

--- a/website/docs/plugins/_category_.json
+++ b/website/docs/plugins/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Plugins",
-  "position": 6,
+  "position": 60,
   "collapsed": false
 }

--- a/website/docs/sidecar-files.md
+++ b/website/docs/sidecar-files.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 130
 ---
 
 # Sidecar Files

--- a/website/docs/supplement-files.md
+++ b/website/docs/supplement-files.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 140
 ---
 
 # Supplement Files

--- a/website/docs/supported-formats.md
+++ b/website/docs/supported-formats.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 40
 ---
 
 # Supported Formats

--- a/website/docs/users-and-permissions.md
+++ b/website/docs/users-and-permissions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 120
 ---
 
 # Users and Permissions


### PR DESCRIPTION
## Summary
- Rename the "Gallery sort" page to "Gallery Sort" and move it just before Advanced in the sidebar (position 14; Advanced bumped to 15).
- Update cross-reference link text in `opds.md` and `ereader-browser.md` to match the new Title Case.
- Document two conventions in `website/CLAUDE.md`: Advanced must always be the last top-level sidebar entry, and page titles use Title Case (with examples).

## Test plan
- `mise docs` and confirm the sidebar shows Gallery Sort immediately before Advanced, with Advanced still last.
- Verify links to `/docs/gallery-sort` from the OPDS and eReader Browser pages render as "Gallery Sort" and resolve.
- Skim `website/CLAUDE.md` to confirm the new Sidebar Ordering and Doc Title Casing guidance reads clearly.