### PR TITLE
[Fix] Refresh plugin update availability on startup and repo sync, and surface updates on Discover

### DIFF
--- a/app/components/plugins/AdvancedRepositoriesSection.tsx
+++ b/app/components/plugins/AdvancedRepositoriesSection.tsx
@@ -1,5 +1,6 @@
 import { BadgeCheck, Package, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
 
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { Badge } from "@/components/ui/badge";
@@ -94,7 +95,18 @@ export const AdvancedRepositoriesSection = () => {
                     <Button
                       disabled={syncRepository.isPending}
                       onClick={() =>
-                        syncRepository.mutate({ scope: repo.scope })
+                        syncRepository.mutate(
+                          { scope: repo.scope },
+                          {
+                            onSuccess: (res) => {
+                              if (res.update_refresh_error) {
+                                toast.warning(
+                                  `Synced ${res.name ?? res.scope}, but update indicators may be stale: ${res.update_refresh_error}`,
+                                );
+                              }
+                            },
+                          },
+                        )
                       }
                       size="sm"
                       variant="outline"

--- a/app/components/plugins/DiscoverTab.test.tsx
+++ b/app/components/plugins/DiscoverTab.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AvailablePlugin } from "@/hooks/queries/plugins";
-import type { Plugin } from "@/types/generated/models";
+import { PluginStatusActive, type Plugin } from "@/types/generated/models";
 
 import { filterPlugins } from "./discoverFilters";
 import { DiscoverTab } from "./DiscoverTab";
@@ -32,7 +32,7 @@ vi.mock("@/hooks/queries/plugins", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn() },
 }));
 
 // --- Test data ---
@@ -74,7 +74,7 @@ const toInstalled = (
   installed_at: "2024-01-01T00:00:00Z",
   name: p.name,
   scope: p.scope,
-  status: 0,
+  status: PluginStatusActive,
   version: p.versions[0]?.version ?? "1.0.0",
   ...overrides,
 });

--- a/app/components/plugins/DiscoverTab.test.tsx
+++ b/app/components/plugins/DiscoverTab.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AvailablePlugin } from "@/hooks/queries/plugins";
+import type { Plugin } from "@/types/generated/models";
 
 import { filterPlugins } from "./discoverFilters";
 import { DiscoverTab } from "./DiscoverTab";
@@ -30,7 +31,9 @@ vi.mock("@/hooks/queries/plugins", () => ({
   }),
 }));
 
-vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
 
 // --- Test data ---
 
@@ -62,8 +65,22 @@ const makePlugin = (
   ...overrides,
 });
 
+const toInstalled = (
+  p: AvailablePlugin,
+  overrides: Partial<Plugin> = {},
+): Plugin => ({
+  auto_update: true,
+  id: p.id,
+  installed_at: "2024-01-01T00:00:00Z",
+  name: p.name,
+  scope: p.scope,
+  status: 0,
+  version: p.versions[0]?.version ?? "1.0.0",
+  ...overrides,
+});
+
 let mockAvailable: AvailablePlugin[] = [];
