### PR TITLE
[Feature] Fetch M4B chapters from Audible via Audnexus

### DIFF
--- a/app/components/files/FetchChaptersDialog.test.tsx
+++ b/app/components/files/FetchChaptersDialog.test.tsx
@@ -150,7 +150,7 @@ describe("FetchChaptersDialog", () => {
       // lands in the result stage before our next assertion.
       await waitFor(() => {
         expect(
-          screen.getByText(/2 chapters from audnexus/i),
+          screen.getByText(/2 chapters from audible/i),
         ).toBeInTheDocument();
       });
 
@@ -339,12 +339,12 @@ describe("FetchChaptersDialog", () => {
       });
     });
 
-    it("goes back to entry stage when Retry is clicked", async () => {
+    it("refetches when Retry is clicked", async () => {
       const user = createUser();
 
-      vi.spyOn(API, "request").mockRejectedValue(
-        new ShishoAPIError("not found", "not_found", 404),
-      );
+      const apiMock = vi
+        .spyOn(API, "request")
+        .mockRejectedValue(new ShishoAPIError("not found", "not_found", 404));
 
       renderWithClient(<FetchChaptersDialog {...defaultProps} />);
 
@@ -358,12 +358,14 @@ describe("FetchChaptersDialog", () => {
         ).toBeInTheDocument();
       });
 
+      const callsBefore = apiMock.mock.calls.length;
       await user.click(screen.getByRole("button", { name: /retry/i }));
 
-      // Should be back at entry stage
-      expect(
-        screen.getByRole("button", { name: /fetch chapters/i }),
-      ).toBeInTheDocument();
+      // Retry should fire a fresh upstream call rather than replaying the
+      // cached error.
+      await waitFor(() => {
+        expect(apiMock.mock.calls.length).toBeGreaterThan(callsBefore);
+      });
     });
   });
 });

