### PR TITLE
[Fix] Select newest plugin update via semver comparison

### DIFF
--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/models"
+	pkgversion "github.com/shishobooks/shisho/pkg/version"
 )
 
 // reservedExtensions are built-in file types that plugins cannot claim.
@@ -535,10 +536,16 @@ func (m *Manager) CheckForUpdates(ctx context.Context) error {
 				if len(compatible) == 0 {
 					continue
 				}
-				// The last compatible version is the latest
-				candidate := compatible[len(compatible)-1].Version
-				if candidate != plugin.Version && (latestVersion == "" || candidate > latestVersion) {
-					latestVersion = candidate
+				for _, v := range compatible {
+					if v.Version == plugin.Version {
+						continue
+					}
+					if pkgversion.Compare(v.Version, plugin.Version) <= 0 {
+						continue
+					}
+					if latestVersion == "" || pkgversion.Compare(v.Version, latestVersion) > 0 {
+						latestVersion = v.Version
+					}
 				}
 			}
 		}

--- a/pkg/plugins/update_check_test.go
+++ b/pkg/plugins/update_check_test.go
@@ -503,9 +503,12 @@ func TestManager_CheckForUpdates_SemverNotLexicographic(t *testing.T) {
 				{
 					ID:   "my-plugin",
 					Name: "My Plugin",
+					// Ordered so the old "last element is latest" code would
+					// have picked 0.2.0, making this a true regression guard
+					// for the lexicographic-comparison bug.
 					Versions: []PluginVersion{
-						{Version: "0.2.0", ManifestVersion: 1},
 						{Version: "0.10.0", ManifestVersion: 1},
+						{Version: "0.2.0", ManifestVersion: 1},
 					},
 				},
 			},

--- a/pkg/plugins/update_check_test.go
+++ b/pkg/plugins/update_check_test.go
@@ -408,6 +408,119 @@ func TestManager_CheckForUpdates_ScopeMismatch(t *testing.T) {
 	assert.Nil(t, updated.UpdateAvailableVersion)
 }
 
