### PR TITLE
[Fix] Library-scope RetrievePerson in eReader AuthorBooks

### DIFF
--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -457,9 +457,6 @@ func (h *handler) AuthorBooks(c echo.Context) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if author == nil {
-		return errcodes.NotFound("Author")
-	}
 
 	// Resolve sort once (so the type-filter branch and the SQL query use
 	// the same ordering) and fetch books for this author + library via

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -448,9 +448,11 @@ func (h *handler) AuthorBooks(c echo.Context) error {
 		return errcodes.Forbidden("Access to this library is denied")
 	}
 
-	// Get author info
+	// Get author info, scoped to the library param so a person ID from a
+	// sibling library cannot leak its name through the page heading.
 	author, err := h.peopleService.RetrievePerson(ctx, people.RetrievePersonOptions{
-		ID: &authorIDInt,
+		ID:        &authorIDInt,
+		LibraryID: &libraryIDInt,
 	})
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/people/service.go
+++ b/pkg/people/service.go
@@ -76,9 +76,12 @@ func (svc *Service) RetrievePerson(ctx context.Context, opts RetrievePersonOptio
 	if opts.ID != nil {
 		q = q.Where("p.id = ?", *opts.ID)
 	}
-	if opts.Name != nil && opts.LibraryID != nil {
+	if opts.Name != nil {
 		// Case-insensitive match
-		q = q.Where("LOWER(p.name) = LOWER(?) AND p.library_id = ?", *opts.Name, *opts.LibraryID)
+		q = q.Where("LOWER(p.name) = LOWER(?)", *opts.Name)
+	}
+	if opts.LibraryID != nil {
+		q = q.Where("p.library_id = ?", *opts.LibraryID)
 	}
 
 	err := q.Scan(ctx)

--- a/pkg/people/service_test.go
+++ b/pkg/people/service_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
@@ -93,4 +95,58 @@ func TestGetAuthoredBooks_DeduplicatesMultipleRoles(t *testing.T) {
 	// Should return only 1 book, not 2 (duplicated for each role)
 	assert.Len(t, books, 1, "Should return 1 book, not duplicated for each role")
 	assert.Equal(t, book.ID, books[0].ID)
+}
+
+// TestRetrievePerson_LibraryScoping verifies that RetrievePerson applies
+// the LibraryID filter as an independent predicate so a person ID from a
+// sibling library cannot leak through. See
+// pkg/ereader/handlers.go AuthorBooks for the motivating call site.
+func TestRetrievePerson_LibraryScoping(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	libA := &models.Library{
+		Name:                     "Library A",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(libA).Exec(ctx)
+	require.NoError(t, err)
+
+	libB := &models.Library{
+		Name:                     "Library B",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err = db.NewInsert().Model(libB).Exec(ctx)
+	require.NoError(t, err)
+
+	personInB := &models.Person{
+		LibraryID:      libB.ID,
+		Name:           "Secret Author",
+		SortName:       "Author, Secret",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(personInB).Exec(ctx)
+	require.NoError(t, err)
+
+	svc := NewService(db)
+
+	// Lookup scoped to lib B succeeds.
+	got, err := svc.RetrievePerson(ctx, RetrievePersonOptions{
+		ID:        &personInB.ID,
+		LibraryID: &libB.ID,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, personInB.ID, got.ID)
+
+	// Lookup scoped to lib A must NOT leak the person from lib B.
+	_, err = svc.RetrievePerson(ctx, RetrievePersonOptions{
+		ID:        &personInB.ID,
+		LibraryID: &libA.ID,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errcodes.NotFound("Person")),
+		"expected NotFound when person ID belongs to a different library, got: %v", err)
 }


### PR DESCRIPTION
## Summary
- Cross-library information disclosure in `pkg/ereader/handlers.go` `AuthorBooks()`: the library access check guarded the library param, but the subsequent `RetrievePerson` lookup had no library filter, so a user with access to library A could visit `/ereader/.../libraries/:libA/authors/:personInLibB` and see the sibling-library person's name rendered into the `<h1>`.
- `RetrievePerson` in `pkg/people/service.go` now applies `LibraryID` as an independent filter (previously only used when bundled with `Name`), so ID-based lookups can be library-scoped.
- `AuthorBooks` now passes `LibraryID: &libraryIDInt` alongside the ID, so a mismatch 404s at the person lookup — same UX as a bad author ID.

## Test plan
- New test `TestRetrievePerson_LibraryScoping` in `pkg/people/service_test.go` covers both the positive path (same-library lookup returns the person) and the negative path (cross-library lookup returns `errcodes.NotFound("Person")`). Confirmed Red → Green.
- Existing OPDS call site (`pkg/opds/service.go` `ListBooksByAuthor`) was already library-scoping via `Name+LibraryID`; behavior unchanged.
- Other `RetrievePerson(ID-only)` call sites in `pkg/people/handlers.go` fetch the person then check `user.HasLibraryAccess(person.LibraryID)` — not the URL-based cross-library pattern, so no leak and no changes needed.
- `go test -race` pass for `pkg/people`, `pkg/ereader`, `pkg/opds`; `mise lint` clean.