--- a/app/components/files/FetchChaptersDialog.test.tsx
+++ b/app/components/files/FetchChaptersDialog.test.tsx
@@ -1,0 +1,369 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { API, ShishoAPIError } from "@/libraries/api";
+import type { ChapterInput } from "@/types";
+
+import FetchChaptersDialog from "./FetchChaptersDialog";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+const renderWithClient = (ui: React.ReactElement) => {
+  const queryClient = createQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const defaultEditedChapters: ChapterInput[] = [
+  { title: "Intro", start_timestamp_ms: 0, children: [] },
+  { title: "Chapter 1", start_timestamp_ms: 60000, children: [] },
+];
+
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  onApply: vi.fn(),
+  editedChapters: defaultEditedChapters,
+  fileDurationMs: 7200000, // 2 hours
+  hasChanges: false,
+};
+
+const audnexusResponse = {
+  asin: "B0AAAATEST",
+  is_accurate: true,
+  runtime_length_ms: 7200000,
+  brand_intro_duration_ms: 0,
+  brand_outro_duration_ms: 0,
+  chapters: [
+    { title: "Audnexus Intro", start_offset_ms: 0, length_ms: 60000 },
+    { title: "Audnexus Chapter 1", start_offset_ms: 60000, length_ms: 7140000 },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FetchChaptersDialog", () => {
+  describe("Entry stage", () => {
+    it("shows 'existing' note and enables Fetch when prefilled with valid ASIN", () => {
+      renderWithClient(
+        <FetchChaptersDialog {...defaultProps} initialAsin="B0AAAATEST" />,
+      );
+
+      // Input should be prefilled
+      const input = screen.getByRole("textbox");
+      expect(input).toHaveValue("B0AAAATEST");
+
+      // Fetch button should be enabled
+      const fetchButton = screen.getByRole("button", {
+        name: /fetch chapters/i,
+      });
+      expect(fetchButton).not.toBeDisabled();
+    });
+
+    it("disables Fetch when ASIN is empty", () => {
+      renderWithClient(<FetchChaptersDialog {...defaultProps} />);
+
+      const fetchButton = screen.getByRole("button", {
+        name: /fetch chapters/i,
+      });
+      expect(fetchButton).toBeDisabled();
+    });
+
+    it("disables Fetch for invalid ASIN (fewer than 10 chars)", async () => {
+      const user = createUser();
+      renderWithClient(<FetchChaptersDialog {...defaultProps} />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "SHORT");
+
+      const fetchButton = screen.getByRole("button", {
+        name: /fetch chapters/i,
+      });
+      expect(fetchButton).toBeDisabled();
+    });
+
+    it("enables Fetch when ASIN is exactly 10 alphanumeric characters", async () => {
+      const user = createUser();
+      renderWithClient(<FetchChaptersDialog {...defaultProps} />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+
+      const fetchButton = screen.getByRole("button", {
+        name: /fetch chapters/i,
+      });
+      expect(fetchButton).not.toBeDisabled();
+    });
+
+    it("disables Fetch for 10 characters with special chars", async () => {
+      const user = createUser();
+      renderWithClient(<FetchChaptersDialog {...defaultProps} />);
+
+      const input = screen.getByRole("textbox");
+      // The input uppercases but special chars are not alphanumeric
+      await user.type(input, "B0AAAA!@#$");
+
+      const fetchButton = screen.getByRole("button", {
+        name: /fetch chapters/i,
+      });
+      expect(fetchButton).toBeDisabled();
+    });
+  });
+
+  describe("Loading and result stages", () => {
+    it("shows result stage after successful fetch", async () => {
+      const user = createUser();
+
+      vi.spyOn(API, "request").mockResolvedValue(audnexusResponse);
+
+      renderWithClient(<FetchChaptersDialog {...defaultProps} />);
+
+      // Type a valid ASIN and click Fetch
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+      await user.click(screen.getByRole("button", { name: /fetch chapters/i }));
+
+      // Wait for result stage — mock resolves in the microtask queue, so
+      // the loading spinner may be visible for only one tick and the DOM
+      // lands in the result stage before our next assertion.
+      await waitFor(() => {
+        expect(
+          screen.getByText(/2 chapters from audnexus/i),
+        ).toBeInTheDocument();
+      });
+
+      // Confirm result-stage action buttons are present
+      expect(
+        screen.getByRole("button", { name: /apply titles only/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("clicking 'Apply titles only' calls onApply with titles replaced and timestamps preserved", async () => {
+      const user = createUser();
+      const onApply = vi.fn();
+
+      vi.spyOn(API, "request").mockResolvedValue(audnexusResponse);
+
+      renderWithClient(
+        <FetchChaptersDialog {...defaultProps} onApply={onApply} />,
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+      await user.click(screen.getByRole("button", { name: /fetch chapters/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /apply titles only/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(
+        screen.getByRole("button", { name: /apply titles only/i }),
+      );
+
+      expect(onApply).toHaveBeenCalledOnce();
+      const applied: ChapterInput[] = onApply.mock.calls[0][0];
+
+      // Titles should come from Audnexus
+      expect(applied[0].title).toBe("Audnexus Intro");
+      expect(applied[1].title).toBe("Audnexus Chapter 1");
+
+      // Timestamps should be preserved from editedChapters
+      expect(applied[0].start_timestamp_ms).toBe(0);
+      expect(applied[1].start_timestamp_ms).toBe(60000);
+    });
+  });
+
+  describe("Apply titles only — chapter count mismatch", () => {
+    it("disables 'Apply titles only' when chapter counts differ", async () => {
+      const user = createUser();
+
+      // Audnexus returns 2 chapters; editedChapters has 2 — make them differ
+      const mismatchedChapters: ChapterInput[] = [
+        { title: "Only One", start_timestamp_ms: 0, children: [] },
+      ];
+
+      vi.spyOn(API, "request").mockResolvedValue(audnexusResponse);
+
+      renderWithClient(
+        <FetchChaptersDialog
+          {...defaultProps}
+          editedChapters={mismatchedChapters}
+        />,
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+      await user.click(screen.getByRole("button", { name: /fetch chapters/i }));
+
+      await waitFor(() => {
+        // Result stage shows chapter count mismatch info
+        expect(screen.getByText(/1/)).toBeInTheDocument();
+      });
+
+      // The "Apply titles only" button should be disabled (counts differ: 1 vs 2)
+      await waitFor(() => {
+        const applyTitlesBtn = screen.getByRole("button", {
+          name: /apply titles only/i,
+        });
+        expect(applyTitlesBtn).toBeDisabled();
+      });
+    });
+  });
+
+  describe("Overwrite warning", () => {
+    it("shows overwrite warning when hasChanges is true", async () => {
+      const user = createUser();
+
+      vi.spyOn(API, "request").mockResolvedValue(audnexusResponse);
+
+      renderWithClient(
+        <FetchChaptersDialog {...defaultProps} hasChanges={true} />,
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+      await user.click(screen.getByRole("button", { name: /fetch chapters/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/unsaved changes will be overwritten/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("does not show overwrite warning when hasChanges is false", async () => {
+      const user = createUser();
+
+      vi.spyOn(API, "request").mockResolvedValue(audnexusResponse);
+
+      renderWithClient(
+        <FetchChaptersDialog {...defaultProps} hasChanges={false} />,
+      );
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+      await user.click(screen.getByRole("button", { name: /fetch chapters/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/unsaved changes will be overwritten/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Error state", () => {
+    it("shows not_found error message when ASIN is not found on Audible", async () => {
+      const user = createUser();
+
+      vi.spyOn(API, "request").mockRejectedValue(
+        new ShishoAPIError("not found", "not_found", 404),
+      );
+
+      renderWithClient(<FetchChaptersDialog {...defaultProps} />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+      await user.click(screen.getByRole("button", { name: /fetch chapters/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/lookup failed/i)).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(/we couldn't find this asin on audible/i),
+      ).toBeInTheDocument();
+    });
+
+    it("shows generic error message for unknown error codes", async () => {
+      const user = createUser();
+
+      vi.spyOn(API, "request").mockRejectedValue(
+        new ShishoAPIError("server error", "server_error", 500),
+      );
+
+      renderWithClient(<FetchChaptersDialog {...defaultProps} />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+      await user.click(screen.getByRole("button", { name: /fetch chapters/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/lookup failed/i)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText(/couldn't reach audible/i)).toBeInTheDocument();
+    });
+
+    it("shows Retry button in error state", async () => {
+      const user = createUser();
+
+      vi.spyOn(API, "request").mockRejectedValue(
+        new ShishoAPIError("not found", "not_found", 404),
+      );
+
+      renderWithClient(<FetchChaptersDialog {...defaultProps} />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+      await user.click(screen.getByRole("button", { name: /fetch chapters/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /retry/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("goes back to entry stage when Retry is clicked", async () => {
+      const user = createUser();
+
+      vi.spyOn(API, "request").mockRejectedValue(
+        new ShishoAPIError("not found", "not_found", 404),
+      );
+
+      renderWithClient(<FetchChaptersDialog {...defaultProps} />);
+
+      const input = screen.getByRole("textbox");
+      await user.type(input, "B0AAAATEST");
+      await user.click(screen.getByRole("button", { name: /fetch chapters/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: /retry/i }),
+        ).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /retry/i }));
+
+      // Should be back at entry stage
+      expect(
+        screen.getByRole("button", { name: /fetch chapters/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/app/components/files/FetchChaptersDialog.tsx
+++ b/app/components/files/FetchChaptersDialog.tsx
@@ -67,6 +67,8 @@ function errorMessage(code: string | undefined): string {
       return "Request timed out. Try again.";
     case "invalid_asin":
       return "Check the ASIN format. It should be 10 alphanumeric characters.";
+    case "rate_limited":
+      return "Audible is rate-limiting lookups right now. Wait a few minutes and try again.";
     default:
       return "Couldn't reach Audible. Try again in a moment.";
   }

--- a/app/components/files/FetchChaptersDialog.tsx
+++ b/app/components/files/FetchChaptersDialog.tsx
@@ -1,0 +1,447 @@
+import { Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  useAudnexusChapters,
+  type AudnexusChaptersResponse,
+} from "@/hooks/queries/audnexus";
+import type { ChapterInput } from "@/types";
+
+import {
+  applyTitlesAndTimestamps,
+  applyTitlesOnly,
+  detectIntroOffset,
+} from "./audnexusChapterUtils";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ASIN_RE = /^[A-Z0-9]{10}$/;
+
+function normalizeAsin(raw: string): string {
+  return raw.trim().toUpperCase();
+}
+
+function isValidAsin(asin: string): boolean {
+  return ASIN_RE.test(asin);
+}
+
+/** Format milliseconds as "Xh Ym Zs" / "Ym Zs" / "Zs". */
+function formatDurationMs(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+function errorMessage(code: string | undefined): string {
+  switch (code) {
+    case "not_found":
+      return "We couldn't find this ASIN on Audible. Double-check the ID on the Audible book page.";
+    case "timeout":
+      return "Request timed out. Try again.";
+    case "invalid_asin":
+      return "Check the ASIN format. It should be 10 alphanumeric characters.";
+    default:
+      return "Couldn't reach Audible. Try again in a moment.";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-stage components
+// ---------------------------------------------------------------------------
+
+interface EntryStageProps {
+  asinInput: string;
+  onAsinChange: (value: string) => void;
+  onFetch: () => void;
+}
+
+const EntryStage = ({ asinInput, onAsinChange, onFetch }: EntryStageProps) => {
+  const normalized = normalizeAsin(asinInput);
+  const valid = isValidAsin(normalized);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && valid) {
+      onFetch();
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="asin-input">Audible ASIN</Label>
+        <Input
+          className="font-mono"
+          id="asin-input"
+          maxLength={10}
+          onChange={(e) => onAsinChange(e.target.value.toUpperCase())}
+          onKeyDown={handleKeyDown}
+          placeholder="B0XXXXXXXX"
+          value={asinInput}
+        />
+        <p className="text-xs text-muted-foreground">
+          10-character code from the Audible book page URL.
+        </p>
+      </div>
+      <Button disabled={!valid} onClick={onFetch} type="button">
+        Fetch chapters
+      </Button>
+    </div>
+  );
+};
+
+const LoadingStage = () => (
+  <div className="flex flex-col items-center gap-3 py-8 text-muted-foreground">
+    <Loader2 className="h-6 w-6 animate-spin" />
+    <span className="text-sm">Looking up chapters on Audnexus...</span>
+  </div>
+);
+
+interface ErrorStageProps {
+  code: string | undefined;
+  onRetry: () => void;
+}
+
+const ErrorStage = ({ code, onRetry }: ErrorStageProps) => (
+  <div className="space-y-4">
+    <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
+      <p className="text-sm font-medium text-destructive">Lookup failed</p>
+      <p className="mt-1 text-sm text-destructive/80">{errorMessage(code)}</p>
+    </div>
+    <Button onClick={onRetry} type="button" variant="outline">
+      Retry
+    </Button>
+  </div>
+);
+
+interface ResultStageProps {
+  data: AudnexusChaptersResponse;
+  editedChapters: ChapterInput[];
+  fileDurationMs: number;
+  hasChanges: boolean;
+  onApply: (chapters: ChapterInput[]) => void;
+  onClose: () => void;
+}
+
+const ResultStage = ({
+  data,
+  editedChapters,
+  fileDurationMs,
+  hasChanges,
+  onApply,
+  onClose,
+}: ResultStageProps) => {
+  const detection = useMemo(
+    () =>
+      detectIntroOffset({
+        runtimeMs: data.runtime_length_ms,
+        introMs: data.brand_intro_duration_ms,
+        outroMs: data.brand_outro_duration_ms,
+        fileDurationMs,
+      }),
+    [data, fileDurationMs],
+  );
+
+  const [applyOffset, setApplyOffset] = useState(detection.applyOffset);
+
+  // Re-seed when new data arrives.
+  useEffect(() => {
+    setApplyOffset(detection.applyOffset);
+  }, [detection.applyOffset]);
+
+  const countsMatch = data.chapters.length === editedChapters.length;
+  const diffMs = Math.abs(data.runtime_length_ms - fileDurationMs);
+
+  const handleTitlesOnly = () => {
+    const result = applyTitlesOnly(editedChapters, data.chapters);
+    onApply(result);
+    onClose();
+  };
+
+  const handleTitlesAndTimestamps = () => {
+    const result = applyTitlesAndTimestamps(data.chapters, {
+      applyIntroOffset: applyOffset,
+      introMs: data.brand_intro_duration_ms,
+    });
+    onApply(result);
+    onClose();
+  };
+
+  const titlesOnlyDisabledTitle = countsMatch
+    ? undefined
+    : `Chapter counts don't match (${editedChapters.length} vs ${data.chapters.length}).`;
+
+  return (
+    <div className="space-y-4">
+      {/* Duration comparison */}
+      <div className="text-sm text-muted-foreground">
+        <span>
+          Audnexus runtime:{" "}
+          <span className="font-mono">
+            {formatDurationMs(data.runtime_length_ms)}
+          </span>
+        </span>
+        <span className="mx-2 text-muted-foreground/50">·</span>
+        <span>
+          File duration:{" "}
+          <span className="font-mono">{formatDurationMs(fileDurationMs)}</span>
+        </span>
+      </div>
+
+      {/* Duration match / mismatch callout */}
+      {!detection.withinTolerance ? (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
+          <p className="text-sm font-medium text-destructive">
+            Duration differs by {formatDurationMs(diffMs)}. May be a different
+            edition.
+          </p>
+          <p className="mt-1 text-sm text-destructive/80">
+            Chapter timestamps may not align with this file. Trim detection
+            requires durations to match within 2 seconds.
+          </p>
+        </div>
+      ) : detection.applyOffset ? (
+        <div className="rounded-md border border-primary/30 bg-primary/5 px-4 py-3">
+          <p className="text-sm font-medium">
+            Intro removed. Chapters offset by -
+            {formatDurationMs(data.brand_intro_duration_ms)}.
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Matches a trimmed file (e.g. Libation rip). Chapters will be shifted
+            to align.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-md border border-primary/30 bg-primary/5 px-4 py-3">
+          <p className="text-sm font-medium">
+            Durations match. File is intact.
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Chapter timestamps will be used as-is.
+          </p>
+        </div>
+      )}
+
+      {/* Intro offset checkbox */}
+      <div className="flex items-center gap-2">
+        <Checkbox
+          checked={applyOffset}
+          id="apply-offset"
+          onCheckedChange={(checked) => setApplyOffset(Boolean(checked))}
+        />
+        <Label className="cursor-pointer" htmlFor="apply-offset">
+          Shift timestamps: subtract intro (
+          {formatDurationMs(data.brand_intro_duration_ms)}) from each chapter
+        </Label>
+      </div>
+
+      {/* Chapter count info */}
+      <p className="text-sm text-muted-foreground">
+        {data.chapters.length} chapter{data.chapters.length !== 1 ? "s" : ""}{" "}
+        from Audnexus
+        {!countsMatch && (
+          <span className="ml-1 text-destructive">
+            (file has {editedChapters.length})
+          </span>
+        )}
+      </p>
+
+      {/* Overwrite warning */}
+      {hasChanges && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
+          <p className="text-sm font-medium text-destructive">
+            Unsaved changes will be overwritten
+          </p>
+          <p className="mt-1 text-sm text-destructive/80">
+            Applying will replace your current edits. Canceling keeps this
+            dialog open but your unsaved edits are still pending.
+          </p>
+        </div>
+      )}
+
+      {/* Action buttons */}
+      <div className="flex flex-col sm:flex-row gap-2">
+        {countsMatch ? (
+          <>
+            <Button onClick={handleTitlesOnly} type="button">
+              Apply titles only
+            </Button>
+            <Button
+              onClick={handleTitlesAndTimestamps}
+              type="button"
+              variant="outline"
+            >
+              Apply titles + timestamps
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button onClick={handleTitlesAndTimestamps} type="button">
+              Apply titles + timestamps
+            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    className="w-full"
+                    disabled
+                    type="button"
+                    variant="outline"
+                  >
+                    Apply titles only
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {titlesOnlyDisabledTitle}
+              </TooltipContent>
+            </Tooltip>
+          </>
+        )}
+        <Button
+          className="sm:ml-auto"
+          onClick={onClose}
+          type="button"
+          variant="ghost"
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Public props + component
+// ---------------------------------------------------------------------------
+
+export interface FetchChaptersDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** ASIN prefilled from the file's existing identifiers, if present. */
+  initialAsin?: string;
+  /** Called when the user clicks an Apply button. Closes the dialog. */
+  onApply: (chapters: ChapterInput[]) => void;
+  /** Current edited chapters; used for the counts-match check. */
+  editedChapters: ChapterInput[];
+  /** File duration in ms; used for trim offset detection. */
+  fileDurationMs: number;
+  /** True if the parent edit form has unsaved edits. */
+  hasChanges: boolean;
+}
+
+type Stage = "entry" | "loading" | "result" | "error";
+
+const FetchChaptersDialog = ({
+  open,
+  onOpenChange,
+  initialAsin,
+  onApply,
+  editedChapters,
+  fileDurationMs,
+  hasChanges,
+}: FetchChaptersDialogProps) => {
+  const [asinInput, setAsinInput] = useState(
+    initialAsin ? normalizeAsin(initialAsin) : "",
+  );
+  const [submittedAsin, setSubmittedAsin] = useState<string | null>(null);
+
+  // Reset to entry stage and reseed ASIN whenever the dialog opens.
+  useEffect(() => {
+    if (open) {
+      setAsinInput(initialAsin ? normalizeAsin(initialAsin) : "");
+      setSubmittedAsin(null);
+    }
+  }, [open, initialAsin]);
+
+  const query = useAudnexusChapters(submittedAsin, {
+    enabled: Boolean(submittedAsin),
+  });
+
+  const stage: Stage = useMemo((): Stage => {
+    if (!submittedAsin) return "entry";
+    if (query.isSuccess) return "result";
+    if (query.isError) return "error";
+    return "loading";
+  }, [submittedAsin, query.isSuccess, query.isError]);
+
+  const handleFetch = () => {
+    const normalized = normalizeAsin(asinInput);
+    if (!isValidAsin(normalized)) return;
+    setSubmittedAsin(normalized);
+  };
+
+  const handleRetry = () => {
+    setSubmittedAsin(null);
+  };
+
+  const handleClose = () => {
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-lg overflow-x-hidden">
+        <DialogHeader className="pr-8">
+          <DialogTitle>Fetch chapters from Audnexus</DialogTitle>
+          <DialogDescription>
+            Look up chapter titles and timestamps using an Audible ASIN.
+          </DialogDescription>
+        </DialogHeader>
+
+        {stage === "entry" && (
+          <EntryStage
+            asinInput={asinInput}
+            onAsinChange={setAsinInput}
+            onFetch={handleFetch}
+          />
+        )}
+
+        {stage === "loading" && <LoadingStage />}
+
+        {stage === "error" && (
+          <ErrorStage code={query.error?.code} onRetry={handleRetry} />
+        )}
+
+        {stage === "result" && query.data && (
+          <ResultStage
+            data={query.data}
+            editedChapters={editedChapters}
+            fileDurationMs={fileDurationMs}
+            hasChanges={hasChanges}
+            onApply={onApply}
+            onClose={handleClose}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FetchChaptersDialog;

--- a/app/components/files/FetchChaptersDialog.tsx
+++ b/app/components/files/FetchChaptersDialog.tsx
@@ -119,7 +119,7 @@ const EntryStage = ({ asinInput, onAsinChange, onFetch }: EntryStageProps) => {
 const LoadingStage = () => (
   <div className="flex flex-col items-center gap-3 py-8 text-muted-foreground">
     <Loader2 className="h-6 w-6 animate-spin" />
-    <span className="text-sm">Looking up chapters on Audnexus...</span>
+    <span className="text-sm">Looking up chapters on Audible...</span>
   </div>
 );
 
@@ -202,7 +202,7 @@ const ResultStage = ({
       {/* Duration comparison */}
       <div className="text-sm text-muted-foreground">
         <span>
-          Audnexus runtime:{" "}
+          Audible runtime:{" "}
           <span className="font-mono">
             {formatDurationMs(data.runtime_length_ms)}
           </span>
@@ -248,29 +248,39 @@ const ResultStage = ({
         </div>
       )}
 
-      {/* Intro offset checkbox */}
-      <div className="flex items-center gap-2">
-        <Checkbox
-          checked={applyOffset}
-          id="apply-offset"
-          onCheckedChange={(checked) => setApplyOffset(Boolean(checked))}
-        />
-        <Label className="cursor-pointer" htmlFor="apply-offset">
-          Shift timestamps: subtract intro (
-          {formatDurationMs(data.brand_intro_duration_ms)}) from each chapter
-        </Label>
-      </div>
+      {/* Intro offset checkbox — only meaningful when Audible reports a non-zero intro */}
+      {data.brand_intro_duration_ms > 0 && (
+        <div className="flex items-center gap-2">
+          <Checkbox
+            checked={applyOffset}
+            id="apply-offset"
+            onCheckedChange={(checked) => setApplyOffset(Boolean(checked))}
+          />
+          <Label className="cursor-pointer" htmlFor="apply-offset">
+            Shift timestamps: subtract intro (
+            {formatDurationMs(data.brand_intro_duration_ms)}) from each chapter
+          </Label>
+        </div>
+      )}
 
       {/* Chapter count info */}
       <p className="text-sm text-muted-foreground">
         {data.chapters.length} chapter{data.chapters.length !== 1 ? "s" : ""}{" "}
-        from Audnexus
+        from Audible
         {!countsMatch && (
           <span className="ml-1 text-destructive">
             (file has {editedChapters.length})
           </span>
         )}
       </p>
+
+      {/* is_accurate flag from Audnexus — warn when timestamps are approximate */}
+      {!data.is_accurate && (
+        <p className="text-sm text-muted-foreground">
+          Note: Audible flagged this entry as approximate. Spot-check timestamps
+          before saving.
+        </p>
+      )}
 
       {/* Overwrite warning */}
       {hasChanges && (
@@ -398,7 +408,9 @@ const FetchChaptersDialog = ({
   };
 
   const handleRetry = () => {
-    setSubmittedAsin(null);
+    // Force a fresh network call rather than replaying a cached error from
+    // tanstack-query.
+    void query.refetch();
   };
 
   const handleClose = () => {
@@ -409,7 +421,7 @@ const FetchChaptersDialog = ({
     <Dialog onOpenChange={onOpenChange} open={open}>
       <DialogContent className="max-w-lg overflow-x-hidden">
         <DialogHeader className="pr-8">
-          <DialogTitle>Fetch chapters from Audnexus</DialogTitle>
+          <DialogTitle>Fetch chapters from Audible</DialogTitle>
           <DialogDescription>
             Look up chapter titles and timestamps using an Audible ASIN.
           </DialogDescription>

--- a/app/components/files/FileChaptersTab.tsx
+++ b/app/components/files/FileChaptersTab.tsx
@@ -16,6 +16,7 @@ import {
   getNextChapterTitle,
   normalizeChapterOrder,
 } from "@/components/files/chapterUtils";
+import FetchChaptersDialog from "@/components/files/FetchChaptersDialog";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,6 +28,7 @@ import {
   FileTypeEPUB,
   FileTypeM4B,
   FileTypePDF,
+  IdentifierTypeASIN,
   type Chapter,
   type ChapterInput,
   type File,
@@ -139,10 +141,21 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
     >(null);
     const playbackTimeoutRef = useRef<number | null>(null);
 
+    // Whether the Fetch from Audible dialog is open
+    const [isFetchDialogOpen, setIsFetchDialogOpen] = useState(false);
+
     const chapters = useMemo(
       () => chaptersQuery.data ?? [],
       [chaptersQuery.data],
     );
+
+    // ASIN from the file's identifiers, used to prefill the Fetch dialog
+    const audibleAsin = useMemo(() => {
+      const asinIdentifier = file.identifiers?.find(
+        (id) => id.type === IdentifierTypeASIN,
+      );
+      return asinIdentifier?.value;
+    }, [file.identifiers]);
 
     // Initialize editedChapters when entering edit mode
     useEffect(() => {
@@ -341,6 +354,26 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
       editInitializedRef.current = true;
       onEditingChange(true);
     };
+
+    /**
+     * Applies chapters from the Fetch from Audible dialog.
+     * Replaces editedChapters with the incoming chapters, and enters edit mode
+     * if not already editing. Sets initialChapters so Cancel reverts correctly.
+     */
+    const handleApplyAudnexus = useCallback(
+      (chapters: ChapterInput[]) => {
+        const newEdited = toEditedChapters(chapters);
+        setEditedChapters(newEdited);
+        if (!isEditing) {
+          setInitialChapters(
+            toEditedChapters(chaptersToInputArray(chaptersQuery.data ?? [])),
+          );
+          editInitializedRef.current = true;
+          onEditingChange(true);
+        }
+      },
+      [isEditing, chaptersQuery.data, onEditingChange],
+    );
 
     /**
      * Handles clicking the uncovered pages warning for page-based files.
@@ -725,16 +758,39 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
             </Button>
           )}
 
-          {/* Add Chapter button for M4B */}
+          {/* Add Chapter + Fetch from Audible buttons for M4B */}
           {isM4b && (
-            <Button
-              className="mt-2"
-              onClick={handleAddChapterM4B}
-              type="button"
-              variant="outline"
-            >
-              Add Chapter
-            </Button>
+            <>
+              <Button
+                className="mt-2"
+                onClick={handleAddChapterM4B}
+                type="button"
+                variant="outline"
+              >
+                Add Chapter
+              </Button>
+              <Button
+                className="mt-2 ml-2"
+                onClick={() => setIsFetchDialogOpen(true)}
+                type="button"
+                variant="outline"
+              >
+                Fetch from Audible
+              </Button>
+            </>
+          )}
+
+          {/* Fetch from Audible dialog (M4B only) */}
+          {isM4b && (
+            <FetchChaptersDialog
+              editedChapters={stripEditKeys(editedChapters)}
+              fileDurationMs={(file.audiobook_duration_seconds ?? 0) * 1000}
+              hasChanges={hasChanges}
+              initialAsin={audibleAsin}
+              onApply={handleApplyAudnexus}
+              onOpenChange={setIsFetchDialogOpen}
+              open={isFetchDialogOpen}
+            />
           )}
         </div>
       );
@@ -771,18 +827,38 @@ const FileChaptersTab = forwardRef<FileChaptersTabHandle, FileChaptersTabProps>(
       }
 
       return (
-        <div className="py-8 text-center">
-          <p className="text-muted-foreground">No chapters</p>
-          {canAddChapters && (
-            <button
-              className="mt-4 px-4 py-2 text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 cursor-pointer"
-              onClick={handleAddChapterFromEmpty}
-              type="button"
-            >
-              Add Chapter
-            </button>
+        <>
+          <div className="py-8 text-center">
+            <p className="text-muted-foreground">No chapters</p>
+            {canAddChapters && (
+              <div className="mt-4 flex items-center justify-center gap-2">
+                <Button onClick={handleAddChapterFromEmpty} type="button">
+                  Add Chapter
+                </Button>
+                {file.file_type === FileTypeM4B && (
+                  <Button
+                    onClick={() => setIsFetchDialogOpen(true)}
+                    type="button"
+                    variant="outline"
+                  >
+                    Fetch from Audible
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+          {file.file_type === FileTypeM4B && (
+            <FetchChaptersDialog
+              editedChapters={chaptersToInputArray(chaptersQuery.data ?? [])}
+              fileDurationMs={(file.audiobook_duration_seconds ?? 0) * 1000}
+              hasChanges={hasChanges}
+              initialAsin={audibleAsin}
+              onApply={handleApplyAudnexus}
+              onOpenChange={setIsFetchDialogOpen}
+              open={isFetchDialogOpen}
+            />
           )}
-        </div>
+        </>
       );
     }
 

--- a/app/components/files/audnexusChapterUtils.test.ts
+++ b/app/components/files/audnexusChapterUtils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { detectIntroOffset } from "./audnexusChapterUtils";
+import {
+  applyTitlesAndTimestamps,
+  applyTitlesOnly,
+  detectIntroOffset,
+} from "./audnexusChapterUtils";
 
 describe("detectIntroOffset", () => {
   it("defaults to false when file matches full runtime", () => {
@@ -61,5 +65,78 @@ describe("detectIntroOffset", () => {
       fileDurationMs: 160_000_000, // way off
     });
     expect(result).toEqual({ applyOffset: false, withinTolerance: false });
+  });
+});
+
+describe("applyTitlesOnly", () => {
+  it("replaces titles by position, keeps timestamps", () => {
+    const existing = [
+      { title: "Old 1", start_timestamp_ms: 0, children: [] },
+      { title: "Old 2", start_timestamp_ms: 60_000, children: [] },
+    ];
+    const fromAudible = [
+      { title: "New 1", start_offset_ms: 100, length_ms: 1 },
+      { title: "New 2", start_offset_ms: 200, length_ms: 1 },
+    ];
+    const result = applyTitlesOnly(existing, fromAudible);
+    expect(result).toEqual([
+      { title: "New 1", start_timestamp_ms: 0, children: [] },
+      { title: "New 2", start_timestamp_ms: 60_000, children: [] },
+    ]);
+  });
+
+  it("returns existing unchanged when counts differ", () => {
+    const existing = [{ title: "A", start_timestamp_ms: 0, children: [] }];
+    const fromAudible = [
+      { title: "X", start_offset_ms: 0, length_ms: 1 },
+      { title: "Y", start_offset_ms: 100, length_ms: 1 },
+    ];
+    const result = applyTitlesOnly(existing, fromAudible);
+    expect(result).toEqual(existing);
+  });
+});
+
+describe("applyTitlesAndTimestamps", () => {
+  it("replaces wholesale with no offset when applyIntroOffset=false", () => {
+    const fromAudible = [
+      { title: "C1", start_offset_ms: 0, length_ms: 1000 },
+      { title: "C2", start_offset_ms: 60_000, length_ms: 1000 },
+    ];
+    const result = applyTitlesAndTimestamps(fromAudible, {
+      applyIntroOffset: false,
+      introMs: 38_000,
+    });
+    expect(result).toEqual([
+      { title: "C1", start_timestamp_ms: 0, children: [] },
+      { title: "C2", start_timestamp_ms: 60_000, children: [] },
+    ]);
+  });
+
+  it("subtracts introMs from every start when applyIntroOffset=true", () => {
+    const fromAudible = [
+      { title: "C1", start_offset_ms: 38_000, length_ms: 1000 },
+      { title: "C2", start_offset_ms: 98_000, length_ms: 1000 },
+    ];
+    const result = applyTitlesAndTimestamps(fromAudible, {
+      applyIntroOffset: true,
+      introMs: 38_000,
+    });
+    expect(result).toEqual([
+      { title: "C1", start_timestamp_ms: 0, children: [] },
+      { title: "C2", start_timestamp_ms: 60_000, children: [] },
+    ]);
+  });
+
+  it("clamps negative timestamps to 0 after offset", () => {
+    const fromAudible = [
+      { title: "Pre", start_offset_ms: 0, length_ms: 1 },
+      { title: "Main", start_offset_ms: 40_000, length_ms: 1 },
+    ];
+    const result = applyTitlesAndTimestamps(fromAudible, {
+      applyIntroOffset: true,
+      introMs: 38_000,
+    });
+    expect(result[0].start_timestamp_ms).toBe(0);
+    expect(result[1].start_timestamp_ms).toBe(2_000);
   });
 });

--- a/app/components/files/audnexusChapterUtils.test.ts
+++ b/app/components/files/audnexusChapterUtils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { detectIntroOffset } from "./audnexusChapterUtils";
+
+describe("detectIntroOffset", () => {
+  it("defaults to false when file matches full runtime", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_938_000,
+    });
+    expect(result).toEqual({ applyOffset: false, withinTolerance: true });
+  });
+
+  it("returns true when file duration matches runtime minus intro", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_900_000, // runtime - intro
+    });
+    expect(result).toEqual({ applyOffset: true, withinTolerance: true });
+  });
+
+  it("returns true when file duration matches runtime minus intro minus outro (Libation)", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_838_000, // runtime - intro - outro
+    });
+    expect(result).toEqual({ applyOffset: true, withinTolerance: true });
+  });
+
+  it("returns false when file duration matches runtime minus outro only (no intro offset needed)", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_876_000, // runtime - outro
+    });
+    expect(result).toEqual({ applyOffset: false, withinTolerance: true });
+  });
+
+  it("accepts ±2000ms tolerance on matches", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_939_500, // +1.5s off full runtime
+    });
+    expect(result).toEqual({ applyOffset: false, withinTolerance: true });
+  });
+
+  it("falls back to false and withinTolerance=false when nothing matches", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 160_000_000, // way off
+    });
+    expect(result).toEqual({ applyOffset: false, withinTolerance: false });
+  });
+});

--- a/app/components/files/audnexusChapterUtils.ts
+++ b/app/components/files/audnexusChapterUtils.ts
@@ -1,0 +1,96 @@
+import type { AudnexusChapter } from "@/hooks/queries/audnexus";
+import type { ChapterInput } from "@/types";
+
+export const TRIM_DETECT_TOLERANCE_MS = 2000;
+
+interface DetectIntroOffsetParams {
+  runtimeMs: number;
+  introMs: number;
+  outroMs: number;
+  fileDurationMs: number;
+}
+
+interface DetectIntroOffsetResult {
+  applyOffset: boolean;
+  withinTolerance: boolean;
+}
+
+/**
+ * Picks whether to apply an intro offset based on which Audnexus duration
+ * candidate is closest to the file's actual duration. Candidates are:
+ *   1. runtime (intact)
+ *   2. runtime - intro
+ *   3. runtime - outro
+ *   4. runtime - intro - outro
+ *
+ * If the closest candidate subtracts intro, applyOffset=true. Otherwise false.
+ * If no candidate is within TRIM_DETECT_TOLERANCE_MS, withinTolerance=false
+ * (UI shows a mismatch warning) and applyOffset defaults to the closest match.
+ */
+export const detectIntroOffset = (
+  params: DetectIntroOffsetParams,
+): DetectIntroOffsetResult => {
+  const { runtimeMs, introMs, outroMs, fileDurationMs } = params;
+  const candidates: { ms: number; subtractsIntro: boolean }[] = [
+    { ms: runtimeMs, subtractsIntro: false },
+    { ms: runtimeMs - introMs, subtractsIntro: true },
+    { ms: runtimeMs - outroMs, subtractsIntro: false },
+    { ms: runtimeMs - introMs - outroMs, subtractsIntro: true },
+  ];
+
+  let best = candidates[0];
+  let bestDiff = Math.abs(candidates[0].ms - fileDurationMs);
+  for (let i = 1; i < candidates.length; i++) {
+    const diff = Math.abs(candidates[i].ms - fileDurationMs);
+    if (diff < bestDiff) {
+      best = candidates[i];
+      bestDiff = diff;
+    }
+  }
+
+  const withinTolerance = bestDiff <= TRIM_DETECT_TOLERANCE_MS;
+  return {
+    applyOffset: withinTolerance ? best.subtractsIntro : false,
+    withinTolerance,
+  };
+};
+
+/**
+ * Replace titles in-place by position; leave timestamps and children alone.
+ * Returns the original array unchanged when lengths differ so the caller
+ * doesn't silently lose data.
+ */
+export const applyTitlesOnly = (
+  existing: ChapterInput[],
+  fromAudible: AudnexusChapter[],
+): ChapterInput[] => {
+  if (existing.length !== fromAudible.length) {
+    return existing;
+  }
+  return existing.map((chapter, i) => ({
+    ...chapter,
+    title: fromAudible[i].title,
+  }));
+};
+
+interface ApplyTitlesAndTimestampsOpts {
+  applyIntroOffset: boolean;
+  introMs: number;
+}
+
+/**
+ * Build a fresh chapter array from Audnexus data, optionally subtracting the
+ * intro duration from every start timestamp. Negative results are clamped
+ * to 0 (only possible for the first chapter).
+ */
+export const applyTitlesAndTimestamps = (
+  fromAudible: AudnexusChapter[],
+  opts: ApplyTitlesAndTimestampsOpts,
+): ChapterInput[] => {
+  const offset = opts.applyIntroOffset ? opts.introMs : 0;
+  return fromAudible.map((c) => ({
+    title: c.title,
+    start_timestamp_ms: Math.max(0, c.start_offset_ms - offset),
+    children: [],
+  }));
+};

--- a/app/hooks/queries/audnexus.ts
+++ b/app/hooks/queries/audnexus.ts
@@ -1,0 +1,54 @@
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+
+import { API, ShishoAPIError } from "@/libraries/api";
+
+export enum QueryKey {
+  AudnexusChapters = "AudnexusChapters",
+}
+
+export interface AudnexusChapter {
+  title: string;
+  start_offset_ms: number;
+  length_ms: number;
+}
+
+export interface AudnexusChaptersResponse {
+  asin: string;
+  is_accurate: boolean;
+  runtime_length_ms: number;
+  brand_intro_duration_ms: number;
+  brand_outro_duration_ms: number;
+  chapters: AudnexusChapter[];
+}
+
+/**
+ * Fetch chapter data for an Audible ASIN. Disabled by default — enable only
+ * when the user explicitly triggers a lookup from the fetch dialog.
+ */
+export const useAudnexusChapters = (
+  asin: string | null,
+  options: Omit<
+    UseQueryOptions<AudnexusChaptersResponse, ShishoAPIError>,
+    "queryKey" | "queryFn"
+  > = {},
+) => {
+  return useQuery<AudnexusChaptersResponse, ShishoAPIError>({
+    enabled: options.enabled !== undefined ? options.enabled : false,
+    retry: false,
+    ...options,
+    queryKey: [QueryKey.AudnexusChapters, asin],
+    queryFn: async ({ signal }) => {
+      if (!asin) {
+        throw new Error("ASIN is required");
+      }
+      const response: AudnexusChaptersResponse = await API.request(
+        "GET",
+        `/audnexus/books/${encodeURIComponent(asin)}/chapters`,
+        null,
+        null,
+        signal,
+      );
+      return response;
+    },
+  });
+};

--- a/docs/superpowers/plans/2026-04-21-audible-chapter-fetch.md
+++ b/docs/superpowers/plans/2026-04-21-audible-chapter-fetch.md
@@ -1,0 +1,2559 @@
+# Fetch Chapters from Audible Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users fetch chapter titles and timestamps from Audible (via Audnexus) on the M4B chapter edit page and stage them into the existing edit form for review before saving.
+
+**Architecture:** New `pkg/audnexus/` package with an HTTP client, in-memory TTL cache, and a single read-only endpoint gated by `books:write`. Frontend adds a `FetchChaptersDialog` with pure-function utilities for trim detection and apply-mode transforms, wired into `FileChaptersTab` at three entry points.
+
+**Tech Stack:** Go (Echo, standard `net/http`, `sync.RWMutex`), React 19 + TypeScript (Tanstack Query, Radix Dialog via shadcn, vitest + RTL).
+
+**Spec:** `docs/superpowers/specs/2026-04-21-audible-chapter-fetch-design.md`
+
+---
+
+## Background notes
+
+- Audnexus endpoint: `GET https://api.audnex.us/books/{ASIN}/chapters`. No auth.
+- ASIN is a 10-character uppercase alphanumeric. Normalize input to uppercase before validation and cache lookup.
+- Vite strips `/api` before proxying, so server routes register without the `/api` prefix. Frontend calls `/api/audnexus/books/:asin/chapters`; server sees `/audnexus/books/:asin/chapters`.
+- Permission middleware pattern: `authMiddleware.Authenticate` + `authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite)`.
+- Route registration lives in `pkg/server/server.go` around line 115–140. Services are constructed and wired there, not in `cmd/api/main.go`.
+- Existing chapter edit state (`editedChapters`, `hasChanges`, play buttons, per-row validation) is in `app/components/files/FileChaptersTab.tsx`. Apply handlers mutate `editedChapters` via the existing `setEditedChapters` setter — no new state machine.
+- `file.audiobook_duration_seconds` is available on the file model for duration comparison.
+- `file.identifiers` includes ASIN when `IdentifierTypeASIN` is present. Use it to prefill the dialog input.
+- Version string comes from `pkg/version.Version` (default `"dev"`, overridden at build time).
+
+---
+
+## Task 1: Scaffold `pkg/audnexus/` package with types and constants
+
+**Files:**
+- Create: `pkg/audnexus/types.go`
+- Create: `pkg/audnexus/errors.go`
+
+- [ ] **Step 1: Create `pkg/audnexus/types.go`**
+
+```go
+package audnexus
+
+// Chapter is a single chapter from Audnexus.
+type Chapter struct {
+	Title         string `json:"title"`
+	StartOffsetMs int64  `json:"start_offset_ms"`
+	LengthMs      int64  `json:"length_ms"`
+}
+
+// Response is the normalized chapters response returned by the service and
+// passed through to the frontend. Field names are snake_case per project
+// API conventions; upstream Audnexus uses camelCase and is converted at the
+// parse boundary.
+type Response struct {
+	ASIN                 string    `json:"asin"`
+	IsAccurate           bool      `json:"is_accurate"`
+	RuntimeLengthMs      int64     `json:"runtime_length_ms"`
+	BrandIntroDurationMs int64     `json:"brand_intro_duration_ms"`
+	BrandOutroDurationMs int64     `json:"brand_outro_duration_ms"`
+	Chapters             []Chapter `json:"chapters"`
+}
+
+// audnexusUpstream matches the Audnexus API camelCase JSON shape for decoding.
+type audnexusUpstream struct {
+	ASIN                 string              `json:"asin"`
+	IsAccurate           bool                `json:"isAccurate"`
+	RuntimeLengthMs      int64               `json:"runtimeLengthMs"`
+	BrandIntroDurationMs int64               `json:"brandIntroDurationMs"`
+	BrandOutroDurationMs int64               `json:"brandOutroDurationMs"`
+	Chapters             []audnexusUpChapter `json:"chapters"`
+}
+
+type audnexusUpChapter struct {
+	Title         string `json:"title"`
+	StartOffsetMs int64  `json:"startOffsetMs"`
+	LengthMs      int64  `json:"lengthMs"`
+}
+```
+
+- [ ] **Step 2: Create `pkg/audnexus/errors.go`**
+
+```go
+package audnexus
+
+import "errors"
+
+// ErrorCode is a stable string identifier used by both the service and the
+// HTTP handler to map failures to user-facing responses.
+type ErrorCode string
+
+const (
+	ErrCodeInvalidASIN   ErrorCode = "invalid_asin"
+	ErrCodeNotFound      ErrorCode = "not_found"
+	ErrCodeTimeout       ErrorCode = "timeout"
+	ErrCodeUpstreamError ErrorCode = "upstream_error"
+)
+
+// Error is a typed error carrying an ErrorCode. Callers can use errors.As to
+// inspect the code for mapping to HTTP status.
+type Error struct {
+	Code ErrorCode
+	Msg  string
+}
+
+func (e *Error) Error() string {
+	if e.Msg != "" {
+		return string(e.Code) + ": " + e.Msg
+	}
+	return string(e.Code)
+}
+
+func newErr(code ErrorCode, msg string) error {
+	return &Error{Code: code, Msg: msg}
+}
+
+// AsAudnexusError extracts an *Error if err wraps one, else returns nil.
+func AsAudnexusError(err error) *Error {
+	var e *Error
+	if errors.As(err, &e) {
+		return e
+	}
+	return nil
+}
+```
+
+- [ ] **Step 3: Verify the package compiles**
+
+Run: `go build ./pkg/audnexus/...`
+Expected: no output (success).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/audnexus/types.go pkg/audnexus/errors.go
+git commit -m "[Backend] Scaffold audnexus package types and error codes"
+```
+
+---
+
+## Task 2: Service skeleton with ASIN validation
+
+**Files:**
+- Create: `pkg/audnexus/service.go`
+- Create: `pkg/audnexus/service_test.go`
+
+- [ ] **Step 1: Write failing test for ASIN validation**
+
+Create `pkg/audnexus/service_test.go`:
+
+```go
+package audnexus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_GetChapters_InvalidASIN(t *testing.T) {
+	t.Parallel()
+	svc := NewService(ServiceConfig{})
+
+	cases := []string{
+		"",
+		"short",
+		"TOO-LONG-ASIN",
+		"1234567890X!",             // non-alphanumeric
+		"B0036UC2L",                // 9 chars
+		"B0036UC2LOX",              // 11 chars
+	}
+	for _, asin := range cases {
+		asin := asin
+		t.Run(asin, func(t *testing.T) {
+			t.Parallel()
+			_, err := svc.GetChapters(context.Background(), asin)
+			require.Error(t, err)
+			e := AsAudnexusError(err)
+			require.NotNil(t, e, "expected *Error")
+			assert.Equal(t, ErrCodeInvalidASIN, e.Code)
+		})
+	}
+}
+
+func TestService_GetChapters_NormalizesASINToUppercase(t *testing.T) {
+	t.Parallel()
+	// Valid lowercase ASIN should pass validation (and would reach upstream,
+	// which we're not testing here — but it must not return invalid_asin).
+	svc := NewService(ServiceConfig{})
+	_, err := svc.GetChapters(context.Background(), "b0036uc2lo")
+	if e := AsAudnexusError(err); e != nil {
+		assert.NotEqual(t, ErrCodeInvalidASIN, e.Code, "lowercase ASIN should normalize to valid")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `go test ./pkg/audnexus/ -run TestService_GetChapters_InvalidASIN -v`
+Expected: FAIL (`NewService` and `GetChapters` not defined).
+
+- [ ] **Step 3: Create `pkg/audnexus/service.go` with skeleton**
+
+```go
+package audnexus
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ServiceConfig holds options for constructing a Service.
+type ServiceConfig struct {
+	// HTTPClient is optional; if nil, a client with a 5-second timeout is used.
+	HTTPClient *http.Client
+	// BaseURL overrides the Audnexus endpoint for tests. Defaults to the real
+	// API when empty.
+	BaseURL string
+	// UserAgent sent on every upstream request. Defaults to "Shisho/unknown".
+	UserAgent string
+	// CacheTTL for successful responses. Defaults to 24 hours if zero.
+	CacheTTL time.Duration
+}
+
+// Service fetches chapter data from Audnexus with in-memory caching.
+type Service struct {
+	http      *http.Client
+	baseURL   string
+	userAgent string
+	cacheTTL  time.Duration
+	mu        sync.RWMutex
+	cache     map[string]*cacheEntry
+}
+
+type cacheEntry struct {
+	value    *Response
+	expireAt time.Time
+}
+
+const defaultBaseURL = "https://api.audnex.us"
+
+// NewService constructs a Service with the given config.
+func NewService(cfg ServiceConfig) *Service {
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	base := cfg.BaseURL
+	if base == "" {
+		base = defaultBaseURL
+	}
+	ua := cfg.UserAgent
+	if ua == "" {
+		ua = "Shisho/unknown"
+	}
+	ttl := cfg.CacheTTL
+	if ttl == 0 {
+		ttl = 24 * time.Hour
+	}
+	return &Service{
+		http:      client,
+		baseURL:   strings.TrimRight(base, "/"),
+		userAgent: ua,
+		cacheTTL:  ttl,
+		cache:     make(map[string]*cacheEntry),
+	}
+}
+
+var asinPattern = regexp.MustCompile(`^[A-Z0-9]{10}$`)
+
+// normalizeASIN uppercases and returns the ASIN if it passes format checks,
+// otherwise returns the empty string.
+func normalizeASIN(asin string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(asin))
+	if !asinPattern.MatchString(normalized) {
+		return ""
+	}
+	return normalized
+}
+
+// GetChapters fetches chapter data for an ASIN. Returns a typed *Error on
+// failure (check with AsAudnexusError).
+func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, error) {
+	normalized := normalizeASIN(asin)
+	if normalized == "" {
+		return nil, newErr(ErrCodeInvalidASIN, "ASIN must be 10 alphanumeric characters")
+	}
+	// Upstream call will be implemented in the next task.
+	return nil, newErr(ErrCodeUpstreamError, "not implemented")
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `go test ./pkg/audnexus/ -run TestService_GetChapters_InvalidASIN -v -count=1`
+Expected: PASS.
+
+Run: `go test ./pkg/audnexus/ -run TestService_GetChapters_NormalizesASINToUppercase -v -count=1`
+Expected: PASS (error code is `upstream_error`, not `invalid_asin`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/audnexus/service.go pkg/audnexus/service_test.go
+git commit -m "[Backend] Add audnexus service skeleton with ASIN validation"
+```
+
+---
+
+## Task 3: Service upstream fetch (happy path)
+
+**Files:**
+- Modify: `pkg/audnexus/service.go`
+- Modify: `pkg/audnexus/service_test.go`
+
+- [ ] **Step 1: Add failing test for happy-path upstream fetch**
+
+Append to `pkg/audnexus/service_test.go`:
+
+```go
+import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+func TestService_GetChapters_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/books/B0036UC2LO/chapters", r.URL.Path)
+		assert.Equal(t, "Shisho/test", r.Header.Get("User-Agent"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"asin": "B0036UC2LO",
+			"isAccurate": true,
+			"runtimeLengthMs": 163938000,
+			"brandIntroDurationMs": 38000,
+			"brandOutroDurationMs": 62000,
+			"chapters": [
+				{"title": "Prelude", "startOffsetMs": 0, "lengthMs": 272000},
+				{"title": "Prologue", "startOffsetMs": 272000, "lengthMs": 1063000}
+			]
+		}`))
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{
+		BaseURL:   upstream.URL,
+		UserAgent: "Shisho/test",
+	})
+
+	resp, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "B0036UC2LO", resp.ASIN)
+	assert.True(t, resp.IsAccurate)
+	assert.Equal(t, int64(163938000), resp.RuntimeLengthMs)
+	assert.Equal(t, int64(38000), resp.BrandIntroDurationMs)
+	assert.Equal(t, int64(62000), resp.BrandOutroDurationMs)
+	require.Len(t, resp.Chapters, 2)
+	assert.Equal(t, "Prelude", resp.Chapters[0].Title)
+	assert.Equal(t, int64(0), resp.Chapters[0].StartOffsetMs)
+	assert.Equal(t, int64(272000), resp.Chapters[0].LengthMs)
+}
+```
+
+- [ ] **Step 2: Run and verify it fails**
+
+Run: `go test ./pkg/audnexus/ -run TestService_GetChapters_HappyPath -v`
+Expected: FAIL (still returns "not implemented").
+
+- [ ] **Step 3: Replace `GetChapters` body with the real upstream call**
+
+In `pkg/audnexus/service.go`, replace the body of `GetChapters`:
+
+```go
+func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, error) {
+	normalized := normalizeASIN(asin)
+	if normalized == "" {
+		return nil, newErr(ErrCodeInvalidASIN, "ASIN must be 10 alphanumeric characters")
+	}
+
+	url := s.baseURL + "/books/" + normalized + "/chapters"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, newErr(ErrCodeUpstreamError, err.Error())
+	}
+	req.Header.Set("User-Agent", s.userAgent)
+
+	resp, err := s.http.Do(req)
+	if err != nil {
+		if ctx.Err() != nil || isTimeout(err) {
+			return nil, newErr(ErrCodeTimeout, err.Error())
+		}
+		return nil, newErr(ErrCodeUpstreamError, err.Error())
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, newErr(ErrCodeNotFound, "ASIN not found on Audible")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, newErr(ErrCodeUpstreamError, "upstream returned "+resp.Status)
+	}
+
+	var upstream audnexusUpstream
+	if err := json.NewDecoder(resp.Body).Decode(&upstream); err != nil {
+		return nil, newErr(ErrCodeUpstreamError, "invalid JSON from upstream")
+	}
+
+	out := &Response{
+		ASIN:                 upstream.ASIN,
+		IsAccurate:           upstream.IsAccurate,
+		RuntimeLengthMs:      upstream.RuntimeLengthMs,
+		BrandIntroDurationMs: upstream.BrandIntroDurationMs,
+		BrandOutroDurationMs: upstream.BrandOutroDurationMs,
+		Chapters:             make([]Chapter, 0, len(upstream.Chapters)),
+	}
+	for _, c := range upstream.Chapters {
+		out.Chapters = append(out.Chapters, Chapter{
+			Title:         c.Title,
+			StartOffsetMs: c.StartOffsetMs,
+			LengthMs:      c.LengthMs,
+		})
+	}
+
+	return out, nil
+}
+
+// isTimeout reports whether err represents a net/http timeout.
+func isTimeout(err error) bool {
+	type timeout interface{ Timeout() bool }
+	var t timeout
+	if errors.As(err, &t) {
+		return t.Timeout()
+	}
+	return false
+}
+```
+
+Update the imports at the top of `pkg/audnexus/service.go` to:
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `go test ./pkg/audnexus/ -run TestService_GetChapters_HappyPath -v -count=1`
+Expected: PASS.
+
+Run the whole package to check the earlier tests still pass:
+
+Run: `go test ./pkg/audnexus/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/audnexus/service.go pkg/audnexus/service_test.go
+git commit -m "[Backend] Implement audnexus upstream fetch"
+```
+
+---
+
+## Task 4: Service error mapping (404, timeout, 5xx, invalid JSON)
+
+**Files:**
+- Modify: `pkg/audnexus/service_test.go`
+
+- [ ] **Step 1: Add failing tests for each error case**
+
+Append to `pkg/audnexus/service_test.go`:
+
+```go
+func TestService_GetChapters_NotFound(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.Error(t, err)
+	assert.Equal(t, ErrCodeNotFound, AsAudnexusError(err).Code)
+}
+
+func TestService_GetChapters_UpstreamError_5xx(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.Error(t, err)
+	assert.Equal(t, ErrCodeUpstreamError, AsAudnexusError(err).Code)
+}
+
+func TestService_GetChapters_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.Error(t, err)
+	assert.Equal(t, ErrCodeUpstreamError, AsAudnexusError(err).Code)
+}
+
+func TestService_GetChapters_Timeout(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{
+		BaseURL:    upstream.URL,
+		HTTPClient: &http.Client{Timeout: 50 * time.Millisecond},
+	})
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.Error(t, err)
+	assert.Equal(t, ErrCodeTimeout, AsAudnexusError(err).Code)
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `go test ./pkg/audnexus/ -run TestService_GetChapters_ -v -count=1`
+Expected: PASS for all four (the error mapping was already implemented in Task 3; these tests verify that mapping).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/audnexus/service_test.go
+git commit -m "[Test] Cover audnexus error mapping for 404/5xx/timeout/invalid JSON"
+```
+
+---
+
+## Task 5: Service in-memory TTL cache
+
+**Files:**
+- Modify: `pkg/audnexus/service.go`
+- Modify: `pkg/audnexus/service_test.go`
+
+- [ ] **Step 1: Add failing test for cache hit and TTL expiry**
+
+Append to `pkg/audnexus/service_test.go`:
+
+```go
+import (
+	"sync/atomic"
+)
+
+func TestService_GetChapters_CacheHit(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"asin":"B0036UC2LO","chapters":[]}`))
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL, CacheTTL: time.Hour})
+
+	// First call hits upstream.
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.NoError(t, err)
+	// Second call with same ASIN hits cache.
+	_, err = svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.NoError(t, err)
+	// Lowercase should normalize to same cache key.
+	_, err = svc.GetChapters(context.Background(), "b0036uc2lo")
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "expected exactly one upstream call")
+}
+
+func TestService_GetChapters_CacheExpires(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"asin":"B0036UC2LO","chapters":[]}`))
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL, CacheTTL: 10 * time.Millisecond})
+
+	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
+	time.Sleep(20 * time.Millisecond)
+	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "expected cache to expire and re-fetch")
+}
+
+func TestService_GetChapters_ErrorsNotCached(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL, CacheTTL: time.Hour})
+
+	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
+	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "errors must not be cached")
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `go test ./pkg/audnexus/ -run "TestService_GetChapters_Cache|TestService_GetChapters_ErrorsNotCached" -v`
+Expected: FAIL — cache is not yet implemented, so `hits` will be 2 or 3 instead of 1.
+
+- [ ] **Step 3: Wire the cache into `GetChapters`**
+
+In `pkg/audnexus/service.go`, update `GetChapters` to check the cache before upstream and to store successful responses:
+
+```go
+func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, error) {
+	normalized := normalizeASIN(asin)
+	if normalized == "" {
+		return nil, newErr(ErrCodeInvalidASIN, "ASIN must be 10 alphanumeric characters")
+	}
+
+	if cached := s.cacheGet(normalized); cached != nil {
+		return cached, nil
+	}
+
+	url := s.baseURL + "/books/" + normalized + "/chapters"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, newErr(ErrCodeUpstreamError, err.Error())
+	}
+	req.Header.Set("User-Agent", s.userAgent)
+
+	resp, err := s.http.Do(req)
+	if err != nil {
+		if ctx.Err() != nil || isTimeout(err) {
+			return nil, newErr(ErrCodeTimeout, err.Error())
+		}
+		return nil, newErr(ErrCodeUpstreamError, err.Error())
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, newErr(ErrCodeNotFound, "ASIN not found on Audible")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, newErr(ErrCodeUpstreamError, "upstream returned "+resp.Status)
+	}
+
+	var upstream audnexusUpstream
+	if err := json.NewDecoder(resp.Body).Decode(&upstream); err != nil {
+		return nil, newErr(ErrCodeUpstreamError, "invalid JSON from upstream")
+	}
+
+	out := &Response{
+		ASIN:                 upstream.ASIN,
+		IsAccurate:           upstream.IsAccurate,
+		RuntimeLengthMs:      upstream.RuntimeLengthMs,
+		BrandIntroDurationMs: upstream.BrandIntroDurationMs,
+		BrandOutroDurationMs: upstream.BrandOutroDurationMs,
+		Chapters:             make([]Chapter, 0, len(upstream.Chapters)),
+	}
+	for _, c := range upstream.Chapters {
+		out.Chapters = append(out.Chapters, Chapter{
+			Title:         c.Title,
+			StartOffsetMs: c.StartOffsetMs,
+			LengthMs:      c.LengthMs,
+		})
+	}
+
+	s.cachePut(normalized, out)
+	return out, nil
+}
+
+func (s *Service) cacheGet(asin string) *Response {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.cache[asin]
+	if !ok || time.Now().After(entry.expireAt) {
+		return nil
+	}
+	return entry.value
+}
+
+func (s *Service) cachePut(asin string, value *Response) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cache[asin] = &cacheEntry{
+		value:    value,
+		expireAt: time.Now().Add(s.cacheTTL),
+	}
+}
+```
+
+- [ ] **Step 4: Run the full package tests**
+
+Run: `go test ./pkg/audnexus/ -count=1`
+Expected: PASS for all tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/audnexus/service.go pkg/audnexus/service_test.go
+git commit -m "[Backend] Add 24h in-memory cache to audnexus service"
+```
+
+---
+
+## Task 6: HTTP handler with ASIN route
+
+**Files:**
+- Create: `pkg/audnexus/handlers.go`
+- Create: `pkg/audnexus/handlers_test.go`
+- Create: `pkg/audnexus/routes.go`
+
+- [ ] **Step 1: Create `pkg/audnexus/handlers.go`**
+
+```go
+package audnexus
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+)
+
+type handler struct {
+	service *Service
+}
+
+func (h *handler) getChapters(c echo.Context) error {
+	asin := c.Param("asin")
+	resp, err := h.service.GetChapters(c.Request().Context(), asin)
+	if err != nil {
+		return mapServiceError(err)
+	}
+	return errors.WithStack(c.JSON(http.StatusOK, resp))
+}
+
+// mapServiceError converts an audnexus *Error into an errcodes response with
+// the right HTTP status. Non-typed errors bubble up as 502 (upstream_error).
+func mapServiceError(err error) error {
+	e := AsAudnexusError(err)
+	if e == nil {
+		return errcodes.BadGateway("upstream_error")
+	}
+	switch e.Code {
+	case ErrCodeInvalidASIN:
+		return errcodes.BadRequest(string(e.Code))
+	case ErrCodeNotFound:
+		return errcodes.NotFound(string(e.Code))
+	case ErrCodeTimeout:
+		return errcodes.GatewayTimeout(string(e.Code))
+	default:
+		return errcodes.BadGateway(string(e.Code))
+	}
+}
+```
+
+If `errcodes.BadGateway` or `errcodes.GatewayTimeout` don't exist in `pkg/errcodes/`, add them. Check with:
+
+Run: `grep -n "^func " pkg/errcodes/*.go | head -20`
+
+If they're missing, add to `pkg/errcodes/errcodes.go` (mirror the shape of existing helpers):
+
+```go
+func BadGateway(message string) *echo.HTTPError {
+	return echo.NewHTTPError(http.StatusBadGateway, message)
+}
+
+func GatewayTimeout(message string) *echo.HTTPError {
+	return echo.NewHTTPError(http.StatusGatewayTimeout, message)
+}
+```
+
+- [ ] **Step 2: Create `pkg/audnexus/routes.go`**
+
+```go
+package audnexus
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// RegisterRoutes wires the audnexus endpoint into the Echo instance. The
+// endpoint is scoped to authenticated users with books:write (the only
+// legitimate use is staging data into an editable chapter form).
+func RegisterRoutes(e *echo.Echo, svc *Service, authMiddleware *auth.Middleware) {
+	g := e.Group("/audnexus")
+	g.Use(authMiddleware.Authenticate)
+	g.Use(authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
+
+	h := &handler{service: svc}
+	g.GET("/books/:asin/chapters", h.getChapters)
+}
+```
+
+- [ ] **Step 3: Write handler tests**
+
+Create `pkg/audnexus/handlers_test.go`:
+
+```go
+package audnexus
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestHandler(t *testing.T, upstreamStatus int, upstreamBody string) *handler {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(upstreamStatus)
+		_, _ = io.WriteString(w, upstreamBody)
+	}))
+	t.Cleanup(upstream.Close)
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	return &handler{service: svc}
+}
+
+func invokeHandler(t *testing.T, h *handler, asin string) (int, string) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/audnexus/books/"+asin+"/chapters", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("asin")
+	c.SetParamValues(asin)
+
+	err := h.getChapters(c)
+	if err != nil {
+		// Echo HTTPError handling — set status from the error.
+		if he, ok := err.(*echo.HTTPError); ok {
+			return he.Code, strings.TrimSpace(he.Message.(string))
+		}
+		return http.StatusInternalServerError, err.Error()
+	}
+	return rec.Code, rec.Body.String()
+}
+
+func TestHandler_GetChapters_Success(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, http.StatusOK, `{"asin":"B0036UC2LO","chapters":[{"title":"C1","startOffsetMs":0,"lengthMs":1000}]}`)
+	code, body := invokeHandler(t, h, "B0036UC2LO")
+
+	assert.Equal(t, http.StatusOK, code)
+	var resp Response
+	require.NoError(t, json.Unmarshal([]byte(body), &resp))
+	assert.Equal(t, "B0036UC2LO", resp.ASIN)
+	require.Len(t, resp.Chapters, 1)
+	assert.Equal(t, "C1", resp.Chapters[0].Title)
+}
+
+func TestHandler_GetChapters_InvalidASIN(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, http.StatusOK, `{}`)
+	code, body := invokeHandler(t, h, "short")
+	assert.Equal(t, http.StatusBadRequest, code)
+	assert.Contains(t, body, "invalid_asin")
+}
+
+func TestHandler_GetChapters_NotFound(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, http.StatusNotFound, ``)
+	code, body := invokeHandler(t, h, "B0036UC2LO")
+	assert.Equal(t, http.StatusNotFound, code)
+	assert.Contains(t, body, "not_found")
+}
+
+func TestHandler_GetChapters_UpstreamError(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, http.StatusInternalServerError, ``)
+	code, body := invokeHandler(t, h, "B0036UC2LO")
+	assert.Equal(t, http.StatusBadGateway, code)
+	assert.Contains(t, body, "upstream_error")
+}
+```
+
+- [ ] **Step 4: Run handler tests**
+
+Run: `go test ./pkg/audnexus/ -run TestHandler -v -count=1`
+Expected: PASS.
+
+Run the whole package:
+
+Run: `go test ./pkg/audnexus/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/audnexus/handlers.go pkg/audnexus/routes.go pkg/audnexus/handlers_test.go pkg/errcodes/
+git commit -m "[Backend] Add audnexus HTTP handler with ASIN route"
+```
+
+---
+
+## Task 7: Wire audnexus service into server.go
+
+**Files:**
+- Modify: `pkg/server/server.go`
+
+- [ ] **Step 1: Inspect where similar services are constructed in `pkg/server/server.go`**
+
+Run: `grep -n "authMiddleware\|RegisterRoutes" pkg/server/server.go | head -30`
+
+Pick a spot near the other top-level `RegisterRoutes` calls (around line 115–120), where the server has access to `e`, `authMiddleware`, and version info.
+
+- [ ] **Step 2: Add the audnexus construction and route registration**
+
+Add the import at the top of `pkg/server/server.go`:
+
+```go
+"github.com/shishobooks/shisho/pkg/audnexus"
+"github.com/shishobooks/shisho/pkg/version"
+```
+
+(If `version` is already imported, skip.)
+
+In the function that wires routes, immediately after the `logs.RegisterRoutes(e, logBuffer, authMiddleware)` line (near line 117), add:
+
+```go
+audnexusService := audnexus.NewService(audnexus.ServiceConfig{
+	UserAgent: "Shisho/" + version.Version,
+})
+audnexus.RegisterRoutes(e, audnexusService, authMiddleware)
+```
+
+- [ ] **Step 3: Build the binary to confirm wiring compiles**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 4: Run all backend tests for regressions**
+
+Run: `go test ./pkg/audnexus/ ./pkg/server/ -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/server/server.go
+git commit -m "[Backend] Register audnexus routes on the Echo server"
+```
+
+---
+
+## Task 8: pkg/audnexus/CLAUDE.md documentation
+
+**Files:**
+- Create: `pkg/audnexus/CLAUDE.md`
+
+- [ ] **Step 1: Create `pkg/audnexus/CLAUDE.md`**
+
+```markdown
+# Audnexus API Integration
+
+This package fetches chapter data for audiobooks from [Audnexus](https://audnex.us), a community-run proxy over Audible's chapter catalog. It's consumed by the M4B chapter edit UI via `GET /audnexus/books/:asin/chapters`.
+
+## Architecture
+
+- `service.go` — `Service` with a 5s-timeout HTTP client and a 24h in-memory TTL cache keyed by normalized (uppercase) ASIN. Only successes are cached; errors pass through so retries work.
+- `handlers.go` — Echo handler that calls the service and maps typed errors to HTTP statuses.
+- `routes.go` — `RegisterRoutes` wires the endpoint with `Authenticate` + `books:write` middleware.
+- `types.go` — Response types with snake_case JSON tags. The upstream Audnexus camelCase shape is decoded into `audnexusUpstream` and converted at the parse boundary.
+- `errors.go` — `ErrorCode` string identifiers and an `*Error` type. Use `AsAudnexusError(err)` to inspect.
+
+## Endpoint
+
+| Method | Path | Permission |
+|--------|------|------------|
+| GET | `/audnexus/books/:asin/chapters` | `books:write` |
+
+### Error codes
+
+| Service code | HTTP status |
+|--------------|-------------|
+| `invalid_asin` | 400 |
+| `not_found` | 404 |
+| `timeout` | 504 |
+| `upstream_error` | 502 |
+
+ASINs are validated before upstream calls: 10 alphanumeric characters, normalized to uppercase.
+
+## Permissions
+
+Uses `books:write` rather than `books:read` because the only legitimate use is staging data into an editable chapter form. Read-only users can't save what they fetch, so exposing the endpoint to them is pointless and widens the surface area. If the UI hides the button, the endpoint must also reject the request.
+
+## Caching
+
+In-memory `map[string]*cacheEntry` protected by `sync.RWMutex`, TTL 24h. No persistence across restarts. The cache is small (one entry per ASIN), and Audnexus data rarely changes, so there's no eviction beyond TTL.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pkg/audnexus/CLAUDE.md
+git commit -m "[Docs] Add pkg/audnexus/CLAUDE.md"
+```
+
+---
+
+## Task 9: Frontend API client + query hook
+
+**Files:**
+- Create: `app/hooks/queries/audnexus.ts`
+
+- [ ] **Step 1: Create `app/hooks/queries/audnexus.ts`**
+
+```typescript
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
+
+import { API, ShishoAPIError } from "@/libraries/api";
+
+export enum QueryKey {
+  AudnexusChapters = "AudnexusChapters",
+}
+
+export interface AudnexusChapter {
+  title: string;
+  start_offset_ms: number;
+  length_ms: number;
+}
+
+export interface AudnexusChaptersResponse {
+  asin: string;
+  is_accurate: boolean;
+  runtime_length_ms: number;
+  brand_intro_duration_ms: number;
+  brand_outro_duration_ms: number;
+  chapters: AudnexusChapter[];
+}
+
+/**
+ * Fetch chapter data for an Audible ASIN. Disabled by default — enable only
+ * when the user explicitly triggers a lookup from the fetch dialog.
+ */
+export const useAudnexusChapters = (
+  asin: string | null,
+  options: Omit<
+    UseQueryOptions<AudnexusChaptersResponse, ShishoAPIError>,
+    "queryKey" | "queryFn"
+  > = {},
+) => {
+  return useQuery<AudnexusChaptersResponse, ShishoAPIError>({
+    enabled: options.enabled !== undefined ? options.enabled : false,
+    retry: false,
+    ...options,
+    queryKey: [QueryKey.AudnexusChapters, asin],
+    queryFn: async ({ signal }) => {
+      if (!asin) {
+        throw new Error("ASIN is required");
+      }
+      return API.request<AudnexusChaptersResponse>(
+        "GET",
+        `/audnexus/books/${encodeURIComponent(asin)}/chapters`,
+        null,
+        null,
+        signal,
+      );
+    },
+  });
+};
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `pnpm lint:types`
+Expected: PASS (no new errors in this file).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/hooks/queries/audnexus.ts
+git commit -m "[Frontend] Add useAudnexusChapters query hook"
+```
+
+---
+
+## Task 10: Frontend utility — trim offset detection
+
+**Files:**
+- Create: `app/components/files/audnexusChapterUtils.ts`
+- Create: `app/components/files/audnexusChapterUtils.test.ts`
+
+- [ ] **Step 1: Write failing tests for trim detection**
+
+Create `app/components/files/audnexusChapterUtils.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+
+import { detectIntroOffset } from "./audnexusChapterUtils";
+
+describe("detectIntroOffset", () => {
+  it("defaults to false when file matches full runtime", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_938_000,
+    });
+    expect(result).toEqual({ applyOffset: false, withinTolerance: true });
+  });
+
+  it("returns true when file duration matches runtime minus intro", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_900_000, // runtime - intro
+    });
+    expect(result).toEqual({ applyOffset: true, withinTolerance: true });
+  });
+
+  it("returns true when file duration matches runtime minus intro minus outro (Libation)", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_838_000, // runtime - intro - outro
+    });
+    expect(result).toEqual({ applyOffset: true, withinTolerance: true });
+  });
+
+  it("returns false when file duration matches runtime minus outro only (no intro offset needed)", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_876_000, // runtime - outro
+    });
+    expect(result).toEqual({ applyOffset: false, withinTolerance: true });
+  });
+
+  it("accepts ±2000ms tolerance on matches", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 163_939_500, // +1.5s off full runtime
+    });
+    expect(result).toEqual({ applyOffset: false, withinTolerance: true });
+  });
+
+  it("falls back to false and withinTolerance=false when nothing matches", () => {
+    const result = detectIntroOffset({
+      runtimeMs: 163_938_000,
+      introMs: 38_000,
+      outroMs: 62_000,
+      fileDurationMs: 160_000_000, // way off
+    });
+    expect(result).toEqual({ applyOffset: false, withinTolerance: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run and verify they fail**
+
+Run: `pnpm vitest run app/components/files/audnexusChapterUtils.test.ts`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Create `app/components/files/audnexusChapterUtils.ts` with `detectIntroOffset`**
+
+```typescript
+import type { AudnexusChaptersResponse } from "@/hooks/queries/audnexus";
+import type { ChapterInput } from "@/types";
+
+export const TRIM_DETECT_TOLERANCE_MS = 2000;
+
+interface DetectIntroOffsetParams {
+  runtimeMs: number;
+  introMs: number;
+  outroMs: number;
+  fileDurationMs: number;
+}
+
+interface DetectIntroOffsetResult {
+  applyOffset: boolean;
+  withinTolerance: boolean;
+}
+
+/**
+ * Picks whether to apply an intro offset based on which Audnexus duration
+ * candidate is closest to the file's actual duration. Candidates are:
+ *   1. runtime (intact)
+ *   2. runtime - intro
+ *   3. runtime - outro
+ *   4. runtime - intro - outro
+ *
+ * If the closest candidate subtracts intro, applyOffset=true. Otherwise false.
+ * If no candidate is within TRIM_DETECT_TOLERANCE_MS, withinTolerance=false
+ * (UI shows a mismatch warning) and applyOffset defaults to the closest match.
+ */
+export const detectIntroOffset = (
+  params: DetectIntroOffsetParams,
+): DetectIntroOffsetResult => {
+  const { runtimeMs, introMs, outroMs, fileDurationMs } = params;
+  const candidates: { ms: number; subtractsIntro: boolean }[] = [
+    { ms: runtimeMs, subtractsIntro: false },
+    { ms: runtimeMs - introMs, subtractsIntro: true },
+    { ms: runtimeMs - outroMs, subtractsIntro: false },
+    { ms: runtimeMs - introMs - outroMs, subtractsIntro: true },
+  ];
+
+  let best = candidates[0];
+  let bestDiff = Math.abs(candidates[0].ms - fileDurationMs);
+  for (let i = 1; i < candidates.length; i++) {
+    const diff = Math.abs(candidates[i].ms - fileDurationMs);
+    if (diff < bestDiff) {
+      best = candidates[i];
+      bestDiff = diff;
+    }
+  }
+
+  return {
+    applyOffset: best.subtractsIntro,
+    withinTolerance: bestDiff <= TRIM_DETECT_TOLERANCE_MS,
+  };
+};
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `pnpm vitest run app/components/files/audnexusChapterUtils.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/files/audnexusChapterUtils.ts app/components/files/audnexusChapterUtils.test.ts
+git commit -m "[Frontend] Add trim offset detection utility"
+```
+
+---
+
+## Task 11: Frontend utility — apply mode transforms
+
+**Files:**
+- Modify: `app/components/files/audnexusChapterUtils.ts`
+- Modify: `app/components/files/audnexusChapterUtils.test.ts`
+
+- [ ] **Step 1: Write failing tests for the two apply functions**
+
+Append to `app/components/files/audnexusChapterUtils.test.ts`:
+
+```typescript
+import {
+  applyTitlesOnly,
+  applyTitlesAndTimestamps,
+} from "./audnexusChapterUtils";
+
+describe("applyTitlesOnly", () => {
+  it("replaces titles by position, keeps timestamps", () => {
+    const existing = [
+      { title: "Old 1", start_timestamp_ms: 0, children: [] },
+      { title: "Old 2", start_timestamp_ms: 60_000, children: [] },
+    ];
+    const fromAudible = [
+      { title: "New 1", start_offset_ms: 100, length_ms: 1 },
+      { title: "New 2", start_offset_ms: 200, length_ms: 1 },
+    ];
+    const result = applyTitlesOnly(existing, fromAudible);
+    expect(result).toEqual([
+      { title: "New 1", start_timestamp_ms: 0, children: [] },
+      { title: "New 2", start_timestamp_ms: 60_000, children: [] },
+    ]);
+  });
+
+  it("returns existing unchanged when counts differ", () => {
+    const existing = [{ title: "A", start_timestamp_ms: 0, children: [] }];
+    const fromAudible = [
+      { title: "X", start_offset_ms: 0, length_ms: 1 },
+      { title: "Y", start_offset_ms: 100, length_ms: 1 },
+    ];
+    const result = applyTitlesOnly(existing, fromAudible);
+    expect(result).toEqual(existing);
+  });
+});
+
+describe("applyTitlesAndTimestamps", () => {
+  it("replaces wholesale with no offset when applyIntroOffset=false", () => {
+    const fromAudible = [
+      { title: "C1", start_offset_ms: 0, length_ms: 1000 },
+      { title: "C2", start_offset_ms: 60_000, length_ms: 1000 },
+    ];
+    const result = applyTitlesAndTimestamps(fromAudible, {
+      applyIntroOffset: false,
+      introMs: 38_000,
+    });
+    expect(result).toEqual([
+      { title: "C1", start_timestamp_ms: 0, children: [] },
+      { title: "C2", start_timestamp_ms: 60_000, children: [] },
+    ]);
+  });
+
+  it("subtracts introMs from every start when applyIntroOffset=true", () => {
+    const fromAudible = [
+      { title: "C1", start_offset_ms: 38_000, length_ms: 1000 },
+      { title: "C2", start_offset_ms: 98_000, length_ms: 1000 },
+    ];
+    const result = applyTitlesAndTimestamps(fromAudible, {
+      applyIntroOffset: true,
+      introMs: 38_000,
+    });
+    expect(result).toEqual([
+      { title: "C1", start_timestamp_ms: 0, children: [] },
+      { title: "C2", start_timestamp_ms: 60_000, children: [] },
+    ]);
+  });
+
+  it("clamps negative timestamps to 0 after offset", () => {
+    const fromAudible = [
+      { title: "Pre", start_offset_ms: 0, length_ms: 1 },
+      { title: "Main", start_offset_ms: 40_000, length_ms: 1 },
+    ];
+    const result = applyTitlesAndTimestamps(fromAudible, {
+      applyIntroOffset: true,
+      introMs: 38_000,
+    });
+    expect(result[0].start_timestamp_ms).toBe(0);
+    expect(result[1].start_timestamp_ms).toBe(2_000);
+  });
+});
+```
+
+- [ ] **Step 2: Run and verify they fail**
+
+Run: `pnpm vitest run app/components/files/audnexusChapterUtils.test.ts`
+Expected: FAIL — functions don't exist.
+
+- [ ] **Step 3: Add the two functions to `app/components/files/audnexusChapterUtils.ts`**
+
+Append:
+
+```typescript
+import type { AudnexusChapter } from "@/hooks/queries/audnexus";
+
+/**
+ * Replace titles in-place by position; leave timestamps and children alone.
+ * Returns the original array unchanged when lengths differ so the caller
+ * doesn't silently lose data.
+ */
+export const applyTitlesOnly = (
+  existing: ChapterInput[],
+  fromAudible: AudnexusChapter[],
+): ChapterInput[] => {
+  if (existing.length !== fromAudible.length) {
+    return existing;
+  }
+  return existing.map((chapter, i) => ({
+    ...chapter,
+    title: fromAudible[i].title,
+  }));
+};
+
+interface ApplyTitlesAndTimestampsOpts {
+  applyIntroOffset: boolean;
+  introMs: number;
+}
+
+/**
+ * Build a fresh chapter array from Audnexus data, optionally subtracting the
+ * intro duration from every start timestamp. Negative results are clamped
+ * to 0 (only possible for the first chapter).
+ */
+export const applyTitlesAndTimestamps = (
+  fromAudible: AudnexusChapter[],
+  opts: ApplyTitlesAndTimestampsOpts,
+): ChapterInput[] => {
+  const offset = opts.applyIntroOffset ? opts.introMs : 0;
+  return fromAudible.map((c) => ({
+    title: c.title,
+    start_timestamp_ms: Math.max(0, c.start_offset_ms - offset),
+    children: [],
+  }));
+};
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `pnpm vitest run app/components/files/audnexusChapterUtils.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/files/audnexusChapterUtils.ts app/components/files/audnexusChapterUtils.test.ts
+git commit -m "[Frontend] Add apply-mode transforms for audnexus chapters"
+```
+
+---
+
+## Task 12: FetchChaptersDialog — ASIN entry + loading + error states
+
+**Files:**
+- Create: `app/components/files/FetchChaptersDialog.tsx`
+
+- [ ] **Step 1: Create the dialog with the initial + loading + error states**
+
+Create `app/components/files/FetchChaptersDialog.tsx`:
+
+```tsx
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  useAudnexusChapters,
+  type AudnexusChaptersResponse,
+} from "@/hooks/queries/audnexus";
+import { cn } from "@/libraries/utils";
+import type { ChapterInput } from "@/types";
+
+export interface FetchChaptersDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** ASIN prefilled from the file's existing identifiers, if present. */
+  initialAsin?: string;
+  /** Called when the user clicks an Apply button. Closes the dialog. */
+  onApply: (chapters: ChapterInput[]) => void;
+  /** Current edited chapters; used for the counts-match check. */
+  editedChapters: ChapterInput[];
+  /** File duration in ms; used for trim offset detection. */
+  fileDurationMs: number;
+  /** True if the parent edit form has unsaved edits. */
+  hasChanges: boolean;
+}
+
+const ASIN_PATTERN = /^[A-Z0-9]{10}$/;
+
+type Stage = "entry" | "result";
+
+export const FetchChaptersDialog = ({
+  open,
+  onOpenChange,
+  initialAsin,
+  onApply,
+  editedChapters,
+  fileDurationMs,
+  hasChanges,
+}: FetchChaptersDialogProps) => {
+  const [stage, setStage] = useState<Stage>("entry");
+  const [asinInput, setAsinInput] = useState("");
+  const [submittedAsin, setSubmittedAsin] = useState<string | null>(null);
+
+  // Reset internal state when the dialog opens so reopening starts fresh.
+  useEffect(() => {
+    if (open) {
+      setAsinInput((initialAsin ?? "").toUpperCase());
+      setSubmittedAsin(null);
+      setStage("entry");
+    }
+  }, [open, initialAsin]);
+
+  const normalizedAsin = useMemo(
+    () => asinInput.trim().toUpperCase(),
+    [asinInput],
+  );
+  const isValidAsin = ASIN_PATTERN.test(normalizedAsin);
+  const prefilledActive =
+    initialAsin !== undefined &&
+    normalizedAsin === initialAsin.trim().toUpperCase();
+
+  const query = useAudnexusChapters(submittedAsin, {
+    enabled: Boolean(submittedAsin),
+  });
+
+  const handleFetch = () => {
+    if (!isValidAsin) return;
+    setSubmittedAsin(normalizedAsin);
+    setStage("result");
+  };
+
+  const handleRetry = () => {
+    void query.refetch();
+  };
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-lg overflow-x-hidden">
+        {stage === "entry" && (
+          <EntryStage
+            asinInput={asinInput}
+            setAsinInput={setAsinInput}
+            isValidAsin={isValidAsin}
+            prefilledActive={prefilledActive}
+            onCancel={() => onOpenChange(false)}
+            onFetch={handleFetch}
+          />
+        )}
+        {stage === "result" && query.isLoading && <LoadingStage />}
+        {stage === "result" && query.isError && (
+          <ErrorStage
+            error={query.error}
+            asinInput={asinInput}
+            setAsinInput={setAsinInput}
+            onRetry={handleRetry}
+            onCancel={() => onOpenChange(false)}
+          />
+        )}
+        {/* Result stage body is added in the next task */}
+        {stage === "result" &&
+          query.isSuccess &&
+          query.data && (
+            <ResultStagePlaceholder
+              data={query.data}
+              editedChapters={editedChapters}
+              fileDurationMs={fileDurationMs}
+              hasChanges={hasChanges}
+              onApply={(chapters) => {
+                onApply(chapters);
+                onOpenChange(false);
+              }}
+              onCancel={() => onOpenChange(false)}
+            />
+          )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+// --- Sub-stages ---
+
+interface EntryStageProps {
+  asinInput: string;
+  setAsinInput: (value: string) => void;
+  isValidAsin: boolean;
+  prefilledActive: boolean;
+  onCancel: () => void;
+  onFetch: () => void;
+}
+
+const EntryStage = ({
+  asinInput,
+  setAsinInput,
+  isValidAsin,
+  prefilledActive,
+  onCancel,
+  onFetch,
+}: EntryStageProps) => (
+  <>
+    <DialogHeader className="pr-8">
+      <DialogTitle>Fetch chapters from Audible</DialogTitle>
+      <DialogDescription>
+        Look up chapter titles and timestamps by Audible ID.
+      </DialogDescription>
+    </DialogHeader>
+
+    <div className="space-y-4">
+      <div>
+        <Label className="mb-1.5 block" htmlFor="audnexus-asin">
+          Audible ID (ASIN)
+        </Label>
+        <Input
+          autoComplete="off"
+          className="font-mono"
+          id="audnexus-asin"
+          onChange={(e) => setAsinInput(e.target.value)}
+          placeholder="B0036UC2LO"
+          value={asinInput}
+        />
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          {prefilledActive
+            ? "Using this file's existing Audible ID."
+            : "10 characters, found on the Audible book page URL."}
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between pt-2">
+        <span className="text-xs text-muted-foreground">
+          Powered by{" "}
+          <a
+            className="underline hover:no-underline"
+            href="https://audnex.us"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Audnexus
+          </a>
+        </span>
+        <div className="flex items-center gap-2">
+          <Button onClick={onCancel} variant="ghost">
+            Cancel
+          </Button>
+          <Button disabled={!isValidAsin} onClick={onFetch}>
+            Fetch
+          </Button>
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+const LoadingStage = () => (
+  <>
+    <DialogHeader className="pr-8">
+      <DialogTitle>Fetch chapters from Audible</DialogTitle>
+    </DialogHeader>
+    <div className="flex flex-col items-center gap-3 py-8">
+      <div
+        aria-label="Loading"
+        className="h-5 w-5 animate-spin rounded-full border-2 border-border border-t-primary"
+      />
+      <p className="text-sm text-muted-foreground">
+        Looking up chapters on Audible…
+      </p>
+    </div>
+  </>
+);
+
+interface ErrorStageProps {
+  error: unknown;
+  asinInput: string;
+  setAsinInput: (value: string) => void;
+  onRetry: () => void;
+  onCancel: () => void;
+}
+
+const ErrorStage = ({
+  error,
+  asinInput,
+  setAsinInput,
+  onRetry,
+  onCancel,
+}: ErrorStageProps) => {
+  const message = errorMessage(error);
+  return (
+    <>
+      <DialogHeader className="pr-8">
+        <DialogTitle>Fetch chapters from Audible</DialogTitle>
+      </DialogHeader>
+      <div className="space-y-4">
+        <div
+          className={cn(
+            "rounded-md border p-3 text-sm",
+            "border-destructive/40 bg-destructive/10 text-destructive",
+          )}
+          role="alert"
+        >
+          {message}
+        </div>
+        <div>
+          <Label className="mb-1.5 block" htmlFor="audnexus-asin-retry">
+            Audible ID (ASIN)
+          </Label>
+          <Input
+            autoComplete="off"
+            className="font-mono"
+            id="audnexus-asin-retry"
+            onChange={(e) => setAsinInput(e.target.value)}
+            value={asinInput}
+          />
+        </div>
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <Button onClick={onCancel} variant="ghost">
+            Cancel
+          </Button>
+          <Button onClick={onRetry}>Retry</Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+const errorMessage = (error: unknown): string => {
+  // ShishoAPIError shape has a `code` field for our error envelope.
+  const code = (error as { code?: string } | null)?.code;
+  switch (code) {
+    case "not_found":
+      return "We couldn't find this ASIN on Audible. Double-check the ID on the Audible book page.";
+    case "timeout":
+      return "Request timed out. Try again.";
+    case "invalid_asin":
+      return "Check the ASIN format. It should be 10 alphanumeric characters.";
+    default:
+      return "Couldn't reach Audible. Try again in a moment.";
+  }
+};
+
+// Placeholder until the next task wires up the real result body.
+interface ResultStagePlaceholderProps {
+  data: AudnexusChaptersResponse;
+  editedChapters: ChapterInput[];
+  fileDurationMs: number;
+  hasChanges: boolean;
+  onApply: (chapters: ChapterInput[]) => void;
+  onCancel: () => void;
+}
+
+const ResultStagePlaceholder = (props: ResultStagePlaceholderProps) => {
+  // Suppress unused-var lint warnings; the next task replaces this.
+  void props;
+  return (
+    <div className="p-4 text-sm text-muted-foreground">
+      Result view is implemented in the next task.
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `pnpm lint:types`
+Expected: PASS (no new errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/files/FetchChaptersDialog.tsx
+git commit -m "[Frontend] Scaffold FetchChaptersDialog with entry/loading/error stages"
+```
+
+---
+
+## Task 13: FetchChaptersDialog — result stage
+
+**Files:**
+- Modify: `app/components/files/FetchChaptersDialog.tsx`
+
+- [ ] **Step 1: Replace `ResultStagePlaceholder` with the real result view**
+
+In `app/components/files/FetchChaptersDialog.tsx`, delete the placeholder and replace with:
+
+```tsx
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+import {
+  applyTitlesAndTimestamps,
+  applyTitlesOnly,
+  detectIntroOffset,
+} from "./audnexusChapterUtils";
+
+interface ResultStageProps {
+  data: AudnexusChaptersResponse;
+  editedChapters: ChapterInput[];
+  fileDurationMs: number;
+  hasChanges: boolean;
+  onApply: (chapters: ChapterInput[]) => void;
+  onCancel: () => void;
+}
+
+const ResultStage = ({
+  data,
+  editedChapters,
+  fileDurationMs,
+  hasChanges,
+  onApply,
+  onCancel,
+}: ResultStageProps) => {
+  const detection = useMemo(
+    () =>
+      detectIntroOffset({
+        runtimeMs: data.runtime_length_ms,
+        introMs: data.brand_intro_duration_ms,
+        outroMs: data.brand_outro_duration_ms,
+        fileDurationMs,
+      }),
+    [data, fileDurationMs],
+  );
+
+  const [applyOffset, setApplyOffset] = useState(detection.applyOffset);
+
+  // Re-sync when a new fetch result lands (different ASIN, say).
+  useEffect(() => {
+    setApplyOffset(detection.applyOffset);
+  }, [detection.applyOffset]);
+
+  const countsMatch = data.chapters.length === editedChapters.length;
+  const durationDiffMs = Math.abs(data.runtime_length_ms - fileDurationMs);
+
+  const handleApplyTitlesOnly = () => {
+    onApply(applyTitlesOnly(editedChapters, data.chapters));
+  };
+
+  const handleApplyBoth = () => {
+    onApply(
+      applyTitlesAndTimestamps(data.chapters, {
+        applyIntroOffset: applyOffset,
+        introMs: data.brand_intro_duration_ms,
+      }),
+    );
+  };
+
+  return (
+    <>
+      <DialogHeader className="pr-8">
+        <DialogTitle>Chapters from Audible</DialogTitle>
+        <DialogDescription>Audible ID: {data.asin}</DialogDescription>
+      </DialogHeader>
+
+      <div className="space-y-4">
+        <DurationComparison
+          audibleMs={data.runtime_length_ms}
+          fileMs={fileDurationMs}
+          introMs={data.brand_intro_duration_ms}
+          outroMs={data.brand_outro_duration_ms}
+          audibleCount={data.chapters.length}
+          fileCount={editedChapters.length}
+        />
+
+        {detection.withinTolerance ? (
+          <InfoCallout
+            heading={
+              detection.applyOffset
+                ? `Intro removed. Chapters offset by −${Math.round(
+                    data.brand_intro_duration_ms / 1000,
+                  )}s.`
+                : "Durations match. File is intact."
+            }
+            body={
+              detection.applyOffset
+                ? "Matches a trimmed file (e.g. Libation rip). Chapters will be shifted to align."
+                : "Chapter timestamps will be used as-is."
+            }
+          />
+        ) : (
+          <WarnCallout
+            heading={`Duration differs by ${formatDurationDiff(durationDiffMs)}. May be a different edition.`}
+            body="None of the trim modes match within 2 seconds. Timestamps may be off."
+          />
+        )}
+
+        {hasChanges && (
+          <WarnCallout
+            heading="Unsaved changes will be overwritten"
+            body="You have unsaved edits to the current chapters. Applying will replace them. You can still Cancel afterward to discard everything."
+          />
+        )}
+
+        <label className="flex cursor-pointer items-start gap-2 text-sm">
+          <Checkbox
+            checked={applyOffset}
+            className="mt-0.5"
+            onCheckedChange={(v) => setApplyOffset(v === true)}
+          />
+          <div>
+            <div>
+              Offset chapters by intro duration (−
+              {Math.round(data.brand_intro_duration_ms / 1000)}s)
+            </div>
+            <div className="mt-0.5 text-xs text-muted-foreground">
+              Enable for files with the Audible intro stripped out (e.g.
+              Libation rips).
+            </div>
+          </div>
+        </label>
+
+        <div className="flex flex-wrap items-center justify-end gap-2 pt-2">
+          <Button onClick={onCancel} variant="ghost">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleApplyBoth}
+            variant={countsMatch ? "outline" : "default"}
+          >
+            Apply titles + timestamps
+          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                    disabled={!countsMatch}
+                    onClick={handleApplyTitlesOnly}
+                  >
+                    Apply titles only
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {!countsMatch && (
+                <TooltipContent>
+                  Chapter counts don't match ({editedChapters.length} vs{" "}
+                  {data.chapters.length}).
+                </TooltipContent>
+              )}
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      </div>
+    </>
+  );
+};
+
+interface DurationComparisonProps {
+  audibleMs: number;
+  fileMs: number;
+  introMs: number;
+  outroMs: number;
+  audibleCount: number;
+  fileCount: number;
+}
+
+const DurationComparison = ({
+  audibleMs,
+  fileMs,
+  introMs,
+  outroMs,
+  audibleCount,
+  fileCount,
+}: DurationComparisonProps) => (
+  <div className="rounded-md border border-border">
+    <KvRow label="Audible runtime">
+      <span>{formatHms(audibleMs)}</span>
+      {(introMs > 0 || outroMs > 0) && (
+        <span className="text-muted-foreground">
+          {" · "}
+          {introMs > 0 && `intro ${formatSeconds(introMs)}`}
+          {introMs > 0 && outroMs > 0 && " · "}
+          {outroMs > 0 && `outro ${formatSeconds(outroMs)}`}
+        </span>
+      )}
+    </KvRow>
+    <KvRow label="Your file">{formatHms(fileMs)}</KvRow>
+    <KvRow label="Chapters">
+      <span>
+        {audibleCount} from Audible <span className="text-muted-foreground">·</span>{" "}
+        <span
+          className={cn(audibleCount !== fileCount && "text-amber-500")}
+        >
+          {fileCount} in your file
+        </span>
+      </span>
+    </KvRow>
+  </div>
+);
+
+const KvRow = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex items-baseline justify-between gap-2 px-3 py-2 [&+&]:border-t [&+&]:border-border">
+    <span className="text-sm text-muted-foreground">{label}</span>
+    <span className="text-sm font-medium">{children}</span>
+  </div>
+);
+
+const InfoCallout = ({ heading, body }: { heading: string; body: string }) => (
+  <div className="rounded-md border border-primary/40 bg-primary/10 p-3 text-sm">
+    <div className="font-medium text-primary">{heading}</div>
+    <div className="mt-0.5 text-xs text-muted-foreground">{body}</div>
+  </div>
+);
+
+const WarnCallout = ({ heading, body }: { heading: string; body: string }) => (
+  <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm">
+    <div className="font-medium text-destructive">{heading}</div>
+    <div className="mt-0.5 text-xs text-muted-foreground">{body}</div>
+  </div>
+);
+
+const formatHms = (ms: number): string => {
+  const total = Math.max(0, Math.round(ms / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+};
+
+const formatSeconds = (ms: number): string => {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  return `${Math.floor(s / 60)}m ${s % 60}s`;
+};
+
+const formatDurationDiff = (ms: number): string => formatHms(ms);
+```
+
+And replace the `<ResultStagePlaceholder ... />` usage in the main component body with:
+
+```tsx
+<ResultStage
+  data={query.data}
+  editedChapters={editedChapters}
+  fileDurationMs={fileDurationMs}
+  hasChanges={hasChanges}
+  onApply={(chapters) => {
+    onApply(chapters);
+    onOpenChange(false);
+  }}
+  onCancel={() => onOpenChange(false)}
+/>
+```
+
+Remove the `ResultStagePlaceholder` function entirely.
+
+- [ ] **Step 2: Type-check and lint**
+
+Run: `pnpm lint:types && pnpm lint:eslint`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/files/FetchChaptersDialog.tsx
+git commit -m "[Frontend] Implement result stage in FetchChaptersDialog"
+```
+
+---
+
+## Task 14: FetchChaptersDialog component tests
+
+**Files:**
+- Create: `app/components/files/FetchChaptersDialog.test.tsx`
+
+- [ ] **Step 1: Create the test file**
+
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { API } from "@/libraries/api";
+
+import { FetchChaptersDialog } from "./FetchChaptersDialog";
+
+const renderWithClient = (ui: React.ReactElement) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+};
+
+describe("FetchChaptersDialog", () => {
+  it("prefills ASIN and enables Fetch when valid", () => {
+    renderWithClient(
+      <FetchChaptersDialog
+        editedChapters={[]}
+        fileDurationMs={0}
+        hasChanges={false}
+        initialAsin="B0036UC2LO"
+        onApply={vi.fn()}
+        onOpenChange={vi.fn()}
+        open
+      />,
+    );
+    expect(screen.getByText("Using this file's existing Audible ID.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Fetch" })).not.toBeDisabled();
+  });
+
+  it("disables Fetch when ASIN is invalid", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderWithClient(
+      <FetchChaptersDialog
+        editedChapters={[]}
+        fileDurationMs={0}
+        hasChanges={false}
+        onApply={vi.fn()}
+        onOpenChange={vi.fn()}
+        open
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Fetch" })).toBeDisabled();
+    await user.type(screen.getByLabelText("Audible ID (ASIN)"), "short");
+    expect(screen.getByRole("button", { name: "Fetch" })).toBeDisabled();
+    await user.clear(screen.getByLabelText("Audible ID (ASIN)"));
+    await user.type(screen.getByLabelText("Audible ID (ASIN)"), "B0036UC2LO");
+    expect(screen.getByRole("button", { name: "Fetch" })).not.toBeDisabled();
+  });
+
+  it("shows loading, then result, and calls onApply with titles-only chapters when counts match", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const apiSpy = vi.spyOn(API, "request").mockResolvedValue({
+      asin: "B0036UC2LO",
+      is_accurate: true,
+      runtime_length_ms: 60_000,
+      brand_intro_duration_ms: 0,
+      brand_outro_duration_ms: 0,
+      chapters: [
+        { title: "New A", start_offset_ms: 0, length_ms: 30_000 },
+        { title: "New B", start_offset_ms: 30_000, length_ms: 30_000 },
+      ],
+    });
+    const onApply = vi.fn();
+    renderWithClient(
+      <FetchChaptersDialog
+        editedChapters={[
+          { title: "Old A", start_timestamp_ms: 0, children: [] },
+          { title: "Old B", start_timestamp_ms: 20_000, children: [] },
+        ]}
+        fileDurationMs={60_000}
+        hasChanges={false}
+        initialAsin="B0036UC2LO"
+        onApply={onApply}
+        onOpenChange={vi.fn()}
+        open
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Fetch" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Apply titles only" }),
+      ).toBeEnabled(),
+    );
+    await user.click(screen.getByRole("button", { name: "Apply titles only" }));
+
+    expect(onApply).toHaveBeenCalledWith([
+      { title: "New A", start_timestamp_ms: 0, children: [] },
+      { title: "New B", start_timestamp_ms: 20_000, children: [] },
+    ]);
+    expect(apiSpy).toHaveBeenCalled();
+  });
+
+  it("disables Apply titles only when counts differ", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    vi.spyOn(API, "request").mockResolvedValue({
+      asin: "B0036UC2LO",
+      is_accurate: true,
+      runtime_length_ms: 60_000,
+      brand_intro_duration_ms: 0,
+      brand_outro_duration_ms: 0,
+      chapters: [
+        { title: "A", start_offset_ms: 0, length_ms: 30_000 },
+        { title: "B", start_offset_ms: 30_000, length_ms: 30_000 },
+      ],
+    });
+    renderWithClient(
+      <FetchChaptersDialog
+        editedChapters={[
+          { title: "Only one", start_timestamp_ms: 0, children: [] },
+        ]}
+        fileDurationMs={60_000}
+        hasChanges={false}
+        initialAsin="B0036UC2LO"
+        onApply={vi.fn()}
+        onOpenChange={vi.fn()}
+        open
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Fetch" }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Apply titles only" }),
+      ).toBeDisabled(),
+    );
+  });
+
+  it("shows overwrite warning when hasChanges=true", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    vi.spyOn(API, "request").mockResolvedValue({
+      asin: "B0036UC2LO",
+      is_accurate: true,
+      runtime_length_ms: 60_000,
+      brand_intro_duration_ms: 0,
+      brand_outro_duration_ms: 0,
+      chapters: [{ title: "A", start_offset_ms: 0, length_ms: 60_000 }],
+    });
+    renderWithClient(
+      <FetchChaptersDialog
+        editedChapters={[{ title: "Old", start_timestamp_ms: 0, children: [] }]}
+        fileDurationMs={60_000}
+        hasChanges
+        initialAsin="B0036UC2LO"
+        onApply={vi.fn()}
+        onOpenChange={vi.fn()}
+        open
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Fetch" }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Unsaved changes will be overwritten/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows error message for not_found", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    vi.spyOn(API, "request").mockRejectedValue({
+      code: "not_found",
+      message: "ASIN not found",
+    });
+    renderWithClient(
+      <FetchChaptersDialog
+        editedChapters={[]}
+        fileDurationMs={0}
+        hasChanges={false}
+        initialAsin="B0036UC2LO"
+        onApply={vi.fn()}
+        onOpenChange={vi.fn()}
+        open
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Fetch" }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(/couldn't find this ASIN/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run component tests**
+
+Run: `pnpm vitest run app/components/files/FetchChaptersDialog.test.tsx`
+Expected: PASS for all cases.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/files/FetchChaptersDialog.test.tsx
+git commit -m "[Frontend] Test FetchChaptersDialog states and apply behavior"
+```
+
+---
+
+## Task 15: Integrate into FileChaptersTab (button, dialog, apply wiring)
+
+**Files:**
+- Modify: `app/components/files/FileChaptersTab.tsx`
+
+- [ ] **Step 1: Read the current file to locate insertion points**
+
+Run: `cat app/components/files/FileChaptersTab.tsx | head -40`
+
+You'll be adding:
+- A new `useState` for dialog open.
+- A computed `audibleAsin` from `file.identifiers`.
+- A permission check via `useCurrentUser()` (there's likely an existing hook; search for it).
+- A `handleApplyAudnexus` that replaces `editedChapters` and enters edit mode.
+- Three button mounts: edit-mode toolbar, view-mode header, empty-state row.
+- The `<FetchChaptersDialog />` rendered at the bottom.
+
+- [ ] **Step 2: Find the existing permission check pattern**
+
+Run: `grep -rn "HasPermission\|hasPermission\|books:write\|OperationWrite" app/components | head -10`
+
+Typical pattern (verify in the repo):
+```tsx
+const { user } = useCurrentUser();
+const canEdit = user?.has_permission?.("books", "write") ?? false;
+```
+
+Use whatever pattern the surrounding code already uses for the "Edit" button in this file.
+
+- [ ] **Step 3: Add imports, state, and handlers**
+
+In `app/components/files/FileChaptersTab.tsx`, add the imports:
+
+```tsx
+import { FetchChaptersDialog } from "@/components/files/FetchChaptersDialog";
+import { IdentifierTypeASIN } from "@/types";
+```
+
+Inside the component body (near the other `useState` calls), add:
+
+```tsx
+const [isFetchDialogOpen, setIsFetchDialogOpen] = useState(false);
+
+const audibleAsin = useMemo(() => {
+  const asinIdentifier = file.identifiers?.find(
+    (id) => id.type === IdentifierTypeASIN,
+  );
+  return asinIdentifier?.value;
+}, [file.identifiers]);
+
+// Only M4B files can use this feature.
+const canFetchFromAudible =
+  file.file_type === FileTypeM4B && userCanEditChapters;
+
+const handleApplyAudnexus = useCallback(
+  (chapters: ChapterInput[]) => {
+    const newEdited = toEditedChapters(chapters);
+    setEditedChapters(newEdited);
+    if (!isEditing) {
+      // Entering edit mode from view/empty state.
+      setInitialChapters(
+        toEditedChapters(chaptersToInputArray(chaptersQuery.data ?? [])),
+      );
+      editInitializedRef.current = true;
+      onEditingChange(true);
+    }
+  },
+  [isEditing, chaptersQuery.data, onEditingChange],
+);
+```
+
+`userCanEditChapters` should be sourced from whatever pattern the current "Edit" button in this component uses (check lines where `onEditingChange(true)` is gated). If the Edit button is always visible in this component and gating happens at the parent, then mirror that: surface `canFetchFromAudible` as the M4B check only, and let the parent's permission gating handle the Edit gating naturally.
+
+- [ ] **Step 4: Add the three button mounts**
+
+Inside `renderEditedChapters` where "Add chapter" for M4B is rendered, add the button next to it:
+
+```tsx
+{isM4b && (
+  <>
+    <Button
+      className="mt-2"
+      onClick={handleAddChapterM4B}
+      type="button"
+      variant="outline"
+    >
+      Add Chapter
+    </Button>
+    {canFetchFromAudible && (
+      <Button
+        className="mt-2 ml-2"
+        onClick={() => setIsFetchDialogOpen(true)}
+        type="button"
+        variant="outline"
+      >
+        Fetch from Audible
+      </Button>
+    )}
+  </>
+)}
+```
+
+In the empty-state branch where `Add Chapter` for M4B is rendered:
+
+```tsx
+{canAddChapters && (
+  <div className="mt-4 flex items-center justify-center gap-2">
+    <button
+      className="cursor-pointer rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:bg-primary/90"
+      onClick={handleAddChapterFromEmpty}
+      type="button"
+    >
+      Add Chapter
+    </button>
+    {file.file_type === FileTypeM4B && canFetchFromAudible && (
+      <Button
+        onClick={() => setIsFetchDialogOpen(true)}
+        type="button"
+        variant="outline"
+      >
+        Fetch from Audible
+      </Button>
+    )}
+  </div>
+)}
+```
+
+The view-mode header button lives in the parent of this component (`FileDetail` or similar). Trace where the Edit button is rendered for chapters and add "Fetch from Audible" next to it, also gated by `file.file_type === FileTypeM4B` and `books:write`. If that parent doesn't expose a slot for extra actions, skip the third entry point for v1 and note it in Task 17 docs.
+
+- [ ] **Step 5: Render the dialog at the end of the component**
+
+Add just before the closing `</div>` of the component's root return:
+
+```tsx
+{canFetchFromAudible && (
+  <FetchChaptersDialog
+    editedChapters={
+      isEditing
+        ? stripEditKeys(editedChapters)
+        : chaptersToInputArray(chaptersQuery.data ?? [])
+    }
+    fileDurationMs={(file.audiobook_duration_seconds ?? 0) * 1000}
+    hasChanges={hasChanges}
+    initialAsin={audibleAsin}
+    onApply={handleApplyAudnexus}
+    onOpenChange={setIsFetchDialogOpen}
+    open={isFetchDialogOpen}
+  />
+)}
+```
+
+- [ ] **Step 6: Type-check, lint, unit tests**
+
+Run: `pnpm lint:types && pnpm lint:eslint && pnpm vitest run app/components/files`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/components/files/FileChaptersTab.tsx
+git commit -m "[Frontend] Wire FetchChaptersDialog into FileChaptersTab"
+```
+
+---
+
+## Task 16: Run the full check suite and fix regressions
+
+**Files:** (none modified by default)
+
+- [ ] **Step 1: Run the full check**
+
+Run: `mise check:quiet`
+Expected: PASS.
+
+- [ ] **Step 2: If anything fails, inspect with full output**
+
+Run: `mise check`
+
+Fix the failing step, re-run `mise check:quiet` until green. Each fix gets its own commit scoped to the failure (e.g., `[Fix] Audnexus test cache race` or `[Frontend] Adjust tooltip role for RTL`).
+
+- [ ] **Step 3: Verify M4B chapter edit UI manually**
+
+Start the dev server:
+
+Run: `mise start` (or `mise start:air` if the frontend is already running)
+
+In the browser:
+1. Navigate to an M4B file's chapter edit page.
+2. Confirm "Fetch from Audible" appears in view mode, edit mode, and empty-state views.
+3. Click it — confirm the ASIN is prefilled when the file has an ASIN identifier.
+4. Fetch with a real Audible ASIN. Confirm result stage shows, durations compare, checkbox defaults to the right state.
+5. Apply titles only — confirm the edit form shows the new titles, timestamps untouched, not saved.
+6. Cancel — confirm the pre-apply chapters come back.
+7. Apply titles + timestamps on a Libation rip (where the checkbox is pre-checked). Confirm chapter rows show sensible timestamps and use the play button to spot-check a couple.
+8. Hit Save and confirm the chapters persist (reload to verify).
+9. Try with a user that lacks `books:write` (Viewer role). Confirm the button isn't visible.
+
+If anything is off, file a task back at the appropriate step and fix before committing.
+
+---
+
+## Task 17: Documentation — website user docs, pkg/mp4/CLAUDE.md
+
+**Files:**
+- Check existing website docs structure first: `ls website/docs/`
+- Create or modify: `website/docs/chapters.md` (or add a section to the appropriate existing page — `supported-formats.md` or `metadata.md`, verify in the sidebar)
+- Modify: `pkg/mp4/CLAUDE.md`
+
+- [ ] **Step 1: Find the right docs location**
+
+Run: `ls website/docs/` and `cat website/sidebars.ts 2>/dev/null || cat website/sidebars.js 2>/dev/null`
+
+Choose one:
+- If a "Chapters" page exists, add a "Fetch from Audible" section at the end.
+- Otherwise create a new page `website/docs/chapter-editing.md` and add it to the sidebar in the appropriate section.
+
+- [ ] **Step 2: Write the user docs**
+
+The page must cover:
+
+```markdown
+## Fetching chapter data from Audible
+
+For M4B audiobook files, Shisho can look up chapter titles and timestamps from Audible's catalog and stage them into the chapter editor. This is useful for files ripped from Audible that have missing or wrong chapter metadata.
+
+### Requirements
+
+- File must be an M4B audiobook.
+- You need an Audible ID (ASIN) for the book. You can copy it from the URL of the book's Audible page (e.g., `https://www.audible.com/pd/Example-Audiobook/B0036UC2LO` — the 10-character code at the end).
+- Your user must have **books:write** permission (Editor or Admin role).
+
+### How it works
+
+1. Open the chapter edit page for an M4B file and click **Fetch from Audible** (available in view mode, edit mode, and when there are no chapters yet).
+2. Paste or confirm the ASIN and click **Fetch**.
+3. Shisho shows the Audible runtime, your file's duration, and the chapter count on each side.
+4. Shisho auto-detects whether your file has the Audible intro removed (as some ripping tools like Libation do by default). The resulting offset is reflected in a checkbox that you can flip if the detection is wrong.
+5. Choose how to apply:
+   - **Apply titles only** — replace chapter titles in place, keep your existing timestamps. Available only when the chapter counts match.
+   - **Apply titles + timestamps** — replace everything with Audible data, respecting the offset checkbox.
+6. The dialog closes and the new data is staged in the edit form. Use the per-chapter play buttons to spot-check timestamps, adjust anything that's off, and click **Save** to commit — or **Cancel** to discard everything, including the fetched data.
+
+### Data source
+
+Chapter data comes from [Audnexus](https://audnex.us), a community-run proxy of Audible chapter data. Shisho caches each ASIN response for 24 hours to minimize upstream calls.
+```
+
+Add to the sidebar if a new page was created.
+
+- [ ] **Step 3: Update `pkg/mp4/CLAUDE.md` with a cross-reference**
+
+Append a new section to `pkg/mp4/CLAUDE.md`:
+
+```markdown
+## External chapter source
+
+For user-initiated chapter enrichment on M4B files, see `pkg/audnexus/` — a single-endpoint integration that fetches chapter titles and timestamps from Audible via the Audnexus public API. The M4B chapter edit UI exposes a "Fetch from Audible" button that stages the fetched data into the edit form without persisting until the user clicks Save.
+```
+
+- [ ] **Step 4: Run the docs build to catch sidebar or markdown issues**
+
+Run: `mise docs` in a separate shell, confirm the new page renders. Stop the server with Ctrl-C when done.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add website/ pkg/mp4/CLAUDE.md
+git commit -m "[Docs] Document fetch chapters from Audible feature"
+```
+
+---
+
+## Self-review checklist (for the implementer)
+
+Before handing off, verify:
+
+- [ ] `mise check:quiet` passes.
+- [ ] New endpoint `/api/audnexus/books/:asin/chapters` returns 400/404/504/502 correctly.
+- [ ] Dialog opens from all three entry points on M4B files and is hidden for non-M4B.
+- [ ] Dialog is hidden for users without `books:write` (verify with Viewer role).
+- [ ] Apply titles only is disabled with a tooltip when counts differ.
+- [ ] Checkbox auto-state is correct for: intact file, intro-only trim, outro-only trim, both-removed trim, and mismatch.
+- [ ] Cancel discards everything after apply.
+- [ ] Out-of-bounds timestamps after offset are flagged by existing `ChapterRow` validation, not silently clamped.
+- [ ] Overwrite warning appears only when `hasChanges` is true before fetching.
+- [ ] No em dashes in any new user-facing copy.

--- a/docs/superpowers/specs/2026-04-21-audible-chapter-fetch-design.md
+++ b/docs/superpowers/specs/2026-04-21-audible-chapter-fetch-design.md
@@ -1,0 +1,249 @@
+# Fetch chapters from Audible: design
+
+**Date:** 2026-04-21
+**Status:** Approved
+
+## Overview
+
+Users can fetch chapter titles and timestamps from Audible (via the Audnexus public API) and apply them to an M4B file's chapters in the existing chapter edit flow. Apply stages the data in the edit form without saving, so the user can spot-check with the existing per-chapter play buttons, tweak if needed, and commit with Save or discard with Cancel.
+
+Scope: M4B files only. No viable external chapter APIs exist for EPUB or CBZ, so no generalized "chapter provider" abstraction.
+
+## Motivation
+
+Ripped audiobook files often ship with wrong or missing chapter data. Audible has authoritative chapter titles and timestamps for every book in its catalog. Audnexus (`api.audnex.us`) proxies this data as a free community service. Surfacing this inside Shisho removes the need for users to hand-edit every chapter or drop into external tools.
+
+## Non-goals
+
+- EPUB or CBZ chapter fetching (no viable public APIs).
+- Audible search within Shisho (v1 requires the user to provide an ASIN; paste-from-URL is enough for the common workflow).
+- Automatic enrichment during scans (user-initiated only in v1).
+- Persistent disk cache across server restarts.
+
+## Architecture
+
+### New backend package: `pkg/audnexus/`
+
+- `service.go`: HTTP client with a 5-second request timeout and an in-memory TTL cache keyed by ASIN. TTL: 24 hours. Cache only successful responses; retries on errors should hit upstream. `sync.RWMutex` around a `map[string]*cachedResponse`. No eviction beyond TTL (one entry per ASIN, trivial footprint).
+- `handlers.go` + `routes.go`: single endpoint `GET /api/audnexus/books/:asin/chapters`. Requires auth plus `books:write` permission (see Permissions below). Invalid ASIN format returns 400 without upstream call.
+- `User-Agent` header: `Shisho/<version>` on every upstream request.
+- Wired into `cmd/api/main.go` alongside other services.
+
+### API surface
+
+**Endpoint:** `GET /api/audnexus/books/:asin/chapters`
+
+**ASIN validation:** 10 characters, alphanumeric. Reject with 400 `{ code: "invalid_asin" }` before any upstream call.
+
+**Response (200):**
+```json
+{
+  "asin": "B0036UC2LO",
+  "is_accurate": true,
+  "runtime_length_ms": 163938000,
+  "brand_intro_duration_ms": 38000,
+  "brand_outro_duration_ms": 62000,
+  "chapters": [
+    { "title": "Prelude", "start_offset_ms": 0, "length_ms": 272000 },
+    { "title": "Prologue: To Kill", "start_offset_ms": 272000, "length_ms": 1063000 }
+  ]
+}
+```
+
+Field names use `snake_case` per project API conventions. This is a one-to-one passthrough of Audnexus fields (converted from the upstream camelCase).
+
+**Error responses:**
+- `400 { code: "invalid_asin" }`: ASIN format check failed.
+- `404 { code: "not_found" }`: Audnexus returned 404.
+- `504 { code: "timeout" }`: Upstream did not respond within 5s.
+- `502 { code: "upstream_error" }`: Any other upstream failure (5xx, connection error, malformed JSON).
+
+### Permissions
+
+Endpoint requires `books:write` (not `books:read`). Rationale:
+
+- The only legitimate use of fetched data is staging it into an editable chapter form, which requires write access to save.
+- Keeps the UI and backend gate coherent: if the "Fetch from Audible" button isn't shown to this user, the endpoint isn't usable either.
+
+### Caching
+
+- In-memory, server lifetime only, no persistence.
+- Keyed by ASIN (normalized to uppercase before lookup).
+- TTL 24 hours (Audnexus data rarely changes).
+- Only successes cached; errors pass through so retries work.
+
+### Rate limiting
+
+None in v1. Audnexus is community-run and generous, and self-hosted Shisho instances won't generate significant load. Revisit if it becomes an issue.
+
+## Frontend
+
+### New files
+
+- `app/hooks/queries/audnexus.ts`: `useAudnexusChapters(asin)` tanstack query hook. `enabled: false` by default; triggered by dialog Fetch button.
+- `app/components/files/FetchChaptersDialog.tsx`: the dialog component.
+- `FileChaptersTab.tsx`: updated to mount the button in three places and wire the apply callback into `editedChapters` state.
+
+### Entry points
+
+The "Fetch from Audible" button appears in three surfaces (all M4B-only, all require `books:write`):
+
+1. **View mode header**, alongside the existing Edit button.
+2. **Empty state**, alongside the "Add chapter" button.
+3. **Edit mode**, alongside the "Add chapter" button at the bottom of the chapter list.
+
+All three entry points open the same dialog. On apply, the data is injected into `editedChapters` and the UI enters edit mode (if not already).
+
+### Dialog states
+
+Visual reference: `tmp/mockups/fetch-chapters.html` (committed snapshot of approved mockups).
+
+**State 1: ASIN entry.**
+- Single input (monospace font) labeled "Audible ID (ASIN)".
+- Prefilled from `file.identifiers` when present; shows a checkmark + "Using this file's existing Audible ID." when prefilled.
+- Fetch button disabled until input is 10 alphanumeric characters.
+- Footer: "Powered by [Audnexus](https://audnex.us)" attribution link.
+
+**State 2: Loading.** Spinner and "Looking up chapters on Audible…". Cancel available throughout.
+
+**State 3: Result.** Shows:
+- Book title and ASIN in the header.
+- Duration comparison block:
+  - Audible runtime (with intro and outro durations when nonzero)
+  - Your file's duration
+  - Chapter count comparison ("N from Audible · M in your file")
+- Trim detection info callout (see Trim detection below).
+- Single checkbox: "Offset chapters by intro duration (−<intro>s)". Checked or unchecked by auto-detection; user can flip.
+- Overwrite warning when the parent edit form already has unsaved changes.
+- Two apply buttons (see Apply behavior).
+
+**State 4: Error.** Human-readable error message based on the error code. Retry button re-runs the fetch.
+
+### Trim detection
+
+Audible files that have had the Audible-branded intro and/or outro stripped (common with Libation rips) have durations that don't match Audnexus's `runtime_length_ms`. Chapter timestamps are offset relative to the original full file, so applying them as-is would be wrong by up to the intro duration.
+
+**Detection algorithm (runs after a successful Audnexus fetch):**
+
+1. Compute four candidate durations:
+   - `runtime_length_ms` (intact)
+   - `runtime_length_ms - brand_intro_duration_ms`
+   - `runtime_length_ms - brand_outro_duration_ms`
+   - `runtime_length_ms - brand_intro_duration_ms - brand_outro_duration_ms`
+2. Pick the candidate closest to `file.audiobook_duration_seconds * 1000`.
+3. If the closest candidate is within ±2000ms (2 seconds) tolerance:
+   - If the matching candidate subtracts intro → set `applyIntroOffset = true`.
+   - Otherwise → set `applyIntroOffset = false`.
+4. If no candidate matches within tolerance: set `applyIntroOffset = false` (closest match default) and show a mismatch warning in the dialog.
+
+**User-facing control:** a single checkbox, "Offset chapters by intro duration (−<intro>s)." The checkbox state is what determines the applied offset. All four detection candidates exist only to set the checkbox's initial value; they are not exposed in the UI.
+
+**Rationale for the single checkbox:** Only two behaviors are actually possible when applying timestamps: subtract the intro duration or don't. The outro affects total file length but not chapter start times, so it does not map to a distinct offset. Exposing four radio options for two outcomes adds friction without value.
+
+### Apply behavior
+
+Two apply buttons:
+
+**"Apply titles only"** (primary when available; disabled with tooltip when chapter counts differ):
+- For each index `i`, replace `editedChapters[i].title` with `audnexus.chapters[i].title`.
+- Leave `start_timestamp_ms` values untouched.
+- Offset checkbox has no effect (timestamps are not touched).
+- Disabled state tooltip: "Chapter counts don't match (N vs M)."
+
+**"Apply titles + timestamps"** (primary when titles-only is disabled; secondary otherwise):
+- Replace `editedChapters` entirely with a new array derived from Audnexus.
+- For each Audnexus chapter:
+  - `title = audnexus.chapters[i].title`
+  - `start_timestamp_ms = audnexus.chapters[i].start_offset_ms - offset`, where `offset = brand_intro_duration_ms` when the checkbox is checked, `0` otherwise.
+  - `children = []`, fresh `_editKey`.
+- Negative post-offset timestamps are clamped to 0 (only possible for the first chapter).
+- After injection, run the existing `normalizeChapterOrder` to sort by `start_timestamp_ms` defensively.
+
+**Out-of-bounds handling:** timestamps that exceed `file.audiobook_duration_seconds * 1000` after offset are NOT clamped or dropped. The existing per-row validation in `ChapterRow` flags them and blocks Save, giving the user clear visual signal about which chapters need manual adjustment. Silent truncation would hide the problem.
+
+**After apply:**
+- Dialog closes.
+- Component enters (or stays in) edit mode.
+- User spot-checks with the existing per-chapter play buttons, adjusts timestamps if needed, Saves or Cancels.
+- Cancel reverts to the pre-fetch state (empty chapters if the fetch was from empty state, prior chapters otherwise).
+
+**Overwrite warning:** if the user re-opens the dialog with unsaved edits already staged (`hasChanges === true`), show a warning callout in the result view: "Unsaved changes will be overwritten." Apply buttons remain enabled. Warning is suppressed when `hasChanges === false`.
+
+### Copy and naming
+
+- Button label: **"Fetch from Audible"**.
+- Dialog title: **"Fetch chapters from Audible"**.
+- Attribution: small "Powered by [Audnexus](https://audnex.us)" link in the dialog footer.
+- Input label: **"Audible ID (ASIN)"**. Long form on the label, short form in the dialog body and elsewhere.
+- Copy contains no em dashes. Use colons for label:value structure and periods for sentence breaks.
+
+## Error surfaces (frontend)
+
+All errors render in State 4 of the dialog:
+
+- `invalid_asin` / pre-fetch format check: "Check the ASIN format. It should be 10 alphanumeric characters."
+- `not_found`: "We couldn't find this ASIN on Audible. Double-check the ID on the Audible book page."
+- `timeout`: "Request timed out. Try again."
+- `upstream_error`: "Couldn't reach Audible. Try again in a moment."
+
+Retry re-runs the same fetch with the same ASIN.
+
+## Testing
+
+### Backend
+
+- `pkg/audnexus/service_test.go` (`t.Parallel()` for pure function cases; serialized for cache tests that share state):
+  - Happy path: upstream 200 → service returns parsed response.
+  - 404 → `not_found` error.
+  - Upstream 500 → `upstream_error`.
+  - Timeout (stub server that sleeps past the 5s deadline) → `timeout`.
+  - Invalid JSON → `upstream_error`.
+  - Cache hit: second call with same ASIN doesn't hit upstream within TTL.
+  - Cache miss after TTL: re-fetches.
+  - ASIN normalization (lowercase input → uppercase cache key).
+- `pkg/audnexus/handlers_test.go`:
+  - Returns 200/404/504/502 for corresponding service states.
+  - Returns 400 for invalid ASIN without calling upstream.
+  - Enforces `books:write` permission (401 unauth, 403 without permission).
+
+### Frontend
+
+- `FetchChaptersDialog.test.tsx` (vitest + RTL):
+  - Renders with ASIN prefilled from file identifier; checkmark note present.
+  - Fetch button disabled until input is valid ASIN format.
+  - Loading → result transition on successful fetch.
+  - Trim detection auto-selection: parameterized table of four scenarios (intact, intro-only, outro-only, both).
+  - Offset checkbox honors user flip: fetch response shows checked by default for Libation case, unchecked for intact.
+  - "Apply titles only" disabled with tooltip when counts differ.
+  - Overwrite warning appears only when `hasChanges === true`.
+  - Apply buttons invoke callbacks with the expected payload shape.
+- `FileChaptersTab.test.tsx` additions:
+  - "Fetch from Audible" button visible only for M4B files.
+  - Button hidden when user lacks `books:write`.
+  - Dialog open/close wiring.
+  - Apply-titles-only replaces titles by position without touching timestamps.
+  - Apply-titles-and-timestamps replaces whole array with offset applied.
+  - Out-of-bounds timestamps trigger existing validation (not clamped).
+
+E2E tests deferred from v1.
+
+## Docs
+
+Required per CLAUDE.md's user-facing-change rule.
+
+- `website/docs/`: add a new page (or section in an existing chapter-related page) covering:
+  - What the feature does.
+  - Where to find ASINs on Audible.
+  - Trim detection behavior.
+  - Apply modes.
+  - Permission requirements.
+  - Sidebar updated to list the page; cross-linked from the M4B format docs.
+- `pkg/audnexus/CLAUDE.md`: new file following the pattern of other package CLAUDE.md files (service overview, caching behavior, error codes).
+- `pkg/mp4/CLAUDE.md`: brief "External chapter source" section pointing to `pkg/audnexus/`.
+
+## Open questions / follow-ups
+
+- Per-user or per-IP rate limiting on the endpoint if Audnexus asks us to throttle.
+- Persistent cache across server restarts (low priority; 24h TTL already minimizes re-fetches within a session).
+- Search-by-title flow to find ASINs without visiting Audible (post-v1).
+- Extending the dialog to other audiobook formats (MP3 sets, future M4A support).

--- a/pkg/audnexus/CLAUDE.md
+++ b/pkg/audnexus/CLAUDE.md
@@ -22,8 +22,11 @@ This package fetches chapter data for audiobooks from [Audnexus](https://audnex.
 |--------------|-------------|
 | `invalid_asin` | 400 |
 | `not_found` | 404 |
+| `rate_limited` | 429 |
 | `timeout` | 504 |
 | `upstream_error` | 502 |
+
+Audnexus rate-limits by IP and can return 429 or 503 under load (see [their error handling docs](https://github.com/laxamentumtech/audnexus#%EF%B8%8F-error-handling-)); both upstream statuses map to `rate_limited`.
 
 ASINs are validated before upstream calls: 10 alphanumeric characters, normalized to uppercase.
 

--- a/pkg/audnexus/CLAUDE.md
+++ b/pkg/audnexus/CLAUDE.md
@@ -1,0 +1,36 @@
+# Audnexus API Integration
+
+This package fetches chapter data for audiobooks from [Audnexus](https://audnex.us), a community-run proxy over Audible's chapter catalog. It's consumed by the M4B chapter edit UI via `GET /audnexus/books/:asin/chapters`.
+
+## Architecture
+
+- `service.go` — `Service` with a 5s-timeout HTTP client and a 24h in-memory TTL cache keyed by normalized (uppercase) ASIN. Only successes are cached; errors pass through so retries work.
+- `handlers.go` — Echo handler that calls the service and maps typed errors to HTTP statuses.
+- `routes.go` — `RegisterRoutes` wires the endpoint with `Authenticate` + `books:write` middleware.
+- `types.go` — Response types with snake_case JSON tags. The upstream Audnexus camelCase shape is decoded into `audnexusUpstream` and converted at the parse boundary.
+- `errors.go` — `ErrorCode` string identifiers and an `*Error` type. Use `AsAudnexusError(err)` to inspect.
+
+## Endpoint
+
+| Method | Path | Permission |
+|--------|------|------------|
+| GET | `/audnexus/books/:asin/chapters` | `books:write` |
+
+### Error codes
+
+| Service code | HTTP status |
+|--------------|-------------|
+| `invalid_asin` | 400 |
+| `not_found` | 404 |
+| `timeout` | 504 |
+| `upstream_error` | 502 |
+
+ASINs are validated before upstream calls: 10 alphanumeric characters, normalized to uppercase.
+
+## Permissions
+
+Uses `books:write` rather than `books:read` because the only legitimate use is staging data into an editable chapter form. Read-only users can't save what they fetch, so exposing the endpoint to them is pointless and widens the surface area. If the UI hides the button, the endpoint must also reject the request.
+
+## Caching
+
+In-memory `map[string]*cacheEntry` protected by `sync.RWMutex`, TTL 24h. No persistence across restarts. The cache is small (one entry per ASIN), and Audnexus data rarely changes, so there's no eviction beyond TTL.

--- a/pkg/audnexus/errors.go
+++ b/pkg/audnexus/errors.go
@@ -11,6 +11,7 @@ const (
 	ErrCodeNotFound      ErrorCode = "not_found"
 	ErrCodeTimeout       ErrorCode = "timeout"
 	ErrCodeUpstreamError ErrorCode = "upstream_error"
+	ErrCodeRateLimited   ErrorCode = "rate_limited"
 )
 
 // Error is a typed error carrying an ErrorCode. Callers can use errors.As to

--- a/pkg/audnexus/errors.go
+++ b/pkg/audnexus/errors.go
@@ -1,0 +1,41 @@
+package audnexus
+
+import "errors"
+
+// ErrorCode is a stable string identifier used by both the service and the
+// HTTP handler to map failures to user-facing responses.
+type ErrorCode string
+
+const (
+	ErrCodeInvalidASIN   ErrorCode = "invalid_asin"
+	ErrCodeNotFound      ErrorCode = "not_found"
+	ErrCodeTimeout       ErrorCode = "timeout"
+	ErrCodeUpstreamError ErrorCode = "upstream_error"
+)
+
+// Error is a typed error carrying an ErrorCode. Callers can use errors.As to
+// inspect the code for mapping to HTTP status.
+type Error struct {
+	Code ErrorCode
+	Msg  string
+}
+
+func (e *Error) Error() string {
+	if e.Msg != "" {
+		return string(e.Code) + ": " + e.Msg
+	}
+	return string(e.Code)
+}
+
+func newErr(code ErrorCode, msg string) error {
+	return &Error{Code: code, Msg: msg}
+}
+
+// AsAudnexusError extracts an *Error if err wraps one, else returns nil.
+func AsAudnexusError(err error) *Error {
+	var e *Error
+	if errors.As(err, &e) {
+		return e
+	}
+	return nil
+}

--- a/pkg/audnexus/handlers.go
+++ b/pkg/audnexus/handlers.go
@@ -1,0 +1,41 @@
+package audnexus
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+)
+
+type handler struct {
+	service *Service
+}
+
+func (h *handler) getChapters(c echo.Context) error {
+	asin := c.Param("asin")
+	resp, err := h.service.GetChapters(c.Request().Context(), asin)
+	if err != nil {
+		return mapServiceError(err)
+	}
+	return errors.WithStack(c.JSON(http.StatusOK, resp))
+}
+
+// mapServiceError converts an audnexus *Error into an errcodes response with
+// the right HTTP status. Non-typed errors bubble up as 502 (upstream_error).
+func mapServiceError(err error) error {
+	e := AsAudnexusError(err)
+	if e == nil {
+		return errcodes.BadGateway(string(ErrCodeUpstreamError))
+	}
+	switch e.Code {
+	case ErrCodeInvalidASIN:
+		return errcodes.BadRequest(string(e.Code))
+	case ErrCodeNotFound:
+		return errcodes.NotFound(string(e.Code))
+	case ErrCodeTimeout:
+		return errcodes.GatewayTimeout(string(e.Code))
+	default:
+		return errcodes.BadGateway(string(e.Code))
+	}
+}

--- a/pkg/audnexus/handlers.go
+++ b/pkg/audnexus/handlers.go
@@ -60,6 +60,12 @@ func mapServiceError(err error) error {
 		status = http.StatusGatewayTimeout
 	case ErrCodeUpstreamError:
 		status = http.StatusBadGateway
+	case ErrCodeRateLimited:
+		status = http.StatusTooManyRequests
+	default:
+		// A new ErrorCode was added to errors.go without wiring it here.
+		// Fall back to 502 and log so the gap surfaces in production.
+		slog.Warn("audnexus: unmapped service error code", "code", string(e.Code))
 	}
 	return &errcodes.Error{
 		HTTPCode: status,

--- a/pkg/audnexus/handlers.go
+++ b/pkg/audnexus/handlers.go
@@ -29,26 +29,41 @@ func (h *handler) getChapters(c echo.Context) error {
 	return errors.WithStack(c.JSON(http.StatusOK, resp))
 }
 
-// mapServiceError converts an audnexus *Error into an errcodes response with
-// the right HTTP status. Non-typed errors bubble up as 502 (upstream_error);
-// they aren't expected in practice, so log when one shows up so future
-// regressions surface.
+// mapServiceError converts an audnexus *Error into an errcodes response that
+// carries the audnexus-specific code as `Code` (so the frontend can map it to
+// a user-facing message) alongside the appropriate HTTP status.
+//
+// The generic errcodes helpers (BadRequest, NotFound, etc.) would set Code to
+// the HTTP family (e.g. "bad_request") and stuff the audnexus slug in
+// Message, which broke the frontend's code-based switch. Building the
+// errcodes.Error directly keeps the audnexus slug in Code end-to-end.
+//
+// Non-typed errors bubble up as 502 (upstream_error); they aren't expected in
+// practice, so log when one shows up so future regressions surface.
 func mapServiceError(err error) error {
 	e := AsAudnexusError(err)
 	if e == nil {
 		slog.Warn("audnexus: unexpected non-typed service error", "err", err.Error())
-		return errcodes.BadGateway(string(ErrCodeUpstreamError))
+		return &errcodes.Error{
+			HTTPCode: http.StatusBadGateway,
+			Message:  string(ErrCodeUpstreamError),
+			Code:     string(ErrCodeUpstreamError),
+		}
 	}
+	status := http.StatusBadGateway
 	switch e.Code {
 	case ErrCodeInvalidASIN:
-		return errcodes.BadRequest(string(e.Code))
+		status = http.StatusBadRequest
 	case ErrCodeNotFound:
-		return errcodes.NotFound(string(e.Code))
+		status = http.StatusNotFound
 	case ErrCodeTimeout:
-		return errcodes.GatewayTimeout(string(e.Code))
+		status = http.StatusGatewayTimeout
 	case ErrCodeUpstreamError:
-		return errcodes.BadGateway(string(e.Code))
-	default:
-		return errcodes.BadGateway(string(e.Code))
+		status = http.StatusBadGateway
+	}
+	return &errcodes.Error{
+		HTTPCode: status,
+		Message:  string(e.Code),
+		Code:     string(e.Code),
 	}
 }

--- a/pkg/audnexus/handlers.go
+++ b/pkg/audnexus/handlers.go
@@ -35,6 +35,8 @@ func mapServiceError(err error) error {
 		return errcodes.NotFound(string(e.Code))
 	case ErrCodeTimeout:
 		return errcodes.GatewayTimeout(string(e.Code))
+	case ErrCodeUpstreamError:
+		return errcodes.BadGateway(string(e.Code))
 	default:
 		return errcodes.BadGateway(string(e.Code))
 	}

--- a/pkg/audnexus/handlers.go
+++ b/pkg/audnexus/handlers.go
@@ -1,6 +1,9 @@
 package audnexus
 
 import (
+	"context"
+	stderrors "errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -16,16 +19,24 @@ func (h *handler) getChapters(c echo.Context) error {
 	asin := c.Param("asin")
 	resp, err := h.service.GetChapters(c.Request().Context(), asin)
 	if err != nil {
+		// If the request was canceled (client disconnect), don't try to
+		// produce a response — nobody is listening.
+		if stderrors.Is(err, context.Canceled) {
+			return nil
+		}
 		return mapServiceError(err)
 	}
 	return errors.WithStack(c.JSON(http.StatusOK, resp))
 }
 
 // mapServiceError converts an audnexus *Error into an errcodes response with
-// the right HTTP status. Non-typed errors bubble up as 502 (upstream_error).
+// the right HTTP status. Non-typed errors bubble up as 502 (upstream_error);
+// they aren't expected in practice, so log when one shows up so future
+// regressions surface.
 func mapServiceError(err error) error {
 	e := AsAudnexusError(err)
 	if e == nil {
+		slog.Warn("audnexus: unexpected non-typed service error", "err", err.Error())
 		return errcodes.BadGateway(string(ErrCodeUpstreamError))
 	}
 	switch e.Code {

--- a/pkg/audnexus/handlers_test.go
+++ b/pkg/audnexus/handlers_test.go
@@ -16,7 +16,7 @@ import (
 
 func newTestHandler(t *testing.T, upstreamStatus int, upstreamBody string) *handler {
 	t.Helper()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(upstreamStatus)
 		_, _ = io.WriteString(w, upstreamBody)
 	}))
@@ -26,7 +26,7 @@ func newTestHandler(t *testing.T, upstreamStatus int, upstreamBody string) *hand
 	return &handler{service: svc}
 }
 
-func invokeHandler(t *testing.T, h *handler, asin string) (statusCode int, errOut error, body string) {
+func invokeHandler(t *testing.T, h *handler, asin string) (statusCode int, body string, errOut error) {
 	t.Helper()
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/audnexus/books/"+asin+"/chapters", nil)
@@ -36,13 +36,13 @@ func invokeHandler(t *testing.T, h *handler, asin string) (statusCode int, errOu
 	c.SetParamValues(asin)
 
 	err := h.getChapters(c)
-	return rec.Code, err, rec.Body.String()
+	return rec.Code, rec.Body.String(), err
 }
 
 func TestHandler_GetChapters_Success(t *testing.T) {
 	t.Parallel()
 	h := newTestHandler(t, http.StatusOK, `{"asin":"B0036UC2LO","chapters":[{"title":"C1","startOffsetMs":0,"lengthMs":1000}]}`)
-	status, err, body := invokeHandler(t, h, "B0036UC2LO")
+	status, body, err := invokeHandler(t, h, "B0036UC2LO")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, status)
 
@@ -56,7 +56,7 @@ func TestHandler_GetChapters_Success(t *testing.T) {
 func TestHandler_GetChapters_InvalidASIN(t *testing.T) {
 	t.Parallel()
 	h := newTestHandler(t, http.StatusOK, `{}`)
-	_, err, _ := invokeHandler(t, h, "short")
+	_, _, err := invokeHandler(t, h, "short")
 	require.Error(t, err)
 	ec := asErrcodesError(t, err)
 	assert.Equal(t, http.StatusBadRequest, ec.HTTPCode)
@@ -65,7 +65,7 @@ func TestHandler_GetChapters_InvalidASIN(t *testing.T) {
 func TestHandler_GetChapters_NotFound(t *testing.T) {
 	t.Parallel()
 	h := newTestHandler(t, http.StatusNotFound, ``)
-	_, err, _ := invokeHandler(t, h, "B0036UC2LO")
+	_, _, err := invokeHandler(t, h, "B0036UC2LO")
 	require.Error(t, err)
 	ec := asErrcodesError(t, err)
 	assert.Equal(t, http.StatusNotFound, ec.HTTPCode)
@@ -74,7 +74,7 @@ func TestHandler_GetChapters_NotFound(t *testing.T) {
 func TestHandler_GetChapters_UpstreamError(t *testing.T) {
 	t.Parallel()
 	h := newTestHandler(t, http.StatusInternalServerError, ``)
-	_, err, _ := invokeHandler(t, h, "B0036UC2LO")
+	_, _, err := invokeHandler(t, h, "B0036UC2LO")
 	require.Error(t, err)
 	ec := asErrcodesError(t, err)
 	assert.Equal(t, http.StatusBadGateway, ec.HTTPCode)

--- a/pkg/audnexus/handlers_test.go
+++ b/pkg/audnexus/handlers_test.go
@@ -90,3 +90,31 @@ func asErrcodesError(t *testing.T, err error) *errcodes.Error {
 	}
 	return ec
 }
+
+// The frontend switches on errcodes.Error.Code. Confirm each service error
+// preserves its audnexus-specific slug end-to-end, not a generic HTTP family
+// code.
+func TestMapServiceError_PreservesAudnexusCode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		err      error
+		wantCode string
+		wantHTTP int
+	}{
+		{"invalid_asin", newErr(ErrCodeInvalidASIN, "x"), "invalid_asin", http.StatusBadRequest},
+		{"not_found", newErr(ErrCodeNotFound, "x"), "not_found", http.StatusNotFound},
+		{"timeout", newErr(ErrCodeTimeout, "x"), "timeout", http.StatusGatewayTimeout},
+		{"upstream_error", newErr(ErrCodeUpstreamError, "x"), "upstream_error", http.StatusBadGateway},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mapped := mapServiceError(tc.err)
+			ec := asErrcodesError(t, mapped)
+			assert.Equal(t, tc.wantCode, ec.Code, "Code")
+			assert.Equal(t, tc.wantHTTP, ec.HTTPCode, "HTTPCode")
+		})
+	}
+}

--- a/pkg/audnexus/handlers_test.go
+++ b/pkg/audnexus/handlers_test.go
@@ -1,0 +1,92 @@
+package audnexus
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestHandler(t *testing.T, upstreamStatus int, upstreamBody string) *handler {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(upstreamStatus)
+		_, _ = io.WriteString(w, upstreamBody)
+	}))
+	t.Cleanup(upstream.Close)
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	return &handler{service: svc}
+}
+
+func invokeHandler(t *testing.T, h *handler, asin string) (statusCode int, errOut error, body string) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/audnexus/books/"+asin+"/chapters", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("asin")
+	c.SetParamValues(asin)
+
+	err := h.getChapters(c)
+	return rec.Code, err, rec.Body.String()
+}
+
+func TestHandler_GetChapters_Success(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, http.StatusOK, `{"asin":"B0036UC2LO","chapters":[{"title":"C1","startOffsetMs":0,"lengthMs":1000}]}`)
+	status, err, body := invokeHandler(t, h, "B0036UC2LO")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	var resp Response
+	require.NoError(t, json.Unmarshal([]byte(body), &resp))
+	assert.Equal(t, "B0036UC2LO", resp.ASIN)
+	require.Len(t, resp.Chapters, 1)
+	assert.Equal(t, "C1", resp.Chapters[0].Title)
+}
+
+func TestHandler_GetChapters_InvalidASIN(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, http.StatusOK, `{}`)
+	_, err, _ := invokeHandler(t, h, "short")
+	require.Error(t, err)
+	ec := asErrcodesError(t, err)
+	assert.Equal(t, http.StatusBadRequest, ec.HTTPCode)
+}
+
+func TestHandler_GetChapters_NotFound(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, http.StatusNotFound, ``)
+	_, err, _ := invokeHandler(t, h, "B0036UC2LO")
+	require.Error(t, err)
+	ec := asErrcodesError(t, err)
+	assert.Equal(t, http.StatusNotFound, ec.HTTPCode)
+}
+
+func TestHandler_GetChapters_UpstreamError(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(t, http.StatusInternalServerError, ``)
+	_, err, _ := invokeHandler(t, h, "B0036UC2LO")
+	require.Error(t, err)
+	ec := asErrcodesError(t, err)
+	assert.Equal(t, http.StatusBadGateway, ec.HTTPCode)
+}
+
+// asErrcodesError extracts an *errcodes.Error from err via errors.As, failing
+// the test if absent.
+func asErrcodesError(t *testing.T, err error) *errcodes.Error {
+	t.Helper()
+	var ec *errcodes.Error
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *errcodes.Error, got %T: %v", err, err)
+	}
+	return ec
+}

--- a/pkg/audnexus/handlers_test.go
+++ b/pkg/audnexus/handlers_test.go
@@ -106,6 +106,7 @@ func TestMapServiceError_PreservesAudnexusCode(t *testing.T) {
 		{"not_found", newErr(ErrCodeNotFound, "x"), "not_found", http.StatusNotFound},
 		{"timeout", newErr(ErrCodeTimeout, "x"), "timeout", http.StatusGatewayTimeout},
 		{"upstream_error", newErr(ErrCodeUpstreamError, "x"), "upstream_error", http.StatusBadGateway},
+		{"rate_limited", newErr(ErrCodeRateLimited, "x"), "rate_limited", http.StatusTooManyRequests},
 	}
 	for _, tc := range cases {
 		tc := tc

--- a/pkg/audnexus/routes.go
+++ b/pkg/audnexus/routes.go
@@ -1,0 +1,19 @@
+package audnexus
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// RegisterRoutes wires the audnexus endpoint into the Echo instance. The
+// endpoint is scoped to authenticated users with books:write (the only
+// legitimate use is staging data into an editable chapter form).
+func RegisterRoutes(e *echo.Echo, svc *Service, authMiddleware *auth.Middleware) {
+	g := e.Group("/audnexus")
+	g.Use(authMiddleware.Authenticate)
+	g.Use(authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
+
+	h := &handler{service: svc}
+	g.GET("/books/:asin/chapters", h.getChapters)
+}

--- a/pkg/audnexus/service.go
+++ b/pkg/audnexus/service.go
@@ -117,6 +117,12 @@ func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, erro
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, newErr(ErrCodeNotFound, "ASIN not found on Audible")
 	}
+	// Audnexus rate-limits by IP; surface 429/503 so the UI can tell the user
+	// to back off. See
+	// https://github.com/laxamentumtech/audnexus#%EF%B8%8F-error-handling-.
+	if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, newErr(ErrCodeRateLimited, "upstream rate limit: "+resp.Status)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, newErr(ErrCodeUpstreamError, "upstream returned "+resp.Status)
 	}

--- a/pkg/audnexus/service.go
+++ b/pkg/audnexus/service.go
@@ -88,6 +88,10 @@ func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, erro
 		return nil, newErr(ErrCodeInvalidASIN, "ASIN must be 10 alphanumeric characters")
 	}
 
+	if cached := s.cacheGet(normalized); cached != nil {
+		return cached, nil
+	}
+
 	url := s.baseURL + "/books/" + normalized + "/chapters"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -132,6 +136,7 @@ func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, erro
 		})
 	}
 
+	s.cachePut(normalized, out)
 	return out, nil
 }
 
@@ -143,4 +148,23 @@ func isTimeout(err error) bool {
 		return t.Timeout()
 	}
 	return false
+}
+
+func (s *Service) cacheGet(asin string) *Response {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.cache[asin]
+	if !ok || time.Now().After(entry.expireAt) {
+		return nil
+	}
+	return entry.value
+}
+
+func (s *Service) cachePut(asin string, value *Response) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cache[asin] = &cacheEntry{
+		value:    value,
+		expireAt: time.Now().Add(s.cacheTTL),
+	}
 }

--- a/pkg/audnexus/service.go
+++ b/pkg/audnexus/service.go
@@ -1,0 +1,90 @@
+package audnexus
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ServiceConfig holds options for constructing a Service.
+type ServiceConfig struct {
+	// HTTPClient is optional; if nil, a client with a 5-second timeout is used.
+	HTTPClient *http.Client
+	// BaseURL overrides the Audnexus endpoint for tests. Defaults to the real
+	// API when empty.
+	BaseURL string
+	// UserAgent sent on every upstream request. Defaults to "Shisho/unknown".
+	UserAgent string
+	// CacheTTL for successful responses. Defaults to 24 hours if zero.
+	CacheTTL time.Duration
+}
+
+// Service fetches chapter data from Audnexus with in-memory caching.
+type Service struct {
+	http      *http.Client
+	baseURL   string
+	userAgent string
+	cacheTTL  time.Duration
+	mu        sync.RWMutex
+	cache     map[string]*cacheEntry
+}
+
+type cacheEntry struct {
+	value    *Response
+	expireAt time.Time
+}
+
+const defaultBaseURL = "https://api.audnex.us"
+
+// NewService constructs a Service with the given config.
+func NewService(cfg ServiceConfig) *Service {
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	base := cfg.BaseURL
+	if base == "" {
+		base = defaultBaseURL
+	}
+	ua := cfg.UserAgent
+	if ua == "" {
+		ua = "Shisho/unknown"
+	}
+	ttl := cfg.CacheTTL
+	if ttl == 0 {
+		ttl = 24 * time.Hour
+	}
+	return &Service{
+		http:      client,
+		baseURL:   strings.TrimRight(base, "/"),
+		userAgent: ua,
+		cacheTTL:  ttl,
+		cache:     make(map[string]*cacheEntry),
+	}
+}
+
+var asinPattern = regexp.MustCompile(`^[A-Z0-9]{10}$`)
+
+// normalizeASIN uppercases and returns the ASIN if it passes format checks,
+// otherwise returns the empty string.
+func normalizeASIN(asin string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(asin))
+	if !asinPattern.MatchString(normalized) {
+		return ""
+	}
+	return normalized
+}
+
+// GetChapters fetches chapter data for an ASIN. Returns a typed *Error on
+// failure (check with AsAudnexusError).
+func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, error) {
+	normalized := normalizeASIN(asin)
+	if normalized == "" {
+		return nil, newErr(ErrCodeInvalidASIN, "ASIN must be 10 alphanumeric characters")
+	}
+	// Upstream call will be implemented in the next task.
+	return nil, newErr(ErrCodeUpstreamError, "not implemented")
+}

--- a/pkg/audnexus/service.go
+++ b/pkg/audnexus/service.go
@@ -2,6 +2,8 @@ package audnexus
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"regexp"
 	"strings"
@@ -85,6 +87,60 @@ func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, erro
 	if normalized == "" {
 		return nil, newErr(ErrCodeInvalidASIN, "ASIN must be 10 alphanumeric characters")
 	}
-	// Upstream call will be implemented in the next task.
-	return nil, newErr(ErrCodeUpstreamError, "not implemented")
+
+	url := s.baseURL + "/books/" + normalized + "/chapters"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, newErr(ErrCodeUpstreamError, err.Error())
+	}
+	req.Header.Set("User-Agent", s.userAgent)
+
+	resp, err := s.http.Do(req)
+	if err != nil {
+		if ctx.Err() != nil || isTimeout(err) {
+			return nil, newErr(ErrCodeTimeout, err.Error())
+		}
+		return nil, newErr(ErrCodeUpstreamError, err.Error())
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, newErr(ErrCodeNotFound, "ASIN not found on Audible")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, newErr(ErrCodeUpstreamError, "upstream returned "+resp.Status)
+	}
+
+	var upstream audnexusUpstream
+	if err := json.NewDecoder(resp.Body).Decode(&upstream); err != nil {
+		return nil, newErr(ErrCodeUpstreamError, "invalid JSON from upstream")
+	}
+
+	out := &Response{
+		ASIN:                 upstream.ASIN,
+		IsAccurate:           upstream.IsAccurate,
+		RuntimeLengthMs:      upstream.RuntimeLengthMs,
+		BrandIntroDurationMs: upstream.BrandIntroDurationMs,
+		BrandOutroDurationMs: upstream.BrandOutroDurationMs,
+		Chapters:             make([]Chapter, 0, len(upstream.Chapters)),
+	}
+	for _, c := range upstream.Chapters {
+		out.Chapters = append(out.Chapters, Chapter{
+			Title:         c.Title,
+			StartOffsetMs: c.StartOffsetMs,
+			LengthMs:      c.LengthMs,
+		})
+	}
+
+	return out, nil
+}
+
+// isTimeout reports whether err represents a net/http timeout.
+func isTimeout(err error) bool {
+	type timeout interface{ Timeout() bool }
+	var t timeout
+	if errors.As(err, &t) {
+		return t.Timeout()
+	}
+	return false
 }

--- a/pkg/audnexus/service.go
+++ b/pkg/audnexus/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -101,7 +102,12 @@ func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, erro
 
 	resp, err := s.http.Do(req)
 	if err != nil {
-		if ctx.Err() != nil || isTimeout(err) {
+		// Propagate user-initiated cancellation as-is so callers (and
+		// observability) can distinguish it from a timeout.
+		if errors.Is(err, context.Canceled) {
+			return nil, err
+		}
+		if errors.Is(err, context.DeadlineExceeded) || isTimeout(err) {
 			return nil, newErr(ErrCodeTimeout, err.Error())
 		}
 		return nil, newErr(ErrCodeUpstreamError, err.Error())
@@ -115,8 +121,11 @@ func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, erro
 		return nil, newErr(ErrCodeUpstreamError, "upstream returned "+resp.Status)
 	}
 
+	// Cap the upstream body to guard against a misbehaving or malicious
+	// response. Real chapter payloads are well under 1 MB.
+	const maxUpstreamBytes = 1 << 20
 	var upstream audnexusUpstream
-	if err := json.NewDecoder(resp.Body).Decode(&upstream); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxUpstreamBytes)).Decode(&upstream); err != nil {
 		return nil, newErr(ErrCodeUpstreamError, "invalid JSON from upstream")
 	}
 

--- a/pkg/audnexus/service.go
+++ b/pkg/audnexus/service.go
@@ -129,11 +129,7 @@ func (s *Service) GetChapters(ctx context.Context, asin string) (*Response, erro
 		Chapters:             make([]Chapter, 0, len(upstream.Chapters)),
 	}
 	for _, c := range upstream.Chapters {
-		out.Chapters = append(out.Chapters, Chapter{
-			Title:         c.Title,
-			StartOffsetMs: c.StartOffsetMs,
-			LengthMs:      c.LengthMs,
-		})
+		out.Chapters = append(out.Chapters, Chapter(c))
 	}
 
 	s.cachePut(normalized, out)

--- a/pkg/audnexus/service_test.go
+++ b/pkg/audnexus/service_test.go
@@ -2,6 +2,8 @@ package audnexus
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,4 +44,45 @@ func TestService_GetChapters_NormalizesASINToUppercase(t *testing.T) {
 	if e := AsAudnexusError(err); e != nil {
 		assert.NotEqual(t, ErrCodeInvalidASIN, e.Code, "lowercase ASIN should normalize to valid")
 	}
+}
+
+func TestService_GetChapters_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/books/B0036UC2LO/chapters", r.URL.Path)
+		assert.Equal(t, "Shisho/test", r.Header.Get("User-Agent"))
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"asin": "B0036UC2LO",
+			"isAccurate": true,
+			"runtimeLengthMs": 163938000,
+			"brandIntroDurationMs": 38000,
+			"brandOutroDurationMs": 62000,
+			"chapters": [
+				{"title": "Prelude", "startOffsetMs": 0, "lengthMs": 272000},
+				{"title": "Prologue", "startOffsetMs": 272000, "lengthMs": 1063000}
+			]
+		}`))
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{
+		BaseURL:   upstream.URL,
+		UserAgent: "Shisho/test",
+	})
+
+	resp, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "B0036UC2LO", resp.ASIN)
+	assert.True(t, resp.IsAccurate)
+	assert.Equal(t, int64(163938000), resp.RuntimeLengthMs)
+	assert.Equal(t, int64(38000), resp.BrandIntroDurationMs)
+	assert.Equal(t, int64(62000), resp.BrandOutroDurationMs)
+	require.Len(t, resp.Chapters, 2)
+	assert.Equal(t, "Prelude", resp.Chapters[0].Title)
+	assert.Equal(t, int64(0), resp.Chapters[0].StartOffsetMs)
+	assert.Equal(t, int64(272000), resp.Chapters[0].LengthMs)
 }

--- a/pkg/audnexus/service_test.go
+++ b/pkg/audnexus/service_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,4 +86,61 @@ func TestService_GetChapters_HappyPath(t *testing.T) {
 	assert.Equal(t, "Prelude", resp.Chapters[0].Title)
 	assert.Equal(t, int64(0), resp.Chapters[0].StartOffsetMs)
 	assert.Equal(t, int64(272000), resp.Chapters[0].LengthMs)
+}
+
+func TestService_GetChapters_NotFound(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.Error(t, err)
+	assert.Equal(t, ErrCodeNotFound, AsAudnexusError(err).Code)
+}
+
+func TestService_GetChapters_UpstreamError_5xx(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.Error(t, err)
+	assert.Equal(t, ErrCodeUpstreamError, AsAudnexusError(err).Code)
+}
+
+func TestService_GetChapters_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not json`))
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.Error(t, err)
+	assert.Equal(t, ErrCodeUpstreamError, AsAudnexusError(err).Code)
+}
+
+func TestService_GetChapters_Timeout(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{
+		BaseURL:    upstream.URL,
+		HTTPClient: &http.Client{Timeout: 50 * time.Millisecond},
+	})
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.Error(t, err)
+	assert.Equal(t, ErrCodeTimeout, AsAudnexusError(err).Code)
 }

--- a/pkg/audnexus/service_test.go
+++ b/pkg/audnexus/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -143,4 +144,65 @@ func TestService_GetChapters_Timeout(t *testing.T) {
 	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
 	require.Error(t, err)
 	assert.Equal(t, ErrCodeTimeout, AsAudnexusError(err).Code)
+}
+
+func TestService_GetChapters_CacheHit(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"asin":"B0036UC2LO","chapters":[]}`))
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL, CacheTTL: time.Hour})
+
+	// First call hits upstream.
+	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.NoError(t, err)
+	// Second call with same ASIN hits cache.
+	_, err = svc.GetChapters(context.Background(), "B0036UC2LO")
+	require.NoError(t, err)
+	// Lowercase should normalize to same cache key.
+	_, err = svc.GetChapters(context.Background(), "b0036uc2lo")
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&hits), "expected exactly one upstream call")
+}
+
+func TestService_GetChapters_CacheExpires(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"asin":"B0036UC2LO","chapters":[]}`))
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL, CacheTTL: 10 * time.Millisecond})
+
+	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
+	time.Sleep(20 * time.Millisecond)
+	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "expected cache to expire and re-fetch")
+}
+
+func TestService_GetChapters_ErrorsNotCached(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	svc := NewService(ServiceConfig{BaseURL: upstream.URL, CacheTTL: time.Hour})
+
+	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
+	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
+
+	assert.Equal(t, int32(2), atomic.LoadInt32(&hits), "errors must not be cached")
 }

