### PR TITLE
[Frontend] Remove in-app back buttons

### DIFF
--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowLeft,
   ArrowRightLeft,
   BookOpen,
   Check,
@@ -1024,15 +1023,9 @@ const BookDetail = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">Book Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The book you're looking for doesn't exist or may have been removed.
           </p>
-          <Button asChild>
-            <Link to={`/libraries/${libraryId}`}>
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Home
-            </Link>
-          </Button>
         </div>
       </LibraryLayout>
     );

--- a/app/components/pages/CreateLibrary.tsx
+++ b/app/components/pages/CreateLibrary.tsx
@@ -1,6 +1,5 @@
-import { ArrowLeft, FolderOpen, Plus, Trash2 } from "lucide-react";
+import { FolderOpen, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
 import { toast } from "sonner";
 
 import DirectoryPickerDialog from "@/components/library/DirectoryPickerDialog";
@@ -166,15 +165,6 @@ const CreateLibrary = () => {
     <div>
       <TopNav />
       <div className="max-w-7xl w-full mx-auto px-6 py-8">
-        <div className="mb-6">
-          <Button asChild variant="ghost">
-            <Link to="/">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back
-            </Link>
-          </Button>
-        </div>
-
         <div className="mb-8">
           <h1 className="text-2xl font-semibold mb-2">Create Library</h1>
           <p className="text-muted-foreground">

--- a/app/components/pages/CreateUser.tsx
+++ b/app/components/pages/CreateUser.tsx
@@ -1,6 +1,5 @@
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -150,15 +149,6 @@ const CreateUser = () => {
 
   return (
     <div>
-      <div className="mb-6">
-        <Button asChild variant="ghost">
-          <Link to="/settings/users">
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Users
-          </Link>
-        </Button>
-      </div>
-
       <div className="mb-8">
         <h1 className="text-2xl font-semibold mb-2">Create User</h1>
         <p className="text-muted-foreground">Add a new user to the system</p>

--- a/app/components/pages/FileDetail.tsx
+++ b/app/components/pages/FileDetail.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, BookOpen, Pencil, Trash2 } from "lucide-react";
+import { BookOpen, Pencil, Trash2 } from "lucide-react";
 import { useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -150,15 +150,9 @@ const FileDetail = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">Book Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The book you're looking for doesn't exist or may have been removed.
           </p>
-          <Button asChild>
-            <Link to={`/libraries/${libraryId}`}>
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Home
-            </Link>
-          </Button>
         </div>
       </LibraryLayout>
     );
@@ -169,15 +163,9 @@ const FileDetail = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">File Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The file you're looking for doesn't exist or may have been removed.
           </p>
-          <Button asChild>
-            <Link to={`/libraries/${libraryId}/books/${bookId}`}>
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Book
-            </Link>
-          </Button>
         </div>
       </LibraryLayout>
     );

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -1,6 +1,6 @@
 import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
 import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
@@ -91,15 +91,9 @@ const GenreDetail = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">Genre Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The genre you're looking for doesn't exist or may have been removed.
           </p>
-          <Link
-            className="text-primary hover:underline"
-            to={`/libraries/${libraryId}/genres`}
-          >
-            Back to Genres
-          </Link>
         </div>
       </LibraryLayout>
     );

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -91,16 +91,10 @@ const ImprintDetail = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">Imprint Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The imprint you're looking for doesn't exist or may have been
             removed.
           </p>
-          <Link
-            className="text-primary hover:underline"
-            to={`/libraries/${libraryId}/imprints`}
-          >
-            Back to Imprints
-          </Link>
         </div>
       </LibraryLayout>
     );

--- a/app/components/pages/JobDetail.tsx
+++ b/app/components/pages/JobDetail.tsx
@@ -1,7 +1,6 @@
 import { formatDistanceToNow } from "date-fns";
