### PR TITLE
[Frontend] Unify admin and library sidebars and top nav

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Project-specific conventions are documented in `CLAUDE.md` files within each sub
 |----------|--------|
 | `pkg/CLAUDE.md` | Go backend: Echo handlers, Bun ORM, workers |
 | `app/CLAUDE.md` | React frontend: Tanstack Query, components, UI patterns |
+| `app/components/layout/CLAUDE.md` | Shared layout primitives: Sidebar, UserMenu, top-nav class constants |
 | `pkg/plugins/CLAUDE.md` | Plugin system: Goja runtime, hooks, host APIs, manifests |
 | `pkg/epub/CLAUDE.md` | EPUB format: OPF, Dublin Core, parsing/generation |
 | `pkg/cbz/CLAUDE.md` | CBZ format: ComicInfo.xml, creator roles, chapter detection |

--- a/app/components/layout/CLAUDE.md
+++ b/app/components/layout/CLAUDE.md
@@ -1,0 +1,19 @@
+# Layout Primitives
+
+Cross-area layout components shared between the library and admin/settings pages. Any UI element that appears in both contexts and needs to stay visually identical should live here (or be added here when it starts drifting).
+
+## Current Primitives
+
+| File | What it owns |
+|------|--------------|
+| `Sidebar.tsx` | Collapsible sidebar chrome: collapse state + `shisho-sidebar-collapsed` localStorage persistence, `NavItem` rendering, tooltip-when-collapsed, collapse toggle, version footer. Takes `items: SidebarItem[]`. |
+| `UserMenu.tsx` | Avatar dropdown with username/role label and Lists / Security / User Settings / Sign out actions. Used in both library `TopNav` and admin header. |
+| `topNavClasses.ts` | `cn()`-wrapped class constants (`TOP_NAV_WRAPPER`, `TOP_NAV_INNER`, `TOP_NAV_ROW`) for the outer top-nav geometry. Both `TopNav` and `AdminHeader` use these to guarantee identical container styling. |
+
+## Usage Pattern
+
+Area-specific sidebars (`app/components/library/LibrarySidebar.tsx`, `app/components/pages/AdminSidebar.tsx`) are thin wrappers: they compute a `SidebarItem[]` from route state and permissions and render `<Sidebar items={items} />`. All chrome (collapse, tooltips, footer) lives in `Sidebar` and cannot drift between the two.
+
+## When to Add Here
+
+If a UI element appears in both the library and admin contexts and needs to stay identical, put it in `layout/`. If it's specific to one context (e.g., `LibraryListPicker` for the library picker dropdown), keep it under that context's directory.