--- a/pkg/audnexus/service_test.go
+++ b/pkg/audnexus/service_test.go
@@ -1,0 +1,45 @@
+package audnexus
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_GetChapters_InvalidASIN(t *testing.T) {
+	t.Parallel()
+	svc := NewService(ServiceConfig{})
+
+	cases := []string{
+		"",
+		"short",
+		"TOO-LONG-ASIN",
+		"1234567890X!", // non-alphanumeric
+		"B0036UC2L",    // 9 chars
+		"B0036UC2LOX",  // 11 chars
+	}
+	for _, asin := range cases {
+		asin := asin
+		t.Run(asin, func(t *testing.T) {
+			t.Parallel()
+			_, err := svc.GetChapters(context.Background(), asin)
+			require.Error(t, err)
+			e := AsAudnexusError(err)
+			require.NotNil(t, e, "expected *Error")
+			assert.Equal(t, ErrCodeInvalidASIN, e.Code)
+		})
+	}
+}
+
+func TestService_GetChapters_NormalizesASINToUppercase(t *testing.T) {
+	t.Parallel()
+	// Valid lowercase ASIN should pass validation (and would reach upstream,
+	// which we're not testing here — but it must not return invalid_asin).
+	svc := NewService(ServiceConfig{})
+	_, err := svc.GetChapters(context.Background(), "b0036uc2lo")
+	if e := AsAudnexusError(err); e != nil {
+		assert.NotEqual(t, ErrCodeInvalidASIN, e.Code, "lowercase ASIN should normalize to valid")
+	}
+}

