### PR TITLE
[Fix] Show "Author not found" in eReader AuthorBooks 404

### DIFF
--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -455,9 +455,6 @@ func (h *handler) AuthorBooks(c echo.Context) error {
 		LibraryID: &libraryIDInt,
 	})
 	if err != nil {
-		// Re-emit the resource noun so users see "Author not found" on
-		// this author-scoped route rather than the generic "Person"
-		// noun produced inside peopleService.
 		if errors.Is(err, errcodes.NotFound("Person")) {
 			return errcodes.NotFound("Author")
 		}

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -455,6 +455,12 @@ func (h *handler) AuthorBooks(c echo.Context) error {
 		LibraryID: &libraryIDInt,
 	})
 	if err != nil {
+		// Re-emit the resource noun so users see "Author not found" on
+		// this author-scoped route rather than the generic "Person"
+		// noun produced inside peopleService.
+		if errors.Is(err, errcodes.NotFound("Person")) {
+			return errcodes.NotFound("Author")
+		}
 		return errors.WithStack(err)
 	}
 


### PR DESCRIPTION
## Summary
- Re-emit `peopleService.RetrievePerson`'s `NotFound("Person")` as `NotFound("Author")` in `AuthorBooks()` so the 404 noun matches the author-scoped route and UI context.

## Test plan
- Visit `/ereader/key/<apiKey>/libraries/<libraryId>/authors/<nonexistent>` and confirm the error text reads "Author not found." instead of "Person not found."
- Confirm a valid author ID still renders the author's books page.
- `mise check:quiet` passes locally.