+func TestManager_CheckForUpdates_NewestFirstOrdering(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(db)
+	mgr := NewManager(service, t.TempDir(), "")
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "official",
+		ID:          "my-plugin",
+		Name:        "My Plugin",
+		Version:     "0.3.3",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err := service.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	repo := &models.PluginRepository{
+		URL:        "https://raw.githubusercontent.com/test/repo/main/manifest.json",
+		Scope:      "official",
+		Name:       strPtr("Official Repo"),
+		IsOfficial: true,
+		Enabled:    true,
+	}
+	err = service.AddRepository(ctx, repo)
+	require.NoError(t, err)
+
+	// Repository lists versions newest-first, matching production repo manifests
+	// and the ordering the frontend and install handler expect.
+	mgr.fetchRepo = func(_ string) (*RepositoryManifest, error) {
+		return &RepositoryManifest{
+			RepositoryVersion: 1,
+			Scope:             "official",
+			Name:              "Official Repo",
+			Plugins: []AvailablePlugin{
+				{
+					ID:   "my-plugin",
+					Name: "My Plugin",
+					Versions: []PluginVersion{
+						{Version: "0.4.0", ManifestVersion: 1},
+						{Version: "0.3.3", ManifestVersion: 1},
+						{Version: "0.2.0", ManifestVersion: 1},
+						{Version: "0.1.0", ManifestVersion: 1},
+					},
+				},
+			},
+		}, nil
+	}
+
+	err = mgr.CheckForUpdates(ctx)
+	require.NoError(t, err)
+
+	updated, err := service.RetrievePlugin(ctx, "official", "my-plugin")
+	require.NoError(t, err)
+	require.NotNil(t, updated.UpdateAvailableVersion)
+	assert.Equal(t, "0.4.0", *updated.UpdateAvailableVersion)
+}
+
+func TestManager_CheckForUpdates_SemverNotLexicographic(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(db)
+	mgr := NewManager(service, t.TempDir(), "")
+	ctx := context.Background()
+
+	plugin := &models.Plugin{
+		Scope:       "official",
+		ID:          "my-plugin",
+		Name:        "My Plugin",
+		Version:     "0.1.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	err := service.InstallPlugin(ctx, plugin)
+	require.NoError(t, err)
+
+	repo := &models.PluginRepository{
+		URL:        "https://raw.githubusercontent.com/test/repo/main/manifest.json",
+		Scope:      "official",
+		Name:       strPtr("Official Repo"),
+		IsOfficial: true,
+		Enabled:    true,
+	}
+	err = service.AddRepository(ctx, repo)
+	require.NoError(t, err)
+
+	// 0.10.0 > 0.2.0 semantically, but "0.10.0" < "0.2.0" lexicographically.
+	mgr.fetchRepo = func(_ string) (*RepositoryManifest, error) {
+		return &RepositoryManifest{
+			RepositoryVersion: 1,
+			Scope:             "official",
+			Name:              "Official Repo",
+			Plugins: []AvailablePlugin{
+				{
+					ID:   "my-plugin",
+					Name: "My Plugin",
+					Versions: []PluginVersion{
+						{Version: "0.2.0", ManifestVersion: 1},
+						{Version: "0.10.0", ManifestVersion: 1},
+					},
+				},
+			},
+		}, nil
+	}
+
+	err = mgr.CheckForUpdates(ctx)
+	require.NoError(t, err)
+
+	updated, err := service.RetrievePlugin(ctx, "official", "my-plugin")
+	require.NoError(t, err)
+	require.NotNil(t, updated.UpdateAvailableVersion)
+	assert.Equal(t, "0.10.0", *updated.UpdateAvailableVersion)
+}
+
 func TestManager_CheckForUpdates_MinShishoVersionFiltered(t *testing.T) {
 	origVersion := version.Version
 	version.Version = "1.0.0"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,9 @@ func isVersionCompatible(currentVersion, minVersion string) bool {
 }
 
 // Compare returns -1 if a < b, 0 if a == b, 1 if a > b using semver
-// comparison (major.minor.patch). Unparseable versions compare equal.
+// comparison on major.minor.patch only. Prerelease suffixes (anything after
+// "-") are stripped before comparing, so "1.0.0-rc1" and "1.0.0" compare
+// equal. Returns 0 if either input is unparseable.
 func Compare(a, b string) int {
 	aParts := parseSemver(a)
 	bParts := parseSemver(b)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -40,6 +40,25 @@ func isVersionCompatible(currentVersion, minVersion string) bool {
 	return true // Equal
 }
 
+// Compare returns -1 if a < b, 0 if a == b, 1 if a > b using semver
+// comparison (major.minor.patch). Unparseable versions compare equal.
+func Compare(a, b string) int {
+	aParts := parseSemver(a)
+	bParts := parseSemver(b)
+	if aParts == nil || bParts == nil {
+		return 0
+	}
+	for i := 0; i < 3; i++ {
+		if aParts[i] < bParts[i] {
+			return -1
+		}
+		if aParts[i] > bParts[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
 // parseSemver extracts [major, minor, patch] from a semver string.
 // Returns nil if the string cannot be parsed.
 func parseSemver(s string) []int {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -63,7 +63,7 @@ func TestCompare(t *testing.T) {
 		{"v prefix on one side", "v1.2.3", "1.2.3", 0},
 		{"v prefix on both", "v2.0.0", "v1.0.0", 1},
 		{"prerelease stripped — compares equal to release", "1.0.0-rc1", "1.0.0", 0},
-		{"partial version treated as zero", "1.2", "1.2.0", 0},
+		{"two-part version equals three-part with zero patch", "1.2", "1.2.0", 0},
 		{"unparseable a returns 0", "abc", "1.0.0", 0},
 		{"unparseable b returns 0", "1.0.0", "abc", 0},
 		{"both unparseable returns 0", "abc", "def", 0},

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -43,6 +43,41 @@ func TestIsCompatible(t *testing.T) {
 	}
 }
 
+func TestCompare(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{"equal", "1.2.3", "1.2.3", 0},
+		{"major greater", "2.0.0", "1.0.0", 1},
+		{"major less", "1.0.0", "2.0.0", -1},
+		{"minor greater", "1.2.0", "1.1.0", 1},
+		{"minor less", "1.1.0", "1.2.0", -1},
+		{"patch greater", "1.0.2", "1.0.1", 1},
+		{"patch less", "1.0.1", "1.0.2", -1},
+		{"double-digit minor greater than single-digit", "0.10.0", "0.2.0", 1},
+		{"v prefix on one side", "v1.2.3", "1.2.3", 0},
+		{"v prefix on both", "v2.0.0", "v1.0.0", 1},
+		{"prerelease stripped — compares equal to release", "1.0.0-rc1", "1.0.0", 0},
+		{"partial version treated as zero", "1.2", "1.2.0", 0},
+		{"unparseable a returns 0", "abc", "1.0.0", 0},
+		{"unparseable b returns 0", "1.0.0", "abc", 0},
+		{"both unparseable returns 0", "abc", "def", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := Compare(tt.a, tt.b)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestParseSemver(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `CheckForUpdates` in `pkg/plugins/manager.go` was taking `compatible[len-1]` as the latest version, assuming the repo's version array was oldest-first. Real manifests list versions newest-first (as the install handler at `handler.go:329` and the frontend `PluginVersionHistory` assume), so the update check picked the oldest compatible version — e.g. surfacing "Update to 0.1.0" on a plugin installed at 0.3.3 with 0.4.0 available.
- Secondary bug: fallback comparison used lexicographic string compare, which would also pick `0.2.0` over `0.10.0`. Replaced with a new `pkg/version.Compare` helper (`-1`/`0`/`1` semver comparison) and made the update check iterate all compatible versions to find the semver max — independent of array ordering.
- Added tests for newest-first ordering (the real-world case) and for semver-vs-lexicographic ordering.

## Test plan
- `mise check:quiet` passes
- `go test ./pkg/plugins -run TestManager_CheckForUpdates` passes (existing + 2 new cases)
- Manually verify: with a plugin installed at 0.3.3 and repo versions [0.4.0, 0.3.3, 0.2.0, 0.1.0] (newest-first), running the update check sets `update_available_version = "0.4.0"` rather than `"0.1.0"`