--- a/pkg/audnexus/service_test.go
+++ b/pkg/audnexus/service_test.go
@@ -91,7 +91,7 @@ func TestService_GetChapters_HappyPath(t *testing.T) {
 
 func TestService_GetChapters_NotFound(t *testing.T) {
 	t.Parallel()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer upstream.Close()
@@ -104,7 +104,7 @@ func TestService_GetChapters_NotFound(t *testing.T) {
 
 func TestService_GetChapters_UpstreamError_5xx(t *testing.T) {
 	t.Parallel()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer upstream.Close()
@@ -117,7 +117,7 @@ func TestService_GetChapters_UpstreamError_5xx(t *testing.T) {
 
 func TestService_GetChapters_InvalidJSON(t *testing.T) {
 	t.Parallel()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`not json`))
 	}))
@@ -131,7 +131,7 @@ func TestService_GetChapters_InvalidJSON(t *testing.T) {
 
 func TestService_GetChapters_Timeout(t *testing.T) {
 	t.Parallel()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		time.Sleep(200 * time.Millisecond)
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -149,7 +149,7 @@ func TestService_GetChapters_Timeout(t *testing.T) {
 func TestService_GetChapters_CacheHit(t *testing.T) {
 	t.Parallel()
 	var hits int32
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		atomic.AddInt32(&hits, 1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"asin":"B0036UC2LO","chapters":[]}`))
@@ -174,7 +174,7 @@ func TestService_GetChapters_CacheHit(t *testing.T) {
 func TestService_GetChapters_CacheExpires(t *testing.T) {
 	t.Parallel()
 	var hits int32
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		atomic.AddInt32(&hits, 1)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"asin":"B0036UC2LO","chapters":[]}`))
@@ -193,7 +193,7 @@ func TestService_GetChapters_CacheExpires(t *testing.T) {
 func TestService_GetChapters_ErrorsNotCached(t *testing.T) {
 	t.Parallel()
 	var hits int32
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		atomic.AddInt32(&hits, 1)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))

--- a/pkg/audnexus/service_test.go
+++ b/pkg/audnexus/service_test.go
@@ -115,6 +115,32 @@ func TestService_GetChapters_UpstreamError_5xx(t *testing.T) {
 	assert.Equal(t, ErrCodeUpstreamError, AsAudnexusError(err).Code)
 }
 
+func TestService_GetChapters_RateLimited(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		status int
+	}{
+		{"429_too_many_requests", http.StatusTooManyRequests},
+		{"503_service_unavailable", http.StatusServiceUnavailable},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer upstream.Close()
+
+			svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+			_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+			require.Error(t, err)
+			assert.Equal(t, ErrCodeRateLimited, AsAudnexusError(err).Code)
+		})
+	}
+}
+
 func TestService_GetChapters_InvalidJSON(t *testing.T) {
 	t.Parallel()
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/audnexus/types.go
+++ b/pkg/audnexus/types.go
@@ -1,0 +1,37 @@
+package audnexus
+
+// Chapter is a single chapter from Audnexus.
+type Chapter struct {
+	Title         string `json:"title"`
+	StartOffsetMs int64  `json:"start_offset_ms"`
+	LengthMs      int64  `json:"length_ms"`
+}
+
+// Response is the normalized chapters response returned by the service and
+// passed through to the frontend. Field names are snake_case per project
+// API conventions; upstream Audnexus uses camelCase and is converted at the
+// parse boundary.
+type Response struct {
+	ASIN                 string    `json:"asin"`
+	IsAccurate           bool      `json:"is_accurate"`
+	RuntimeLengthMs      int64     `json:"runtime_length_ms"`
+	BrandIntroDurationMs int64     `json:"brand_intro_duration_ms"`
+	BrandOutroDurationMs int64     `json:"brand_outro_duration_ms"`
+	Chapters             []Chapter `json:"chapters"`
+}
+
+// audnexusUpstream matches the Audnexus API camelCase JSON shape for decoding.
+type audnexusUpstream struct {
+	ASIN                 string              `json:"asin"`
+	IsAccurate           bool                `json:"isAccurate"`
+	RuntimeLengthMs      int64               `json:"runtimeLengthMs"`
+	BrandIntroDurationMs int64               `json:"brandIntroDurationMs"`
+	BrandOutroDurationMs int64               `json:"brandOutroDurationMs"`
+	Chapters             []audnexusUpChapter `json:"chapters"`
+}
+
+type audnexusUpChapter struct {
+	Title         string `json:"title"`
+	StartOffsetMs int64  `json:"startOffsetMs"`
+	LengthMs      int64  `json:"lengthMs"`
+}

--- a/pkg/errcodes/errors.go
+++ b/pkg/errcodes/errors.go
@@ -121,6 +121,24 @@ func Unauthorized(msg string) error {
 	}
 }
 