-import { ArrowLeft } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import LogViewer from "@/components/library/LogViewer";
@@ -175,13 +174,6 @@ const JobDetail = () => {
     <div>
       {/* Header */}
       <div className="mb-6">
-        <Link
-          className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground mb-4"
-          to="/settings/jobs"
-        >
-          <ArrowLeft className="h-4 w-4 mr-1" />
-          Back to Jobs
-        </Link>
         <div className="flex items-center gap-4">
           <h1 className="text-2xl font-semibold">Job #{job.id}</h1>
           <Badge className={getStatusColor(job.status)} variant="secondary">

--- a/app/components/pages/LibrarySettings.tsx
+++ b/app/components/pages/LibrarySettings.tsx
@@ -1,7 +1,7 @@
 import equal from "fast-deep-equal";
-import { ArrowLeft, FolderOpen, Trash2 } from "lucide-react";
+import { FolderOpen, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
 import DirectoryPickerDialog from "@/components/library/DirectoryPickerDialog";
@@ -231,16 +231,10 @@ const LibrarySettings = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">Library Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The library you're looking for doesn't exist or may have been
             removed.
           </p>
-          <Button asChild>
-            <Link to="/">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back to Home
-            </Link>
-          </Button>
         </div>
       </LibraryLayout>
     );
@@ -248,15 +242,6 @@ const LibrarySettings = () => {
 
   return (
     <LibraryLayout>
-      <div className="mb-6">
-        <Button asChild variant="ghost">
-          <Link to={`/libraries/${libraryId}`}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Library
-          </Link>
-        </Button>
-      </div>
-
       <div className="mb-8">
         <h1 className="text-2xl font-semibold mb-2">Library Settings</h1>
         <p className="text-muted-foreground">

--- a/app/components/pages/ListDetail.tsx
+++ b/app/components/pages/ListDetail.tsx
@@ -1,12 +1,7 @@
 import { format, formatDistanceToNow } from "date-fns";
 import { Edit, Save, Share2, Trash2 } from "lucide-react";
 import { useState } from "react";
-import {
-  Link,
-  useNavigate,
-  useParams,
-  useSearchParams,
-} from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 
 import BookItem from "@/components/library/BookItem";
@@ -142,13 +137,10 @@ const ListDetail = () => {
             <h1 className="text-xl md:text-2xl font-semibold mb-4">
               List Not Found
             </h1>
-            <p className="text-muted-foreground mb-6">
+            <p className="text-muted-foreground">
               The list you're looking for doesn't exist or may have been
               removed.
             </p>
-            <Link className="text-primary hover:underline" to="/lists">
-              Back to Lists
-            </Link>
           </div>
         </div>
       </div>

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -97,16 +97,10 @@ const PersonDetail = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">Person Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The person you're looking for doesn't exist or may have been
             removed.
           </p>
-          <Link
-            className="text-primary hover:underline"
-            to={`/libraries/${libraryId}/people`}
-          >
-            Back to People
-          </Link>
         </div>
       </LibraryLayout>
     );

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -91,16 +91,10 @@ const PublisherDetail = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">Publisher Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The publisher you're looking for doesn't exist or may have been
             removed.
           </p>
-          <Link
-            className="text-primary hover:underline"
-            to={`/libraries/${libraryId}/publishers`}
-          >
-            Back to Publishers
-          </Link>
         </div>
       </LibraryLayout>
     );

--- a/app/components/pages/SecuritySettings.tsx
+++ b/app/components/pages/SecuritySettings.tsx
@@ -1,6 +1,6 @@
-import { ArrowLeft, Copy, Plus, Trash2 } from "lucide-react";
+import { Copy, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState, type FormEvent } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 
 import Logo from "@/components/library/Logo";
@@ -163,15 +163,6 @@ const SecuritySettings = () => {
     <div>
       <TopNav />
       <div className="mx-auto w-full max-w-7xl px-6 py-8">
-        <div className="mb-6">
-          <Button asChild variant="ghost">
-            <Link to="/">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back
-            </Link>
-          </Button>
-        </div>
-
         <div className="mb-8">
           <h1 className="mb-2 text-2xl font-semibold">Security Settings</h1>
           <p className="text-muted-foreground">

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -1,6 +1,6 @@
 import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
 import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
@@ -94,16 +94,10 @@ const SeriesDetail = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">Series Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The series you're looking for doesn't exist or may have been
             removed.
           </p>
-          <Link
-            className="text-primary hover:underline"
-            to={`/libraries/${libraryId}/series`}
-          >
-            Back to Series
-          </Link>
         </div>
       </LibraryLayout>
     );

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -1,6 +1,6 @@
 import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
 import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
@@ -91,15 +91,9 @@ const TagDetail = () => {
       <LibraryLayout>
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-4">Tag Not Found</h1>
-          <p className="text-muted-foreground mb-6">
+          <p className="text-muted-foreground">
             The tag you're looking for doesn't exist or may have been removed.
           </p>
-          <Link
-            className="text-primary hover:underline"
-            to={`/libraries/${libraryId}/tags`}
-          >
-            Back to Tags
-          </Link>
         </div>
       </LibraryLayout>
     );

--- a/app/components/pages/UserDetail.tsx
+++ b/app/components/pages/UserDetail.tsx
@@ -1,7 +1,7 @@
 import equal from "fast-deep-equal";
-import { ArrowLeft, Loader2, Save, Shield, Trash2 } from "lucide-react";
+import { Loader2, Save, Shield, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
@@ -266,15 +266,6 @@ const UserDetail = () => {
 
   return (
     <div>
-      <div className="mb-6">
-        <Button asChild variant="ghost">
-          <Link to="/settings/users">
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Users
-          </Link>
-        </Button>
-      </div>
-
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center gap-4">
           <h1 className="text-2xl font-semibold">{user.username}</h1>

--- a/app/components/pages/UserSettings.tsx
+++ b/app/components/pages/UserSettings.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Check, KeyRound, Moon, Sun } from "lucide-react";
+import { Check, KeyRound, Moon, Sun } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { useTheme, type Theme } from "@/components/contexts/Theme/context";
@@ -45,15 +45,6 @@ const UserSettings = () => {
     <div>
       <TopNav />
       <div className="max-w-7xl w-full mx-auto px-6 py-8">
-        <div className="mb-6">
-          <Button asChild variant="ghost">
-            <Link to="/">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back
-            </Link>
-          </Button>
-        </div>
-
         <div className="mb-8">
           <h1 className="text-2xl font-semibold mb-2">User Settings</h1>
           <p className="text-muted-foreground">


### PR DESCRIPTION
## Summary
- Removed 11 redundant back buttons across 8 pages (create/edit forms, settings, not-found error states). Sidebar nav, breadcrumbs on nested entity pages, and clear page titles already communicate location.
- Kept the PageReader exit arrow (only way out of the `fixed inset-0` reader) and the IdentifyReviewForm step-back (internal wizard navigation, not page nav).
- Dropped now-unused `ArrowLeft` / `Link` imports alongside each removal.

## Test plan
- Visit each affected page and confirm no "Back" button renders: Create Library, Create User, User Detail, Library Settings, Security Settings, User Settings, Job Detail.
- Visit a non-existent book/file/library URL and confirm the Not Found state no longer has a back button (sidebar still navigates).
- Confirm the PDF/CBZ reader (`PageReader`) still has its top-left back arrow — it's the only way to exit.
- Run the Identify Book flow and confirm the wizard's "Review Changes" step still has its back arrow to the previous step.
- `mise check:quiet` passes.