### PR TITLE
[Backend] Add shisho.yaml host API and scoped filePath access for enrichers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	golang.org/x/image v0.39.0
 	golang.org/x/net v0.53.0
 	golang.org/x/text v0.36.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -85,7 +86,6 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.68.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/packages/plugin-sdk/hooks.d.ts
+++ b/packages/plugin-sdk/hooks.d.ts
@@ -38,12 +38,14 @@ export interface SearchContext {
     fileType?: string;
     /**
      * Absolute path to the enrichment target file. The runtime grants the
-     * enricher scoped read access to exactly this one file via the sandbox's
-     * allowedPaths, so `shisho.fs.readFile(context.file.filePath)` works
-     * without the plugin declaring the broader `fileAccess` capability.
-     * Sibling files (sidecars, covers) are NOT included — the scope is the
-     * target file only. Omitted when there is no target file (e.g., a
-     * pre-scan enrichment with no file yet).
+     * enricher scoped **read-only** access to exactly this one file, so
+     * `shisho.fs.readFile(context.file.filePath)` works without the plugin
+     * declaring the broader `fileAccess` capability. Writes to this path
+     * are NOT granted — a plugin that needs to modify the file must declare
+     * `fileAccess: { level: "readwrite" }` in its manifest. Sibling files
+     * (sidecars, covers) are also not included; the scope is the target
+     * file only. Omitted when there is no target file (e.g. a pre-scan
+     * enrichment with no file yet).
      */
     filePath?: string;
     /** Audiobook duration in seconds. */

--- a/packages/plugin-sdk/hooks.d.ts
+++ b/packages/plugin-sdk/hooks.d.ts
@@ -36,6 +36,16 @@ export interface SearchContext {
   file?: {
     /** File type extension (e.g., "epub", "cbz", "m4b", "pdf"). */
     fileType?: string;
+    /**
+     * Absolute path to the enrichment target file. The runtime grants the
+     * enricher scoped read access to exactly this one file via the sandbox's
+     * allowedPaths, so `shisho.fs.readFile(context.file.filePath)` works
+     * without the plugin declaring the broader `fileAccess` capability.
+     * Sibling files (sidecars, covers) are NOT included — the scope is the
+     * target file only. Omitted when there is no target file (e.g., a
+     * pre-scan enrichment with no file yet).
+     */
+    filePath?: string;
     /** Audiobook duration in seconds. */
     duration?: number;
     /** Number of pages (CBZ/PDF). */

--- a/packages/plugin-sdk/host-api.d.ts
+++ b/packages/plugin-sdk/host-api.d.ts
@@ -238,6 +238,35 @@ export interface ShishoHTML {
   querySelectorAll(doc: HtmlElement, selector: string): HtmlElement[];
 }
 
+/**
+ * YAML parsing and serialization. No capability required.
+ *
+ * Backed by Go's gopkg.in/yaml.v3, which does not instantiate arbitrary
+ * objects from custom tags (unlike PyYAML's full loader or Ruby's Psych),
+ * so parsing untrusted YAML cannot execute code. Oversized inputs are still
+ * bounded by the plugin hook timeout.
+ */
+export interface ShishoYAML {
+  /**
+   * Parse a YAML string into a plain JS value (object, array, string, number, boolean, or null).
+   * Throws on invalid YAML.
+   *
+   * @example
+   * var config = shisho.yaml.parse("title: My Book\nauthor: Alice");
+   * config.title // "My Book"
+   */
+  parse(content: string): unknown;
+
+  /**
+   * Serialize a JS value to a YAML string.
+   *
+   * @example
+   * shisho.yaml.stringify({ title: "My Book", pages: 100 });
+   * // "title: My Book\npages: 100\n"
+   */
+  stringify(value: unknown): string;
+}
+
 /** Result from shisho.ffmpeg.transcode(). */
 export interface TranscodeResult {
   /** Process exit code (0 = success). */
@@ -425,6 +454,7 @@ export interface ShishoHostAPI {
   archive: ShishoArchive;
   xml: ShishoXML;
   html: ShishoHTML;
+  yaml: ShishoYAML;
   ffmpeg: ShishoFFmpeg;
   shell: ShishoShell;
 }

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "fast-xml-parser": "^5.7.1",
-    "linkedom": "^0.18.12"
+    "linkedom": "^0.18.12",
+    "yaml": "^2.6.1"
   }
 }

--- a/packages/plugin-sdk/testing/index.ts
+++ b/packages/plugin-sdk/testing/index.ts
@@ -341,6 +341,12 @@ function createHTMLImpl(): ShishoHTML {
 
 // ---------------------------------------------------------------------------
 // YAML implementation (eemeli/yaml — real parser, matches Go's yaml.v3 shape)
+//
+// Both this mock and the production runtime (gopkg.in/yaml.v3) target YAML
+// 1.2 semantics, so booleans like `yes`/`no`/`on`/`off` stay as strings in
+// both. Divergence is still possible on edge cases — empty documents,
+// non-string mapping keys, mapping-key ordering — so plugin authors should
+// run the real runtime when asserting against anything subtle.
 // ---------------------------------------------------------------------------
 
 function createYAMLImpl(): ShishoYAML {

--- a/packages/plugin-sdk/testing/index.ts
+++ b/packages/plugin-sdk/testing/index.ts
@@ -1,5 +1,6 @@
 import { XMLParser } from "fast-xml-parser";
 import { parseHTML } from "linkedom";
+import { parse as parseYAML, stringify as stringifyYAML } from "yaml";
 
 import type {
   FetchResponse,
@@ -13,6 +14,7 @@ import type {
   ShishoLog,
   ShishoURL,
   ShishoXML,
+  ShishoYAML,
   XMLElement,
 } from "../index";
 
@@ -338,6 +340,31 @@ function createHTMLImpl(): ShishoHTML {
 }
 
 // ---------------------------------------------------------------------------
+// YAML implementation (eemeli/yaml — real parser, matches Go's yaml.v3 shape)
+// ---------------------------------------------------------------------------
+
+function createYAMLImpl(): ShishoYAML {
+  return {
+    parse(content: string): unknown {
+      try {
+        return parseYAML(content);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`shisho.yaml.parse: ${message}`);
+      }
+    },
+    stringify(value: unknown): string {
+      try {
+        return stringifyYAML(value);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`shisho.yaml.stringify: ${message}`);
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Main factory
 // ---------------------------------------------------------------------------
 
@@ -345,7 +372,7 @@ function createHTMLImpl(): ShishoHTML {
  * Create a mock `shisho` host API object for testing plugins.
  *
  * Provides mock implementations of log, config, http, url, and fs.
- * Provides real implementations of xml and html (backed by fast-xml-parser and linkedom).
+ * Provides real implementations of xml, html, and yaml (backed by fast-xml-parser, linkedom, and the `yaml` package).
  *
  * @example
  * ```ts
@@ -606,6 +633,7 @@ export function createMockShisho(
     },
     xml: createXMLImpl(),
     html: createHTMLImpl(),
+    yaml: createYAMLImpl(),
     ffmpeg: {
       transcode: notImplemented("ffmpeg.transcode") as never,
       probe: notImplemented("ffmpeg.probe") as never,

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -17,6 +17,7 @@ pkg/plugins/
   hostapi_archive.go - ZIP operations
   hostapi_xml.go    - XML parsing
   hostapi_html.go   - HTML parsing with CSS selectors (cascadia)
+  hostapi_yaml.go   - YAML parse/stringify (gopkg.in/yaml.v3)
   hostapi_ffmpeg.go - FFmpeg transcode/probe/version
   hostapi_shell.go  - Shell exec with command allowlist
   generator.go      - PluginGenerator (filegen.Generator interface)
@@ -38,7 +39,7 @@ packages/plugin-sdk/
 ├── package.json       # @shisho/plugin-sdk
 ├── index.d.ts         # Re-exports everything + imports global declarations
 ├── global.d.ts        # Declares global `shisho` and `plugin` variables
-├── host-api.d.ts      # ShishoHostAPI (log, config, http, url, fs, archive, xml, html, ffmpeg, shell)
+├── host-api.d.ts      # ShishoHostAPI (log, config, http, url, fs, archive, xml, html, yaml, ffmpeg, shell)
 ├── hooks.d.ts         # Hook contexts, return types, ShishoPlugin interface
 ├── metadata.d.ts      # ParsedMetadata, ParsedAuthor, ParsedIdentifier, ParsedChapter
 └── manifest.d.ts      # PluginManifest, Capabilities, ConfigSchema, ConfigField
@@ -200,6 +201,7 @@ metadataEnricher: {
 
     // context.file        - read-only file hints (non-modifiable)
     // context.file.fileType      - "epub", "cbz", "m4b", "pdf"
+    // context.file.filePath      - absolute path to the enrichment target (scoped read access via allowedPaths)
     // context.file.duration      - seconds (audiobooks only, float)
     // context.file.pageCount     - CBZ/PDF page count (integer)
     // context.file.filesizeBytes - file size in bytes (integer)
@@ -229,7 +231,9 @@ metadataEnricher: {
 }
 ```
 
-**Go invocation:** `Manager.RunMetadataSearch(ctx, rt, searchCtx) → *SearchResponse`
+**Go invocation:** `Manager.RunMetadataSearch(ctx, rt, searchCtx, targetFilePath) → *SearchResponse`
+
+The `targetFilePath` argument is the absolute path of the file being enriched and, when non-empty, is added to the FSContext's `allowedPaths` so the enricher can read exactly that file without declaring `fileAccess`. Scope is file-only — sibling files in the same directory are not included. Pass `""` when there is no target file.
 
 **Search results are `ParsedMetadata` directly** — `parseSearchResponse` in `hooks.go` populates `mediafile.ParsedMetadata` structs directly (no intermediate type). `releaseDate` strings are parsed inline in both `"2006-01-02"` and RFC3339 formats. `PluginScope` and `PluginID` are set on each result for server-side tracking. The HTTP handler wraps results in `EnrichSearchResult` (adds `DisabledFields`) for the frontend response only.
 
@@ -393,6 +397,20 @@ elem.attributes   // Record<string, string>
 elem.children     // HtmlElement[]
 ```
 
+### shisho.yaml
+
+```javascript
+// No capability required — pure in-memory parser, no I/O.
+var doc = shisho.yaml.parse("title: My Book\npages: 100");
+doc.title  // "My Book"
+doc.pages  // 100
+
+var out = shisho.yaml.stringify({ title: "My Book", pages: 100 });
+// "title: My Book\npages: 100\n"
+```
+
+Backed by `gopkg.in/yaml.v3`, which does not instantiate arbitrary objects from custom tags (unlike PyYAML's full loader / Ruby's Psych), so parsing untrusted YAML cannot execute code. DoS risk from oversized or deeply-nested inputs is bounded by the plugin hook timeout — same class of risk as `shisho.xml`, `shisho.html`, and `resp.json()`.
+
 ### shisho.ffmpeg
 
 ```javascript
@@ -439,11 +457,11 @@ Each hook invocation creates an `FSContext` controlling access:
 | Path | Read | Write |
 |------|------|-------|
 | Plugin's own directory | Always | Always |
-| Hook-provided paths (sourcePath, targetDir, etc.) | Always | Always |
+| Hook-provided paths (sourcePath, targetDir, enricher filePath, etc.) | Always | Always |
 | Temp directory (lazy-created) | Always | Always |
 | Anywhere else | Only if `fileAccess.level` is `"read"` or `"readwrite"` | Only if `"readwrite"` |
 
-**Enrichers** get no extra allowed paths (only plugin dir + temp + fileAccess).
+**Enrichers** get the enrichment target file only in `allowedPaths` (file-only scope, not the parent directory). A plugin that needs to read sibling files — e.g., an `.opf` sidecar next to the book — must declare `fileAccess: read` in its manifest.
 
 Temp dirs are auto-cleaned after hook returns.
 

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -233,7 +233,7 @@ metadataEnricher: {
 
 **Go invocation:** `Manager.RunMetadataSearch(ctx, rt, searchCtx, targetFilePath) → *SearchResponse`
 
-The `targetFilePath` argument is the absolute path of the file being enriched and, when non-empty, is added to the FSContext's `allowedPaths` so the enricher can read exactly that file without declaring `fileAccess`. Scope is file-only — sibling files in the same directory are not included. Pass `""` when there is no target file.
+The `targetFilePath` argument is the absolute path of the file being enriched and, when non-empty, is added to the FSContext's **read-only** allowed-paths list (`SetReadOnlyAllowedPaths`) so the enricher can read exactly that file without declaring `fileAccess`. Writes to the target path are NOT granted — the read-only list is consulted only by `isReadAllowed`, not `isWriteAllowed`. A plugin that legitimately needs to modify files must declare `fileAccess: readwrite` in its manifest. Scope is file-only — sibling files in the same directory are not included. Pass `""` when there is no target file.
 
 **Search results are `ParsedMetadata` directly** — `parseSearchResponse` in `hooks.go` populates `mediafile.ParsedMetadata` structs directly (no intermediate type). `releaseDate` strings are parsed inline in both `"2006-01-02"` and RFC3339 formats. `PluginScope` and `PluginID` are set on each result for server-side tracking. The HTTP handler wraps results in `EnrichSearchResult` (adds `DisabledFields`) for the frontend response only.
 
@@ -457,11 +457,14 @@ Each hook invocation creates an `FSContext` controlling access:
 | Path | Read | Write |
 |------|------|-------|
 | Plugin's own directory | Always | Always |
-| Hook-provided paths (sourcePath, targetDir, enricher filePath, etc.) | Always | Always |
+| Hook-provided paths — RW (converter sourcePath/targetDir, parser filePath, generator destPath) | Always | Always |
+| Hook-provided paths — RO (enricher target `filePath`) | Always | **Never** |
 | Temp directory (lazy-created) | Always | Always |
 | Anywhere else | Only if `fileAccess.level` is `"read"` or `"readwrite"` | Only if `"readwrite"` |
 
-**Enrichers** get the enrichment target file only in `allowedPaths` (file-only scope, not the parent directory). A plugin that needs to read sibling files — e.g., an `.opf` sidecar next to the book — must declare `fileAccess: read` in its manifest.
+**Enrichers** get the enrichment target file only in the read-only allowed-paths list (file-only scope, not the parent directory; reads allowed, writes denied). A plugin that needs to read sibling files — e.g., an `.opf` sidecar next to the book — must declare `fileAccess: read` in its manifest. A plugin that needs to modify the target file must declare `fileAccess: readwrite`.
+
+**Known limitation (pre-existing, all hook types):** `isPathWithin` does not resolve symlinks, so a path containing a symlinked component is compared against the configured allowed paths literally. Tightening this would require `filepath.EvalSymlinks`, which fails for not-yet-existing write targets; handling both read and write paths cleanly needs care and is tracked separately.
 
 Temp dirs are auto-cleaned after hook returns.
 

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -1517,11 +1517,13 @@ func (h *handler) searchMetadata(c echo.Context) error {
 
 	// Add file hints from the target file (non-modifiable context)
 	var fileType string
+	var targetFilePath string
 	if targetFile != nil {
 		f := targetFile
 		fileType = f.FileType
 		fileCtx := map[string]interface{}{
 			"fileType": f.FileType,
+			"filePath": f.Filepath,
 		}
 		if f.AudiobookDurationSeconds != nil {
 			fileCtx["duration"] = *f.AudiobookDurationSeconds
@@ -1531,6 +1533,7 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		}
 		fileCtx["filesizeBytes"] = f.FilesizeBytes
 		searchCtx["file"] = fileCtx
+		targetFilePath = f.Filepath
 	}
 
 	log := logger.FromContext(ctx)
@@ -1562,7 +1565,7 @@ func (h *handler) searchMetadata(c echo.Context) error {
 			}
 		}
 
-		resp, sErr := h.manager.RunMetadataSearch(ctx, rt, searchCtx)
+		resp, sErr := h.manager.RunMetadataSearch(ctx, rt, searchCtx, targetFilePath)
 		if sErr != nil {
 			log.Warn("enricher search failed", logger.Data{
 				"scope":  rt.Scope(),

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -203,10 +203,12 @@ type SearchResponse struct {
 
 // RunMetadataSearch invokes a plugin's metadataEnricher.search() hook.
 //
-// targetFilePath, if non-empty, grants the enricher read/write access to
-// exactly that one file (the enrichment target) via FSContext.allowedPaths —
-// without it, enrichers get no filesystem access beyond the plugin's own
-// directory unless they declare the broader fileAccess capability.
+// targetFilePath, if non-empty, grants the enricher read-only access to
+// exactly that one file (the enrichment target) via FSContext's read-only
+// allowedPaths — without it, enrichers get no filesystem access beyond the
+// plugin's own directory unless they declare the broader fileAccess
+// capability. Writes to the target path are NOT granted; a plugin that
+// needs to modify files must declare fileAccess: readwrite explicitly.
 func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx map[string]interface{}, targetFilePath string) (*SearchResponse, error) {
 	if rt.metadataEnricher == nil {
 		return nil, errors.New("plugin does not have a metadataEnricher hook")
@@ -218,15 +220,14 @@ func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx 
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
-	// Scope FS access to the target file only. The allowedPaths list matches
-	// exact file paths (or descendants when the entry is a directory); passing
-	// just the file means the plugin cannot read siblings like sidecars.
-	var allowedPaths []string
-	if targetFilePath != "" {
-		allowedPaths = []string{targetFilePath}
-	}
+	// Scope FS access to the target file only, read-only. Using the read-only
+	// allowedPaths list means a malicious enricher cannot overwrite the user's
+	// book file — isWriteAllowed does not consult this list.
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
-	fsCtx := NewFSContext(pluginDir, rt.dataDir, allowedPaths, rt.manifest.Capabilities.FileAccess)
+	fsCtx := NewFSContext(pluginDir, rt.dataDir, nil, rt.manifest.Capabilities.FileAccess)
+	if targetFilePath != "" {
+		fsCtx.SetReadOnlyAllowedPaths([]string{targetFilePath})
+	}
 	rt.SetFSContext(fsCtx)
 	defer func() {
 		rt.SetFSContext(nil)

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -202,7 +202,12 @@ type SearchResponse struct {
 }
 
 // RunMetadataSearch invokes a plugin's metadataEnricher.search() hook.
-func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx map[string]interface{}) (*SearchResponse, error) {
+//
+// targetFilePath, if non-empty, grants the enricher read/write access to
+// exactly that one file (the enrichment target) via FSContext.allowedPaths —
+// without it, enrichers get no filesystem access beyond the plugin's own
+// directory unless they declare the broader fileAccess capability.
+func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx map[string]interface{}, targetFilePath string) (*SearchResponse, error) {
 	if rt.metadataEnricher == nil {
 		return nil, errors.New("plugin does not have a metadataEnricher hook")
 	}
@@ -213,9 +218,15 @@ func (m *Manager) RunMetadataSearch(ctx context.Context, rt *Runtime, searchCtx 
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 
-	// Set up FSContext (no extra allowed paths for enrichers)
+	// Scope FS access to the target file only. The allowedPaths list matches
+	// exact file paths (or descendants when the entry is a directory); passing
+	// just the file means the plugin cannot read siblings like sidecars.
+	var allowedPaths []string
+	if targetFilePath != "" {
+		allowedPaths = []string{targetFilePath}
+	}
 	pluginDir := filepath.Join(m.pluginDir, rt.scope, rt.pluginID)
-	fsCtx := NewFSContext(pluginDir, rt.dataDir, nil, rt.manifest.Capabilities.FileAccess)
+	fsCtx := NewFSContext(pluginDir, rt.dataDir, allowedPaths, rt.manifest.Capabilities.FileAccess)
 	rt.SetFSContext(fsCtx)
 	defer func() {
 		rt.SetFSContext(nil)

--- a/pkg/plugins/hooks_test.go
+++ b/pkg/plugins/hooks_test.go
@@ -553,9 +553,10 @@ func TestRunMetadataSearch_NoNewFields(t *testing.T) {
 }
 
 // TestRunMetadataSearch_TargetFilePathScopedAccess verifies that passing a
-// targetFilePath to RunMetadataSearch grants the enricher read access to
-// exactly that file — without needing to declare the broader fileAccess
+// targetFilePath to RunMetadataSearch grants the enricher READ-ONLY access
+// to exactly that file — without needing to declare the broader fileAccess
 // capability — and that omitting it leaves the enricher without access.
+// Write access to the target path must be denied even when read is granted.
 func TestRunMetadataSearch_TargetFilePathScopedAccess(t *testing.T) {
 	t.Parallel()
 
@@ -566,8 +567,11 @@ func TestRunMetadataSearch_TargetFilePathScopedAccess(t *testing.T) {
 	destDir := filepath.Join(pluginDir, "test", "scoped-enricher")
 	require.NoError(t, os.MkdirAll(destDir, 0755))
 
-	// Enricher returns the content it reads from the target file so we can
-	// observe whether the read succeeded or threw.
+	// Enricher dispatches on context.query: "read" reads the target,
+	// "write" tries to overwrite the target. Each branch returns a result
+	// prefixed with "ok:" or "denied:" plus the specific error message so
+	// the test can distinguish a permission denial from an unrelated
+	// runtime error.
 	manifest := `{
   "manifestVersion": 1,
   "id": "scoped-enricher",
@@ -586,10 +590,14 @@ func TestRunMetadataSearch_TargetFilePathScopedAccess(t *testing.T) {
     metadataEnricher: {
       search: function(context) {
         try {
+          if (context.query === "write") {
+            shisho.fs.writeTextFile(context.file.filePath, "tampered");
+            return { results: [{ title: "ok:wrote" }] };
+          }
           var content = shisho.fs.readTextFile(context.file.filePath);
-          return { results: [{ title: "read:" + content }] };
+          return { results: [{ title: "ok:" + content }] };
         } catch (e) {
-          return { results: [{ title: "denied:" + e.message }] };
+          return { results: [{ title: "denied:" + String(e) }] };
         }
       }
     }
@@ -616,35 +624,52 @@ func TestRunMetadataSearch_TargetFilePathScopedAccess(t *testing.T) {
 	targetPath := filepath.Join(libraryDir, "book.epub")
 	require.NoError(t, os.WriteFile(targetPath, []byte("book-bytes"), 0644))
 
-	searchCtx := map[string]interface{}{
-		"query": "Test",
+	readCtx := map[string]interface{}{
+		"query": "read",
 		"file":  map[string]interface{}{"fileType": "epub", "filePath": targetPath},
 	}
 
 	// With targetFilePath set, the enricher can read the file.
-	resp, err := manager.RunMetadataSearch(ctx, rt, searchCtx, targetPath)
+	resp, err := manager.RunMetadataSearch(ctx, rt, readCtx, targetPath)
 	require.NoError(t, err)
 	require.Len(t, resp.Results, 1)
-	assert.Equal(t, "read:book-bytes", resp.Results[0].Title)
+	assert.Equal(t, "ok:book-bytes", resp.Results[0].Title)
+
+	// But writes to the same path are denied — scope is read-only.
+	writeCtx := map[string]interface{}{
+		"query": "write",
+		"file":  map[string]interface{}{"fileType": "epub", "filePath": targetPath},
+	}
+	resp, err = manager.RunMetadataSearch(ctx, rt, writeCtx, targetPath)
+	require.NoError(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Contains(t, resp.Results[0].Title, "denied:", "enricher must not have write access to the target file")
+	assert.Contains(t, resp.Results[0].Title, "access denied", "expected permission-denial error, not unrelated failure")
+	// Confirm the target file was not actually modified.
+	actual, err := os.ReadFile(targetPath)
+	require.NoError(t, err)
+	assert.Equal(t, "book-bytes", string(actual), "target file must be unchanged")
 
 	// A sibling in the same directory must NOT be readable — scope is the
 	// target file only, not its parent directory.
 	siblingPath := filepath.Join(libraryDir, "sibling.opf")
 	require.NoError(t, os.WriteFile(siblingPath, []byte("sidecar"), 0644))
 	siblingCtx := map[string]interface{}{
-		"query": "Test",
+		"query": "read",
 		"file":  map[string]interface{}{"fileType": "epub", "filePath": siblingPath},
 	}
 	resp, err = manager.RunMetadataSearch(ctx, rt, siblingCtx, targetPath)
 	require.NoError(t, err)
 	require.Len(t, resp.Results, 1)
 	assert.Contains(t, resp.Results[0].Title, "denied:", "sibling file must not be readable when scope is the target file")
+	assert.Contains(t, resp.Results[0].Title, "access denied", "expected permission-denial error, not unrelated failure")
 
 	// Without targetFilePath, the enricher gets no access to external paths.
-	resp, err = manager.RunMetadataSearch(ctx, rt, searchCtx, "")
+	resp, err = manager.RunMetadataSearch(ctx, rt, readCtx, "")
 	require.NoError(t, err)
 	require.Len(t, resp.Results, 1)
 	assert.Contains(t, resp.Results[0].Title, "denied:", "expected read to be denied without targetFilePath")
+	assert.Contains(t, resp.Results[0].Title, "access denied", "expected permission-denial error, not unrelated failure")
 }
 
 func TestSearchMetadataCarriesAllFields(t *testing.T) {

--- a/pkg/plugins/hooks_test.go
+++ b/pkg/plugins/hooks_test.go
@@ -325,7 +325,7 @@ func TestRunMetadataSearch_ReturnsResults(t *testing.T) {
 		},
 	}
 
-	resp, err := mgr.RunMetadataSearch(ctx, rt, searchCtx)
+	resp, err := mgr.RunMetadataSearch(ctx, rt, searchCtx, "")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Len(t, resp.Results, 1)
@@ -420,7 +420,7 @@ func TestRunMetadataSearch_NoHook(t *testing.T) {
 	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")
 	ctx := context.Background()
 
-	_, err := mgr.RunMetadataSearch(ctx, rt, map[string]interface{}{})
+	_, err := mgr.RunMetadataSearch(ctx, rt, map[string]interface{}{}, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not have a metadataEnricher hook")
 }
@@ -442,7 +442,7 @@ func TestRunMetadataSearch_NewFields(t *testing.T) {
 		},
 	}
 
-	resp, err := mgr.RunMetadataSearch(ctx, rt, searchCtx)
+	resp, err := mgr.RunMetadataSearch(ctx, rt, searchCtx, "")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Len(t, resp.Results, 1)
@@ -538,7 +538,7 @@ func TestRunMetadataSearch_NoNewFields(t *testing.T) {
 		"author": "Test Author",
 	}
 
-	resp, err := manager.RunMetadataSearch(ctx, rt, searchCtx)
+	resp, err := manager.RunMetadataSearch(ctx, rt, searchCtx, "")
 	require.NoError(t, err)
 	require.Len(t, resp.Results, 1)
 
@@ -550,6 +550,101 @@ func TestRunMetadataSearch_NoNewFields(t *testing.T) {
 	assert.Nil(t, result.Genres)
 	assert.Nil(t, result.Tags)
 	assert.Nil(t, result.Narrators)
+}
+
+// TestRunMetadataSearch_TargetFilePathScopedAccess verifies that passing a
+// targetFilePath to RunMetadataSearch grants the enricher read access to
+// exactly that file — without needing to declare the broader fileAccess
+// capability — and that omitting it leaves the enricher without access.
+func TestRunMetadataSearch_TargetFilePathScopedAccess(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	service := NewService(db)
+	pluginDir := t.TempDir()
+
+	destDir := filepath.Join(pluginDir, "test", "scoped-enricher")
+	require.NoError(t, os.MkdirAll(destDir, 0755))
+
+	// Enricher returns the content it reads from the target file so we can
+	// observe whether the read succeeded or threw.
+	manifest := `{
+  "manifestVersion": 1,
+  "id": "scoped-enricher",
+  "name": "Scoped Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "description": "Reads the enrichment target",
+      "fileTypes": ["epub"],
+      "fields": ["title"]
+    }
+  }
+}`
+	mainJS := `var plugin = (function() {
+  return {
+    metadataEnricher: {
+      search: function(context) {
+        try {
+          var content = shisho.fs.readTextFile(context.file.filePath);
+          return { results: [{ title: "read:" + content }] };
+        } catch (e) {
+          return { results: [{ title: "denied:" + e.message }] };
+        }
+      }
+    }
+  };
+})();`
+
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "manifest.json"), []byte(manifest), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644))
+
+	manager := NewManager(service, pluginDir, "")
+	ctx := context.Background()
+	plugin := &models.Plugin{
+		Scope: "test", ID: "scoped-enricher", Name: "Scoped Enricher",
+		Version: "1.0.0", Status: models.PluginStatusActive, InstalledAt: time.Now(),
+	}
+	require.NoError(t, service.InstallPlugin(ctx, plugin))
+	require.NoError(t, manager.LoadPlugin(ctx, "test", "scoped-enricher"))
+
+	rt := manager.GetRuntime("test", "scoped-enricher")
+	require.NotNil(t, rt)
+
+	// Create a target file outside the plugin dir.
+	libraryDir := t.TempDir()
+	targetPath := filepath.Join(libraryDir, "book.epub")
+	require.NoError(t, os.WriteFile(targetPath, []byte("book-bytes"), 0644))
+
+	searchCtx := map[string]interface{}{
+		"query": "Test",
+		"file":  map[string]interface{}{"fileType": "epub", "filePath": targetPath},
+	}
+
+	// With targetFilePath set, the enricher can read the file.
+	resp, err := manager.RunMetadataSearch(ctx, rt, searchCtx, targetPath)
+	require.NoError(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "read:book-bytes", resp.Results[0].Title)
+
+	// A sibling in the same directory must NOT be readable — scope is the
+	// target file only, not its parent directory.
+	siblingPath := filepath.Join(libraryDir, "sibling.opf")
+	require.NoError(t, os.WriteFile(siblingPath, []byte("sidecar"), 0644))
+	siblingCtx := map[string]interface{}{
+		"query": "Test",
+		"file":  map[string]interface{}{"fileType": "epub", "filePath": siblingPath},
+	}
+	resp, err = manager.RunMetadataSearch(ctx, rt, siblingCtx, targetPath)
+	require.NoError(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Contains(t, resp.Results[0].Title, "denied:", "sibling file must not be readable when scope is the target file")
+
+	// Without targetFilePath, the enricher gets no access to external paths.
+	resp, err = manager.RunMetadataSearch(ctx, rt, searchCtx, "")
+	require.NoError(t, err)
+	require.Len(t, resp.Results, 1)
+	assert.Contains(t, resp.Results[0].Title, "denied:", "expected read to be denied without targetFilePath")
 }
 
 func TestSearchMetadataCarriesAllFields(t *testing.T) {
@@ -627,7 +722,7 @@ func TestSearchMetadataCarriesAllFields(t *testing.T) {
 		"author": "Test Author",
 	}
 
-	searchResp, err := manager.RunMetadataSearch(ctx, rt, searchCtx)
+	searchResp, err := manager.RunMetadataSearch(ctx, rt, searchCtx, "")
 	require.NoError(t, err)
 	require.Len(t, searchResp.Results, 1)
 

--- a/pkg/plugins/hostapi.go
+++ b/pkg/plugins/hostapi.go
@@ -78,6 +78,11 @@ func InjectHostAPIs(rt *Runtime, configGetter ConfigGetter) error {
 		return err
 	}
 
+	// Set up yaml namespace
+	if err := injectYAMLNamespace(vm, shishoObj); err != nil {
+		return err
+	}
+
 	// Set up ffmpeg namespace
 	if err := injectFFmpegNamespace(vm, shishoObj, rt); err != nil {
 		return err

--- a/pkg/plugins/hostapi_fs.go
+++ b/pkg/plugins/hostapi_fs.go
@@ -12,13 +12,23 @@ import (
 
 // FSContext tracks allowed paths and temp dir for a single hook invocation.
 // It controls what filesystem operations a plugin can perform.
+//
+// allowedPaths grants read+write on hook-provided paths (e.g. a file parser's
+// sourcePath, an output generator's destPath). Callers pass a file path for
+// file-only scope or a directory for subtree scope — there is no third option,
+// because isPathWithin does prefix matching against a trailing separator.
+//
+// allowedReadOnlyPaths is a strict subset of allowedPaths' semantics but only
+// grants reads. Used by the metadata enricher to expose the enrichment target
+// without letting the plugin overwrite the user's book file.
 type FSContext struct {
-	pluginDir     string         // Plugin's own directory (always accessible)
-	dataDir       string         // Persistent data directory (always accessible, read+write)
-	allowedPaths  []string       // Hook-provided paths (always accessible)
-	fileAccessCap *FileAccessCap // From manifest (nil = no global file access)
-	tempDir       string         // Lazy-created temp directory path
-	tempDirOnce   sync.Once      // Ensures tempDir is created only once
+	pluginDir            string         // Plugin's own directory (always accessible)
+	dataDir              string         // Persistent data directory (always accessible, read+write)
+	allowedPaths         []string       // Hook-provided paths (read+write)
+	allowedReadOnlyPaths []string       // Hook-provided paths (read-only)
+	fileAccessCap        *FileAccessCap // From manifest (nil = no global file access)
+	tempDir              string         // Lazy-created temp directory path
+	tempDirOnce          sync.Once      // Ensures tempDir is created only once
 }
 
 // NewFSContext creates a new FSContext for a hook invocation.
@@ -29,6 +39,13 @@ func NewFSContext(pluginDir, dataDir string, allowedPaths []string, fileAccessCa
 		allowedPaths:  allowedPaths,
 		fileAccessCap: fileAccessCap,
 	}
+}
+
+// SetReadOnlyAllowedPaths adds paths that the plugin may read but not write.
+// Pass a file path for file-only scope, or a directory for subtree scope
+// (same semantics as allowedPaths).
+func (ctx *FSContext) SetReadOnlyAllowedPaths(paths []string) {
+	ctx.allowedReadOnlyPaths = paths
 }
 
 // Cleanup removes the temp directory if it was created.
@@ -85,6 +102,17 @@ func (ctx *FSContext) isReadAllowed(path string) bool {
 			continue
 		}
 		// Exact match or prefix (for directory paths)
+		if absPath == absAllowed || isPathWithin(absPath, absAllowed) {
+			return true
+		}
+	}
+
+	// Read-only hook-provided paths also allow reads
+	for _, allowed := range ctx.allowedReadOnlyPaths {
+		absAllowed, err := filepath.Abs(allowed)
+		if err != nil {
+			continue
+		}
 		if absPath == absAllowed || isPathWithin(absPath, absAllowed) {
 			return true
 		}

--- a/pkg/plugins/hostapi_fs.go
+++ b/pkg/plugins/hostapi_fs.go
@@ -41,9 +41,9 @@ func NewFSContext(pluginDir, dataDir string, allowedPaths []string, fileAccessCa
 	}
 }
 
-// SetReadOnlyAllowedPaths adds paths that the plugin may read but not write.
-// Pass a file path for file-only scope, or a directory for subtree scope
-// (same semantics as allowedPaths).
+// SetReadOnlyAllowedPaths replaces the set of paths the plugin may read but
+// not write. Pass a file path for file-only scope, or a directory for subtree
+// scope (same semantics as allowedPaths).
 func (ctx *FSContext) SetReadOnlyAllowedPaths(paths []string) {
 	ctx.allowedReadOnlyPaths = paths
 }

--- a/pkg/plugins/hostapi_yaml.go
+++ b/pkg/plugins/hostapi_yaml.go
@@ -56,6 +56,11 @@ func injectYAMLNamespace(vm *goja.Runtime, shishoObj *goja.Object) error {
 // decodes maps as map[string]interface{} by default when the target is
 // interface{}, but non-string keys can still produce map[interface{}]interface{}
 // — this walk handles both shapes and also recurses into slices.
+//
+// Non-string keys are coerced via fmt.Sprintf("%v", ...). This means a YAML
+// document with e.g. both `1: a` and `"1": b` would collapse to a single
+// string key "1"; callers that need to preserve non-string key semantics
+// should decode into typed Go structs instead (not exposed via the JS API).
 func normalizeYAMLValue(v interface{}) interface{} {
 	switch val := v.(type) {
 	case map[interface{}]interface{}:

--- a/pkg/plugins/hostapi_yaml.go
+++ b/pkg/plugins/hostapi_yaml.go
@@ -1,0 +1,82 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+	"gopkg.in/yaml.v3"
+)
+
+// injectYAMLNamespace sets up shisho.yaml with parse and stringify.
+// No file access or capability required — operates on in-memory strings.
+//
+// Parsing uses gopkg.in/yaml.v3, which does not support arbitrary object
+// instantiation via custom tags (unlike PyYAML's full loader or Ruby's
+// Psych), so parsing untrusted YAML cannot execute code. Residual DoS risk
+// from oversized or deeply-nested inputs is bounded by plugin hook
+// timeouts — same risk profile as shisho.xml, shisho.html, and resp.json().
+func injectYAMLNamespace(vm *goja.Runtime, shishoObj *goja.Object) error {
+	yamlObj := vm.NewObject()
+	if err := shishoObj.Set("yaml", yamlObj); err != nil {
+		return fmt.Errorf("failed to set shisho.yaml: %w", err)
+	}
+
+	yamlObj.Set("parse", func(call goja.FunctionCall) goja.Value { //nolint:errcheck
+		if len(call.Arguments) < 1 {
+			panic(vm.ToValue("shisho.yaml.parse: content argument is required"))
+		}
+		content := call.Argument(0).String()
+
+		var parsed interface{}
+		if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+			panic(vm.ToValue("shisho.yaml.parse: " + err.Error()))
+		}
+
+		return vm.ToValue(normalizeYAMLValue(parsed))
+	})
+
+	yamlObj.Set("stringify", func(call goja.FunctionCall) goja.Value { //nolint:errcheck
+		if len(call.Arguments) < 1 {
+			panic(vm.ToValue("shisho.yaml.stringify: value argument is required"))
+		}
+		val := call.Argument(0).Export()
+
+		out, err := yaml.Marshal(val)
+		if err != nil {
+			panic(vm.ToValue("shisho.yaml.stringify: " + err.Error()))
+		}
+		return vm.ToValue(string(out))
+	})
+
+	return nil
+}
+
+// normalizeYAMLValue recursively converts yaml.v3's map[interface{}]interface{}
+// into map[string]interface{} so goja exposes plain JS objects. yaml.v3 actually
+// decodes maps as map[string]interface{} by default when the target is
+// interface{}, but non-string keys can still produce map[interface{}]interface{}
+// — this walk handles both shapes and also recurses into slices.
+func normalizeYAMLValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case map[interface{}]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, inner := range val {
+			out[fmt.Sprintf("%v", k)] = normalizeYAMLValue(inner)
+		}
+		return out
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(val))
+		for k, inner := range val {
+			out[k] = normalizeYAMLValue(inner)
+		}
+		return out
+	case []interface{}:
+		out := make([]interface{}, len(val))
+		for i, inner := range val {
+			out[i] = normalizeYAMLValue(inner)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/pkg/plugins/hostapi_yaml_test.go
+++ b/pkg/plugins/hostapi_yaml_test.go
@@ -1,0 +1,115 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestYAML_Parse_Scalars(t *testing.T) {
+	t.Parallel()
+	rt := newTestRuntime("official", "test-plugin")
+	cfg := &mockConfigGetter{configs: map[string]*string{}}
+	require.NoError(t, InjectHostAPIs(rt, cfg))
+
+	val, err := rt.vm.RunString(`
+		JSON.stringify({
+			str: shisho.yaml.parse("hello"),
+			num: shisho.yaml.parse("42"),
+			bool: shisho.yaml.parse("true"),
+		});
+	`)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"str":"hello","num":42,"bool":true}`, val.String())
+}
+
+func TestYAML_Parse_Mapping(t *testing.T) {
+	t.Parallel()
+	rt := newTestRuntime("official", "test-plugin")
+	cfg := &mockConfigGetter{configs: map[string]*string{}}
+	require.NoError(t, InjectHostAPIs(rt, cfg))
+
+	val, err := rt.vm.RunString(`
+		var doc = shisho.yaml.parse("title: My Book\nauthor: Alice\npages: 100");
+		JSON.stringify({title: doc.title, author: doc.author, pages: doc.pages});
+	`)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"title":"My Book","author":"Alice","pages":100}`, val.String())
+}
+
+func TestYAML_Parse_NestedAndSequence(t *testing.T) {
+	t.Parallel()
+	rt := newTestRuntime("official", "test-plugin")
+	cfg := &mockConfigGetter{configs: map[string]*string{}}
+	require.NoError(t, InjectHostAPIs(rt, cfg))
+
+	val, err := rt.vm.RunString(`
+		var doc = shisho.yaml.parse(
+			"book:\n" +
+			"  title: My Book\n" +
+			"  authors:\n" +
+			"    - Alice\n" +
+			"    - Bob\n"
+		);
+		JSON.stringify({
+			title: doc.book.title,
+			authors: doc.book.authors,
+			count: doc.book.authors.length,
+		});
+	`)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"title":"My Book","authors":["Alice","Bob"],"count":2}`, val.String())
+}
+
+func TestYAML_Parse_Invalid(t *testing.T) {
+	t.Parallel()
+	rt := newTestRuntime("official", "test-plugin")
+	cfg := &mockConfigGetter{configs: map[string]*string{}}
+	require.NoError(t, InjectHostAPIs(rt, cfg))
+
+	_, err := rt.vm.RunString(`shisho.yaml.parse("title: My Book\n  unexpected: indent");`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shisho.yaml.parse")
+}
+
+func TestYAML_Parse_MissingArg(t *testing.T) {
+	t.Parallel()
+	rt := newTestRuntime("official", "test-plugin")
+	cfg := &mockConfigGetter{configs: map[string]*string{}}
+	require.NoError(t, InjectHostAPIs(rt, cfg))
+
+	_, err := rt.vm.RunString(`shisho.yaml.parse();`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "content argument is required")
+}
+
+func TestYAML_Stringify_Object(t *testing.T) {
+	t.Parallel()
+	rt := newTestRuntime("official", "test-plugin")
+	cfg := &mockConfigGetter{configs: map[string]*string{}}
+	require.NoError(t, InjectHostAPIs(rt, cfg))
+
+	val, err := rt.vm.RunString(`shisho.yaml.stringify({title: "My Book", pages: 100});`)
+	require.NoError(t, err)
+	// Round-trip via parse to avoid asserting against yaml.v3's exact formatting.
+	roundtrip, err := rt.vm.RunString(`
+		var s = shisho.yaml.stringify({title: "My Book", pages: 100});
+		var back = shisho.yaml.parse(s);
+		JSON.stringify({title: back.title, pages: back.pages});
+	`)
+	require.NoError(t, err)
+	assert.NotEmpty(t, val.String())
+	assert.JSONEq(t, `{"title":"My Book","pages":100}`, roundtrip.String())
+}
+
+func TestYAML_Stringify_MissingArg(t *testing.T) {
+	t.Parallel()
+	rt := newTestRuntime("official", "test-plugin")
+	cfg := &mockConfigGetter{configs: map[string]*string{}}
+	require.NoError(t, InjectHostAPIs(rt, cfg))
+
+	_, err := rt.vm.RunString(`shisho.yaml.stringify();`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "value argument is required")
+}

--- a/pkg/plugins/integration_test.go
+++ b/pkg/plugins/integration_test.go
@@ -222,7 +222,7 @@ func TestPluginLifecycle(t *testing.T) {
 		},
 	}
 
-	searchResp, err := manager.RunMetadataSearch(ctx, rt, searchCtx)
+	searchResp, err := manager.RunMetadataSearch(ctx, rt, searchCtx, "")
 	require.NoError(t, err)
 	require.NotNil(t, searchResp)
 	require.Len(t, searchResp.Results, 1)
@@ -403,7 +403,7 @@ func TestPluginLifecycle_ConfigIntegration(t *testing.T) {
 		"file":  map[string]interface{}{"fileType": "epub"},
 	}
 
-	result, err := manager.RunMetadataSearch(ctx, rt, searchCtx)
+	result, err := manager.RunMetadataSearch(ctx, rt, searchCtx, "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, result.Results, 1)

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -3083,9 +3083,11 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 		}
 
 		// Add file hints (non-modifiable context)
+		var targetFilePath string
 		if file != nil {
 			fileCtx := map[string]interface{}{
 				"fileType": file.FileType,
+				"filePath": file.Filepath,
 			}
 			if file.AudiobookDurationSeconds != nil {
 				fileCtx["duration"] = *file.AudiobookDurationSeconds
@@ -3095,9 +3097,10 @@ func (w *Worker) runMetadataEnrichers(ctx context.Context, metadata *mediafile.P
 			}
 			fileCtx["filesizeBytes"] = file.FilesizeBytes
 			searchCtx["file"] = fileCtx
+			targetFilePath = file.Filepath
 		}
 
-		searchResp, sErr := w.pluginManager.RunMetadataSearch(ctx, rt, searchCtx)
+		searchResp, sErr := w.pluginManager.RunMetadataSearch(ctx, rt, searchCtx, targetFilePath)
 		if sErr != nil {
 			logWarn("enricher search failed", logger.Data{
 				"plugin": rt.Manifest().ID,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.2.2(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+        version: 4.2.2(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@tanstack/react-query':
         specifier: ^5.99.0
         version: 5.99.2(react@19.2.5)
@@ -98,7 +98,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+        version: 6.0.1(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -164,7 +164,7 @@ importers:
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       vite:
         specifier: ^8.0.8
-        version: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+        version: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -222,7 +222,7 @@ importers:
         version: 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+        version: 4.1.4(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugin-sdk:
     dependencies:
@@ -232,6 +232,9 @@ importers:
       linkedom:
         specifier: ^0.18.12
         version: 0.18.12
+      yaml:
+        specifier: ^2.6.1
+        version: 2.8.3
 
   website:
     dependencies:
@@ -7951,6 +7954,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -11531,12 +11539,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))':
+  '@tailwindcss/vite@4.2.2(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
 
   '@tanstack/query-core@5.99.2': {}
 
@@ -11860,10 +11868,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
 
   '@vitest/coverage-istanbul@4.1.4(vitest@4.1.4)':
     dependencies:
@@ -11877,7 +11885,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -11894,7 +11902,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+      vitest: 4.1.4(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -11905,13 +11913,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -16934,7 +16942,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1):
+  vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -16947,11 +16955,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.46.1
+      yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)):
+  vitest@4.1.4(@types/node@24.12.0)(@vitest/coverage-istanbul@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -16968,7 +16977,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)
+      vite: 8.0.8(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
@@ -17237,6 +17246,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
 

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -329,6 +329,7 @@ var plugin = (function() {
 
         // context.file — read-only file metadata for matching
         // context.file.fileType      — "epub", "cbz", "m4b", "pdf"
+        // context.file.filePath      — absolute path (scoped read access, see File Hints below)
         // context.file.duration      — seconds (audiobooks only)
         // context.file.pageCount     — CBZ/PDF page count
         // context.file.filesizeBytes — file size in bytes
@@ -475,6 +476,7 @@ The `context.file` object provides read-only metadata about the file being enric
 search: function(context) {
   // context.file — read-only file metadata for matching
   // context.file.fileType      — "epub", "cbz", "m4b", "pdf"
+  // context.file.filePath      — absolute path to the enrichment target (see below)
   // context.file.duration      — seconds (audiobooks only)
   // context.file.pageCount     — CBZ/PDF page count
   // context.file.filesizeBytes — file size in bytes
@@ -492,6 +494,25 @@ search: function(context) {
   // ...
 }
 ```
+
+**Reading the enrichment target.** `context.file.filePath` is the absolute path of the file being enriched. Shisho grants scoped read access to **exactly that one file** for the duration of the `search()` call, so you can inspect bytes directly without declaring the broader `fileAccess` capability:
+
+```javascript
+search: function(context) {
+  if (context.file && context.file.filePath) {
+    // Scoped to just this file — reads work even without fileAccess in manifest.
+    var bytes = shisho.fs.readFile(context.file.filePath);
+    // Inspect the bytes to pull an embedded identifier, ISBN barcode, etc.
+  }
+  // ...
+}
+```
+
+Important caveats:
+
+- Scope is the **target file only**. Sibling files in the same directory (covers, sidecars like `.opf`, `.cbr` companions) are **not** readable. If your plugin needs them, declare `fileAccess: { level: "read" }` in the manifest — this grants read access to the full filesystem.
+- `filePath` is absent when there is no target file (e.g. a pre-scan enrichment path); always null-check.
+- The scoped access also covers the other `shisho.fs.*` read methods (`readTextFile`, `exists`) and the archive helpers for reading — it does not grant writes.
 
 #### Confidence Scores
 
@@ -744,6 +765,35 @@ Each returned element has:
 - `text` — recursive inner text content
 - `innerHTML` — raw inner HTML string
 - `children` — child elements
+
+### YAML
+
+Parse and serialize YAML. No capability required — it's a pure in-memory parser.
+
+```javascript
+// Parse a YAML string into a plain JS value
+var config = shisho.yaml.parse("title: My Book\npages: 100");
+config.title;  // "My Book"
+config.pages;  // 100
+
+// Nested structures and sequences map to nested objects and arrays
+var doc = shisho.yaml.parse(
+  "book:\n" +
+  "  title: My Book\n" +
+  "  authors:\n" +
+  "    - Alice\n" +
+  "    - Bob\n"
+);
+doc.book.authors[0];  // "Alice"
+
+// Serialize any JS value back to a YAML string
+var out = shisho.yaml.stringify({ title: "My Book", pages: 100 });
+// "title: My Book\npages: 100\n"
+```
+
+Invalid YAML throws — wrap in `try/catch` if you're parsing responses from an external source that might return malformed YAML.
+
+**Security.** The underlying parser (`gopkg.in/yaml.v3`) does not instantiate arbitrary objects from custom tags, so parsing untrusted YAML cannot execute code. This is unlike some other ecosystems' default loaders (e.g. PyYAML's full loader, Ruby's Psych). The residual risk from oversized or deeply-nested inputs is bounded by the plugin's hook timeout — the same risk profile as `shisho.xml`, `shisho.html`, or parsing JSON from an HTTP response.
 
 ### FFmpeg
 

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -495,7 +495,7 @@ search: function(context) {
 }
 ```
 
-**Reading the enrichment target.** `context.file.filePath` is the absolute path of the file being enriched. Shisho grants scoped read access to **exactly that one file** for the duration of the `search()` call, so you can inspect bytes directly without declaring the broader `fileAccess` capability:
+**Reading the enrichment target.** `context.file.filePath` is the absolute path of the file being enriched. Shisho grants scoped **read-only** access to **exactly that one file** for the duration of the `search()` call, so you can inspect bytes directly without declaring the broader `fileAccess` capability:
 
 ```javascript
 search: function(context) {
@@ -510,9 +510,10 @@ search: function(context) {
 
 Important caveats:
 
+- Scope is **read-only**. `shisho.fs.writeFile(context.file.filePath, ...)` throws "access denied" — a plugin that needs to modify the target file must declare `fileAccess: { level: "readwrite" }` in the manifest.
 - Scope is the **target file only**. Sibling files in the same directory (covers, sidecars like `.opf`, `.cbr` companions) are **not** readable. If your plugin needs them, declare `fileAccess: { level: "read" }` in the manifest — this grants read access to the full filesystem.
 - `filePath` is absent when there is no target file (e.g. a pre-scan enrichment path); always null-check.
-- The scoped access also covers the other `shisho.fs.*` read methods (`readTextFile`, `exists`) and the archive helpers for reading — it does not grant writes.
+- The scoped access also covers the other `shisho.fs.*` read methods (`readTextFile`, `exists`) and the archive helpers for reading.
 
 #### Confidence Scores
 


### PR DESCRIPTION
## Summary
- Add `shisho.yaml` host API (`parse` / `stringify`) backed by `gopkg.in/yaml.v3`. No capability gate — it's a pure in-memory parser with the same risk profile as `shisho.xml` / `shisho.html`, and `yaml.v3` doesn't instantiate arbitrary objects from custom tags so parsing untrusted YAML can't execute code.
- Expose `context.file.filePath` to metadata enrichers and grant file-only scoped read access to that exact path via the sandbox's `allowedPaths`. Plugins can now `shisho.fs.readFile(context.file.filePath)` without declaring the broader `fileAccess` capability. Sibling files (sidecars, covers) are still out of scope — plugins that need them must declare `fileAccess: read`.
- SDK updated in sync: new `ShishoYAML` interface, `SearchContext.file.filePath` typed, testing mock uses the real `yaml` npm package so plugin authors' unit tests exercise actual YAML parsing instead of a stub. Docs updated in `pkg/plugins/CLAUDE.md` and `website/docs/plugins/development.md`.

## Test plan
- `mise check:quiet` passes (Go lint/tests, JS lint/tests)
- New `TestRunMetadataSearch_TargetFilePathScopedAccess` confirms the enricher can read the target file with `targetFilePath` set, **cannot** read a sibling file in the same directory (proving file-only scope), and is denied entirely when `targetFilePath` is empty
- New `TestYAML_*` suite covers parse scalars / mappings / nested sequences, stringify round-trip, invalid YAML, and missing-arg errors
- SDK testing mock builds cleanly (`pnpm -C packages/plugin-sdk build`)