--- a/app/components/layout/Sidebar.test.tsx
+++ b/app/components/layout/Sidebar.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Book, Settings } from "lucide-react";
+import { MemoryRouter } from "react-router-dom";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import Sidebar, { type SidebarItem } from "./Sidebar";
+
+beforeAll(() => {
+  // @ts-expect-error - global defined by Vite
+  globalThis.__APP_VERSION__ = "test";
+});
+
+const renderSidebar = (items: SidebarItem[]) =>
+  render(
+    <MemoryRouter>
+      <Sidebar items={items} />
+    </MemoryRouter>,
+  );
+
+const buildItem = (overrides: Partial<SidebarItem> = {}): SidebarItem => ({
+  to: "/books",
+  icon: <Book className="h-4 w-4" />,
+  label: "Books",
+  isActive: false,
+  ...overrides,
+});
+
+describe("Sidebar", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders each visible item's label", () => {
+    renderSidebar([
+      buildItem({ to: "/a", label: "Alpha" }),
+      buildItem({ to: "/b", label: "Bravo" }),
+    ]);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+  });
+
+  it("hides items with show: false", () => {
+    renderSidebar([
+      buildItem({ to: "/a", label: "Alpha" }),
+      buildItem({ to: "/b", label: "Bravo", show: false }),
+    ]);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Bravo")).not.toBeInTheDocument();
+  });
+
+  it("treats missing show as visible", () => {
+    renderSidebar([buildItem({ to: "/a", label: "Alpha" })]);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+  });
+
+  it("starts expanded by default and shows version footer", () => {
+    renderSidebar([buildItem()]);
+    expect(screen.getByText("shisho")).toBeInTheDocument();
+  });
+
+  it("starts collapsed when localStorage says so, and hides version footer", () => {
+    localStorage.setItem("shisho-sidebar-collapsed", "true");
+    renderSidebar([buildItem()]);
+    expect(screen.queryByText("shisho")).not.toBeInTheDocument();
+  });
+
+  it("toggles collapsed state and persists to localStorage", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderSidebar([buildItem()]);
+    expect(localStorage.getItem("shisho-sidebar-collapsed")).toBe("false");
+
+    const collapseButton = screen.getByRole("button", {
+      name: /collapse sidebar/i,
+    });
+    await user.click(collapseButton);
+
+    expect(localStorage.getItem("shisho-sidebar-collapsed")).toBe("true");
+    expect(
+      screen.getByRole("button", { name: /expand sidebar/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("applies active styling to active items", () => {
+    renderSidebar([
+      buildItem({ to: "/a", label: "Alpha", isActive: true }),
+      buildItem({ to: "/b", label: "Bravo", isActive: false }),
+    ]);
+    const alpha = screen.getByText("Alpha").closest("a");
+    const bravo = screen.getByText("Bravo").closest("a");
+    expect(alpha?.className).toContain("bg-primary/10");
+    expect(bravo?.className).not.toContain("bg-primary/10");
+  });
+
+  it("supports a Settings icon item type", () => {
+    renderSidebar([
+      buildItem({
+        to: "/settings",
+        icon: <Settings className="h-4 w-4" data-testid="settings-icon" />,
+        label: "Settings",
+      }),
+    ]);
+    expect(screen.getByTestId("settings-icon")).toBeInTheDocument();
+  });
+});

--- a/app/components/layout/Sidebar.tsx
+++ b/app/components/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import { ChevronsLeft, ChevronsRight } from "lucide-react";
 import { useEffect, useState, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 
+import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
@@ -86,14 +87,14 @@ const Sidebar = ({ items }: SidebarProps) => {
           <div className="border-t border-border/50 pt-3">
             <Tooltip delayDuration={0}>
               <TooltipTrigger asChild>
-                <button
+                <Button
                   aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
                   className={cn(
-                    "flex w-full cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
-                    "text-muted-foreground/60 hover:bg-muted/50 hover:text-muted-foreground",
+                    "h-auto w-full justify-start gap-3 px-3 py-2 text-sm font-medium text-muted-foreground/60 hover:bg-muted/50 hover:text-muted-foreground",
                     collapsed && "justify-center px-2",
                   )}
                   onClick={() => setCollapsed(!collapsed)}
+                  variant="ghost"
                 >
                   {collapsed ? (
                     <ChevronsRight className="h-4 w-4" />
@@ -103,7 +104,7 @@ const Sidebar = ({ items }: SidebarProps) => {
                       <span className="text-xs">Collapse</span>
                     </>
                   )}
-                </button>
+                </Button>
               </TooltipTrigger>
               {collapsed && (
                 <TooltipContent side="right">Expand sidebar</TooltipContent>

--- a/app/components/layout/Sidebar.tsx
+++ b/app/components/layout/Sidebar.tsx
@@ -1,0 +1,136 @@
+import { ChevronsLeft, ChevronsRight } from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/libraries/utils";
+
+const SIDEBAR_COLLAPSED_KEY = "shisho-sidebar-collapsed";
+
+export type SidebarItem = {
+  to: string;
+  icon: ReactNode;
+  label: string;
+  isActive: boolean;
+  show?: boolean;
+};
+
+interface NavItemProps {
+  item: SidebarItem;
+  collapsed: boolean;
+}
+
+const NavItem = ({ item, collapsed }: NavItemProps) => {
+  const linkContent = (
+    <Link
+      className={cn(
+        "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+        collapsed && "justify-center px-2",
+        item.isActive
+          ? "bg-primary/10 text-primary dark:bg-violet-500/20 dark:text-violet-300"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      )}
+      to={item.to}
+    >
+      {item.icon}
+      {!collapsed && item.label}
+    </Link>
+  );
+
+  if (collapsed) {
+    return (
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
+        <TooltipContent side="right">{item.label}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return linkContent;
+};
+
+interface SidebarProps {
+  items: SidebarItem[];
+}
+
+const Sidebar = ({ items }: SidebarProps) => {
+  const [collapsed, setCollapsed] = useState(() => {
+    const stored = localStorage.getItem(SIDEBAR_COLLAPSED_KEY);
+    return stored === "true";
+  });
+
+  useEffect(() => {
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(collapsed));
+  }, [collapsed]);
+
+  const visibleItems = items.filter((item) => item.show !== false);
+
+  return (
+    <aside
+      className={cn(
+        "sticky top-14 flex h-[calc(100vh-3.5rem)] shrink-0 flex-col border-r border-border bg-muted/30 transition-all duration-200 md:top-16 md:h-[calc(100vh-4rem)] dark:bg-neutral-900/50",
+        collapsed ? "w-14" : "w-48",
+      )}
+    >
+      <div className="flex-1">
+        <nav className={cn("space-y-1 p-4", collapsed && "px-2")}>
+          {visibleItems.map((item) => (
+            <NavItem collapsed={collapsed} item={item} key={item.to} />
+          ))}
+        </nav>
+        <div className={cn("px-4 pt-2", collapsed && "px-2")}>
+          <div className="border-t border-border/50 pt-3">
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <button
+                  aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+                  className={cn(
+                    "flex w-full cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    "text-muted-foreground/60 hover:bg-muted/50 hover:text-muted-foreground",
+                    collapsed && "justify-center px-2",
+                  )}
+                  onClick={() => setCollapsed(!collapsed)}
+                >
+                  {collapsed ? (
+                    <ChevronsRight className="h-4 w-4" />
+                  ) : (
+                    <>
+                      <ChevronsLeft className="h-4 w-4" />
+                      <span className="text-xs">Collapse</span>
+                    </>
+                  )}
+                </button>
+              </TooltipTrigger>
+              {collapsed && (
+                <TooltipContent side="right">Expand sidebar</TooltipContent>
+              )}
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+      {!collapsed && (
+        <div className="p-4 pt-0">
+          <a
+            className="group flex items-center justify-center gap-1.5 rounded border border-transparent py-1.5 transition-all duration-200 hover:border-border/40 hover:bg-muted/30"
+            href="https://github.com/shishobooks/shisho/releases"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span className="text-[10px] text-muted-foreground/40 transition-colors group-hover:text-muted-foreground/70">
+              shisho
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground/50 transition-colors group-hover:text-muted-foreground">
+              {__APP_VERSION__}
+            </span>
+          </a>
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/app/components/layout/UserMenu.tsx
+++ b/app/components/layout/UserMenu.tsx
@@ -1,0 +1,75 @@
+import { KeyRound, List, LogOut, User, UserCog } from "lucide-react";
+import { useCallback } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useAuth } from "@/hooks/useAuth";
+
+const UserMenu = () => {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = useCallback(async () => {
+    try {
+      await logout();
+      toast.success("Signed out successfully");
+      navigate("/login");
+    } catch {
+      toast.error("Failed to sign out");
+    }
+  }, [logout, navigate]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className="h-9 w-9" size="icon" variant="ghost">
+          <User className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>
+          <div className="flex flex-col">
+            <span>{user?.username}</span>
+            <span className="text-xs font-normal text-muted-foreground">
+              {user?.role_name}
+            </span>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link to="/lists">
+            <List className="h-4 w-4" />
+            Lists
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link to="/user/security">
+            <KeyRound className="h-4 w-4" />
+            Security
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link to="/user/settings">
+            <UserCog className="h-4 w-4" />
+            User Settings
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleLogout}>
+          <LogOut className="h-4 w-4" />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default UserMenu;

--- a/app/components/layout/topNavClasses.ts
+++ b/app/components/layout/topNavClasses.ts
@@ -1,0 +1,7 @@
+import { cn } from "@/libraries/utils";
+
+export const TOP_NAV_WRAPPER = cn(
+  "sticky top-0 z-30 border-b border-border bg-background dark:bg-neutral-900",
+);
+export const TOP_NAV_INNER = cn("mx-auto max-w-7xl px-4 md:px-6");
+export const TOP_NAV_ROW = cn("flex h-14 items-center justify-between md:h-16");

--- a/app/components/library/LibraryLayout.tsx
+++ b/app/components/library/LibraryLayout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import LibrarySidebar from "@/components/library/LibrarySidebar";
 import TopNav from "@/components/library/TopNav";
+import { cn } from "@/libraries/utils";
 
 interface LibraryLayoutProps {
   children: ReactNode;
@@ -22,7 +23,10 @@ const LibraryLayout = ({
           <LibrarySidebar />
         </div>
         <main
-          className={`flex-1 w-full mx-auto px-4 py-4 md:px-6 md:py-8 ${maxWidth}`}
+          className={cn(
+            "flex-1 w-full mx-auto px-4 py-4 md:px-6 md:py-8",
+            maxWidth,
+          )}
         >
           {children}
         </main>

--- a/app/components/library/LibrarySidebar.tsx
+++ b/app/components/library/LibrarySidebar.tsx
@@ -1,66 +1,19 @@
-import { Book, Bookmark, Layers, Settings, Tags, Users } from "lucide-react";
-import { useLocation, useParams } from "react-router-dom";
-
 import Sidebar, { type SidebarItem } from "@/components/layout/Sidebar";
-import { useAuth } from "@/hooks/useAuth";
+
+import { useLibraryNavItems } from "./useLibraryNavItems";
 
 const LibrarySidebar = () => {
-  const { libraryId } = useParams();
-  const location = useLocation();
-  const { hasPermission } = useAuth();
+  const navItems = useLibraryNavItems();
 
-  if (!libraryId) return null;
+  if (!navItems) return null;
 
-  const basePath = `/libraries/${libraryId}`;
-
-  const isBooksActive =
-    location.pathname === basePath ||
-    (location.pathname.startsWith(`${basePath}/books`) &&
-      !location.pathname.startsWith(`${basePath}/series`) &&
-      !location.pathname.startsWith(`${basePath}/people`) &&
-      !location.pathname.startsWith(`${basePath}/genres`) &&
-      !location.pathname.startsWith(`${basePath}/tags`) &&
-      !location.pathname.startsWith(`${basePath}/settings`));
-
-  const items: SidebarItem[] = [
-    {
-      to: basePath,
-      icon: <Book className="h-4 w-4" />,
-      label: "Books",
-      isActive: isBooksActive,
-    },
-    {
-      to: `${basePath}/series`,
-      icon: <Layers className="h-4 w-4" />,
-      label: "Series",
-      isActive: location.pathname.startsWith(`${basePath}/series`),
-    },
-    {
-      to: `${basePath}/people`,
-      icon: <Users className="h-4 w-4" />,
-      label: "People",
-      isActive: location.pathname.startsWith(`${basePath}/people`),
-    },
-    {
-      to: `${basePath}/genres`,
-      icon: <Bookmark className="h-4 w-4" />,
-      label: "Genres",
-      isActive: location.pathname.startsWith(`${basePath}/genres`),
-    },
-    {
-      to: `${basePath}/tags`,
-      icon: <Tags className="h-4 w-4" />,
-      label: "Tags",
-      isActive: location.pathname.startsWith(`${basePath}/tags`),
-    },
-    {
-      to: `${basePath}/settings`,
-      icon: <Settings className="h-4 w-4" />,
-      label: "Settings",
-      isActive: location.pathname.startsWith(`${basePath}/settings`),
-      show: hasPermission("libraries", "write"),
-    },
-  ];
+  const items: SidebarItem[] = navItems.map((item) => ({
+    to: item.to,
+    icon: <item.Icon className="h-4 w-4" />,
+    label: item.label,
+    isActive: item.isActive,
+    show: item.show,
+  }));
 
   return <Sidebar items={items} />;
 };

--- a/app/components/library/LibrarySidebar.tsx
+++ b/app/components/library/LibrarySidebar.tsx
@@ -1,75 +1,13 @@
-import {
-  Book,
-  Bookmark,
-  ChevronsLeft,
-  ChevronsRight,
-  Layers,
-  Settings,
-  Tags,
-  Users,
-} from "lucide-react";
-import { useEffect, useState } from "react";
-import { Link, useLocation, useParams } from "react-router-dom";
+import { Book, Bookmark, Layers, Settings, Tags, Users } from "lucide-react";
+import { useLocation, useParams } from "react-router-dom";
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import Sidebar, { type SidebarItem } from "@/components/layout/Sidebar";
 import { useAuth } from "@/hooks/useAuth";
-import { cn } from "@/libraries/utils";
-
-const SIDEBAR_COLLAPSED_KEY = "shisho-sidebar-collapsed";
-
-interface NavItemProps {
-  to: string;
-  icon: React.ReactNode;
-  label: string;
-  isActive: boolean;
-  collapsed: boolean;
-}
-
-const NavItem = ({ to, icon, label, isActive, collapsed }: NavItemProps) => {
-  const linkContent = (
-    <Link
-      className={cn(
-        "flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors",
-        collapsed && "justify-center px-2",
-        isActive
-          ? "bg-primary/10 text-primary dark:bg-violet-500/20 dark:text-violet-300"
-          : "text-muted-foreground hover:bg-muted hover:text-foreground",
-      )}
-      to={to}
-    >
-      {icon}
-      {!collapsed && label}
-    </Link>
-  );
-
-  if (collapsed) {
-    return (
-      <Tooltip delayDuration={0}>
-        <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
-        <TooltipContent side="right">{label}</TooltipContent>
-      </Tooltip>
-    );
-  }
-
-  return linkContent;
-};
 
 const LibrarySidebar = () => {
   const { libraryId } = useParams();
   const location = useLocation();
   const { hasPermission } = useAuth();
-  const [collapsed, setCollapsed] = useState(() => {
-    const stored = localStorage.getItem(SIDEBAR_COLLAPSED_KEY);
-    return stored === "true";
-  });
-
-  useEffect(() => {
-    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(collapsed));
-  }, [collapsed]);
 
   if (!libraryId) return null;
 
@@ -84,128 +22,47 @@ const LibrarySidebar = () => {
       !location.pathname.startsWith(`${basePath}/tags`) &&
       !location.pathname.startsWith(`${basePath}/settings`));
 
-  const isSeriesActive = location.pathname.startsWith(`${basePath}/series`);
-  const isPeopleActive = location.pathname.startsWith(`${basePath}/people`);
-  const isGenresActive = location.pathname.startsWith(`${basePath}/genres`);
-  const isTagsActive = location.pathname.startsWith(`${basePath}/tags`);
-  const isSettingsActive = location.pathname.startsWith(`${basePath}/settings`);
-
-  const navItems = [
+  const items: SidebarItem[] = [
     {
       to: basePath,
       icon: <Book className="h-4 w-4" />,
       label: "Books",
       isActive: isBooksActive,
-      show: true,
     },
     {
       to: `${basePath}/series`,
       icon: <Layers className="h-4 w-4" />,
       label: "Series",
-      isActive: isSeriesActive,
-      show: true,
+      isActive: location.pathname.startsWith(`${basePath}/series`),
     },
     {
       to: `${basePath}/people`,
       icon: <Users className="h-4 w-4" />,
       label: "People",
-      isActive: isPeopleActive,
-      show: true,
+      isActive: location.pathname.startsWith(`${basePath}/people`),
     },
     {
       to: `${basePath}/genres`,
       icon: <Bookmark className="h-4 w-4" />,
       label: "Genres",
-      isActive: isGenresActive,
-      show: true,
+      isActive: location.pathname.startsWith(`${basePath}/genres`),
     },
     {
       to: `${basePath}/tags`,
       icon: <Tags className="h-4 w-4" />,
       label: "Tags",
-      isActive: isTagsActive,
-      show: true,
+      isActive: location.pathname.startsWith(`${basePath}/tags`),
     },
     {
       to: `${basePath}/settings`,
       icon: <Settings className="h-4 w-4" />,
       label: "Settings",
-      isActive: isSettingsActive,
+      isActive: location.pathname.startsWith(`${basePath}/settings`),
       show: hasPermission("libraries", "write"),
     },
   ];
 
-  return (
-    <aside
-      className={cn(
-        "shrink-0 border-r border-border bg-muted/30 dark:bg-neutral-900/50 transition-all duration-200 h-[calc(100vh-3.5rem)] md:h-[calc(100vh-4rem)] sticky top-14 md:top-16 flex flex-col",
-        collapsed ? "w-14" : "w-48",
-      )}
-    >
-      <div className="flex-1">
-        <nav className={cn("p-4 space-y-1", collapsed && "px-2")}>
-          {navItems
-            .filter((item) => item.show)
-            .map((item) => (
-              <NavItem
-                collapsed={collapsed}
-                icon={item.icon}
-                isActive={item.isActive}
-                key={item.to}
-                label={item.label}
-                to={item.to}
-              />
-            ))}
-        </nav>
-        <div className={cn("px-4 pt-2", collapsed && "px-2")}>
-          <div className="border-t border-border/50 pt-3">
-            <Tooltip delayDuration={0}>
-              <TooltipTrigger asChild>
-                <button
-                  aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-                  className={cn(
-                    "flex items-center gap-3 w-full px-3 py-2 rounded-md text-sm font-medium transition-colors cursor-pointer",
-                    "text-muted-foreground/60 hover:text-muted-foreground hover:bg-muted/50",
-                    collapsed && "justify-center px-2",
-                  )}
-                  onClick={() => setCollapsed(!collapsed)}
-                >
-                  {collapsed ? (
-                    <ChevronsRight className="h-4 w-4" />
-                  ) : (
-                    <>
-                      <ChevronsLeft className="h-4 w-4" />
-                      <span className="text-xs">Collapse</span>
-                    </>
-                  )}
-                </button>
-              </TooltipTrigger>
-              {collapsed && (
-                <TooltipContent side="right">Expand sidebar</TooltipContent>
-              )}
-            </Tooltip>
-          </div>
-        </div>
-      </div>
-      {!collapsed && (
-        <div className="p-4 pt-0">
-          <a
-            className="group flex items-center justify-center gap-1.5 py-1.5 rounded border border-transparent hover:border-border/40 hover:bg-muted/30 transition-all duration-200"
-            href="https://github.com/shishobooks/shisho/releases"
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            <span className="text-[10px] text-muted-foreground/40 group-hover:text-muted-foreground/70 transition-colors">
-              shisho
-            </span>
-            <span className="text-[10px] font-mono text-muted-foreground/50 group-hover:text-muted-foreground transition-colors">
-              {__APP_VERSION__}
-            </span>
-          </a>
-        </div>
-      )}
-    </aside>
-  );
+  return <Sidebar items={items} />;
 };
 
 export default LibrarySidebar;

--- a/app/components/library/MobileDrawer.tsx
+++ b/app/components/library/MobileDrawer.tsx
@@ -1,13 +1,17 @@
 import {
   Book,
   Bookmark,
+  Briefcase,
   Check,
   ChevronRight,
+  Cog,
   KeyRound,
   Layers,
   Library,
   List,
   LogOut,
+  Puzzle,
+  ScrollText,
   Settings,
   Tags,
   UserCog,
@@ -180,6 +184,56 @@ const MobileDrawer = () => {
       ]
     : [];
 
+  const isAdminContext = location.pathname.startsWith("/settings");
+  const adminNavItems = isAdminContext
+    ? [
+        {
+          to: "/settings/server",
+          icon: <Cog className="h-5 w-5" />,
+          label: "Server",
+          isActive:
+            location.pathname === "/settings/server" ||
+            location.pathname === "/settings",
+          show: hasPermission("config", "read"),
+        },
+        {
+          to: "/settings/libraries",
+          icon: <Library className="h-5 w-5" />,
+          label: "Libraries",
+          isActive: location.pathname.startsWith("/settings/libraries"),
+          show: hasPermission("libraries", "read"),
+        },
+        {
+          to: "/settings/users",
+          icon: <Users className="h-5 w-5" />,
+          label: "Users",
+          isActive: location.pathname.startsWith("/settings/users"),
+          show: hasPermission("users", "read"),
+        },
+        {
+          to: "/settings/jobs",
+          icon: <Briefcase className="h-5 w-5" />,
+          label: "Jobs",
+          isActive: location.pathname === "/settings/jobs",
+          show: hasPermission("jobs", "read"),
+        },
+        {
+          to: "/settings/plugins",
+          icon: <Puzzle className="h-5 w-5" />,
+          label: "Plugins",
+          isActive: location.pathname === "/settings/plugins",
+          show: hasPermission("config", "read"),
+        },
+        {
+          to: "/settings/logs",
+          icon: <ScrollText className="h-5 w-5" />,
+          label: "Logs",
+          isActive: location.pathname === "/settings/logs",
+          show: hasPermission("config", "read"),
+        },
+      ]
+    : [];
+
   // Check if user has any admin permissions
   const canAccessAdmin =
     hasPermission("config", "read") ||
@@ -344,6 +398,24 @@ const MobileDrawer = () => {
           {isLibraryContext && libraryNavItems.length > 0 && (
             <nav className="py-2 border-b border-border">
               {libraryNavItems
+                .filter((item) => item.show)
+                .map((item) => (
+                  <NavItem
+                    icon={item.icon}
+                    isActive={item.isActive}
+                    key={item.to}
+                    label={item.label}
+                    onClick={close}
+                    to={item.to}
+                  />
+                ))}
+            </nav>
+          )}
+
+          {/* Admin Navigation (when on /settings routes) */}
+          {isAdminContext && adminNavItems.length > 0 && (
+            <nav className="py-2 border-b border-border">
+              {adminNavItems
                 .filter((item) => item.show)
                 .map((item) => (
                   <NavItem

--- a/app/components/library/MobileDrawer.tsx
+++ b/app/components/library/MobileDrawer.tsx
@@ -308,22 +308,23 @@ const MobileDrawer = () => {
           )}
 
           {/* Admin Navigation (when on /settings routes) */}
-          {isAdminContext && (
-            <nav className="py-2 border-b border-border">
-              {adminNavItems
-                .filter((item) => item.show)
-                .map((item) => (
-                  <NavItem
-                    icon={<item.Icon className="h-5 w-5" />}
-                    isActive={item.isActive}
-                    key={item.to}
-                    label={item.label}
-                    onClick={close}
-                    to={item.to}
-                  />
-                ))}
-            </nav>
-          )}
+          {isAdminContext &&
+            adminNavItems.filter((item) => item.show).length > 0 && (
+              <nav className="py-2 border-b border-border">
+                {adminNavItems
+                  .filter((item) => item.show)
+                  .map((item) => (
+                    <NavItem
+                      icon={<item.Icon className="h-5 w-5" />}
+                      isActive={item.isActive}
+                      key={item.to}
+                      label={item.label}
+                      onClick={close}
+                      to={item.to}
+                    />
+                  ))}
+              </nav>
+            )}
 
           {/* General Navigation */}
           <nav className="py-2 border-b border-border">

--- a/app/components/library/MobileDrawer.tsx
+++ b/app/components/library/MobileDrawer.tsx
@@ -413,7 +413,7 @@ const MobileDrawer = () => {
           )}
 
           {/* Admin Navigation (when on /settings routes) */}
-          {isAdminContext && adminNavItems.length > 0 && (
+          {isAdminContext && (
             <nav className="py-2 border-b border-border">
               {adminNavItems
                 .filter((item) => item.show)

--- a/app/components/library/MobileDrawer.tsx
+++ b/app/components/library/MobileDrawer.tsx
@@ -124,10 +124,12 @@ const MobileDrawer = () => {
 
   // Library navigation items (when in library context)
   const libraryNavDefs = useLibraryNavItems();
-  const libraryNavItems = libraryNavDefs ?? [];
+  const visibleLibraryItems = (libraryNavDefs ?? []).filter(
+    (item) => item.show,
+  );
 
   const isAdminContext = location.pathname.startsWith("/settings");
-  const adminNavItems = useAdminNavItems();
+  const visibleAdminItems = useAdminNavItems().filter((item) => item.show);
 
   // Check if user has any admin permissions
   const canAccessAdmin =
@@ -290,41 +292,36 @@ const MobileDrawer = () => {
           )}
 
           {/* Library Navigation (when in library context) */}
-          {isLibraryContext && libraryNavItems.length > 0 && (
+          {isLibraryContext && visibleLibraryItems.length > 0 && (
             <nav className="py-2 border-b border-border">
-              {libraryNavItems
-                .filter((item) => item.show)
-                .map((item) => (
-                  <NavItem
-                    icon={<item.Icon className="h-5 w-5" />}
-                    isActive={item.isActive}
-                    key={item.to}
-                    label={item.drawerLabel ?? item.label}
-                    onClick={close}
-                    to={item.to}
-                  />
-                ))}
+              {visibleLibraryItems.map((item) => (
+                <NavItem
+                  icon={<item.Icon className="h-5 w-5" />}
+                  isActive={item.isActive}
+                  key={item.to}
+                  label={item.drawerLabel ?? item.label}
+                  onClick={close}
+                  to={item.to}
+                />
+              ))}
             </nav>
           )}
 
           {/* Admin Navigation (when on /settings routes) */}
-          {isAdminContext &&
-            adminNavItems.filter((item) => item.show).length > 0 && (
-              <nav className="py-2 border-b border-border">
-                {adminNavItems
-                  .filter((item) => item.show)
-                  .map((item) => (
-                    <NavItem
-                      icon={<item.Icon className="h-5 w-5" />}
-                      isActive={item.isActive}
-                      key={item.to}
-                      label={item.label}
-                      onClick={close}
-                      to={item.to}
-                    />
-                  ))}
-              </nav>
-            )}
+          {isAdminContext && visibleAdminItems.length > 0 && (
+            <nav className="py-2 border-b border-border">
+              {visibleAdminItems.map((item) => (
+                <NavItem
+                  icon={<item.Icon className="h-5 w-5" />}
+                  isActive={item.isActive}
+                  key={item.to}
+                  label={item.label}
+                  onClick={close}
+                  to={item.to}
+                />
+              ))}
+            </nav>
+          )}
 
           {/* General Navigation */}
           <nav className="py-2 border-b border-border">

--- a/app/components/library/MobileDrawer.tsx
+++ b/app/components/library/MobileDrawer.tsx
@@ -1,32 +1,26 @@
 import {
-  Book,
-  Bookmark,
-  Briefcase,
   Check,
   ChevronRight,
-  Cog,
   KeyRound,
-  Layers,
   Library,
   List,
   LogOut,
-  Puzzle,
-  ScrollText,
   Settings,
-  Tags,
   UserCog,
-  Users,
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 
+import { useAdminNavItems } from "@/components/pages/useAdminNavItems";
 import { useMobileNav } from "@/contexts/MobileNav";
 import { useLibraries } from "@/hooks/queries/libraries";
 import { useListLists } from "@/hooks/queries/lists";
 import { useAuth } from "@/hooks/useAuth";
 import { cn } from "@/libraries/utils";
+
+import { useLibraryNavItems } from "./useLibraryNavItems";
 
 interface NavItemProps {
   to: string;
@@ -129,110 +123,11 @@ const MobileDrawer = () => {
   );
 
   // Library navigation items (when in library context)
-  const basePath = libraryId ? `/libraries/${libraryId}` : "";
-  const libraryNavItems = libraryId
-    ? [
-        {
-          to: basePath,
-          icon: <Book className="h-5 w-5" />,
-          label: "Books",
-          isActive:
-            location.pathname === basePath ||
-            (location.pathname.startsWith(`${basePath}/books`) &&
-              !location.pathname.includes("/series") &&
-              !location.pathname.includes("/people") &&
-              !location.pathname.includes("/genres") &&
-              !location.pathname.includes("/tags") &&
-              !location.pathname.includes("/settings")),
-          show: true,
-        },
-        {
-          to: `${basePath}/series`,
-          icon: <Layers className="h-5 w-5" />,
-          label: "Series",
-          isActive: location.pathname.startsWith(`${basePath}/series`),
-          show: true,
-        },
-        {
-          to: `${basePath}/people`,
-          icon: <Users className="h-5 w-5" />,
-          label: "People",
-          isActive: location.pathname.startsWith(`${basePath}/people`),
-          show: true,
-        },
-        {
-          to: `${basePath}/genres`,
-          icon: <Bookmark className="h-5 w-5" />,
-          label: "Genres",
-          isActive: location.pathname.startsWith(`${basePath}/genres`),
-          show: true,
-        },
-        {
-          to: `${basePath}/tags`,
-          icon: <Tags className="h-5 w-5" />,
-          label: "Tags",
-          isActive: location.pathname.startsWith(`${basePath}/tags`),
-          show: true,
-        },
-        {
-          to: `${basePath}/settings`,
-          icon: <Settings className="h-5 w-5" />,
-          label: "Library Settings",
-          isActive: location.pathname.startsWith(`${basePath}/settings`),
-          show: hasPermission("libraries", "write"),
-        },
-      ]
-    : [];
+  const libraryNavDefs = useLibraryNavItems();
+  const libraryNavItems = libraryNavDefs ?? [];
 
   const isAdminContext = location.pathname.startsWith("/settings");
-  const adminNavItems = isAdminContext
-    ? [
-        {
-          to: "/settings/server",
-          icon: <Cog className="h-5 w-5" />,
-          label: "Server",
-          isActive:
-            location.pathname === "/settings/server" ||
-            location.pathname === "/settings",
-          show: hasPermission("config", "read"),
-        },
-        {
-          to: "/settings/libraries",
-          icon: <Library className="h-5 w-5" />,
-          label: "Libraries",
-          isActive: location.pathname.startsWith("/settings/libraries"),
-          show: hasPermission("libraries", "read"),
-        },
-        {
-          to: "/settings/users",
-          icon: <Users className="h-5 w-5" />,
-          label: "Users",
-          isActive: location.pathname.startsWith("/settings/users"),
-          show: hasPermission("users", "read"),
-        },
-        {
-          to: "/settings/jobs",
-          icon: <Briefcase className="h-5 w-5" />,
-          label: "Jobs",
-          isActive: location.pathname === "/settings/jobs",
-          show: hasPermission("jobs", "read"),
-        },
-        {
-          to: "/settings/plugins",
-          icon: <Puzzle className="h-5 w-5" />,
-          label: "Plugins",
-          isActive: location.pathname === "/settings/plugins",
-          show: hasPermission("config", "read"),
-        },
-        {
-          to: "/settings/logs",
-          icon: <ScrollText className="h-5 w-5" />,
-          label: "Logs",
-          isActive: location.pathname === "/settings/logs",
-          show: hasPermission("config", "read"),
-        },
-      ]
-    : [];
+  const adminNavItems = useAdminNavItems();
 
   // Check if user has any admin permissions
   const canAccessAdmin =
@@ -401,10 +296,10 @@ const MobileDrawer = () => {
                 .filter((item) => item.show)
                 .map((item) => (
                   <NavItem
-                    icon={item.icon}
+                    icon={<item.Icon className="h-5 w-5" />}
                     isActive={item.isActive}
                     key={item.to}
-                    label={item.label}
+                    label={item.drawerLabel ?? item.label}
                     onClick={close}
                     to={item.to}
                   />
@@ -419,7 +314,7 @@ const MobileDrawer = () => {
                 .filter((item) => item.show)
                 .map((item) => (
                   <NavItem
-                    icon={item.icon}
+                    icon={<item.Icon className="h-5 w-5" />}
                     isActive={item.isActive}
                     key={item.to}
                     label={item.label}

--- a/app/components/library/TopNav.tsx
+++ b/app/components/library/TopNav.tsx
@@ -1,31 +1,13 @@
-import {
-  KeyRound,
-  List,
-  LogOut,
-  Menu,
-  Search,
-  Settings,
-  User,
-  UserCog,
-  X,
-} from "lucide-react";
-import { useCallback, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
-import { toast } from "sonner";
+import { Menu, Search, Settings, X } from "lucide-react";
+import { useState } from "react";
+import { Link, useParams } from "react-router-dom";
 
+import UserMenu from "@/components/layout/UserMenu";
 import GlobalSearch from "@/components/library/GlobalSearch";
 import LibraryListPicker from "@/components/library/LibraryListPicker";
 import Logo from "@/components/library/Logo";
 import { ResyncButton } from "@/components/library/ResyncButton";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   Tooltip,
   TooltipContent,
@@ -38,8 +20,7 @@ import { cn } from "@/libraries/utils";
 
 const TopNav = () => {
   const { libraryId } = useParams();
-  const navigate = useNavigate();
-  const { user, logout, hasPermission } = useAuth();
+  const { hasPermission } = useAuth();
   const { toggle } = useMobileNav();
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
 
@@ -51,16 +32,6 @@ const TopNav = () => {
     hasPermission("libraries", "read");
 
   const canResync = hasPermission("jobs", "write");
-
-  const handleLogout = useCallback(async () => {
-    try {
-      await logout();
-      toast.success("Signed out successfully");
-      navigate("/login");
-    } catch {
-      toast.error("Failed to sign out");
-    }
-  }, [logout, navigate]);
 
   return (
     <div className="border-b border-border bg-background dark:bg-neutral-900 sticky top-0 z-30">
@@ -141,46 +112,7 @@ const TopNav = () => {
                 </Tooltip>
               </TooltipProvider>
             )}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button className="h-9 w-9" size="icon" variant="ghost">
-                  <User className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuLabel>
-                  <div className="flex flex-col">
-                    <span>{user?.username}</span>
-                    <span className="text-xs font-normal text-muted-foreground">
-                      {user?.role_name}
-                    </span>
-                  </div>
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem asChild>
-                  <Link to="/lists">
-                    <List className="h-4 w-4" />
-                    Lists
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link to="/user/security">
-                    <KeyRound className="h-4 w-4" />
-                    Security
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem asChild>
-                  <Link to="/user/settings">
-                    <UserCog className="h-4 w-4" />
-                    User Settings
-                  </Link>
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={handleLogout}>
-                  <LogOut className="h-4 w-4" />
-                  Sign out
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <UserMenu />
           </div>
         </div>
 

--- a/app/components/library/TopNav.tsx
+++ b/app/components/library/TopNav.tsx
@@ -2,6 +2,11 @@ import { Menu, Search, Settings, X } from "lucide-react";
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
+import {
+  TOP_NAV_INNER,
+  TOP_NAV_ROW,
+  TOP_NAV_WRAPPER,
+} from "@/components/layout/topNavClasses";
 import UserMenu from "@/components/layout/UserMenu";
 import GlobalSearch from "@/components/library/GlobalSearch";
 import LibraryListPicker from "@/components/library/LibraryListPicker";
@@ -34,9 +39,9 @@ const TopNav = () => {
   const canResync = hasPermission("jobs", "write");
 
   return (
-    <div className="border-b border-border bg-background dark:bg-neutral-900 sticky top-0 z-30">
-      <div className="max-w-7xl mx-auto px-4 md:px-6">
-        <div className="flex items-center justify-between h-14 md:h-16">
+    <div className={TOP_NAV_WRAPPER}>
+      <div className={TOP_NAV_INNER}>
+        <div className={TOP_NAV_ROW}>
           {/* Left section */}
           <div className="flex items-center gap-2 md:gap-8">
             {/* Mobile hamburger menu */}

--- a/app/components/library/useLibraryNavItems.ts
+++ b/app/components/library/useLibraryNavItems.ts
@@ -1,0 +1,86 @@
+import {
+  Book,
+  Bookmark,
+  Layers,
+  Settings,
+  Tags,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+import { useLocation, useParams } from "react-router-dom";
+
+import { useAuth } from "@/hooks/useAuth";
+
+export type LibraryNavItem = {
+  to: string;
+  Icon: LucideIcon;
+  label: string;
+  drawerLabel?: string;
+  isActive: boolean;
+  show: boolean;
+};
+
+export const useLibraryNavItems = (): LibraryNavItem[] | null => {
+  const { libraryId } = useParams();
+  const location = useLocation();
+  const { hasPermission } = useAuth();
+
+  if (!libraryId) return null;
+
+  const basePath = `/libraries/${libraryId}`;
+
+  const isBooksActive =
+    location.pathname === basePath ||
+    (location.pathname.startsWith(`${basePath}/books`) &&
+      !location.pathname.startsWith(`${basePath}/series`) &&
+      !location.pathname.startsWith(`${basePath}/people`) &&
+      !location.pathname.startsWith(`${basePath}/genres`) &&
+      !location.pathname.startsWith(`${basePath}/tags`) &&
+      !location.pathname.startsWith(`${basePath}/settings`));
+
+  return [
+    {
+      to: basePath,
+      Icon: Book,
+      label: "Books",
+      isActive: isBooksActive,
+      show: true,
+    },
+    {
+      to: `${basePath}/series`,
+      Icon: Layers,
+      label: "Series",
+      isActive: location.pathname.startsWith(`${basePath}/series`),
+      show: true,
+    },
+    {
+      to: `${basePath}/people`,
+      Icon: Users,
+      label: "People",
+      isActive: location.pathname.startsWith(`${basePath}/people`),
+      show: true,
+    },
+    {
+      to: `${basePath}/genres`,
+      Icon: Bookmark,
+      label: "Genres",
+      isActive: location.pathname.startsWith(`${basePath}/genres`),
+      show: true,
+    },
+    {
+      to: `${basePath}/tags`,
+      Icon: Tags,
+      label: "Tags",
+      isActive: location.pathname.startsWith(`${basePath}/tags`),
+      show: true,
+    },
+    {
+      to: `${basePath}/settings`,
+      Icon: Settings,
+      label: "Settings",
+      drawerLabel: "Library Settings",
+      isActive: location.pathname.startsWith(`${basePath}/settings`),
+      show: hasPermission("libraries", "write"),
+    },
+  ];
+};

--- a/app/components/pages/AdminLayout.tsx
+++ b/app/components/pages/AdminLayout.tsx
@@ -1,62 +1,28 @@
-import {
-  Briefcase,
-  Cog,
-  Library,
-  LogOut,
-  Menu,
-  Puzzle,
-  ScrollText,
-  Users,
-} from "lucide-react";
-import {
-  Link,
-  Outlet,
-  ScrollRestoration,
-  useLocation,
-  useNavigate,
-} from "react-router-dom";
-import { toast } from "sonner";
+import { Menu, Settings } from "lucide-react";
+import { Outlet } from "react-router-dom";
 
+import {
+  TOP_NAV_INNER,
+  TOP_NAV_ROW,
+  TOP_NAV_WRAPPER,
+} from "@/components/layout/topNavClasses";
+import UserMenu from "@/components/layout/UserMenu";
 import Logo from "@/components/library/Logo";
-import MobileDrawer from "@/components/library/MobileDrawer";
+import AdminSidebar from "@/components/pages/AdminSidebar";
 import { Button } from "@/components/ui/button";
-import { Toaster } from "@/components/ui/sonner";
-import { MobileNavProvider, useMobileNav } from "@/contexts/MobileNav";
-import { useAuth } from "@/hooks/useAuth";
-
-interface NavItemProps {
-  to: string;
-  icon: React.ReactNode;
-  label: string;
-  isActive: boolean;
-}
-
-const NavItem = ({ to, icon, label, isActive }: NavItemProps) => (
-  <Link
-    className={`flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-      isActive
-        ? "bg-primary/10 text-primary dark:bg-violet-900/30 dark:text-violet-300"
-        : "text-muted-foreground hover:bg-muted hover:text-foreground"
-    }`}
-    to={to}
-  >
-    {icon}
-    {label}
-  </Link>
-);
+import { useMobileNav } from "@/contexts/MobileNav";
 
 const AdminHeader = () => {
   const { toggle } = useMobileNav();
 
   return (
-    <div className="border-b border-border bg-background dark:bg-neutral-900 sticky top-0 z-30">
-      <div className="max-w-7xl mx-auto px-4 md:px-6">
-        <div className="flex items-center justify-between h-14 md:h-16">
+    <div className={TOP_NAV_WRAPPER}>
+      <div className={TOP_NAV_INNER}>
+        <div className={TOP_NAV_ROW}>
           <div className="flex items-center gap-2 md:gap-8">
-            {/* Mobile hamburger menu */}
             <Button
               aria-label="Open navigation menu"
-              className="md:hidden h-9 w-9 -ml-1"
+              className="-ml-1 h-9 w-9 md:hidden"
               onClick={toggle}
               size="icon"
               variant="ghost"
@@ -64,258 +30,33 @@ const AdminHeader = () => {
               <Menu className="h-5 w-5" />
             </Button>
             <Logo asLink />
-            <span className="hidden sm:inline text-sm text-muted-foreground">
-              Settings
-            </span>
-          </div>
-          <div className="flex items-center gap-2 md:gap-4">
-            <Button asChild size="sm" variant="ghost">
-              <Link className="hidden sm:flex" to="/">
-                ← Back to Library
-              </Link>
-            </Button>
-            <Button asChild className="sm:hidden" size="icon" variant="ghost">
-              <Link to="/">
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              </Link>
-            </Button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-interface MobileNavItemProps {
-  to: string;
-  icon: React.ReactNode;
-  label: string;
-  isActive: boolean;
-}
-
-const MobileNavItem = ({ to, icon, label, isActive }: MobileNavItemProps) => (
-  <Link
-    className={`flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium whitespace-nowrap transition-colors ${
-      isActive
-        ? "bg-primary/10 text-primary dark:bg-violet-900/30 dark:text-violet-300"
-        : "text-muted-foreground hover:bg-muted hover:text-foreground"
-    }`}
-    to={to}
-  >
-    {icon}
-    {label}
-  </Link>
-);
-
-const AdminLayoutContent = () => {
-  const location = useLocation();
-  const navigate = useNavigate();
-  const { user, logout, hasPermission } = useAuth();
-
-  const handleLogout = async () => {
-    try {
-      await logout();
-      toast.success("Logged out successfully");
-      navigate("/login");
-    } catch {
-      toast.error("Failed to log out");
-    }
-  };
-
-  const canViewLibraries = hasPermission("libraries", "read");
-  const canViewUsers = hasPermission("users", "read");
-  const canViewJobs = hasPermission("jobs", "read");
-  const canViewConfig = hasPermission("config", "read");
-
-  const mobileNavItems = [
-    {
-      to: "/settings/server",
-      icon: <Cog className="h-4 w-4" />,
-      label: "Server",
-      isActive:
-        location.pathname === "/settings/server" ||
-        location.pathname === "/settings",
-      show: canViewConfig,
-    },
-    {
-      to: "/settings/libraries",
-      icon: <Library className="h-4 w-4" />,
-      label: "Libraries",
-      isActive: location.pathname.startsWith("/settings/libraries"),
-      show: canViewLibraries,
-    },
-    {
-      to: "/settings/users",
-      icon: <Users className="h-4 w-4" />,
-      label: "Users",
-      isActive: location.pathname.startsWith("/settings/users"),
-      show: canViewUsers,
-    },
-    {
-      to: "/settings/jobs",
-      icon: <Briefcase className="h-4 w-4" />,
-      label: "Jobs",
-      isActive: location.pathname === "/settings/jobs",
-      show: canViewJobs,
-    },
-    {
-      to: "/settings/plugins",
-      icon: <Puzzle className="h-4 w-4" />,
-      label: "Plugins",
-      isActive: location.pathname === "/settings/plugins",
-      show: canViewConfig,
-    },
-    {
-      to: "/settings/logs",
-      icon: <ScrollText className="h-4 w-4" />,
-      label: "Logs",
-      isActive: location.pathname === "/settings/logs",
-      show: canViewConfig,
-    },
-  ].filter((item) => item.show);
-
-  return (
-    <div className="min-h-screen bg-background">
-      <AdminHeader />
-      <MobileDrawer />
-
-      {/* Mobile horizontal nav - visible only on mobile */}
-      <div className="md:hidden border-b border-border bg-background overflow-x-auto">
-        <div className="flex gap-1 px-4 py-2">
-          {mobileNavItems.map((item) => (
-            <MobileNavItem
-              icon={item.icon}
-              isActive={item.isActive}
-              key={item.to}
-              label={item.label}
-              to={item.to}
-            />
-          ))}
-        </div>
-      </div>
-
-      <div className="max-w-7xl mx-auto px-4 md:px-6 py-4 md:py-8">
-        <div className="flex gap-8">
-          {/* Desktop Sidebar - hidden on mobile */}
-          <aside className="hidden md:block w-56 flex-shrink-0">
-            <nav className="space-y-1">
-              {canViewConfig && (
-                <NavItem
-                  icon={<Cog className="h-4 w-4" />}
-                  isActive={
-                    location.pathname === "/settings/server" ||
-                    location.pathname === "/settings"
-                  }
-                  label="Server"
-                  to="/settings/server"
-                />
-              )}
-              {canViewLibraries && (
-                <NavItem
-                  icon={<Library className="h-4 w-4" />}
-                  isActive={location.pathname.startsWith("/settings/libraries")}
-                  label="Libraries"
-                  to="/settings/libraries"
-                />
-              )}
-              {canViewUsers && (
-                <NavItem
-                  icon={<Users className="h-4 w-4" />}
-                  isActive={location.pathname.startsWith("/settings/users")}
-                  label="Users"
-                  to="/settings/users"
-                />
-              )}
-              {canViewJobs && (
-                <NavItem
-                  icon={<Briefcase className="h-4 w-4" />}
-                  isActive={location.pathname === "/settings/jobs"}
-                  label="Jobs"
-                  to="/settings/jobs"
-                />
-              )}
-              {canViewConfig && (
-                <NavItem
-                  icon={<Puzzle className="h-4 w-4" />}
-                  isActive={location.pathname === "/settings/plugins"}
-                  label="Plugins"
-                  to="/settings/plugins"
-                />
-              )}
-              {canViewConfig && (
-                <NavItem
-                  icon={<ScrollText className="h-4 w-4" />}
-                  isActive={location.pathname === "/settings/logs"}
-                  label="Logs"
-                  to="/settings/logs"
-                />
-              )}
-            </nav>
-
-            {/* User info and logout */}
-            <div className="mt-8 pt-6 border-t border-border">
-              <div className="px-3 mb-3">
-                <p className="text-sm font-medium text-foreground">
-                  {user?.username}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {user?.role_name}
-                </p>
-              </div>
-              <Button
-                className="w-full justify-start gap-3 text-muted-foreground hover:text-foreground"
-                onClick={handleLogout}
-                size="sm"
-                variant="ghost"
-              >
-                <LogOut className="h-4 w-4" />
-                Sign out
-              </Button>
-              <a
-                className="group mt-4 mx-3 flex items-center justify-center gap-1.5 py-1.5 rounded border border-transparent hover:border-border/40 hover:bg-muted/30 transition-all duration-200"
-                href="https://github.com/shishobooks/shisho/releases"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                <span className="text-[10px] text-muted-foreground/40 group-hover:text-muted-foreground/70 transition-colors">
-                  shisho
-                </span>
-                <span className="text-[10px] font-mono text-muted-foreground/50 group-hover:text-muted-foreground transition-colors">
-                  {__APP_VERSION__}
-                </span>
-              </a>
+            <div className="hidden items-center gap-2 text-sm font-medium text-muted-foreground sm:flex">
+              <Settings className="h-4 w-4" />
+              <span>Settings</span>
             </div>
-          </aside>
-
-          {/* Main content */}
-          <main className="flex-1 min-w-0">
-            <Outlet />
-          </main>
+          </div>
+          <div className="flex items-center gap-1 md:gap-4">
+            <UserMenu />
+          </div>
         </div>
       </div>
-      <Toaster richColors />
     </div>
   );
 };
 
 const AdminLayout = () => {
   return (
-    <MobileNavProvider>
-      <ScrollRestoration />
-      <AdminLayoutContent />
-    </MobileNavProvider>
+    <div className="flex min-h-screen flex-col">
+      <AdminHeader />
+      <div className="flex flex-1">
+        <div className="hidden md:block">
+          <AdminSidebar />
+        </div>
+        <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-4 md:px-6 md:py-8">
+          <Outlet />
+        </main>
+      </div>
+    </div>
   );
 };
 

--- a/app/components/pages/AdminLayout.tsx
+++ b/app/components/pages/AdminLayout.tsx
@@ -46,13 +46,13 @@ const AdminHeader = () => {
 
 const AdminLayout = () => {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex flex-col min-h-screen">
       <AdminHeader />
       <div className="flex flex-1">
         <div className="hidden md:block">
           <AdminSidebar />
         </div>
-        <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-4 md:px-6 md:py-8">
+        <main className="flex-1 w-full mx-auto max-w-7xl px-4 py-4 md:px-6 md:py-8">
           <Outlet />
         </main>
       </div>

--- a/app/components/pages/AdminLayout.tsx
+++ b/app/components/pages/AdminLayout.tsx
@@ -30,7 +30,7 @@ const AdminHeader = () => {
               <Menu className="h-5 w-5" />
             </Button>
             <Logo asLink />
-            <div className="hidden items-center gap-2 text-sm font-medium text-muted-foreground sm:flex">
+            <div className="hidden h-9 items-center gap-2 rounded-md px-4 py-2 text-sm font-medium text-muted-foreground sm:flex">
               <Settings className="h-4 w-4" />
               <span>Settings</span>
             </div>

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -76,7 +76,7 @@ const AdminSettings = () => {
         </p>
       </div>
 
-      <div className="grid gap-6 max-w-2xl">
+      <div className="grid gap-6">
         {/* Database Settings */}
         <div className="border border-border rounded-md p-4 md:p-6">
           <h2 className="text-base md:text-lg font-semibold mb-3 md:mb-4">

--- a/app/components/pages/AdminSidebar.tsx
+++ b/app/components/pages/AdminSidebar.tsx
@@ -1,0 +1,73 @@
+import {
+  Briefcase,
+  Cog,
+  Library,
+  Puzzle,
+  ScrollText,
+  Users,
+} from "lucide-react";
+import { useLocation } from "react-router-dom";
+
+import Sidebar, { type SidebarItem } from "@/components/layout/Sidebar";
+import { useAuth } from "@/hooks/useAuth";
+
+const AdminSidebar = () => {
+  const location = useLocation();
+  const { hasPermission } = useAuth();
+
+  const canViewConfig = hasPermission("config", "read");
+  const canViewLibraries = hasPermission("libraries", "read");
+  const canViewUsers = hasPermission("users", "read");
+  const canViewJobs = hasPermission("jobs", "read");
+
+  const items: SidebarItem[] = [
+    {
+      to: "/settings/server",
+      icon: <Cog className="h-4 w-4" />,
+      label: "Server",
+      isActive:
+        location.pathname === "/settings/server" ||
+        location.pathname === "/settings",
+      show: canViewConfig,
+    },
+    {
+      to: "/settings/libraries",
+      icon: <Library className="h-4 w-4" />,
+      label: "Libraries",
+      isActive: location.pathname.startsWith("/settings/libraries"),
+      show: canViewLibraries,
+    },
+    {
+      to: "/settings/users",
+      icon: <Users className="h-4 w-4" />,
+      label: "Users",
+      isActive: location.pathname.startsWith("/settings/users"),
+      show: canViewUsers,
+    },
+    {
+      to: "/settings/jobs",
+      icon: <Briefcase className="h-4 w-4" />,
+      label: "Jobs",
+      isActive: location.pathname === "/settings/jobs",
+      show: canViewJobs,
+    },
+    {
+      to: "/settings/plugins",
+      icon: <Puzzle className="h-4 w-4" />,
+      label: "Plugins",
+      isActive: location.pathname === "/settings/plugins",
+      show: canViewConfig,
+    },
+    {
+      to: "/settings/logs",
+      icon: <ScrollText className="h-4 w-4" />,
+      label: "Logs",
+      isActive: location.pathname === "/settings/logs",
+      show: canViewConfig,
+    },
+  ];
+
+  return <Sidebar items={items} />;
+};
+
+export default AdminSidebar;

--- a/app/components/pages/AdminSidebar.tsx
+++ b/app/components/pages/AdminSidebar.tsx
@@ -1,71 +1,17 @@
-import {
-  Briefcase,
-  Cog,
-  Library,
-  Puzzle,
-  ScrollText,
-  Users,
-} from "lucide-react";
-import { useLocation } from "react-router-dom";
-
 import Sidebar, { type SidebarItem } from "@/components/layout/Sidebar";
-import { useAuth } from "@/hooks/useAuth";
+
+import { useAdminNavItems } from "./useAdminNavItems";
 
 const AdminSidebar = () => {
-  const location = useLocation();
-  const { hasPermission } = useAuth();
+  const navItems = useAdminNavItems();
 
-  const canViewConfig = hasPermission("config", "read");
-  const canViewLibraries = hasPermission("libraries", "read");
-  const canViewUsers = hasPermission("users", "read");
-  const canViewJobs = hasPermission("jobs", "read");
-
-  const items: SidebarItem[] = [
-    {
-      to: "/settings/server",
-      icon: <Cog className="h-4 w-4" />,
-      label: "Server",
-      isActive:
-        location.pathname === "/settings/server" ||
-        location.pathname === "/settings",
-      show: canViewConfig,
-    },
-    {
-      to: "/settings/libraries",
-      icon: <Library className="h-4 w-4" />,
-      label: "Libraries",
-      isActive: location.pathname.startsWith("/settings/libraries"),
-      show: canViewLibraries,
-    },
-    {
-      to: "/settings/users",
-      icon: <Users className="h-4 w-4" />,
-      label: "Users",
-      isActive: location.pathname.startsWith("/settings/users"),
-      show: canViewUsers,
-    },
-    {
-      to: "/settings/jobs",
-      icon: <Briefcase className="h-4 w-4" />,
-      label: "Jobs",
-      isActive: location.pathname === "/settings/jobs",
-      show: canViewJobs,
-    },
-    {
-      to: "/settings/plugins",
-      icon: <Puzzle className="h-4 w-4" />,
-      label: "Plugins",
-      isActive: location.pathname === "/settings/plugins",
-      show: canViewConfig,
-    },
-    {
-      to: "/settings/logs",
-      icon: <ScrollText className="h-4 w-4" />,
-      label: "Logs",
-      isActive: location.pathname === "/settings/logs",
-      show: canViewConfig,
-    },
-  ];
+  const items: SidebarItem[] = navItems.map((item) => ({
+    to: item.to,
+    icon: <item.Icon className="h-4 w-4" />,
+    label: item.label,
+    isActive: item.isActive,
+    show: item.show,
+  }));
 
   return <Sidebar items={items} />;
 };

--- a/app/components/pages/useAdminNavItems.ts
+++ b/app/components/pages/useAdminNavItems.ts
@@ -70,7 +70,7 @@ export const useAdminNavItems = (): AdminNavItem[] => {
       to: "/settings/logs",
       Icon: ScrollText,
       label: "Logs",
-      isActive: location.pathname === "/settings/logs",
+      isActive: location.pathname.startsWith("/settings/logs"),
       show: canViewConfig,
     },
   ];

--- a/app/components/pages/useAdminNavItems.ts
+++ b/app/components/pages/useAdminNavItems.ts
@@ -1,0 +1,77 @@
+import {
+  Briefcase,
+  Cog,
+  Library,
+  Puzzle,
+  ScrollText,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+import { useLocation } from "react-router-dom";
+
+import { useAuth } from "@/hooks/useAuth";
+
+export type AdminNavItem = {
+  to: string;
+  Icon: LucideIcon;
+  label: string;
+  isActive: boolean;
+  show: boolean;
+};
+
+export const useAdminNavItems = (): AdminNavItem[] => {
+  const location = useLocation();
+  const { hasPermission } = useAuth();
+
+  const canViewConfig = hasPermission("config", "read");
+  const canViewLibraries = hasPermission("libraries", "read");
+  const canViewUsers = hasPermission("users", "read");
+  const canViewJobs = hasPermission("jobs", "read");
+
+  return [
+    {
+      to: "/settings/server",
+      Icon: Cog,
+      label: "Server",
+      isActive:
+        location.pathname === "/settings/server" ||
+        location.pathname === "/settings",
+      show: canViewConfig,
+    },
+    {
+      to: "/settings/libraries",
+      Icon: Library,
+      label: "Libraries",
+      isActive: location.pathname.startsWith("/settings/libraries"),
+      show: canViewLibraries,
+    },
+    {
+      to: "/settings/users",
+      Icon: Users,
+      label: "Users",
+      isActive: location.pathname.startsWith("/settings/users"),
+      show: canViewUsers,
+    },
+    {
+      to: "/settings/jobs",
+      Icon: Briefcase,
+      label: "Jobs",
+      isActive: location.pathname === "/settings/jobs",
+      show: canViewJobs,
+    },
+    {
+      to: "/settings/plugins",
+      Icon: Puzzle,
+      label: "Plugins",
+      isActive: location.pathname === "/settings/plugins",
+      show: canViewConfig,
+    },
+    {
+      to: "/settings/logs",
+      Icon: ScrollText,
+      label: "Logs",
+      isActive: location.pathname === "/settings/logs",
+      show: canViewConfig,
+    },
+  ];
+};

--- a/app/components/pages/useAdminNavItems.ts
+++ b/app/components/pages/useAdminNavItems.ts
@@ -56,14 +56,14 @@ export const useAdminNavItems = (): AdminNavItem[] => {
       to: "/settings/jobs",
       Icon: Briefcase,
       label: "Jobs",
-      isActive: location.pathname === "/settings/jobs",
+      isActive: location.pathname.startsWith("/settings/jobs"),
       show: canViewJobs,
     },
     {
       to: "/settings/plugins",
       Icon: Puzzle,
       label: "Plugins",
-      isActive: location.pathname === "/settings/plugins",
+      isActive: location.pathname.startsWith("/settings/plugins"),
       show: canViewConfig,
     },
     {

--- a/app/router.tsx
+++ b/app/router.tsx
@@ -49,166 +49,169 @@ export const router = createBrowserRouter([
     path: "/setup",
     Component: Setup,
   },
-  // Settings routes with dedicated layout (formerly admin)
-  {
-    path: "/settings",
-    element: (
-      <ProtectedRoute>
-        <AdminLayout />
-      </ProtectedRoute>
-    ),
-    children: [
-      {
-        index: true,
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "config", operation: "read" }}
-          >
-            <AdminSettings />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "server",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "config", operation: "read" }}
-          >
-            <AdminSettings />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "libraries",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "libraries", operation: "read" }}
-          >
-            <AdminLibraries />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "users",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "users", operation: "read" }}
-          >
-            <AdminUsers />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "users/create",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "users", operation: "write" }}
-          >
-            <CreateUser />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "users/:id",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "users", operation: "read" }}
-          >
-            <UserDetail />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "jobs",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "jobs", operation: "read" }}
-          >
-            <AdminJobs />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "jobs/:id",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "jobs", operation: "read" }}
-          >
-            <JobDetail />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "plugins",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "config", operation: "read" }}
-          >
-            <AdminPlugins />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "plugins/installed",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "config", operation: "read" }}
-          >
-            <AdminPlugins />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "plugins/discover",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "config", operation: "read" }}
-          >
-            <AdminPlugins />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "plugins/browse",
-        element: <Navigate replace to="/settings/plugins/discover" />,
-      },
-      {
-        path: "plugins/order",
-        element: <Navigate replace to="/settings/plugins?advanced=order" />,
-      },
-      {
-        path: "plugins/repositories",
-        element: (
-          <Navigate replace to="/settings/plugins?advanced=repositories" />
-        ),
-      },
-      {
-        path: "plugins/:scope/:id",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "config", operation: "read" }}
-          >
-            <PluginDetail />
-          </ProtectedRoute>
-        ),
-      },
-      {
-        path: "logs",
-        element: (
-          <ProtectedRoute
-            requiredPermission={{ resource: "config", operation: "read" }}
-          >
-            <AdminLogs />
-          </ProtectedRoute>
-        ),
-      },
-    ],
-  },
   // Protected routes (require authentication)
   {
     path: "/",
     Component: Root,
     children: [
+      // Settings routes with dedicated layout (formerly admin)
+      {
+        path: "settings",
+        element: (
+          <ProtectedRoute>
+            <AdminLayout />
+          </ProtectedRoute>
+        ),
+        children: [
+          {
+            index: true,
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "config", operation: "read" }}
+              >
+                <AdminSettings />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "server",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "config", operation: "read" }}
+              >
+                <AdminSettings />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "libraries",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{
+                  resource: "libraries",
+                  operation: "read",
+                }}
+              >
+                <AdminLibraries />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "users",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "users", operation: "read" }}
+              >
+                <AdminUsers />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "users/create",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "users", operation: "write" }}
+              >
+                <CreateUser />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "users/:id",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "users", operation: "read" }}
+              >
+                <UserDetail />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "jobs",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "jobs", operation: "read" }}
+              >
+                <AdminJobs />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "jobs/:id",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "jobs", operation: "read" }}
+              >
+                <JobDetail />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "plugins",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "config", operation: "read" }}
+              >
+                <AdminPlugins />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "plugins/installed",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "config", operation: "read" }}
+              >
+                <AdminPlugins />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "plugins/discover",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "config", operation: "read" }}
+              >
+                <AdminPlugins />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "plugins/browse",
+            element: <Navigate replace to="/settings/plugins/discover" />,
+          },
+          {
+            path: "plugins/order",
+            element: <Navigate replace to="/settings/plugins?advanced=order" />,
+          },
+          {
+            path: "plugins/repositories",
+            element: (
+              <Navigate replace to="/settings/plugins?advanced=repositories" />
+            ),
+          },
+          {
+            path: "plugins/:scope/:id",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "config", operation: "read" }}
+              >
+                <PluginDetail />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "logs",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "config", operation: "read" }}
+              >
+                <AdminLogs />
+              </ProtectedRoute>
+            ),
+          },
+        ],
+      },
       {
         path: "",
         element: (

--- a/docs/superpowers/plans/2026-04-21-admin-sidebar-consistency.md
+++ b/docs/superpowers/plans/2026-04-21-admin-sidebar-consistency.md
@@ -1,0 +1,996 @@
+# Admin Sidebar & Top Nav Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring admin-page sidebar and top nav in line with the library-page versions, extracting shared pieces into single-source components so they cannot drift again.
+
+**Architecture:** Extract a shared `<Sidebar>` primitive that owns the collapse/localStorage/styling/footer chrome, with thin area-specific wrappers (`LibrarySidebar`, `AdminSidebar`) that only compute nav items. Extract a shared `<UserMenu>` used by both top navs. Share top-nav container classes via `cn()`-wrapped constants rather than a full shell component (library top nav has too much area-specific behavior to slot cleanly). Remove the admin page's "Back to Library" link and mobile horizontal nav strip; the mobile drawer takes over mobile nav (with a small change to show admin items when on `/settings/*` routes).
+
+**Tech Stack:** React 19, TypeScript, TailwindCSS, Radix UI (via shadcn/ui), Vitest + React Testing Library, React Router v6.
+
+---
+
+## File Structure
+
+**Create:**
+- `app/components/layout/Sidebar.tsx` — shared sidebar primitive
+- `app/components/layout/Sidebar.test.tsx` — component tests
+- `app/components/layout/UserMenu.tsx` — shared user dropdown
+- `app/components/layout/topNavClasses.ts` — shared container classes
+- `app/components/pages/AdminSidebar.tsx` — admin thin wrapper
+
+**Modify:**
+- `app/components/library/LibrarySidebar.tsx` — becomes thin wrapper over `<Sidebar>`
+- `app/components/library/TopNav.tsx` — use `<UserMenu>` and class constants
+- `app/components/library/MobileDrawer.tsx` — show admin nav items when on `/settings/*`
+- `app/components/pages/AdminLayout.tsx` — drop inline sidebar and mobile strip, use `<AdminSidebar>`; update `AdminHeader` to remove back link, add icon+label Settings, add `<UserMenu>`, use class constants
+
+---
+
+## Task 1: Establish baseline
+
+**Files:** (none changed — verification only)
+
+- [ ] **Step 1: Confirm all checks pass on current branch**
+
+Run: `mise check:quiet`
+Expected: All checks pass. If anything fails, stop and fix before proceeding.
+
+---
+
+## Task 2: Create shared top-nav class constants
+
+**Files:**
+- Create: `app/components/layout/topNavClasses.ts`
+
+- [ ] **Step 1: Create the constants file**
+
+```ts
+// app/components/layout/topNavClasses.ts
+import { cn } from "@/libraries/utils";
+
+export const TOP_NAV_WRAPPER = cn(
+  "sticky top-0 z-30 border-b border-border bg-background dark:bg-neutral-900",
+);
+export const TOP_NAV_INNER = cn("mx-auto max-w-7xl px-4 md:px-6");
+export const TOP_NAV_ROW = cn("flex h-14 items-center justify-between md:h-16");
+```
+
+- [ ] **Step 2: Verify types compile**
+
+Run: `pnpm lint:types`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/layout/topNavClasses.ts
+git commit -m "[Frontend] Add shared top-nav class constants"
+```
+
+---
+
+## Task 3: Extract `<UserMenu>` component
+
+**Files:**
+- Create: `app/components/layout/UserMenu.tsx`
+- Modify: `app/components/library/TopNav.tsx`
+
+- [ ] **Step 1: Create the UserMenu component**
+
+```tsx
+// app/components/layout/UserMenu.tsx
+import { KeyRound, List, LogOut, User, UserCog } from "lucide-react";
+import { useCallback } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useAuth } from "@/hooks/useAuth";
+
+const UserMenu = () => {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = useCallback(async () => {
+    try {
+      await logout();
+      toast.success("Signed out successfully");
+      navigate("/login");
+    } catch {
+      toast.error("Failed to sign out");
+    }
+  }, [logout, navigate]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className="h-9 w-9" size="icon" variant="ghost">
+          <User className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>
+          <div className="flex flex-col">
+            <span>{user?.username}</span>
+            <span className="text-xs font-normal text-muted-foreground">
+              {user?.role_name}
+            </span>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link to="/lists">
+            <List className="h-4 w-4" />
+            Lists
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link to="/user/security">
+            <KeyRound className="h-4 w-4" />
+            Security
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link to="/user/settings">
+            <UserCog className="h-4 w-4" />
+            User Settings
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleLogout}>
+          <LogOut className="h-4 w-4" />
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default UserMenu;
+```
+
+- [ ] **Step 2: Replace the inline user menu in `TopNav.tsx`**
+
+In `app/components/library/TopNav.tsx`:
+
+- Delete lines 144–183 (the entire `<DropdownMenu>...</DropdownMenu>` block for the user menu).
+- Replace with: `<UserMenu />`.
+- Add import at the top: `import UserMenu from "@/components/layout/UserMenu";`
+- Remove now-unused imports from the top of the file: `KeyRound`, `List`, `LogOut`, `User`, `UserCog` from `lucide-react`; `DropdownMenu`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuLabel`, `DropdownMenuSeparator`, `DropdownMenuTrigger` from the dropdown import; `toast` from sonner; `useCallback` from react; `useNavigate` from react-router-dom (if no longer used — keep if still referenced).
+- Remove the now-unused `handleLogout` function and `logout`/`navigate` destructurings from `useAuth()` and `useNavigate()` (keep `user`, `hasPermission` from `useAuth`).
+
+- [ ] **Step 3: Verify lint, types, and tests**
+
+Run: `mise check:quiet`
+Expected: All checks pass.
+
+- [ ] **Step 4: Manually verify the library user menu still works**
+
+Start dev server if not already running: `mise start` (in another terminal).
+In the browser on any `/libraries/:id` page, click the user icon in the top nav. Confirm:
+- Dropdown opens showing username and role.
+- Lists, Security, User Settings links work.
+- Sign out signs you out and redirects to `/login`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/layout/UserMenu.tsx app/components/library/TopNav.tsx
+git commit -m "[Frontend] Extract UserMenu component from library TopNav"
+```
+
+---
+
+## Task 4: Create `<Sidebar>` primitive with tests
+
+**Files:**
+- Create: `app/components/layout/Sidebar.tsx`
+- Create: `app/components/layout/Sidebar.test.tsx`
+
+- [ ] **Step 1: Write failing tests for the Sidebar primitive**
+
+```tsx
+// app/components/layout/Sidebar.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Book, Settings } from "lucide-react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import Sidebar, { type SidebarItem } from "./Sidebar";
+
+const renderSidebar = (items: SidebarItem[]) =>
+  render(
+    <MemoryRouter>
+      <Sidebar items={items} />
+    </MemoryRouter>,
+  );
+
+const buildItem = (overrides: Partial<SidebarItem> = {}): SidebarItem => ({
+  to: "/books",
+  icon: <Book className="h-4 w-4" />,
+  label: "Books",
+  isActive: false,
+  ...overrides,
+});
+
+describe("Sidebar", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders each visible item's label", () => {
+    renderSidebar([
+      buildItem({ to: "/a", label: "Alpha" }),
+      buildItem({ to: "/b", label: "Bravo" }),
+    ]);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Bravo")).toBeInTheDocument();
+  });
+
+  it("hides items with show: false", () => {
+    renderSidebar([
+      buildItem({ to: "/a", label: "Alpha" }),
+      buildItem({ to: "/b", label: "Bravo", show: false }),
+    ]);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.queryByText("Bravo")).not.toBeInTheDocument();
+  });
+
+  it("treats missing show as visible", () => {
+    renderSidebar([buildItem({ to: "/a", label: "Alpha" })]);
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+  });
+
+  it("starts expanded by default and shows version footer", () => {
+    renderSidebar([buildItem()]);
+    expect(screen.getByText("shisho")).toBeInTheDocument();
+  });
+
+  it("starts collapsed when localStorage says so, and hides version footer", () => {
+    localStorage.setItem("shisho-sidebar-collapsed", "true");
+    renderSidebar([buildItem()]);
+    expect(screen.queryByText("shisho")).not.toBeInTheDocument();
+  });
+
+  it("toggles collapsed state and persists to localStorage", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderSidebar([buildItem()]);
+    expect(localStorage.getItem("shisho-sidebar-collapsed")).toBe("false");
+
+    const collapseButton = screen.getByRole("button", {
+      name: /collapse sidebar/i,
+    });
+    await user.click(collapseButton);
+
+    expect(localStorage.getItem("shisho-sidebar-collapsed")).toBe("true");
+    expect(
+      screen.getByRole("button", { name: /expand sidebar/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("applies active styling to active items", () => {
+    renderSidebar([
+      buildItem({ to: "/a", label: "Alpha", isActive: true }),
+      buildItem({ to: "/b", label: "Bravo", isActive: false }),
+    ]);
+    const alpha = screen.getByText("Alpha").closest("a");
+    const bravo = screen.getByText("Bravo").closest("a");
+    expect(alpha?.className).toContain("bg-primary/10");
+    expect(bravo?.className).not.toContain("bg-primary/10");
+  });
+
+  it("supports a Settings icon item type", () => {
+    renderSidebar([
+      buildItem({
+        to: "/settings",
+        icon: <Settings className="h-4 w-4" data-testid="settings-icon" />,
+        label: "Settings",
+      }),
+    ]);
+    expect(screen.getByTestId("settings-icon")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and confirm they fail**
+
+Run: `pnpm test:unit -- app/components/layout/Sidebar.test.tsx`
+Expected: FAIL — module not found (`./Sidebar`).
+
+- [ ] **Step 3: Implement the Sidebar primitive**
+
+```tsx
+// app/components/layout/Sidebar.tsx
+import { ChevronsLeft, ChevronsRight } from "lucide-react";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/libraries/utils";
+
+const SIDEBAR_COLLAPSED_KEY = "shisho-sidebar-collapsed";
+
+export type SidebarItem = {
+  to: string;
+  icon: ReactNode;
+  label: string;
+  isActive: boolean;
+  show?: boolean;
+};
+
+interface NavItemProps {
+  item: SidebarItem;
+  collapsed: boolean;
+}
+
+const NavItem = ({ item, collapsed }: NavItemProps) => {
+  const linkContent = (
+    <Link
+      className={cn(
+        "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+        collapsed && "justify-center px-2",
+        item.isActive
+          ? "bg-primary/10 text-primary dark:bg-violet-500/20 dark:text-violet-300"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      )}
+      to={item.to}
+    >
+      {item.icon}
+      {!collapsed && item.label}
+    </Link>
+  );
+
+  if (collapsed) {
+    return (
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>{linkContent}</TooltipTrigger>
+        <TooltipContent side="right">{item.label}</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return linkContent;
+};
+
+interface SidebarProps {
+  items: SidebarItem[];
+}
+
+const Sidebar = ({ items }: SidebarProps) => {
+  const [collapsed, setCollapsed] = useState(() => {
+    const stored = localStorage.getItem(SIDEBAR_COLLAPSED_KEY);
+    return stored === "true";
+  });
+
+  useEffect(() => {
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(collapsed));
+  }, [collapsed]);
+
+  const visibleItems = items.filter((item) => item.show !== false);
+
+  return (
+    <aside
+      className={cn(
+        "sticky top-14 flex h-[calc(100vh-3.5rem)] shrink-0 flex-col border-r border-border bg-muted/30 transition-all duration-200 md:top-16 md:h-[calc(100vh-4rem)] dark:bg-neutral-900/50",
+        collapsed ? "w-14" : "w-48",
+      )}
+    >
+      <div className="flex-1">
+        <nav className={cn("space-y-1 p-4", collapsed && "px-2")}>
+          {visibleItems.map((item) => (
+            <NavItem collapsed={collapsed} item={item} key={item.to} />
+          ))}
+        </nav>
+        <div className={cn("px-4 pt-2", collapsed && "px-2")}>
+          <div className="border-t border-border/50 pt-3">
+            <Tooltip delayDuration={0}>
+              <TooltipTrigger asChild>
+                <button
+                  aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+                  className={cn(
+                    "flex w-full cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+                    "text-muted-foreground/60 hover:bg-muted/50 hover:text-muted-foreground",
+                    collapsed && "justify-center px-2",
+                  )}
+                  onClick={() => setCollapsed(!collapsed)}
+                >
+                  {collapsed ? (
+                    <ChevronsRight className="h-4 w-4" />
+                  ) : (
+                    <>
+                      <ChevronsLeft className="h-4 w-4" />
+                      <span className="text-xs">Collapse</span>
+                    </>
+                  )}
+                </button>
+              </TooltipTrigger>
+              {collapsed && (
+                <TooltipContent side="right">Expand sidebar</TooltipContent>
+              )}
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+      {!collapsed && (
+        <div className="p-4 pt-0">
+          <a
+            className="group flex items-center justify-center gap-1.5 rounded border border-transparent py-1.5 transition-all duration-200 hover:border-border/40 hover:bg-muted/30"
+            href="https://github.com/shishobooks/shisho/releases"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <span className="text-[10px] text-muted-foreground/40 transition-colors group-hover:text-muted-foreground/70">
+              shisho
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground/50 transition-colors group-hover:text-muted-foreground">
+              {__APP_VERSION__}
+            </span>
+          </a>
+        </div>
+      )}
+    </aside>
+  );
+};
+
+export default Sidebar;
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+Run: `pnpm test:unit -- app/components/layout/Sidebar.test.tsx`
+Expected: All tests pass.
+
+- [ ] **Step 5: Verify full check still passes**
+
+Run: `mise check:quiet`
+Expected: All checks pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/components/layout/Sidebar.tsx app/components/layout/Sidebar.test.tsx
+git commit -m "[Frontend] Add shared Sidebar primitive"
+```
+
+---
+
+## Task 5: Refactor `LibrarySidebar` to use `<Sidebar>`
+
+**Files:**
+- Modify: `app/components/library/LibrarySidebar.tsx`
+
+- [ ] **Step 1: Replace LibrarySidebar with thin wrapper**
+
+Replace the entire contents of `app/components/library/LibrarySidebar.tsx` with:
+
+```tsx
+// app/components/library/LibrarySidebar.tsx
+import { Book, Bookmark, Layers, Settings, Tags, Users } from "lucide-react";
+import { useLocation, useParams } from "react-router-dom";
+
+import Sidebar, { type SidebarItem } from "@/components/layout/Sidebar";
+import { useAuth } from "@/hooks/useAuth";
+
+const LibrarySidebar = () => {
+  const { libraryId } = useParams();
+  const location = useLocation();
+  const { hasPermission } = useAuth();
+
+  if (!libraryId) return null;
+
+  const basePath = `/libraries/${libraryId}`;
+
+  const isBooksActive =
+    location.pathname === basePath ||
+    (location.pathname.startsWith(`${basePath}/books`) &&
+      !location.pathname.startsWith(`${basePath}/series`) &&
+      !location.pathname.startsWith(`${basePath}/people`) &&
+      !location.pathname.startsWith(`${basePath}/genres`) &&
+      !location.pathname.startsWith(`${basePath}/tags`) &&
+      !location.pathname.startsWith(`${basePath}/settings`));
+
+  const items: SidebarItem[] = [
+    {
+      to: basePath,
+      icon: <Book className="h-4 w-4" />,
+      label: "Books",
+      isActive: isBooksActive,
+    },
+    {
+      to: `${basePath}/series`,
+      icon: <Layers className="h-4 w-4" />,
+      label: "Series",
+      isActive: location.pathname.startsWith(`${basePath}/series`),
+    },
+    {
+      to: `${basePath}/people`,
+      icon: <Users className="h-4 w-4" />,
+      label: "People",
+      isActive: location.pathname.startsWith(`${basePath}/people`),
+    },
+    {
+      to: `${basePath}/genres`,
+      icon: <Bookmark className="h-4 w-4" />,
+      label: "Genres",
+      isActive: location.pathname.startsWith(`${basePath}/genres`),
+    },
+    {
+      to: `${basePath}/tags`,
+      icon: <Tags className="h-4 w-4" />,
+      label: "Tags",
+      isActive: location.pathname.startsWith(`${basePath}/tags`),
+    },
+    {
+      to: `${basePath}/settings`,
+      icon: <Settings className="h-4 w-4" />,
+      label: "Settings",
+      isActive: location.pathname.startsWith(`${basePath}/settings`),
+      show: hasPermission("libraries", "write"),
+    },
+  ];
+
+  return <Sidebar items={items} />;
+};
+
+export default LibrarySidebar;
+```
+
+- [ ] **Step 2: Verify checks**
+
+Run: `mise check:quiet`
+Expected: All checks pass.
+
+- [ ] **Step 3: Manually verify library sidebar**
+
+Visit any `/libraries/:id` page. Confirm:
+- Sidebar renders with all items.
+- Clicking each item navigates and highlights.
+- Collapse toggle works and persists after reload.
+- Settings item only shows if user has `libraries:write`.
+- Tooltips appear when collapsed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/library/LibrarySidebar.tsx
+git commit -m "[Frontend] Refactor LibrarySidebar to use shared Sidebar primitive"
+```
+
+---
+
+## Task 6: Create `AdminSidebar`
+
+**Files:**
+- Create: `app/components/pages/AdminSidebar.tsx`
+
+- [ ] **Step 1: Create AdminSidebar**
+
+```tsx
+// app/components/pages/AdminSidebar.tsx
+import { Briefcase, Cog, Library, Puzzle, ScrollText, Users } from "lucide-react";
+import { useLocation } from "react-router-dom";
+
+import Sidebar, { type SidebarItem } from "@/components/layout/Sidebar";
+import { useAuth } from "@/hooks/useAuth";
+
+const AdminSidebar = () => {
+  const location = useLocation();
+  const { hasPermission } = useAuth();
+
+  const canViewConfig = hasPermission("config", "read");
+  const canViewLibraries = hasPermission("libraries", "read");
+  const canViewUsers = hasPermission("users", "read");
+  const canViewJobs = hasPermission("jobs", "read");
+
+  const items: SidebarItem[] = [
+    {
+      to: "/settings/server",
+      icon: <Cog className="h-4 w-4" />,
+      label: "Server",
+      isActive:
+        location.pathname === "/settings/server" ||
+        location.pathname === "/settings",
+      show: canViewConfig,
+    },
+    {
+      to: "/settings/libraries",
+      icon: <Library className="h-4 w-4" />,
+      label: "Libraries",
+      isActive: location.pathname.startsWith("/settings/libraries"),
+      show: canViewLibraries,
+    },
+    {
+      to: "/settings/users",
+      icon: <Users className="h-4 w-4" />,
+      label: "Users",
+      isActive: location.pathname.startsWith("/settings/users"),
+      show: canViewUsers,
+    },
+    {
+      to: "/settings/jobs",
+      icon: <Briefcase className="h-4 w-4" />,
+      label: "Jobs",
+      isActive: location.pathname === "/settings/jobs",
+      show: canViewJobs,
+    },
+    {
+      to: "/settings/plugins",
+      icon: <Puzzle className="h-4 w-4" />,
+      label: "Plugins",
+      isActive: location.pathname === "/settings/plugins",
+      show: canViewConfig,
+    },
+    {
+      to: "/settings/logs",
+      icon: <ScrollText className="h-4 w-4" />,
+      label: "Logs",
+      isActive: location.pathname === "/settings/logs",
+      show: canViewConfig,
+    },
+  ];
+
+  return <Sidebar items={items} />;
+};
+
+export default AdminSidebar;
+```
+
+- [ ] **Step 2: Verify types and lint**
+
+Run: `pnpm lint:types && pnpm lint:eslint`
+Expected: No errors. (Note: the component is not yet used; that's OK for now — lint should still pass since it's exported.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/pages/AdminSidebar.tsx
+git commit -m "[Frontend] Add AdminSidebar using shared Sidebar primitive"
+```
+
+---
+
+## Task 7: Update `MobileDrawer` to show admin nav when on `/settings/*`
+
+**Files:**
+- Modify: `app/components/library/MobileDrawer.tsx`
+
+Background: `MobileDrawer` currently only renders library nav items when in a library context (`libraryId` is present). It does not list admin sub-pages. Because Task 8 removes the admin page's mobile horizontal strip, the drawer must cover admin nav on `/settings/*` routes.
+
+- [ ] **Step 1: Add admin nav items computation in MobileDrawer**
+
+In `app/components/library/MobileDrawer.tsx`, add the following logic inside the `MobileDrawer` component, after the `libraryNavItems` declaration (after line 181) and before the `canAccessAdmin` declaration:
+
+```tsx
+  // Admin nav items (when on /settings/* routes)
+  const isAdminContext = location.pathname.startsWith("/settings");
+  const adminNavItems = isAdminContext
+    ? [
+        {
+          to: "/settings/server",
+          icon: <Cog className="h-5 w-5" />,
+          label: "Server",
+          isActive:
+            location.pathname === "/settings/server" ||
+            location.pathname === "/settings",
+          show: hasPermission("config", "read"),
+        },
+        {
+          to: "/settings/libraries",
+          icon: <Library className="h-5 w-5" />,
+          label: "Libraries",
+          isActive: location.pathname.startsWith("/settings/libraries"),
+          show: hasPermission("libraries", "read"),
+        },
+        {
+          to: "/settings/users",
+          icon: <Users className="h-5 w-5" />,
+          label: "Users",
+          isActive: location.pathname.startsWith("/settings/users"),
+          show: hasPermission("users", "read"),
+        },
+        {
+          to: "/settings/jobs",
+          icon: <Briefcase className="h-5 w-5" />,
+          label: "Jobs",
+          isActive: location.pathname === "/settings/jobs",
+          show: hasPermission("jobs", "read"),
+        },
+        {
+          to: "/settings/plugins",
+          icon: <Puzzle className="h-5 w-5" />,
+          label: "Plugins",
+          isActive: location.pathname === "/settings/plugins",
+          show: hasPermission("config", "read"),
+        },
+        {
+          to: "/settings/logs",
+          icon: <ScrollText className="h-5 w-5" />,
+          label: "Logs",
+          isActive: location.pathname === "/settings/logs",
+          show: hasPermission("config", "read"),
+        },
+      ]
+    : [];
+```
+
+Add these icon imports to the existing `from "lucide-react"` import block at the top: `Briefcase`, `Cog`, `Puzzle`, `ScrollText`. (`Library`, `Users`, `Settings` are already imported.)
+
+- [ ] **Step 2: Render the admin nav section**
+
+Find the "Library Navigation" block (currently around lines 343–359) that looks like:
+
+```tsx
+{isLibraryContext && libraryNavItems.length > 0 && (
+  <nav className="py-2 border-b border-border">
+    {libraryNavItems
+      .filter((item) => item.show)
+      .map((item) => (
+        <NavItem ... />
+      ))}
+  </nav>
+)}
+```
+
+Add a matching block immediately after it:
+
+```tsx
+{isAdminContext && adminNavItems.length > 0 && (
+  <nav className="py-2 border-b border-border">
+    {adminNavItems
+      .filter((item) => item.show)
+      .map((item) => (
+        <NavItem
+          icon={item.icon}
+          isActive={item.isActive}
+          key={item.to}
+          label={item.label}
+          onClick={close}
+          to={item.to}
+        />
+      ))}
+  </nav>
+)}
+```
+
+- [ ] **Step 3: Verify checks**
+
+Run: `mise check:quiet`
+Expected: All checks pass.
+
+- [ ] **Step 4: Manually verify mobile drawer on admin routes**
+
+Resize browser to mobile width (or use devtools mobile emulator). Visit `/settings/users`. Open the hamburger menu. Confirm:
+- Drawer opens and lists all admin sub-nav items the user has permission to see.
+- Active highlighting matches the current route.
+- Clicking an item navigates and closes the drawer.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/MobileDrawer.tsx
+git commit -m "[Frontend] Show admin nav in mobile drawer on /settings routes"
+```
+
+---
+
+## Task 8: Refactor `AdminLayout` — new sidebar, new header, drop mobile strip
+
+**Files:**
+- Modify: `app/components/pages/AdminLayout.tsx`
+
+Context: `app/components/pages/Root.tsx` already wraps all routes in `<MobileNavProvider>` and renders `<MobileDrawer />`, `<Toaster />`, and `<ScrollRestoration />`. `LibraryLayout` does not redundantly wrap these, but the current `AdminLayout` does. The new `AdminLayout` follows `LibraryLayout`'s pattern (no redundant wrapping).
+
+- [ ] **Step 1: Replace the entire file contents**
+
+Replace everything in `app/components/pages/AdminLayout.tsx` with:
+
+```tsx
+// app/components/pages/AdminLayout.tsx
+import { Menu, Settings } from "lucide-react";
+import { Outlet } from "react-router-dom";
+
+import {
+  TOP_NAV_INNER,
+  TOP_NAV_ROW,
+  TOP_NAV_WRAPPER,
+} from "@/components/layout/topNavClasses";
+import UserMenu from "@/components/layout/UserMenu";
+import Logo from "@/components/library/Logo";
+import AdminSidebar from "@/components/pages/AdminSidebar";
+import { Button } from "@/components/ui/button";
+import { useMobileNav } from "@/contexts/MobileNav";
+
+const AdminHeader = () => {
+  const { toggle } = useMobileNav();
+
+  return (
+    <div className={TOP_NAV_WRAPPER}>
+      <div className={TOP_NAV_INNER}>
+        <div className={TOP_NAV_ROW}>
+          <div className="flex items-center gap-2 md:gap-8">
+            <Button
+              aria-label="Open navigation menu"
+              className="-ml-1 h-9 w-9 md:hidden"
+              onClick={toggle}
+              size="icon"
+              variant="ghost"
+            >
+              <Menu className="h-5 w-5" />
+            </Button>
+            <Logo asLink />
+            <div className="hidden items-center gap-2 text-sm font-medium text-muted-foreground sm:flex">
+              <Settings className="h-4 w-4" />
+              <span>Settings</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-1 md:gap-4">
+            <UserMenu />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const AdminLayout = () => {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <AdminHeader />
+      <div className="flex flex-1">
+        <div className="hidden md:block">
+          <AdminSidebar />
+        </div>
+        <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-4 md:px-6 md:py-8">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AdminLayout;
+```
+
+This mirrors `LibraryLayout`'s structure exactly (outer `flex flex-col min-h-screen`, sidebar in `hidden md:block`, main as `flex-1 w-full mx-auto max-w-7xl` with padding).
+
+- [ ] **Step 2: Verify checks**
+
+Run: `mise check:quiet`
+Expected: All checks pass.
+
+- [ ] **Step 3: Manually verify admin pages**
+
+Visit `/settings/server`. Confirm:
+- Top nav shows: logo, "Settings" with gear icon (non-interactive), user menu icon on the right. No "Back to Library" link.
+- Left sidebar shows: Server, Libraries, Users, Jobs, Plugins, Logs (gated by permissions). Current page is highlighted.
+- Collapse toggle works and persists. Persists across navigating to library page and back.
+- Navigating each sidebar item works, highlight moves correctly.
+- User menu opens, Sign out works.
+
+Resize to mobile width. Confirm:
+- Sidebar is hidden.
+- Horizontal strip of admin nav items is GONE.
+- Hamburger opens the mobile drawer with admin nav.
+- "Settings" label and text in top nav is hidden on mobile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/pages/AdminLayout.tsx
+git commit -m "[Frontend] Rebuild AdminLayout using shared Sidebar and UserMenu"
+```
+
+---
+
+## Task 9: Update library `TopNav` to use shared class constants
+
+**Files:**
+- Modify: `app/components/library/TopNav.tsx`
+
+- [ ] **Step 1: Replace the outer container classes with constants**
+
+In `app/components/library/TopNav.tsx`, find the return statement and the outer `<div>`:
+
+```tsx
+<div className="border-b border-border bg-background dark:bg-neutral-900 sticky top-0 z-30">
+  <div className="max-w-7xl mx-auto px-4 md:px-6">
+    <div className="flex items-center justify-between h-14 md:h-16">
+```
+
+Replace with:
+
+```tsx
+<div className={TOP_NAV_WRAPPER}>
+  <div className={TOP_NAV_INNER}>
+    <div className={TOP_NAV_ROW}>
+```
+
+Add this import near the top of the file:
+
+```ts
+import {
+  TOP_NAV_INNER,
+  TOP_NAV_ROW,
+  TOP_NAV_WRAPPER,
+} from "@/components/layout/topNavClasses";
+```
+
+- [ ] **Step 2: Verify checks**
+
+Run: `mise check:quiet`
+Expected: All checks pass.
+
+- [ ] **Step 3: Manually compare library and admin top navs**
+
+Visit a library page, then an admin page. Confirm:
+- Outer container looks identical (border, background, sticky, height).
+- "Settings" label on admin pages sits at the same horizontal position (left of where "Books" sits on library pages).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/library/TopNav.tsx
+git commit -m "[Frontend] Use shared class constants in library TopNav"
+```
+
+---
+
+## Task 10: Final verification
+
+**Files:** (none changed)
+
+- [ ] **Step 1: Run full check**
+
+Run: `mise check:quiet`
+Expected: All checks pass.
+
+- [ ] **Step 2: Manual regression pass**
+
+In the browser, test:
+
+**Library pages** (`/libraries/:id`):
+- Top nav: logo, library picker, resync button (if permitted), search, gear icon (if admin), user menu. All work.
+- Sidebar: all items, collapse/expand, tooltips, persistence. Settings item gated.
+- Mobile hamburger opens drawer with library nav items.
+
+**Admin pages** (`/settings/*`):
+- Top nav: logo, "Settings" with gear (non-interactive, no dropdown), user menu. No "Back to Library".
+- Sidebar: all items (permissions-gated), collapse/expand works.
+- Mobile hamburger opens drawer with admin nav items.
+
+**Cross-flow:**
+- Collapse the sidebar on a library page, navigate to `/settings/server` — sidebar stays collapsed.
+- Expand it on admin, navigate to library — expanded.
+
+- [ ] **Step 3: Confirm no stray files**
+
+Run: `git status`
+Expected: clean working tree.
+
+---
+
+## Out of Scope (not addressed by this plan)
+
+- Changing the admin nav item set, ordering, or permissions.
+- Changing the library nav item set.
+- Adding scan/resync to the admin top nav.
+- Making the "Settings" label in admin a dropdown.
+- Extracting a full top-nav shell component with slots.

--- a/docs/superpowers/specs/2026-04-21-admin-sidebar-consistency-design.md
+++ b/docs/superpowers/specs/2026-04-21-admin-sidebar-consistency-design.md
@@ -1,0 +1,154 @@
+# Admin Sidebar & Top Nav Consistency
+
+## Background
+
+The library pages (`LibrarySidebar`, `TopNav`) and admin pages (`AdminLayout`'s inline sidebar and `AdminHeader`) implement the same UI elements — a left navigation sidebar and a top navigation bar — but in drifted, separately-maintained code. The library implementations are better: a collapsible sidebar with icon-only mode and tooltips, a top nav with a user menu and global search. The admin implementations have their own patterns (non-collapsible desktop sidebar, mobile horizontal strip, no user menu, a "← Back to Library" link) and have diverged in styling details (dark mode color shades, layout structure).
+
+## Goal
+
+Bring the admin sidebar and top nav in line with the library versions, and extract the shared pieces into components/constants so the two cannot drift again.
+
+## Approach
+
+Two principles guide which pieces become shared components and which do not:
+
+1. **Same shape, high drift risk → shared component.** Pieces where the two sites implement the same visual/behavioral element deserve a single source of truth.
+2. **Different shape, low shared surface → don't force a shell.** The library top nav is a rich component (library picker, resync, global search with mobile-expand behavior). The admin top nav after this change is minimal (label + user menu). Forcing them into a slotted shell moves code without preventing meaningful drift.
+
+The pieces with same-shape / high-drift characteristics are:
+- The whole sidebar chrome (container, collapse state, nav items, tooltips, footer)
+- The user menu dropdown
+
+The piece with limited shared surface is the top nav shell itself — handled with shared className constants rather than a component.
+
+## Components and Files
+
+### New: `app/components/layout/Sidebar.tsx`
+
+A generic sidebar primitive. Owns everything that should not drift:
+- Collapsed state with `localStorage` persistence under the key `shisho-sidebar-collapsed` (shared across admin and library — the same key that `LibrarySidebar` currently uses).
+- Width animation: `w-14` collapsed, `w-48` expanded.
+- Container styling: `shrink-0 border-r border-border bg-muted/30 dark:bg-neutral-900/50 transition-all duration-200 h-[calc(100vh-3.5rem)] md:h-[calc(100vh-4rem)] sticky top-14 md:top-16 flex flex-col`.
+- `NavItem` rendering: link styling, active/inactive color states, tooltip wrapper when collapsed.
+- Collapse toggle button (chevrons-left/chevrons-right) with tooltip when collapsed.
+- Version link footer — identical to the current `LibrarySidebar` footer, shown only when expanded.
+
+Props:
+
+```ts
+export type SidebarItem = {
+  to: string;
+  icon: ReactNode;
+  label: string;
+  isActive: boolean;
+  show?: boolean; // defaults to true; false hides the item
+};
+
+type SidebarProps = {
+  items: SidebarItem[];
+};
+```
+
+The component filters by `show` internally. No footer slot — the version link is baked in because both current and planned consumers want the same footer. If that ever needs to vary, we add a prop then, not now.
+
+### New: `app/components/pages/AdminSidebar.tsx`
+
+Thin wrapper. Computes the admin nav items with active-state logic and permission gates, passes them to `<Sidebar>`. Items:
+
+- **Server** — `/settings/server` (active on `/settings` as well) — `canViewConfig`
+- **Libraries** — `/settings/libraries` — `canViewLibraries`
+- **Users** — `/settings/users` — `canViewUsers`
+- **Jobs** — `/settings/jobs` — `canViewJobs`
+- **Plugins** — `/settings/plugins` — `canViewConfig`
+- **Logs** — `/settings/logs` — `canViewConfig`
+
+Uses the same lucide icons as the current admin sidebar (`Cog`, `Library`, `Users`, `Briefcase`, `Puzzle`, `ScrollText`).
+
+### Refactored: `app/components/library/LibrarySidebar.tsx`
+
+Becomes a thin wrapper, same shape as `AdminSidebar`. Retains the `if (!libraryId) return null;` guard. Computes the 6 library nav items (Books, Series, People, Genres, Tags, Settings) with their current active-state logic and the Settings permission check. Passes items to `<Sidebar>`.
+
+### New: `app/components/layout/UserMenu.tsx`
+
+Extracted verbatim from `TopNav.tsx` lines 144–183. The dropdown shows username + role, then links to Lists, Security, User Settings, and Sign out. Owns its own `handleLogout` logic (the `useAuth` and `useNavigate` hooks move into this component).
+
+No props — the component gets everything it needs from `useAuth`.
+
+### New: `app/components/layout/topNavClasses.ts`
+
+Shared className constants for the outer top nav layout. Wrapped in `cn()` so the prettier Tailwind plugin sorts them.
+
+```ts
+import { cn } from "@/libraries/utils";
+
+export const TOP_NAV_WRAPPER = cn(
+  "sticky top-0 z-30 border-b border-border bg-background dark:bg-neutral-900",
+);
+export const TOP_NAV_INNER = cn("mx-auto max-w-7xl px-4 md:px-6");
+export const TOP_NAV_ROW = cn("flex h-14 items-center justify-between md:h-16");
+```
+
+Both `TopNav` and `AdminHeader` import and use these.
+
+### Refactored: `AdminLayout.tsx`
+
+Changes:
+
+1. **`AdminHeader`:**
+   - Remove both "← Back to Library" variants (the desktop `<Link>` and the mobile home-icon button).
+   - Replace the `<span className="hidden sm:inline text-sm text-muted-foreground">Settings</span>` with a styled element that matches the layout of `LibraryListPicker`'s trigger — same `h-9 gap-2 text-muted-foreground` row, gear icon (`Settings` from lucide) + "Settings" text — but rendered as a non-interactive `<div>`: no dropdown, no chevron, no hover state. Hidden on mobile (`hidden sm:flex`) like the library's picker is hidden on mobile.
+   - Add `<UserMenu />` in the right section.
+   - Container classes use the new constants.
+
+2. **`AdminLayoutContent`:**
+   - Remove the mobile horizontal nav strip (currently lines 194–207) and its supporting `mobileNavItems` array and `MobileNavItem` component.
+   - Replace the inline desktop `<aside>` (lines 212–300) with `<AdminSidebar />`.
+   - Remove the inline `NavItem` component.
+   - Remove the user/logout block (now in `UserMenu`).
+
+3. The existing `<MobileDrawer />` call at line 192 stays. See "Verification required" below.
+
+### Refactored: `TopNav.tsx`
+
+- Replace the inline user menu dropdown (lines 144–183) with `<UserMenu />`.
+- Replace the outer container classes (line 66) with the new `TOP_NAV_*` constants.
+
+No behavior changes.
+
+## Layout Alignment Detail
+
+The user called out that the admin nav's "Settings" text sits at a different horizontal position than the library nav's "Books" button. In the library nav, "Books" is inside `LibraryListPicker`'s `<Button variant="ghost" className="h-9 gap-2 ...">` with the library icon to its left. After this change, admin's "Settings" uses the same 9-unit row height, same `gap-2`, same muted color, and the same gear icon to the left — so it occupies the same visual slot.
+
+No dropdown indicator, no hover state, no click handler.
+
+## Verification Required During Implementation
+
+**`MobileDrawer` contents.** The current `AdminLayoutContent` renders both `<MobileDrawer />` and its own mobile horizontal nav strip. This plan drops the strip and relies on `MobileDrawer` to show admin nav items on mobile. Before removing the strip, verify that `MobileDrawer` is route-aware and renders admin items on `/settings/*` routes. If it only shows library items today, it needs to be updated to render the admin nav set as well — probably by deriving items from the same `SidebarItem[]` arrays the sidebars use, so mobile drawer content can't drift from sidebar content either.
+
+This is the one place in the plan that might require additional work beyond the files listed above; it will be handled in the implementation plan.
+
+## Migration / Compatibility
+
+- No backend changes.
+- No route changes.
+- No API changes.
+- No user-facing doc changes (nothing user-configurable changes; the nav arrangement is implementation detail).
+
+## Out of Scope
+
+- Changing the admin nav item set, order, or permissions.
+- Changing the library nav item set.
+- Adding a scan/resync button to admin (explicitly requested not to).
+- Making the new "Settings" label a dropdown (explicitly requested not to).
+- Extracting a full top-nav shell component (covered above — intentionally declined).
+
+## Testing
+
+- Manual verification in the browser for both library and admin pages across desktop and mobile breakpoints:
+  - Sidebar collapses/expands and persists across page reloads and across library ↔ admin navigation.
+  - Tooltips appear on hover when collapsed.
+  - Active state highlights correctly on every admin and library route.
+  - User menu opens, all four links work, Sign out works.
+  - Mobile: hamburger opens `MobileDrawer`, which shows the correct nav items for the current area.
+  - Admin "Settings" label aligns visually with library "Books" button.
+- No new unit tests required — the extracted components are pure structural refactors of existing JSX. If the `Sidebar` component's `show`-filtering logic grows any real logic, revisit.


### PR DESCRIPTION
## Summary
- Extracted shared `<Sidebar>` primitive, `<UserMenu>`, and top-nav class constants so the admin and library chrome share single sources of truth (collapse state, item styling, tooltips, version footer, user dropdown).
- Rebuilt admin pages' header and sidebar to mirror library's: added user menu, removed the "← Back to Library" link, replaced the plain "Settings" text with a gear+label matching the library picker's geometry, and swapped the mobile horizontal nav strip for the shared mobile drawer.
- Moved the `/settings` route tree under `Root` so admin pages inherit Root's `MobileNavProvider`, `MobileDrawer`, `Toaster`, and `ScrollRestoration` instead of `AdminLayout` wrapping its own copies.
- Extracted `useAdminNavItems` / `useLibraryNavItems` hooks so `AdminSidebar`, `LibrarySidebar`, and `MobileDrawer` share item definitions — adding a new admin or library section now requires editing exactly one file.

## Test plan
- Run `mise check:quiet` — lint, Go tests, JS unit, and E2E all pass.
- On `/libraries/:id` pages: top nav shows logo, library picker, resync, search, gear (if admin), user menu; sidebar collapses/expands and persists; mobile hamburger opens drawer with library nav.
- On `/settings/*` pages: top nav shows logo, gear-prefixed "Settings" label aligned with library picker, user menu (no more "Back to Library"); sidebar items permission-gated and collapse state shared with library; Server Settings content fills the main column like other admin pages.
- Toggle sidebar collapsed on a library page, navigate to `/settings/server` — stays collapsed. Toggle expanded on admin, back to library — stays expanded.
- Resize to mobile: admin horizontal strip is gone; hamburger drawer shows the correct nav set for the current area.