+// BadGateway returns a 502 error with the given message.
+func BadGateway(msg string) error {
+	return &Error{
+		http.StatusBadGateway,
+		msg,
+		"bad_gateway",
+	}
+}
+
+// GatewayTimeout returns a 504 error with the given message.
+func GatewayTimeout(msg string) error {
+	return &Error{
+		http.StatusGatewayTimeout,
+		msg,
+		"gateway_timeout",
+	}
+}
+
 // Conflict returns a 409 error with the given message.
 func Conflict(msg string) error {
 	return &Error{

--- a/pkg/mp4/CLAUDE.md
+++ b/pkg/mp4/CLAUDE.md
@@ -481,3 +481,7 @@ const handleAudioPlay = (timestampMs: number) => {
 See `app/components/files/FileChaptersTab.tsx`:
 - `handleAudioPlay` - Playback with timeout handling
 - `handleAudioStop` - Cleanup and state reset
+
+## External chapter source
+
+For user-initiated chapter enrichment on M4B files, see `pkg/audnexus/` — a single-endpoint integration that fetches chapter titles and timestamps from Audible via the Audnexus public API. The M4B chapter edit UI exposes a "Fetch from Audible" button that stages the fetched data into the edit form without persisting until the user clicks Save.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/robinjoseph08/golib/echo/v4/middleware/logger"
 	"github.com/robinjoseph08/golib/echo/v4/middleware/recovery"
 	"github.com/shishobooks/shisho/pkg/apikeys"
+	"github.com/shishobooks/shisho/pkg/audnexus"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/binder"
 	"github.com/shishobooks/shisho/pkg/books"
@@ -45,6 +46,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/tags"
 	"github.com/shishobooks/shisho/pkg/testutils"
 	"github.com/shishobooks/shisho/pkg/users"
+	"github.com/shishobooks/shisho/pkg/version"
 	"github.com/shishobooks/shisho/pkg/worker"
 	"github.com/uptrace/bun"
 )
@@ -115,6 +117,12 @@ func New(cfg *config.Config, db *bun.DB, w *worker.Worker, pm *plugins.Manager, 
 
 	// Log viewer endpoint (admin only)
 	logs.RegisterRoutes(e, logBuffer, authMiddleware)
+
+	// Audnexus chapter lookup (books:write required)
+	audnexusService := audnexus.NewService(audnexus.ServiceConfig{
+		UserAgent: "Shisho/" + version.Version,
+	})
+	audnexus.RegisterRoutes(e, audnexusService, authMiddleware)
 
 	echo.NotFoundHandler = notFoundHandler
 	e.HTTPErrorHandler = errcodes.NewHandler().Handle

--- a/website/docs/advanced/_category_.json
+++ b/website/docs/advanced/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Advanced",
-  "position": 160,
+  "position": 170,
   "collapsed": true
 }

--- a/website/docs/audible-chapters.md
+++ b/website/docs/audible-chapters.md
@@ -1,0 +1,33 @@
+---
+sidebar_position: 160
+---
+
+# Fetch Chapters from Audible
+
+For M4B audiobook files, Shisho can look up chapter titles and timestamps from Audible's catalog and stage them into the chapter editor. This is useful for files ripped from Audible that have missing or wrong chapter metadata.
+
+## Requirements
+
+- File must be an M4B audiobook.
+- You need an Audible ID (ASIN) for the book. You can copy it from the URL of the book's Audible page. For example, in `https://www.audible.com/pd/Example-Audiobook/B0036UC2LO`, the 10-character code at the end is the ASIN.
+- Your user must have **books:write** permission (Editor or Admin role).
+
+## How it works
+
+1. Open the chapter edit view for an M4B file. Click **Edit** to enter edit mode, then click **Fetch from Audible** next to the "Add Chapter" button. If the file has no chapters yet, you can click **Fetch from Audible** directly from the empty state.
+2. Paste or confirm the ASIN. If the file already has an Audible identifier set, it is prefilled.
+3. Click **Fetch**.
+4. Shisho shows the Audible runtime, your file's duration, and the chapter count on each side.
+5. Shisho auto-detects whether your file has the Audible intro removed (as some ripping tools like Libation do by default). The resulting offset is reflected in a checkbox that you can flip if the detection is wrong.
+6. Choose how to apply:
+   - **Apply titles only** replaces chapter titles in place but keeps your existing timestamps. Available only when the chapter counts match.
+   - **Apply titles + timestamps** replaces everything with Audible data, respecting the offset checkbox.
+7. The dialog closes and the new data is staged in the edit form. Use the per-chapter play buttons to spot-check timestamps, adjust anything that's off, and click **Save** to commit. Click **Cancel** to discard everything, including the fetched data.
+
+## Duration mismatch
+
+If the Audible runtime and your file duration differ by more than 2 seconds (even with intro/outro offsets applied), Shisho shows a mismatch warning. The chapter data may still be usable, but timestamps are likely off. This often means you're looking at a different edition of the audiobook on Audible.
+
+## Data source
+
+Chapter data comes from [Audnexus](https://audnex.us), a community-run proxy of Audible chapter data. Shisho caches each ASIN response for 24 hours to minimize upstream calls.


### PR DESCRIPTION
## Summary
- Adds a "Fetch from Audible" flow in the M4B chapter edit UI that looks up chapter titles and timestamps from Audible's catalog via the [Audnexus](https://audnex.us) public API.
- Backend: new `pkg/audnexus/` package with `GET /api/audnexus/books/:asin/chapters` (requires `books:write`), a 5s-timeout HTTP client, and a 24h in-memory TTL cache keyed by normalized ASIN.
- Frontend: new `FetchChaptersDialog` with ASIN entry, auto-detected intro-offset checkbox (handles Libation-trimmed files), duration comparison, and two apply modes (titles only vs titles + timestamps). Staged into the existing edit form — nothing saves until the user clicks Save; Cancel discards everything.

## Test plan
- Run `mise check:quiet` and confirm all steps pass (Go lint, Go tests, JS lint, JS tests, E2E).
- Start `mise start`, open an M4B file's chapter edit view, click Edit, then Fetch from Audible.
- With an ASIN identifier already on the file, confirm it's prefilled with a checkmark note.
- Fetch a real ASIN (e.g. `B0036UC2LO` for *The Way of Kings*), confirm the result view shows durations, chapter counts, and correct trim-detection callout.
- Click Apply titles only — confirm titles replace in place and timestamps are untouched; Save persists, reload verifies.
- Click Apply titles + timestamps on a Libation-trimmed file (intro-offset checkbox pre-checked) — confirm chapters shift by intro duration and play buttons hit the right audio positions.
- Cancel from edit mode after fetch — confirm pre-fetch state is restored.
- Empty state: on an M4B with no chapters, confirm Fetch from Audible appears next to Add Chapter.
- Non-M4B files (CBZ/PDF/EPUB): confirm Fetch from Audible is not shown.
- Backend smoke: `curl -b cookies.txt http://localhost:3689/api/audnexus/books/B0036UC2LO/chapters` returns JSON with snake_case fields.
- Error paths: try a bad ASIN (short / invalid), a not-found ASIN, and confirm the dialog shows the correct copy.

## Deferred follow-up
- View-mode entry point in `FileDetail.tsx` page header (alongside Edit) is not implemented in this PR. The button is available in edit mode and in the empty state; a user currently clicks Edit → Fetch from Audible when chapters already exist. Plumbing the dialog open state up to `FileDetail` is a separate change.

## Docs
- New user docs page: `website/docs/audible-chapters.md`.
- Cross-reference added to `pkg/mp4/CLAUDE.md`.
- New `pkg/audnexus/CLAUDE.md` documents the package architecture, endpoint, errors, permissions, and caching.
- Spec and plan checked in under `docs/superpowers/`.