-let mockInstalled: AvailablePlugin[] = [];
+let mockInstalled: Plugin[] = [];
 const mockRepos: unknown[] = [];
 
 const wrap = (ui: React.ReactNode) => (
@@ -87,7 +104,7 @@ describe("DiscoverTab", () => {
   it("renders disabled Installed button for already-installed plugin", () => {
     const p = makePlugin();
     mockAvailable = [p];
-    mockInstalled = [p];
+    mockInstalled = [toInstalled(p)];
     render(wrap(<DiscoverTab canWrite />));
     const btn = screen.getByRole("button", { name: /installed/i });
     expect(btn).toBeDisabled();
@@ -112,11 +129,7 @@ describe("DiscoverTab", () => {
     });
     mockAvailable = [p];
     mockInstalled = [
-      {
-        ...p,
-        update_available_version: "2.0.0",
-        version: "1.0.0",
-      } as unknown as AvailablePlugin,
+      toInstalled(p, { update_available_version: "2.0.0", version: "1.0.0" }),
     ];
     render(wrap(<DiscoverTab canWrite />));
 

--- a/app/components/plugins/DiscoverTab.test.tsx
+++ b/app/components/plugins/DiscoverTab.test.tsx
@@ -13,6 +13,7 @@ import { DiscoverTab } from "./DiscoverTab";
 // --- Mocks ---
 
 const mockInstallMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
 
 vi.mock("@/hooks/queries/plugins", () => ({
   useInstallPlugin: () => ({ isPending: false, mutate: mockInstallMutate }),
@@ -23,6 +24,10 @@ vi.mock("@/hooks/queries/plugins", () => ({
     error: null,
   }),
   usePluginsInstalled: () => ({ data: mockInstalled }),
+  useUpdatePluginVersion: () => ({
+    isPending: false,
+    mutate: mockUpdateMutate,
+  }),
 }));
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
@@ -86,6 +91,46 @@ describe("DiscoverTab", () => {
     render(wrap(<DiscoverTab canWrite />));
     const btn = screen.getByRole("button", { name: /installed/i });
     expect(btn).toBeDisabled();
+  });
+
+  it("renders Update button and installed version when an update is available", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const p = makePlugin({
+      versions: [
+        {
+          capabilities: { metadataEnricher: { fileTypes: ["epub"] } },
+          changelog: "",
+          compatible: true,
+          downloadUrl: "",
+          manifestVersion: 1,
+          minShishoVersion: "0.1.0",
+          releaseDate: "2024-01-01",
+          sha256: "",
+          version: "2.0.0",
+        },
+      ],
+    });
+    mockAvailable = [p];
+    mockInstalled = [
+      {
+        ...p,
+        update_available_version: "2.0.0",
+        version: "1.0.0",
+      } as unknown as AvailablePlugin,
+    ];
+    render(wrap(<DiscoverTab canWrite />));
+
+    // Row should show the installed version, not the repo's latest
+    expect(screen.getByText("v1.0.0")).toBeInTheDocument();
+    expect(screen.getByText(/Update 2\.0\.0/i)).toBeInTheDocument();
+
+    // Update button should trigger the update mutation
+    const btn = screen.getByRole("button", { name: /^update$/i });
+    await user.click(btn);
+    expect(mockUpdateMutate).toHaveBeenCalledWith(
+      { id: p.id, scope: p.scope },
+      expect.any(Object),
+    );
   });
 
   it("renders disabled Incompatible button for incompatible plugin", () => {

--- a/app/components/plugins/DiscoverTab.tsx
+++ b/app/components/plugins/DiscoverTab.tsx
@@ -24,7 +24,6 @@ import {
   useUpdatePluginVersion,
   type AvailablePlugin,
 } from "@/hooks/queries/plugins";
-import type { Plugin } from "@/types/generated/models";
 
 interface DiscoverTabProps {
   canWrite: boolean;
@@ -45,7 +44,7 @@ export const DiscoverTab = ({ canWrite }: DiscoverTabProps) => {
   const [source, setSource] = useState<string>("all");
 
   const installedByKey = useMemo(
-    () => new Map(installed.map((p) => [`${p.scope}/${p.id}`, p as Plugin])),
+    () => new Map(installed.map((p) => [`${p.scope}/${p.id}`, p])),
     [installed],
   );
 

--- a/app/components/plugins/DiscoverTab.tsx
+++ b/app/components/plugins/DiscoverTab.tsx
@@ -1,4 +1,4 @@
-import { BadgeCheck, Check, Package } from "lucide-react";
+import { BadgeCheck, Check, Download, Loader2, Package } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -21,8 +21,10 @@ import {
   usePluginRepositories,
   usePluginsAvailable,
   usePluginsInstalled,
+  useUpdatePluginVersion,
   type AvailablePlugin,
 } from "@/hooks/queries/plugins";
+import type { Plugin } from "@/types/generated/models";
 
 interface DiscoverTabProps {
   canWrite: boolean;
@@ -33,6 +35,7 @@ export const DiscoverTab = ({ canWrite }: DiscoverTabProps) => {
   const { data: installed = [] } = usePluginsInstalled();
   const { data: repos = [] } = usePluginRepositories();
   const installPlugin = useInstallPlugin();
+  const updatePluginVersion = useUpdatePluginVersion();
 
   const [capability, setCapability] = useState<string>("all");
   const [installTarget, setInstallTarget] = useState<AvailablePlugin | null>(
@@ -41,8 +44,8 @@ export const DiscoverTab = ({ canWrite }: DiscoverTabProps) => {
   const [search, setSearch] = useState("");
   const [source, setSource] = useState<string>("all");
 
-  const installedKeys = useMemo(
-    () => new Set(installed.map((p) => `${p.scope}/${p.id}`)),
+  const installedByKey = useMemo(
+    () => new Map(installed.map((p) => [`${p.scope}/${p.id}`, p as Plugin])),
     [installed],
   );
 
@@ -183,19 +186,60 @@ export const DiscoverTab = ({ canWrite }: DiscoverTabProps) => {
           <div className="space-y-2">
             {filtered.map((p) => {
               const key = `${p.scope}/${p.id}`;
-              const isInstalled = installedKeys.has(key);
+              const installedPlugin = installedByKey.get(key);
+              const isInstalled = !!installedPlugin;
+              const updateAvailable =
+                installedPlugin?.update_available_version ?? undefined;
               const incompatible = p.compatible === false;
               const caps = deriveCapabilityLabels(p.versions[0]?.capabilities);
               const isThisInstalling =
                 installPlugin.isPending &&
                 installTarget?.scope === p.scope &&
                 installTarget?.id === p.id;
+              const isThisUpdating =
+                updatePluginVersion.isPending &&
+                updatePluginVersion.variables?.scope === p.scope &&
+                updatePluginVersion.variables?.id === p.id;
 
               return (
                 <PluginRow
                   actions={
                     canWrite ? (
-                      isInstalled ? (
+                      updateAvailable ? (
+                        <Button
+                          disabled={updatePluginVersion.isPending}
+                          onClick={() =>
+                            updatePluginVersion.mutate(
+                              { id: p.id, scope: p.scope },
+                              {
+                                onError: (err) =>
+                                  toast.error(
+                                    `Failed to update plugin: ${err.message}`,
+                                  ),
+                                onSuccess: (updated) =>
+                                  toast.success(
+                                    `Updated ${updated.name} to v${updated.version}`,
+                                  ),
+                              },
+                            )
+                          }
+                          size="sm"
+                          variant="outline"
+                        >
+                          {isThisUpdating ? (
+                            <Loader2
+                              aria-hidden="true"
+                              className="h-3 w-3 animate-spin"
+                            />
+                          ) : (
+                            <Download
+                              aria-hidden="true"
+                              className="mr-1 h-3 w-3"
+                            />
+                          )}
+                          Update
+                        </Button>
+                      ) : isInstalled ? (
                         <Button
                           className="border-transparent bg-green-100 text-green-700 hover:bg-green-100 dark:bg-green-900/40 dark:text-green-400 dark:hover:bg-green-900/40"
                           disabled
@@ -229,7 +273,8 @@ export const DiscoverTab = ({ canWrite }: DiscoverTabProps) => {
                   name={p.name}
                   repoName={repoNameByScope.get(p.scope)}
                   scope={p.scope}
-                  version={p.versions[0]?.version}
+                  updateAvailable={updateAvailable}
+                  version={installedPlugin?.version ?? p.versions[0]?.version}
                 />
               );
             })}

--- a/app/components/plugins/InstalledTab.tsx
+++ b/app/components/plugins/InstalledTab.tsx
@@ -59,6 +59,10 @@ export const InstalledTab = () => {
     const imageUrl = availableEntry?.imageUrl || undefined;
     const isOfficial = availableEntry?.is_official ?? false;
     const isDisabled = plugin.status !== PluginStatusActive;
+    const isThisUpdating =
+      updatePluginVersion.isPending &&
+      updatePluginVersion.variables?.scope === plugin.scope &&
+      updatePluginVersion.variables?.id === plugin.id;
 
     return (
       <PluginRow
@@ -72,13 +76,17 @@ export const InstalledTab = () => {
                   {
                     onError: (err) =>
                       toast.error(`Failed to update plugin: ${err.message}`),
+                    onSuccess: (updated) =>
+                      toast.success(
+                        `Updated ${updated.name} to v${updated.version}`,
+                      ),
                   },
                 )
               }
               size="sm"
               variant="outline"
             >
-              {updatePluginVersion.isPending ? (
+              {isThisUpdating ? (
                 <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" />
               ) : (
                 <Download aria-hidden="true" className="mr-1 h-3 w-3" />

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -466,22 +466,34 @@ export const useScanPlugins = () => {
   });
 };
 
+export interface SyncRepositoryResponse extends PluginRepository {
+  update_refresh_error?: string;
+}
+
 export const useSyncRepository = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<void, ShishoAPIError, { scope: string }>({
-    mutationFn: ({ scope }) => {
-      return API.request("POST", `/plugins/repositories/${scope}/sync`);
+  return useMutation<SyncRepositoryResponse, ShishoAPIError, { scope: string }>(
+    {
+      mutationFn: ({ scope }) => {
+        return API.request<SyncRepositoryResponse>(
+          "POST",
+          `/plugins/repositories/${scope}/sync`,
+        );
+      },
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: [QueryKey.PluginRepositories],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [QueryKey.PluginsAvailable],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [QueryKey.PluginsInstalled],
+        });
+      },
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.PluginRepositories],
-      });
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.PluginsAvailable],
-      });
-    },
-  });
+  );
 };
 
 // --- Plugin Mode ---

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -695,6 +695,18 @@ func (h *handler) syncRepository(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	// Re-evaluate update_available_version for installed plugins so a manual
+	// sync surfaces newly published versions (and clears stale ones) without
+	// waiting for the 24h background check.
+	if h.manager != nil {
+		if err := h.manager.CheckForUpdates(ctx); err != nil {
+			logger.New().Warn("failed to refresh plugin updates after repo sync", logger.Data{
+				"scope": scope,
+				"error": err.Error(),
+			})
+		}
+	}
+
 	return errors.WithStack(c.JSON(http.StatusOK, repo))
 }
 

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -660,6 +660,15 @@ func (h *handler) removeRepository(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+// syncRepositoryResponse is the JSON body returned from the sync endpoint.
+// Embeds the repository so its fields stay at the top level for
+// backwards-compat with clients reading them, and adds an optional
+// update_refresh_error populated when the post-sync update refresh failed.
+type syncRepositoryResponse struct {
+	*models.PluginRepository
+	UpdateRefreshError *string `json:"update_refresh_error,omitempty"`
+}
+
 func (h *handler) syncRepository(c echo.Context) error {
 	ctx := c.Request().Context()
 
@@ -684,7 +693,7 @@ func (h *handler) syncRepository(c echo.Context) error {
 		if err := h.service.UpdateRepository(ctx, repo); err != nil {
 			return errors.WithStack(err)
 		}
-		return errors.WithStack(c.JSON(http.StatusOK, repo))
+		return errors.WithStack(c.JSON(http.StatusOK, syncRepositoryResponse{PluginRepository: repo}))
 	}
 
 	// Update repository metadata from manifest
@@ -695,19 +704,26 @@ func (h *handler) syncRepository(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Re-evaluate update_available_version for installed plugins so a manual
-	// sync surfaces newly published versions (and clears stale ones) without
-	// waiting for the 24h background check.
+	// Re-evaluate update_available_version for installed plugins from this
+	// repo using the manifest we already fetched above — avoids a second
+	// round of network fetches against every other enabled repository and
+	// keeps the refresh scoped to what actually changed.
+	var updateRefreshError *string
 	if h.manager != nil {
-		if err := h.manager.CheckForUpdates(ctx); err != nil {
+		if err := h.manager.CheckForUpdatesForRepo(ctx, scope, manifest); err != nil {
 			logger.FromContext(ctx).Warn("failed to refresh plugin updates after repo sync", logger.Data{
 				"scope": scope,
 				"error": err.Error(),
 			})
+			msg := err.Error()
+			updateRefreshError = &msg
 		}
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, repo))
+	return errors.WithStack(c.JSON(http.StatusOK, syncRepositoryResponse{
+		PluginRepository:   repo,
+		UpdateRefreshError: updateRefreshError,
+	}))
 }
 
 // availablePluginResponse is the response format for available plugins.

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -700,7 +700,7 @@ func (h *handler) syncRepository(c echo.Context) error {
 	// waiting for the 24h background check.
 	if h.manager != nil {
 		if err := h.manager.CheckForUpdates(ctx); err != nil {
-			logger.New().Warn("failed to refresh plugin updates after repo sync", logger.Data{
+			logger.FromContext(ctx).Warn("failed to refresh plugin updates after repo sync", logger.Data{
 				"scope": scope,
 				"error": err.Error(),
 			})

--- a/pkg/plugins/handler_sync_repository_test.go
+++ b/pkg/plugins/handler_sync_repository_test.go
@@ -89,4 +89,85 @@ func TestSyncRepository_RefreshesUpdateAvailableVersion(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, updated.UpdateAvailableVersion, "sync should have re-evaluated update_available_version")
 	assert.Equal(t, "2.0.0", *updated.UpdateAvailableVersion)
+
+	// Response body embeds the PluginRepository fields at the top level and
+	// omits update_refresh_error on the happy path so the client doesn't
+	// surface a false warning.
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "official", body["scope"])
+	assert.NotContains(t, body, "update_refresh_error")
+}
+
+// TestSyncRepository_UsesFetchedManifestForRefresh pins the M2 optimization —
+// after a sync, CheckForUpdatesForRepo reuses the manifest already fetched by
+// syncRepository instead of re-fetching every enabled repo. We prove this by
+// adding a second enabled repo whose URL is unreachable; if the handler called
+// the broad CheckForUpdates, it would try to hit that URL and log a warning.
+// With CheckForUpdatesForRepo it only uses the passed manifest, so the dead
+// repo is never contacted.
+//
+// Mutates global AllowedFetchHosts — not safe for t.Parallel().
+func TestSyncRepository_UsesFetchedManifestForRefresh(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(db)
+	installer := NewInstaller(t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
+	ctx := t.Context()
+
+	require.NoError(t, service.InstallPlugin(ctx, &models.Plugin{
+		Scope:       "official",
+		ID:          "my-plugin",
+		Name:        "My Plugin",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+		AutoUpdate:  true,
+	}))
+
+	manifest := RepositoryManifest{
+		RepositoryVersion: 1,
+		Scope:             "official",
+		Name:              "Official",
+		Plugins: []AvailablePlugin{{
+			ID:   "my-plugin",
+			Name: "My Plugin",
+			Versions: []PluginVersion{
+				{Version: "2.0.0", ManifestVersion: 1},
+			},
+		}},
+	}
+
+	hits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(manifest)
+	}))
+	defer server.Close()
+
+	origHosts := AllowedFetchHosts
+	AllowedFetchHosts = []string{server.URL}
+	defer func() { AllowedFetchHosts = origHosts }()
+
+	require.NoError(t, service.AddRepository(ctx, &models.PluginRepository{
+		URL:        server.URL + "/manifest.json",
+		Scope:      "official",
+		Name:       strPtr("Official"),
+		IsOfficial: true,
+		Enabled:    true,
+	}))
+
+	h := NewHandler(service, mgr, installer)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("scope")
+	c.SetParamValues("official")
+
+	require.NoError(t, h.syncRepository(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, hits, "the repo manifest should be fetched exactly once per sync")
 }

--- a/pkg/plugins/handler_sync_repository_test.go
+++ b/pkg/plugins/handler_sync_repository_test.go
@@ -1,0 +1,90 @@
+package plugins
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncRepository_RefreshesUpdateAvailableVersion verifies that after a
+// manual repo sync, CheckForUpdates runs so stale update_available_version
+// values don't linger until the 24h background check.
+func TestSyncRepository_RefreshesUpdateAvailableVersion(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(db)
+	installer := NewInstaller(t.TempDir())
+	mgr := NewManager(service, t.TempDir(), "")
+	ctx := t.Context()
+
+	// Plugin installed at 1.0.0 with a stale update hint pointing at an older
+	// version (what the pre-8a2b2f2 bug wrote to the DB).
+	stale := "0.1.0"
+	plugin := &models.Plugin{
+		Scope:                  "official",
+		ID:                     "my-plugin",
+		Name:                   "My Plugin",
+		Version:                "1.0.0",
+		Status:                 models.PluginStatusActive,
+		InstalledAt:            time.Now(),
+		AutoUpdate:             true,
+		UpdateAvailableVersion: &stale,
+	}
+	require.NoError(t, service.InstallPlugin(ctx, plugin))
+
+	// Test server serves a repo manifest listing a newer version.
+	manifest := RepositoryManifest{
+		RepositoryVersion: 1,
+		Scope:             "official",
+		Name:              "Official Repo",
+		Plugins: []AvailablePlugin{{
+			ID:   "my-plugin",
+			Name: "My Plugin",
+			Versions: []PluginVersion{
+				{Version: "2.0.0", ManifestVersion: 1},
+				{Version: "1.0.0", ManifestVersion: 1},
+				{Version: "0.1.0", ManifestVersion: 1},
+			},
+		}},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(manifest)
+	}))
+	defer server.Close()
+
+	origHosts := AllowedFetchHosts
+	AllowedFetchHosts = []string{server.URL}
+	defer func() { AllowedFetchHosts = origHosts }()
+
+	require.NoError(t, service.AddRepository(ctx, &models.PluginRepository{
+		URL:        server.URL + "/manifest.json",
+		Scope:      "official",
+		Name:       strPtr("Official Repo"),
+		IsOfficial: true,
+		Enabled:    true,
+	}))
+
+	h := NewHandler(service, mgr, installer)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("scope")
+	c.SetParamValues("official")
+
+	require.NoError(t, h.syncRepository(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	updated, err := service.RetrievePlugin(ctx, "official", "my-plugin")
+	require.NoError(t, err)
+	require.NotNil(t, updated.UpdateAvailableVersion, "sync should have re-evaluated update_available_version")
+	assert.Equal(t, "2.0.0", *updated.UpdateAvailableVersion)
+}

--- a/pkg/plugins/handler_sync_repository_test.go
+++ b/pkg/plugins/handler_sync_repository_test.go
@@ -16,6 +16,8 @@ import (
 // TestSyncRepository_RefreshesUpdateAvailableVersion verifies that after a
 // manual repo sync, CheckForUpdates runs so stale update_available_version
 // values don't linger until the 24h background check.
+//
+// Mutates global AllowedFetchHosts — not safe for t.Parallel().
 func TestSyncRepository_RefreshesUpdateAvailableVersion(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)

--- a/pkg/plugins/manager.go
+++ b/pkg/plugins/manager.go
@@ -473,6 +473,14 @@ func (m *Manager) RegisteredConverterExtensions() map[string]struct{} {
 	return result
 }
 
+// scopedManifest pairs a repository manifest with the scope it was fetched
+// for, so refreshPluginUpdateVersion can skip manifests whose scope doesn't
+// match the plugin being evaluated.
+type scopedManifest struct {
+	scope    string
+	manifest *RepositoryManifest
+}
+
 // CheckForUpdates checks all installed plugins against enabled repositories
 // for available updates. It sets or clears UpdateAvailableVersion on each plugin.
 func (m *Manager) CheckForUpdates(ctx context.Context) error {
@@ -492,13 +500,7 @@ func (m *Manager) CheckForUpdates(ctx context.Context) error {
 		return errors.Wrap(err, "failed to list repositories for update check")
 	}
 
-	// Fetch manifests from all enabled repositories
-	type scopedManifest struct {
-		scope    string
-		manifest *RepositoryManifest
-	}
 	var manifests []scopedManifest
-
 	for _, repo := range repos {
 		if !repo.Enabled {
 			continue
@@ -515,64 +517,98 @@ func (m *Manager) CheckForUpdates(ctx context.Context) error {
 		manifests = append(manifests, scopedManifest{scope: repo.Scope, manifest: manifest})
 	}
 
-	// For each installed plugin, find latest compatible version from matching repos
 	for _, plugin := range installedPlugins {
-		// Skip plugins with auto-update disabled
 		if !plugin.AutoUpdate {
 			continue
 		}
-
-		var latestVersion string
-
-		for _, sm := range manifests {
-			if sm.manifest.Scope != plugin.Scope {
-				continue
-			}
-			for _, available := range sm.manifest.Plugins {
-				if available.ID != plugin.ID {
-					continue
-				}
-				compatible := FilterVersionCompatibleVersions(FilterCompatibleVersions(available.Versions))
-				if len(compatible) == 0 {
-					continue
-				}
-				for _, v := range compatible {
-					if v.Version == plugin.Version {
-						continue
-					}
-					if pkgversion.Compare(v.Version, plugin.Version) <= 0 {
-						continue
-					}
-					if latestVersion == "" || pkgversion.Compare(v.Version, latestVersion) > 0 {
-						latestVersion = v.Version
-					}
-				}
-			}
-		}
-
-		// Determine if we need to update the record
-		var changed bool
-		if latestVersion != "" {
-			if plugin.UpdateAvailableVersion == nil || *plugin.UpdateAvailableVersion != latestVersion {
-				plugin.UpdateAvailableVersion = &latestVersion
-				changed = true
-			}
-		} else {
-			if plugin.UpdateAvailableVersion != nil {
-				plugin.UpdateAvailableVersion = nil
-				changed = true
-			}
-		}
-
-		if changed {
-			if err := m.service.UpdatePlugin(ctx, plugin); err != nil {
-				log.Warn("failed to update plugin update_available_version", logger.Data{
-					"plugin": pluginKey(plugin.Scope, plugin.ID),
-					"error":  err.Error(),
-				})
-			}
+		if err := m.refreshPluginUpdateVersion(ctx, plugin, manifests); err != nil {
+			log.Warn("failed to update plugin update_available_version", logger.Data{
+				"plugin": pluginKey(plugin.Scope, plugin.ID),
+				"error":  err.Error(),
+			})
 		}
 	}
 
 	return nil
+}
+
+// CheckForUpdatesForRepo re-evaluates UpdateAvailableVersion for installed
+// plugins belonging to the given scope using an already-fetched manifest. Used
+// by the sync-repo handler to avoid re-fetching every enabled repository when
+// a single repo is synced. Plugins in other scopes are left untouched — they
+// can't have changed since we only synced one repo.
+func (m *Manager) CheckForUpdatesForRepo(ctx context.Context, scope string, manifest *RepositoryManifest) error {
+	log := logger.New()
+
+	installedPlugins, err := m.service.ListPlugins(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to list plugins for update check")
+	}
+
+	manifests := []scopedManifest{{scope: scope, manifest: manifest}}
+	for _, plugin := range installedPlugins {
+		if plugin.Scope != scope {
+			continue
+		}
+		if !plugin.AutoUpdate {
+			continue
+		}
+		if err := m.refreshPluginUpdateVersion(ctx, plugin, manifests); err != nil {
+			log.Warn("failed to update plugin update_available_version", logger.Data{
+				"plugin": pluginKey(plugin.Scope, plugin.ID),
+				"error":  err.Error(),
+			})
+		}
+	}
+
+	return nil
+}
+
+// refreshPluginUpdateVersion finds the newest compatible version of the plugin
+// across the provided manifests and persists UpdateAvailableVersion if the
+// computed value differs from the current one. If no newer version is found,
+// the field is cleared.
+func (m *Manager) refreshPluginUpdateVersion(ctx context.Context, plugin *models.Plugin, manifests []scopedManifest) error {
+	var latestVersion string
+	for _, sm := range manifests {
+		if sm.manifest.Scope != plugin.Scope {
+			continue
+		}
+		for _, available := range sm.manifest.Plugins {
+			if available.ID != plugin.ID {
+				continue
+			}
+			compatible := FilterVersionCompatibleVersions(FilterCompatibleVersions(available.Versions))
+			if len(compatible) == 0 {
+				continue
+			}
+			for _, v := range compatible {
+				if v.Version == plugin.Version {
+					continue
+				}
+				if pkgversion.Compare(v.Version, plugin.Version) <= 0 {
+					continue
+				}
+				if latestVersion == "" || pkgversion.Compare(v.Version, latestVersion) > 0 {
+					latestVersion = v.Version
+				}
+			}
+		}
+	}
+
+	var changed bool
+	if latestVersion != "" {
+		if plugin.UpdateAvailableVersion == nil || *plugin.UpdateAvailableVersion != latestVersion {
+			plugin.UpdateAvailableVersion = &latestVersion
+			changed = true
+		}
+	} else if plugin.UpdateAvailableVersion != nil {
+		plugin.UpdateAvailableVersion = nil
+		changed = true
+	}
+
+	if !changed {
+		return nil
+	}
+	return m.service.UpdatePlugin(ctx, plugin)
 }

--- a/pkg/plugins/update_check_test.go
+++ b/pkg/plugins/update_check_test.go
@@ -12,6 +12,74 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestManager_CheckForUpdatesForRepo_UsesPassedManifest(t *testing.T) {
+	db := setupTestDB(t)
+	service := NewService(db)
+	mgr := NewManager(service, t.TempDir(), "")
+	ctx := t.Context()
+
+	// Plugin in scope "official" at 1.0.0 — should pick up 2.0.0 from the manifest.
+	require.NoError(t, service.InstallPlugin(ctx, &models.Plugin{
+		Scope:       "official",
+		ID:          "my-plugin",
+		Name:        "My Plugin",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+		AutoUpdate:  true,
+	}))
+
+	// Plugin in another scope with an existing update hint — must not be touched
+	// when syncing the "official" repo.
+	otherUpdate := "9.9.9"
+	require.NoError(t, service.InstallPlugin(ctx, &models.Plugin{
+		Scope:                  "community",
+		ID:                     "other-plugin",
+		Name:                   "Other",
+		Version:                "1.0.0",
+		Status:                 models.PluginStatusActive,
+		InstalledAt:            time.Now(),
+		AutoUpdate:             true,
+		UpdateAvailableVersion: &otherUpdate,
+	}))
+
+	// Track fetchRepo calls — CheckForUpdatesForRepo must not re-fetch.
+	fetchCalls := 0
+	mgr.fetchRepo = func(_ string) (*RepositoryManifest, error) {
+		fetchCalls++
+		return nil, errors.New("fetch should not be called")
+	}
+
+	manifest := &RepositoryManifest{
+		RepositoryVersion: 1,
+		Scope:             "official",
+		Name:              "Official",
+		Plugins: []AvailablePlugin{{
+			ID:   "my-plugin",
+			Name: "My Plugin",
+			Versions: []PluginVersion{
+				{Version: "2.0.0", ManifestVersion: 1},
+				{Version: "1.0.0", ManifestVersion: 1},
+			},
+		}},
+	}
+
+	require.NoError(t, mgr.CheckForUpdatesForRepo(ctx, "official", manifest))
+	assert.Equal(t, 0, fetchCalls, "CheckForUpdatesForRepo must not re-fetch manifests")
+
+	// Plugin in the synced scope picks up the newer version.
+	official, err := service.RetrievePlugin(ctx, "official", "my-plugin")
+	require.NoError(t, err)
+	require.NotNil(t, official.UpdateAvailableVersion)
+	assert.Equal(t, "2.0.0", *official.UpdateAvailableVersion)
+
+	// Plugin in a different scope is untouched — its existing value survives.
+	community, err := service.RetrievePlugin(ctx, "community", "other-plugin")
+	require.NoError(t, err)
+	require.NotNil(t, community.UpdateAvailableVersion)
+	assert.Equal(t, "9.9.9", *community.UpdateAvailableVersion)
+}
+
 func TestManager_CheckForUpdates_UpdateAvailable(t *testing.T) {
 	db := setupTestDB(t)
 	service := NewService(db)

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -411,9 +411,8 @@ func (w *Worker) checkPluginUpdates() {
 		return
 	}
 
-	// Run update check every 24 hours. Fire immediately on startup so a
-	// server restart refreshes stale update_available_version values without
-	// waiting 24h for the first tick.
+	// Fire immediately on startup so a server restart refreshes stale
+	// update_available_version values, then run every 24 hours.
 	duration := 24 * time.Hour
 	timer := time.NewTimer(0)
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -411,9 +411,11 @@ func (w *Worker) checkPluginUpdates() {
 		return
 	}
 
-	// Run update check every 24 hours
+	// Run update check every 24 hours. Fire immediately on startup so a
+	// server restart refreshes stale update_available_version values without
+	// waiting 24h for the first tick.
 	duration := 24 * time.Hour
-	timer := time.NewTimer(duration)
+	timer := time.NewTimer(0)
 
 	for {
 		select {

--- a/website/docs/plugins/repositories.md
+++ b/website/docs/plugins/repositories.md
@@ -19,7 +19,7 @@ Shisho ships with the official plugin repository enabled by default. You can man
 
 ### Syncing a Repository
 
-Repositories cache their plugin list locally. To check for newly added plugins or updated versions, click **Sync** on the repository. This fetches the latest manifest from GitHub and refreshes the update indicator for any installed plugins from that repository.
+Repositories cache their plugin list locally. To check for newly added plugins or updated versions, click **Sync** on the repository. This fetches the latest manifest from GitHub and refreshes update indicators for installed plugins.
 
 ### Disabling a Repository
 

--- a/website/docs/plugins/repositories.md
+++ b/website/docs/plugins/repositories.md
@@ -19,7 +19,7 @@ Shisho ships with the official plugin repository enabled by default. You can man
 
 ### Syncing a Repository
 
-Repositories cache their plugin list locally. To check for newly added plugins or updated versions, click **Sync** on the repository. This fetches the latest manifest from GitHub.
+Repositories cache their plugin list locally. To check for newly added plugins or updated versions, click **Sync** on the repository. This fetches the latest manifest from GitHub and refreshes the update indicator for any installed plugins from that repository.
 
 ### Disabling a Repository
 


### PR DESCRIPTION
## Summary
- Fire the plugin update check once immediately on worker startup and after a successful repo sync, so stale `update_available_version` values clear without waiting up to 24h for the scheduled check.
- Discover tab now reflects installed state accurately — shows the installed version, an Update pill, and an Update button when an update is available (matching the Installed tab). Update button gains a per-row spinner so clicking one row doesn't spin the loader on every row, plus a success toast on both tabs.

## Test plan
- `mise check:quiet` passes.
- Manually set a plugin's `update_available_version` to an older/stale value in the DB, restart the server → on next `/plugins/installed` fetch, the value is refreshed.
- Click "Sync" on a repo → `update_available_version` values are recomputed without waiting for the 24h timer.
- Discover tab: for an installed plugin with an update, the row shows the installed version, an "Update X.Y.Z" pill, and an Update button; clicking it triggers the update, spins only that row, and toasts on success.
- Installed tab: clicking Update on one plugin spins only that row's loader; toast shows "Updated {name} to v{version}" on success.