### PR TITLE
[Backend] Paginate eReader AuthorBooks, SeriesBooks, and LibrarySearch

### DIFF
--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -165,12 +165,7 @@ func (h *handler) LibraryAllBooks(c echo.Context) error {
 	}
 
 	// Parse query params
-	page := 1
-	if pageStr := c.QueryParam("page"); pageStr != "" {
-		if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
-			page = p
-		}
-	}
+	page := parsePageParam(c.QueryParam("page"))
 	typesFilter := c.QueryParam("types")
 	coversParam := c.QueryParam("covers")
 	showCovers := coversParam == "on"
@@ -191,41 +186,12 @@ func (h *handler) LibraryAllBooks(c echo.Context) error {
 
 	sort := h.resolveSort(ctx, apiKey, libraryIDInt)
 
-	// Fetch more books than needed to account for filtering
-	// When filtering by type, we fetch all and filter client-side
-	var booksResult []*models.Book
-	var total int
-	if typesFilter != "" && typesFilter != "all" {
-		// Fetch all books and filter (pagination happens after filtering)
-		allBooks, _, err := h.bookService.ListBooksWithTotal(ctx, books.ListBooksOptions{
-			LibraryID: &libraryIDInt,
-			Sort:      sort,
-		})
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		filtered := filterBooksByType(allBooks, typesFilter)
-		total = len(filtered)
-		// Apply pagination to filtered results
-		offset := (page - 1) * defaultPageSize
-		end := offset + defaultPageSize
-		if end > total {
-			end = total
-		}
-		if offset < total {
-			booksResult = filtered[offset:end]
-		}
-	} else {
-		offset := (page - 1) * defaultPageSize
-		booksResult, total, err = h.bookService.ListBooksWithTotal(ctx, books.ListBooksOptions{
-			Limit:     intPtr(defaultPageSize),
-			Offset:    intPtr(offset),
-			LibraryID: &libraryIDInt,
-			Sort:      sort,
-		})
-		if err != nil {
-			return errors.WithStack(err)
-		}
+	booksResult, total, err := h.listBooksPaginated(ctx, books.ListBooksOptions{
+		LibraryID: &libraryIDInt,
+		Sort:      sort,
+	}, page, typesFilter)
+	if err != nil {
+		return errors.WithStack(err)
 	}
 
 	var content strings.Builder
@@ -304,7 +270,8 @@ func (h *handler) SeriesBooks(c echo.Context) error {
 		return errcodes.Unauthorized("API key not found")
 	}
 
-	// Parse filter params
+	// Parse query and filter params
+	page := parsePageParam(c.QueryParam("page"))
 	typesFilter := c.QueryParam("types")
 	coversParam := c.QueryParam("covers")
 	showCovers := coversParam == "on"
@@ -339,18 +306,15 @@ func (h *handler) SeriesBooks(c echo.Context) error {
 		return errcodes.NotFound("Series")
 	}
 
-	// Get books in series
-	booksResult, _, err := h.bookService.ListBooksWithTotal(ctx, books.ListBooksOptions{
+	// Get books in series (paginated)
+	booksResult, total, err := h.listBooksPaginated(ctx, books.ListBooksOptions{
 		LibraryID: &libraryIDInt,
 		SeriesID:  &seriesIDInt,
 		Sort:      sort,
-	})
+	}, page, typesFilter)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
-	// Apply type filter
-	booksResult = filterBooksByType(booksResult, typesFilter)
 
 	var content strings.Builder
 	content.WriteString(navBar(baseURL + "/"))
@@ -365,6 +329,10 @@ func (h *handler) SeriesBooks(c echo.Context) error {
 		coverURL := getBookCoverURL(baseURL, book)
 		content.WriteString(itemHTMLWithCover(book.Title, bookURL, meta, coverURL, showCovers))
 	}
+
+	// Pagination (preserve filter params)
+	totalPages := (total + defaultPageSize - 1) / defaultPageSize
+	content.WriteString(paginationWithParams(page, totalPages, currentURL, typesFilter, coversParam))
 
 	return c.HTML(http.StatusOK, RenderPage(content.String()))
 }
@@ -424,7 +392,8 @@ func (h *handler) AuthorBooks(c echo.Context) error {
 		return errcodes.Unauthorized("API key not found")
 	}
 
-	// Parse filter params
+	// Parse query and filter params
+	page := parsePageParam(c.QueryParam("page"))
 	typesFilter := c.QueryParam("types")
 	coversParam := c.QueryParam("covers")
 	showCovers := coversParam == "on"
@@ -466,19 +435,14 @@ func (h *handler) AuthorBooks(c echo.Context) error {
 	// across every library and filtered in Go, which both ignored sort
 	// and scanned more rows than necessary.
 	sort := h.resolveSort(ctx, apiKey, libraryIDInt)
-	booksInLibrary, _, err := h.bookService.ListBooksWithTotal(ctx, books.ListBooksOptions{
+	booksInLibrary, total, err := h.listBooksPaginated(ctx, books.ListBooksOptions{
 		LibraryID: &libraryIDInt,
 		PersonID:  &authorIDInt,
 		Sort:      sort,
-	})
+	}, page, typesFilter)
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
-	// Apply type filter (in-memory, matches LibraryAllBooks behavior —
-	// books service's FileTypes filter is "any file matches", but the
-	// eReader UI shows the dominant per-book type via getBookFileType).
-	booksInLibrary = filterBooksByType(booksInLibrary, typesFilter)
 
 	var content strings.Builder
 	content.WriteString(navBar(baseURL + "/"))
@@ -494,6 +458,10 @@ func (h *handler) AuthorBooks(c echo.Context) error {
 		content.WriteString(itemHTMLWithCover(book.Title, bookURL, meta, coverURL, showCovers))
 	}
 
+	// Pagination (preserve filter params)
+	totalPages := (total + defaultPageSize - 1) / defaultPageSize
+	content.WriteString(paginationWithParams(page, totalPages, currentURL, typesFilter, coversParam))
+
 	return c.HTML(http.StatusOK, RenderPage(content.String()))
 }
 
@@ -508,6 +476,7 @@ func (h *handler) LibrarySearch(c echo.Context) error {
 	}
 
 	query := c.QueryParam("q")
+	page := parsePageParam(c.QueryParam("page"))
 	typesFilter := c.QueryParam("types")
 	coversParam := c.QueryParam("covers")
 	showCovers := coversParam == "on"
@@ -537,21 +506,17 @@ func (h *handler) LibrarySearch(c echo.Context) error {
 	content.WriteString(filterBar(searchURL, typesFilter, coversParam))
 
 	if query != "" {
-		// Search for books
-		booksResult, _, err := h.bookService.ListBooksWithTotal(ctx, books.ListBooksOptions{
+		// Search for books (paginated)
+		booksResult, total, err := h.listBooksPaginated(ctx, books.ListBooksOptions{
 			LibraryID: &libraryIDInt,
 			Search:    &query,
-			Limit:     intPtr(defaultPageSize),
 			Sort:      sort,
-		})
+		}, page, typesFilter)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 
-		// Apply type filter
-		booksResult = filterBooksByType(booksResult, typesFilter)
-
-		content.WriteString(fmt.Sprintf("<p>Found %d results</p>", len(booksResult)))
+		content.WriteString(fmt.Sprintf("<p>Found %d results</p>", total))
 
 		for _, book := range booksResult {
 			meta := formatBookMeta(book)
@@ -559,6 +524,10 @@ func (h *handler) LibrarySearch(c echo.Context) error {
 			coverURL := getBookCoverURL(baseURL, book)
 			content.WriteString(itemHTMLWithCover(book.Title, bookURL, meta, coverURL, showCovers))
 		}
+
+		// Pagination (preserve q + filter params)
+		totalPages := (total + defaultPageSize - 1) / defaultPageSize
+		content.WriteString(paginationWithParams(page, totalPages, searchURL, typesFilter, coversParam, [2]string{"q", query}))
 	}
 
 	return c.HTML(http.StatusOK, RenderPage(content.String()))
@@ -1097,6 +1066,57 @@ func containsInt(slice []int, val int) bool {
 
 func intPtr(i int) *int {
 	return &i
+}
+
+// parsePageParam parses a ?page= query value, defaulting to 1 for
+// missing or invalid input (including non-positive numbers).
+func parsePageParam(raw string) int {
+	if raw == "" {
+		return 1
+	}
+	if p, err := strconv.Atoi(raw); err == nil && p > 0 {
+		return p
+	}
+	return 1
+}
+
+// listBooksPaginated fetches a single page of books, applying the
+// eReader's in-memory type filter (when active) before paginating.
+// Returns the books for the requested page and the total count used to
+// drive the pagination UI.
+//
+// When typesFilter is active, we fetch all books and filter in Go
+// because the books service's FileTypes filter is "any file matches"
+// while the eReader UI shows the dominant per-book type via
+// getBookFileType — the two definitions disagree on books with mixed
+// file types, so we filter to match what the UI displays.
+func (h *handler) listBooksPaginated(ctx context.Context, opts books.ListBooksOptions, page int, typesFilter string) ([]*models.Book, int, error) {
+	if typesFilter != "" && typesFilter != "all" {
+		allBooks, _, err := h.bookService.ListBooksWithTotal(ctx, opts)
+		if err != nil {
+			return nil, 0, errors.WithStack(err)
+		}
+		filtered := filterBooksByType(allBooks, typesFilter)
+		total := len(filtered)
+		offset := (page - 1) * defaultPageSize
+		if offset >= total {
+			return nil, total, nil
+		}
+		end := offset + defaultPageSize
+		if end > total {
+			end = total
+		}
+		return filtered[offset:end], total, nil
+	}
+
+	offset := (page - 1) * defaultPageSize
+	opts.Limit = intPtr(defaultPageSize)
+	opts.Offset = intPtr(offset)
+	result, total, err := h.bookService.ListBooksWithTotal(ctx, opts)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+	return result, total, nil
 }
 
 // ResolveShortURL redirects a short code to the full eReader URL.

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -503,7 +503,7 @@ func (h *handler) LibrarySearch(c echo.Context) error {
 
 	searchURL := fmt.Sprintf("%s/libraries/%s/search", baseURL, libraryID)
 	content.WriteString(searchForm(searchURL, query))
-	content.WriteString(filterBar(searchURL, typesFilter, coversParam))
+	content.WriteString(filterBar(searchURL, typesFilter, coversParam, [2]string{"q", query}))
 
 	if query != "" {
 		// Search for books (paginated)

--- a/pkg/ereader/handlers_pagination_test.go
+++ b/pkg/ereader/handlers_pagination_test.go
@@ -1,0 +1,170 @@
+package ereader
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParsePageParam pins the ?page= query-string contract: any
+// non-parseable, missing, or non-positive value defaults to page 1 so
+// the handlers never render with a bogus offset.
+func TestParsePageParam(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw  string
+		want int
+	}{
+		{raw: "", want: 1},
+		{raw: "1", want: 1},
+		{raw: "2", want: 2},
+		{raw: "9999", want: 9999},
+		{raw: "0", want: 1},
+		{raw: "-1", want: 1},
+		{raw: "abc", want: 1},
+		{raw: " 2", want: 1},                   // strconv.Atoi rejects leading whitespace.
+		{raw: "99999999999999999999", want: 1}, // overflow -> Atoi errors -> 1.
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("raw=%q", tc.raw), func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, parsePageParam(tc.raw))
+		})
+	}
+}
+
+// TestListBooksPaginated_NoFilter confirms SQL-side pagination when no
+// type filter is active: each page returns defaultPageSize books (or
+// the remainder on the last page) and total reflects the full
+// unfiltered count.
+func TestListBooksPaginated_NoFilter(t *testing.T) {
+	t.Parallel()
+
+	db := setupEReaderDB(t)
+	ctx := context.Background()
+
+	lib := &models.Library{
+		Name:                     "Books",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(ctx)
+	require.NoError(t, err)
+
+	// Seed defaultPageSize + 5 books to exercise multi-page behavior.
+	total := defaultPageSize + 5
+	for i := 0; i < total; i++ {
+		b := &models.Book{
+			LibraryID:       lib.ID,
+			Title:           fmt.Sprintf("Book %03d", i),
+			TitleSource:     models.DataSourceFilepath,
+			SortTitle:       fmt.Sprintf("Book %03d", i),
+			SortTitleSource: models.DataSourceFilepath,
+			AuthorSource:    models.DataSourceFilepath,
+			Filepath:        fmt.Sprintf("/b/%d", i),
+		}
+		_, err := db.NewInsert().Model(b).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	h := &handler{bookService: books.NewService(db)}
+	opts := books.ListBooksOptions{LibraryID: &lib.ID}
+
+	got, gotTotal, err := h.listBooksPaginated(ctx, opts, 1, "")
+	require.NoError(t, err)
+	assert.Equal(t, total, gotTotal)
+	assert.Len(t, got, defaultPageSize, "page 1 returns a full page")
+
+	got, gotTotal, err = h.listBooksPaginated(ctx, opts, 2, "")
+	require.NoError(t, err)
+	assert.Equal(t, total, gotTotal)
+	assert.Len(t, got, 5, "page 2 returns the remainder")
+
+	// Out-of-range pages return an empty slice but still report the
+	// real total so the UI can render "Page N of M" instead of
+	// double-fetching to discover the bounds.
+	got, gotTotal, err = h.listBooksPaginated(ctx, opts, 99, "")
+	require.NoError(t, err)
+	assert.Equal(t, total, gotTotal)
+	assert.Empty(t, got)
+}
+
+// TestListBooksPaginated_TypeFilter confirms that an active type
+// filter switches to in-memory pagination and returns the filtered
+// total (not the unfiltered SQL total). This matches the
+// filter-then-paginate path used by LibraryAllBooks since the books
+// service's FileTypes filter is "any file matches", which disagrees
+// with the eReader's dominant-per-book display when a book has mixed
+// file types.
+func TestListBooksPaginated_TypeFilter(t *testing.T) {
+	t.Parallel()
+
+	db := setupEReaderDB(t)
+	ctx := context.Background()
+
+	lib := &models.Library{
+		Name:                     "Books",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(ctx)
+	require.NoError(t, err)
+
+	// 3 EPUB books and 2 CBZ books.
+	mkBook := func(i int, fileType string) {
+		b := &models.Book{
+			LibraryID:       lib.ID,
+			Title:           fmt.Sprintf("Book %03d", i),
+			TitleSource:     models.DataSourceFilepath,
+			SortTitle:       fmt.Sprintf("Book %03d", i),
+			SortTitleSource: models.DataSourceFilepath,
+			AuthorSource:    models.DataSourceFilepath,
+			Filepath:        fmt.Sprintf("/b/%d", i),
+		}
+		_, err := db.NewInsert().Model(b).Exec(ctx)
+		require.NoError(t, err)
+		f := &models.File{
+			LibraryID:     lib.ID,
+			BookID:        b.ID,
+			FileType:      fileType,
+			FileRole:      models.FileRoleMain,
+			Filepath:      fmt.Sprintf("/b/%d/f", i),
+			FilesizeBytes: 1,
+		}
+		_, err = db.NewInsert().Model(f).Exec(ctx)
+		require.NoError(t, err)
+		_, err = db.NewUpdate().
+			Model((*models.Book)(nil)).
+			Set("primary_file_id = ?", f.ID).
+			Where("id = ?", b.ID).
+			Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	for i := 0; i < 3; i++ {
+		mkBook(i, models.FileTypeEPUB)
+	}
+	for i := 3; i < 5; i++ {
+		mkBook(i, models.FileTypeCBZ)
+	}
+
+	h := &handler{bookService: books.NewService(db)}
+	opts := books.ListBooksOptions{LibraryID: &lib.ID}
+
+	got, total, err := h.listBooksPaginated(ctx, opts, 1, "epub")
+	require.NoError(t, err)
+	assert.Equal(t, 3, total, "total reflects filtered count, not SQL count")
+	assert.Len(t, got, 3)
+
+	// "all" short-circuits the filter path (treated as no filter).
+	_, total, err = h.listBooksPaginated(ctx, opts, 1, "all")
+	require.NoError(t, err)
+	assert.Equal(t, 5, total, `"all" is equivalent to no filter`)
+}

--- a/pkg/ereader/templates.go
+++ b/pkg/ereader/templates.go
@@ -3,6 +3,7 @@ package ereader
 import (
 	"fmt"
 	"html"
+	"net/url"
 	"strconv"
 	"strings"
 )
@@ -39,22 +40,32 @@ func navBar(homeURL string) string {
 	return fmt.Sprintf(`<div class="nav"><a href="%s" class="nav-btn">Home</a></div>`, html.EscapeString(homeURL))
 }
 
-// paginationWithParams generates pagination links with button styling, preserving filter params.
-func paginationWithParams(currentPage, totalPages int, baseURL, typesFilter, coversParam string) string {
+// paginationWithParams generates pagination links with button styling,
+// preserving filter params. extraParams contains additional query
+// parameters to thread through each page link (e.g., a search query).
+// Values are URL-encoded; keys must already be safe identifiers.
+func paginationWithParams(currentPage, totalPages int, baseURL, typesFilter, coversParam string, extraParams ...[2]string) string {
 	if totalPages <= 1 {
 		return ""
 	}
 
 	// Build query string with filter params
 	buildURL := func(page int) string {
-		url := baseURL + "?page=" + strconv.Itoa(page)
+		q := make(url.Values)
+		q.Set("page", strconv.Itoa(page))
 		if typesFilter != "" && typesFilter != "all" {
-			url += "&types=" + typesFilter
+			q.Set("types", typesFilter)
 		}
 		if coversParam == "on" {
-			url += "&covers=on"
+			q.Set("covers", "on")
 		}
-		return url
+		for _, kv := range extraParams {
+			if kv[1] == "" {
+				continue
+			}
+			q.Set(kv[0], kv[1])
+		}
+		return baseURL + "?" + q.Encode()
 	}
 
 	var parts []string

--- a/pkg/ereader/templates.go
+++ b/pkg/ereader/templates.go
@@ -8,6 +8,30 @@ import (
 	"strings"
 )
 
+// buildFilterQuery seeds a url.Values with the eReader's standard
+// filter params (types, covers) plus any extra key/value pairs threaded
+// through by the caller (e.g., "q" for search). Skips empty values so
+// an unset filter doesn't show up as "?types=" in the link. Using
+// url.Values ensures consistent encoding — values like a search query
+// containing "&" or "#" are percent-encoded correctly and key order is
+// stable across calls.
+func buildFilterQuery(typesFilter, coversParam string, extraParams ...[2]string) url.Values {
+	q := make(url.Values)
+	if typesFilter != "" && typesFilter != "all" {
+		q.Set("types", typesFilter)
+	}
+	if coversParam == "on" {
+		q.Set("covers", "on")
+	}
+	for _, kv := range extraParams {
+		if kv[1] == "" {
+			continue
+		}
+		q.Set(kv[0], kv[1])
+	}
+	return q
+}
+
 const baseTemplate = `<!DOCTYPE html>
 <html>
 <head>
@@ -44,27 +68,25 @@ func navBar(homeURL string) string {
 // preserving filter params. extraParams contains additional query
 // parameters to thread through each page link (e.g., a search query).
 // Values are URL-encoded; keys must already be safe identifiers.
+//
+// currentPage is clamped into [1, totalPages] so a URL-edited ?page=
+// overshoot renders a sensible "Page M of M" rather than "Page 9999 of 3"
+// with misleading Prev/Next targets.
 func paginationWithParams(currentPage, totalPages int, baseURL, typesFilter, coversParam string, extraParams ...[2]string) string {
 	if totalPages <= 1 {
 		return ""
 	}
+	if currentPage < 1 {
+		currentPage = 1
+	}
+	if currentPage > totalPages {
+		currentPage = totalPages
+	}
 
 	// Build query string with filter params
 	buildURL := func(page int) string {
-		q := make(url.Values)
+		q := buildFilterQuery(typesFilter, coversParam, extraParams...)
 		q.Set("page", strconv.Itoa(page))
-		if typesFilter != "" && typesFilter != "all" {
-			q.Set("types", typesFilter)
-		}
-		if coversParam == "on" {
-			q.Set("covers", "on")
-		}
-		for _, kv := range extraParams {
-			if kv[1] == "" {
-				continue
-			}
-			q.Set(kv[0], kv[1])
-		}
 		return baseURL + "?" + q.Encode()
 	}
 
@@ -109,21 +131,24 @@ func searchForm(actionURL, query string) string {
 </form>`, html.EscapeString(actionURL), html.EscapeString(query))
 }
 
-// filterBar generates the file type and cover filter UI with button-style links.
-func filterBar(baseURL, currentTypes, currentCovers string) string {
+// filterBar generates the file type and cover filter UI with
+// button-style links. extraParams preserves additional query params
+// (e.g., "q" on the search page) so changing a filter doesn't drop the
+// user's in-progress state.
+func filterBar(baseURL, currentTypes, currentCovers string, extraParams ...[2]string) string {
 	// Build type filter links
 	typeLinks := []string{
-		filterLink(baseURL, "types", "all", currentTypes, currentCovers, "All"),
-		filterLink(baseURL, "types", "epub", currentTypes, currentCovers, "EPUB"),
-		filterLink(baseURL, "types", "cbz", currentTypes, currentCovers, "CBZ"),
-		filterLink(baseURL, "types", "m4b", currentTypes, currentCovers, "M4B"),
-		filterLink(baseURL, "types", "pdf", currentTypes, currentCovers, "PDF"),
+		filterLink(baseURL, "types", "all", currentTypes, currentCovers, "All", extraParams...),
+		filterLink(baseURL, "types", "epub", currentTypes, currentCovers, "EPUB", extraParams...),
+		filterLink(baseURL, "types", "cbz", currentTypes, currentCovers, "CBZ", extraParams...),
+		filterLink(baseURL, "types", "m4b", currentTypes, currentCovers, "M4B", extraParams...),
+		filterLink(baseURL, "types", "pdf", currentTypes, currentCovers, "PDF", extraParams...),
 	}
 
 	// Build cover toggle links
 	coverLinks := []string{
-		filterLink(baseURL, "covers", "off", currentTypes, currentCovers, "Off"),
-		filterLink(baseURL, "covers", "on", currentTypes, currentCovers, "On"),
+		filterLink(baseURL, "covers", "off", currentTypes, currentCovers, "Off", extraParams...),
+		filterLink(baseURL, "covers", "on", currentTypes, currentCovers, "On", extraParams...),
 	}
 
 	return fmt.Sprintf(`<div class="filter">
@@ -134,7 +159,7 @@ func filterBar(baseURL, currentTypes, currentCovers string) string {
 
 // filterLink generates a single filter link with button styling for easier tapping.
 // The current selection is shown in bold without a link.
-func filterLink(baseURL, param, value, currentTypes, currentCovers, label string) string {
+func filterLink(baseURL, param, value, currentTypes, currentCovers, label string, extraParams ...[2]string) string {
 	// Determine query params
 	types := currentTypes
 	covers := currentCovers
@@ -145,15 +170,10 @@ func filterLink(baseURL, param, value, currentTypes, currentCovers, label string
 		covers = value
 	}
 
-	// Build URL with query params
-	url := baseURL
-	sep := "?"
-	if types != "" && types != "all" {
-		url += sep + "types=" + types
-		sep = "&"
-	}
-	if covers == "on" {
-		url += sep + "covers=on"
+	q := buildFilterQuery(types, covers, extraParams...)
+	linkURL := baseURL
+	if encoded := q.Encode(); encoded != "" {
+		linkURL += "?" + encoded
 	}
 
 	// Check if this is the current selection
@@ -168,7 +188,7 @@ func filterLink(baseURL, param, value, currentTypes, currentCovers, label string
 	if isCurrent {
 		return fmt.Sprintf(`<span class="filter-btn" style="font-weight: bold; border-color: #000;">%s</span>`, label)
 	}
-	return fmt.Sprintf(`<a href="%s" class="filter-btn">%s</a>`, html.EscapeString(url), label)
+	return fmt.Sprintf(`<a href="%s" class="filter-btn">%s</a>`, html.EscapeString(linkURL), label)
 }
 
 // itemHTMLWithCover generates an HTML item with optional cover image.

--- a/pkg/ereader/templates_test.go
+++ b/pkg/ereader/templates_test.go
@@ -1,0 +1,95 @@
+package ereader
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPaginationWithParams_ClampsCurrentPage pins the bounds-check on
+// currentPage: a URL-edited ?page=9999 on a 3-page listing should
+// render "Page 3 of 3" with Prev enabled and Next disabled, rather
+// than advertising Prev/Next targets that don't exist.
+func TestPaginationWithParams_ClampsCurrentPage(t *testing.T) {
+	t.Parallel()
+
+	got := paginationWithParams(9999, 3, "/base", "", "")
+	assert.Contains(t, got, "Page 3 of 3", "currentPage clamped up to totalPages")
+	assert.Contains(t, got, `href="/base?page=2"`, "Prev points at clamped-page - 1")
+	assert.NotContains(t, got, "page=9998", "no stale overshoot URLs")
+	assert.NotContains(t, got, `href="/base?page=4"`, "Next disabled at the last page")
+
+	got = paginationWithParams(0, 3, "/base", "", "")
+	assert.Contains(t, got, "Page 1 of 3", "currentPage clamped up to 1")
+	assert.Contains(t, got, `href="/base?page=2"`, "Next enabled from page 1")
+
+	got = paginationWithParams(-5, 3, "/base", "", "")
+	assert.Contains(t, got, "Page 1 of 3", "negative currentPage clamped up to 1")
+}
+
+// TestPaginationWithParams_ThreadsExtraParams confirms search queries
+// (and any other caller-supplied params) ride along on Prev/Next
+// links. Empty values are dropped so a blank param doesn't leave
+// "&q=" in the URL.
+func TestPaginationWithParams_ThreadsExtraParams(t *testing.T) {
+	t.Parallel()
+
+	got := paginationWithParams(2, 3, "/s", "epub", "on", [2]string{"q", "brandon sanderson"})
+	assert.Contains(t, got, "page=1")
+	assert.Contains(t, got, "page=3")
+	assert.Contains(t, got, "q=brandon+sanderson", "query is URL-encoded")
+	assert.Contains(t, got, "types=epub")
+	assert.Contains(t, got, "covers=on")
+
+	got = paginationWithParams(2, 3, "/s", "", "", [2]string{"q", ""})
+	assert.NotContains(t, got, "q=", "empty extra params are skipped")
+}
+
+// TestFilterBar_PreservesExtraParams is the behavioral pin for the M2
+// fix: on the paginated search page, clicking a type filter must not
+// drop the ?q= query. Before this fix, filterLink only preserved
+// types/covers; now it threads through arbitrary extras via the same
+// mechanism as paginationWithParams.
+func TestFilterBar_PreservesExtraParams(t *testing.T) {
+	t.Parallel()
+
+	got := filterBar("/s", "", "", [2]string{"q", "sanderson"})
+
+	// Every non-current filter link must carry ?q=sanderson...
+	for _, label := range []string{"EPUB", "CBZ", "M4B", "PDF"} {
+		idx := strings.Index(got, ">"+label+"<")
+		if !assert.NotEqual(t, -1, idx, "label %q rendered", label) {
+			continue
+		}
+		// Find the href of the link containing this label
+		anchorStart := strings.LastIndex(got[:idx], `href="`)
+		if !assert.NotEqual(t, -1, anchorStart, "label %q has an href", label) {
+			continue
+		}
+		anchorEnd := strings.Index(got[anchorStart+6:], `"`)
+		href := got[anchorStart+6 : anchorStart+6+anchorEnd]
+		assert.Contains(t, href, "q=sanderson", "filter link for %q preserves the search query", label)
+	}
+
+	// And the covers=on link preserves it too.
+	assert.Contains(t, got, "q=sanderson")
+}
+
+// TestFilterLink_UsesURLValuesEncoding pins the M3 fix: filterLink now
+// uses url.Values.Encode() like paginationWithParams, so values with
+// special characters (hypothetical future filter option) are
+// percent-encoded instead of naively concatenated.
+func TestFilterLink_UsesURLValuesEncoding(t *testing.T) {
+	t.Parallel()
+
+	// With no filters set, the link should have no query string at all
+	// (previously: "?" was emitted bare when both were empty).
+	got := filterLink("/s", "types", "all", "", "", "All")
+	assert.NotContains(t, got, "?", `"all" link with no other params is clean`)
+
+	// Preserves a search query through the encoding path.
+	got = filterLink("/s", "types", "epub", "", "", "EPUB", [2]string{"q", "a&b"})
+	assert.Contains(t, got, "q=a%26b", "ampersand in q is percent-encoded")
+	assert.Contains(t, got, "types=epub")
+}

--- a/website/docs/ereader-browser.md
+++ b/website/docs/ereader-browser.md
@@ -32,9 +32,11 @@ The eReader browser provides the same navigation as the main web UI:
 
 - **Libraries** — Browse your libraries
 - **All books** — Paginated list of every book in a library
-- **Series** — Browse by series
-- **Authors** — Browse by author
-- **Search** — Full-text search within a library
+- **Series** — Paginated list of books in a series
+- **Authors** — Paginated list of books by an author
+- **Search** — Paginated full-text search within a library
+
+All book listings are paged in fixed-size batches (50 books per page) with **← Prev** / **Next →** links at the bottom. This keeps each page small enough for the limited memory of e-ink browsers — even libraries with prolific authors (e.g., 500+ book runs) render quickly.
 
 ### File type filtering
 


### PR DESCRIPTION
## Summary

- `AuthorBooks`, `SeriesBooks`, and `LibrarySearch` in `pkg/ereader/handlers.go` were rendering every matching book into a single HTML page with no page size. A prolific author's catalog (500+ book manga runs) would overwhelm a Kobo/Kindle browser's limited memory.
- Extract the paginate-with-in-memory-type-filter pattern already used by `LibraryAllBooks` into a `listBooksPaginated` helper, apply it to the three unpaginated handlers, and render Prev/Next links via `paginationWithParams` (now accepts an `extraParams` variadic so `LibrarySearch` can thread its `?q=` through page links).
- Updated `website/docs/ereader-browser.md` to document pagination on all listing pages.

Closes the ticket: [Paginate eReader AuthorBooks (scaling concern for 500+ book catalogs)](https://www.notion.so/348f24d3107d8151abc7e217c421a51c)

## Test plan

- [x] `mise check:quiet` passes (Go tests, JS tests, Go lint, JS lint)
- [ ] Manual: visit an author's page on the eReader browser and confirm Prev/Next links appear when books > 50, preserve `types=` and `covers=on` filters, and page bounds are respected
- [ ] Manual: same for a series page and search results