### PR TITLE
[Frontend] Add Extract Subtitle affordance to book edit forms

### DIFF
--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { SortNameInput } from "@/components/common/SortNameInput";
+import { ExtractSubtitleButton } from "@/components/library/ExtractSubtitleButton";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -495,6 +496,13 @@ export function BookEditDialog({
               id="title"
               onChange={(e) => setTitle(e.target.value)}
               value={title}
+            />
+            <ExtractSubtitleButton
+              onExtract={(t, s) => {
+                setTitle(t);
+                setSubtitle(s);
+              }}
+              title={title}
             />
           </div>
 

--- a/app/components/library/ExtractSubtitleButton.test.tsx
+++ b/app/components/library/ExtractSubtitleButton.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ExtractSubtitleButton } from "./ExtractSubtitleButton";
+
+describe("ExtractSubtitleButton", () => {
+  it("renders nothing when title has no colon", () => {
+    const onExtract = vi.fn();
+    const { container } = render(
+      <ExtractSubtitleButton onExtract={onExtract} title="Why We Sleep" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when title has colon but split is empty on one side", () => {
+    const onExtract = vi.fn();
+    const { container } = render(
+      <ExtractSubtitleButton onExtract={onExtract} title="Title:" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders button when title has a splittable colon", () => {
+    const onExtract = vi.fn();
+    render(
+      <ExtractSubtitleButton
+        onExtract={onExtract}
+        title="Why We Sleep: Unlocking the Power of Sleep and Dreams"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /extract subtitle/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("fires onExtract with the split values on click", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onExtract = vi.fn();
+    render(
+      <ExtractSubtitleButton
+        onExtract={onExtract}
+        title="Star Wars: Thrawn: Alliances"
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /extract subtitle/i }));
+    expect(onExtract).toHaveBeenCalledWith("Star Wars", "Thrawn: Alliances");
+  });
+});

--- a/app/components/library/ExtractSubtitleButton.tsx
+++ b/app/components/library/ExtractSubtitleButton.tsx
@@ -1,0 +1,22 @@
+import { extractSubtitleFromTitle } from "@/utils/extractSubtitle";
+
+interface Props {
+  title: string;
+  onExtract: (title: string, subtitle: string) => void;
+}
+
+export function ExtractSubtitleButton({ title, onExtract }: Props) {
+  const split = extractSubtitleFromTitle(title);
+  if (!split) return null;
+  return (
+    <div className="flex justify-end">
+      <button
+        className="text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+        onClick={() => onExtract(split.title, split.subtitle)}
+        type="button"
+      >
+        Extract subtitle
+      </button>
+    </div>
+  );
+}

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -855,29 +855,31 @@ export function IdentifyReviewForm({
       )}
 
       {/* Title */}
-      <FieldWrapper
-        currentValue={book.title || undefined}
-        disabled={isDisabled("title")}
-        field="title"
-        onUseCurrent={() => setTitle(book.title)}
-        status={defaults.title.status}
-      >
-        <Input
+      <div className="space-y-1.5">
+        <FieldWrapper
+          currentValue={book.title || undefined}
           disabled={isDisabled("title")}
-          onChange={(e) => setTitle(e.target.value)}
-          value={title}
-        />
-      </FieldWrapper>
+          field="title"
+          onUseCurrent={() => setTitle(book.title)}
+          status={defaults.title.status}
+        >
+          <Input
+            disabled={isDisabled("title")}
+            onChange={(e) => setTitle(e.target.value)}
+            value={title}
+          />
+        </FieldWrapper>
 
-      {!isDisabled("title") && !isDisabled("subtitle") && (
-        <ExtractSubtitleButton
-          onExtract={(t, s) => {
-            setTitle(t);
-            setSubtitle(s);
-          }}
-          title={title}
-        />
-      )}
+        {!isDisabled("title") && !isDisabled("subtitle") && (
+          <ExtractSubtitleButton
+            onExtract={(t, s) => {
+              setTitle(t);
+              setSubtitle(s);
+            }}
+            title={title}
+          />
+        )}
+      </div>
 
       {/* Subtitle */}
       <FieldWrapper

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -10,6 +10,7 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+import { ExtractSubtitleButton } from "@/components/library/ExtractSubtitleButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -867,6 +868,16 @@ export function IdentifyReviewForm({
           value={title}
         />
       </FieldWrapper>
+
+      {!isDisabled("title") && !isDisabled("subtitle") && (
+        <ExtractSubtitleButton
+          onExtract={(t, s) => {
+            setTitle(t);
+            setSubtitle(s);
+          }}
+          title={title}
+        />
+      )}
 
       {/* Subtitle */}
       <FieldWrapper

--- a/app/utils/extractSubtitle.test.ts
+++ b/app/utils/extractSubtitle.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { extractSubtitleFromTitle } from "./extractSubtitle";
+
+describe("extractSubtitleFromTitle", () => {
+  it("returns null when title has no colon", () => {
+    expect(extractSubtitleFromTitle("Why We Sleep")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractSubtitleFromTitle("")).toBeNull();
+  });
+
+  it("returns null when colon is leading", () => {
+    expect(extractSubtitleFromTitle(": Subtitle")).toBeNull();
+  });
+
+  it("returns null when colon is trailing", () => {
+    expect(extractSubtitleFromTitle("Title:")).toBeNull();
+  });
+
+  it("returns null for a bare colon", () => {
+    expect(extractSubtitleFromTitle(":")).toBeNull();
+  });
+
+  it("returns null when only whitespace on one side", () => {
+    expect(extractSubtitleFromTitle("   : Subtitle")).toBeNull();
+    expect(extractSubtitleFromTitle("Title :   ")).toBeNull();
+  });
+
+  it("splits on the first colon and trims both sides", () => {
+    expect(
+      extractSubtitleFromTitle(
+        "Why We Sleep: Unlocking the Power of Sleep and Dreams",
+      ),
+    ).toEqual({
+      title: "Why We Sleep",
+      subtitle: "Unlocking the Power of Sleep and Dreams",
+    });
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(extractSubtitleFromTitle("  Foo  :  Bar  ")).toEqual({
+      title: "Foo",
+      subtitle: "Bar",
+    });
+  });
+
+  it("preserves additional colons in the subtitle (splits on first only)", () => {
+    expect(extractSubtitleFromTitle("Star Wars: Thrawn: Alliances")).toEqual({
+      title: "Star Wars",
+      subtitle: "Thrawn: Alliances",
+    });
+  });
+});

--- a/app/utils/extractSubtitle.ts
+++ b/app/utils/extractSubtitle.ts
@@ -1,0 +1,10 @@
+export function extractSubtitleFromTitle(
+  title: string,
+): { title: string; subtitle: string } | null {
+  const idx = title.indexOf(":");
+  if (idx === -1) return null;
+  const newTitle = title.slice(0, idx).trim();
+  const newSubtitle = title.slice(idx + 1).trim();
+  if (!newTitle || !newSubtitle) return null;
+  return { title: newTitle, subtitle: newSubtitle };
+}

--- a/docs/superpowers/plans/2026-04-23-extract-subtitle.md
+++ b/docs/superpowers/plans/2026-04-23-extract-subtitle.md
@@ -1,0 +1,511 @@
+# Extract Subtitle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a one-click "Extract subtitle" affordance to the book edit and identify-review forms that splits a combined `"Title: Subtitle"` string into separate fields.
+
+**Architecture:** Introduce a pure helper (`extractSubtitleFromTitle`) in `app/utils/`, a thin presentational component (`ExtractSubtitleButton`) in `app/components/library/`, and wire that component into both `BookEditDialog` and `IdentifyReviewForm`. Render-gate inside the component so callers don't have to check the "has splittable colon" condition themselves.
+
+**Tech Stack:** React 19, TypeScript, TailwindCSS, Vitest, React Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-extract-subtitle-design.md`
+
+## File Structure
+
+- **Create** `app/utils/extractSubtitle.ts` — pure helper. Splits title on first `:`, trims both sides, returns `null` when the split would produce an empty side.
+- **Create** `app/utils/extractSubtitle.test.ts` — unit tests for the helper.
+- **Create** `app/components/library/ExtractSubtitleButton.tsx` — presentational button. Calls the helper; renders `null` when nothing to extract; fires callback on click.
+- **Create** `app/components/library/ExtractSubtitleButton.test.tsx` — component tests.
+- **Modify** `app/components/library/BookEditDialog.tsx` — add the button below the title `<Input>` (inside the Title `<div className="space-y-2">` block around lines 491-499).
+- **Modify** `app/components/library/IdentifyReviewForm.tsx` — add the button between the title `FieldWrapper` and the subtitle `FieldWrapper` (around lines 856-869). Guard on `!isDisabled("title") && !isDisabled("subtitle")`.
+
+---
+
+### Task 1: Helper — tests first
+
+**Files:**
+- Create: `app/utils/extractSubtitle.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import { extractSubtitleFromTitle } from "./extractSubtitle";
+
+describe("extractSubtitleFromTitle", () => {
+  it("returns null when title has no colon", () => {
+    expect(extractSubtitleFromTitle("Why We Sleep")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractSubtitleFromTitle("")).toBeNull();
+  });
+
+  it("returns null when colon is leading", () => {
+    expect(extractSubtitleFromTitle(": Subtitle")).toBeNull();
+  });
+
+  it("returns null when colon is trailing", () => {
+    expect(extractSubtitleFromTitle("Title:")).toBeNull();
+  });
+
+  it("returns null for a bare colon", () => {
+    expect(extractSubtitleFromTitle(":")).toBeNull();
+  });
+
+  it("returns null when only whitespace on one side", () => {
+    expect(extractSubtitleFromTitle("   : Subtitle")).toBeNull();
+    expect(extractSubtitleFromTitle("Title :   ")).toBeNull();
+  });
+
+  it("splits on the first colon and trims both sides", () => {
+    expect(
+      extractSubtitleFromTitle(
+        "Why We Sleep: Unlocking the Power of Sleep and Dreams",
+      ),
+    ).toEqual({
+      title: "Why We Sleep",
+      subtitle: "Unlocking the Power of Sleep and Dreams",
+    });
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(extractSubtitleFromTitle("  Foo  :  Bar  ")).toEqual({
+      title: "Foo",
+      subtitle: "Bar",
+    });
+  });
+
+  it("preserves additional colons in the subtitle (splits on first only)", () => {
+    expect(extractSubtitleFromTitle("Star Wars: Thrawn: Alliances")).toEqual({
+      title: "Star Wars",
+      subtitle: "Thrawn: Alliances",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+pnpm vitest run app/utils/extractSubtitle.test.ts
+```
+
+Expected: all tests fail because `./extractSubtitle` does not yet exist (module-not-found error).
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add app/utils/extractSubtitle.test.ts
+git commit -m "[Test] Add failing tests for extractSubtitleFromTitle"
+```
+
+---
+
+### Task 2: Helper — implementation
+
+**Files:**
+- Create: `app/utils/extractSubtitle.ts`
+
+- [ ] **Step 1: Implement the helper**
+
+```ts
+export function extractSubtitleFromTitle(
+  title: string,
+): { title: string; subtitle: string } | null {
+  const idx = title.indexOf(":");
+  if (idx === -1) return null;
+  const newTitle = title.slice(0, idx).trim();
+  const newSubtitle = title.slice(idx + 1).trim();
+  if (!newTitle || !newSubtitle) return null;
+  return { title: newTitle, subtitle: newSubtitle };
+}
+```
+
+- [ ] **Step 2: Run the tests and verify they pass**
+
+Run:
+
+```bash
+pnpm vitest run app/utils/extractSubtitle.test.ts
+```
+
+Expected: all 9 tests pass.
+
+- [ ] **Step 3: Commit the implementation**
+
+```bash
+git add app/utils/extractSubtitle.ts
+git commit -m "[Frontend] Add extractSubtitleFromTitle helper"
+```
+
+---
+
+### Task 3: Button component — tests first
+
+**Files:**
+- Create: `app/components/library/ExtractSubtitleButton.test.tsx`
+
+- [ ] **Step 1: Write the failing component tests**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { ExtractSubtitleButton } from "./ExtractSubtitleButton";
+
+describe("ExtractSubtitleButton", () => {
+  it("renders nothing when title has no colon", () => {
+    const onExtract = vi.fn();
+    const { container } = render(
+      <ExtractSubtitleButton onExtract={onExtract} title="Why We Sleep" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when title has colon but split is empty on one side", () => {
+    const onExtract = vi.fn();
+    const { container } = render(
+      <ExtractSubtitleButton onExtract={onExtract} title="Title:" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders button when title has a splittable colon", () => {
+    const onExtract = vi.fn();
+    render(
+      <ExtractSubtitleButton
+        onExtract={onExtract}
+        title="Why We Sleep: Unlocking the Power of Sleep and Dreams"
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /extract subtitle/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("fires onExtract with the split values on click", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onExtract = vi.fn();
+    render(
+      <ExtractSubtitleButton
+        onExtract={onExtract}
+        title="Star Wars: Thrawn: Alliances"
+      />,
+    );
+    await user.click(
+      screen.getByRole("button", { name: /extract subtitle/i }),
+    );
+    expect(onExtract).toHaveBeenCalledWith("Star Wars", "Thrawn: Alliances");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run:
+
+```bash
+pnpm vitest run app/components/library/ExtractSubtitleButton.test.tsx
+```
+
+Expected: all tests fail because `./ExtractSubtitleButton` does not yet exist (module-not-found error).
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add app/components/library/ExtractSubtitleButton.test.tsx
+git commit -m "[Test] Add failing tests for ExtractSubtitleButton"
+```
+
+---
+
+### Task 4: Button component — implementation
+
+**Files:**
+- Create: `app/components/library/ExtractSubtitleButton.tsx`
+
+- [ ] **Step 1: Implement the component**
+
+```tsx
+import { extractSubtitleFromTitle } from "@/utils/extractSubtitle";
+
+interface Props {
+  title: string;
+  onExtract: (title: string, subtitle: string) => void;
+}
+
+export function ExtractSubtitleButton({ title, onExtract }: Props) {
+  const split = extractSubtitleFromTitle(title);
+  if (!split) return null;
+  return (
+    <div className="flex justify-end">
+      <button
+        className="text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+        onClick={() => onExtract(split.title, split.subtitle)}
+        type="button"
+      >
+        Extract subtitle
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run the component tests and verify they pass**
+
+Run:
+
+```bash
+pnpm vitest run app/components/library/ExtractSubtitleButton.test.tsx
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 3: Commit the implementation**
+
+```bash
+git add app/components/library/ExtractSubtitleButton.tsx
+git commit -m "[Frontend] Add ExtractSubtitleButton component"
+```
+
+---
+
+### Task 5: Wire into BookEditDialog
+
+**Files:**
+- Modify: `app/components/library/BookEditDialog.tsx` (Title block around lines 491-499)
+
+- [ ] **Step 1: Add the import**
+
+In the existing `@/components/...` import block near the top of the file (alongside the other `@/components/library/...` imports if present, otherwise in alpha order), add:
+
+```tsx
+import { ExtractSubtitleButton } from "@/components/library/ExtractSubtitleButton";
+```
+
+- [ ] **Step 2: Render the button below the Title `<Input>`**
+
+Locate the Title block (currently lines 491-499):
+
+```tsx
+{/* Title */}
+<div className="space-y-2">
+  <Label htmlFor="title">Title</Label>
+  <Input
+    id="title"
+    onChange={(e) => setTitle(e.target.value)}
+    value={title}
+  />
+</div>
+```
+
+Replace with:
+
+```tsx
+{/* Title */}
+<div className="space-y-2">
+  <Label htmlFor="title">Title</Label>
+  <Input
+    id="title"
+    onChange={(e) => setTitle(e.target.value)}
+    value={title}
+  />
+  <ExtractSubtitleButton
+    onExtract={(t, s) => {
+      setTitle(t);
+      setSubtitle(s);
+    }}
+    title={title}
+  />
+</div>
+```
+
+- [ ] **Step 3: Manually verify the dev server**
+
+Run `mise start` (or confirm it's already running), open a book in the library, click Edit, and enter a title like `Why We Sleep: Unlocking the Power of Sleep and Dreams`. Confirm:
+
+- The "Extract subtitle" text appears below the title input, right-aligned, muted.
+- Clicking it changes Title to `Why We Sleep` and Subtitle to `Unlocking the Power of Sleep and Dreams`.
+- After the click, the button disappears (title no longer has `:`).
+- Clearing the title or entering one without `:` keeps the button hidden.
+- Clicking Save persists the change; clicking Cancel (via the Unsaved Changes dialog) rolls it back.
+
+- [ ] **Step 4: Run the frontend lint and typecheck**
+
+Run:
+
+```bash
+pnpm lint:eslint && pnpm lint:types
+```
+
+Expected: clean exit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/BookEditDialog.tsx
+git commit -m "[Frontend] Wire ExtractSubtitleButton into BookEditDialog"
+```
+
+---
+
+### Task 6: Wire into IdentifyReviewForm
+
+**Files:**
+- Modify: `app/components/library/IdentifyReviewForm.tsx` (Title/Subtitle blocks around lines 856-884)
+
+- [ ] **Step 1: Add the import**
+
+Add to the import block at the top of the file (alpha order within `@/components/library/...` imports):
+
+```tsx
+import { ExtractSubtitleButton } from "@/components/library/ExtractSubtitleButton";
+```
+
+- [ ] **Step 2: Render the button between the Title and Subtitle `FieldWrapper` blocks**
+
+Locate the Title and Subtitle blocks (currently lines 856-884):
+
+```tsx
+{/* Title */}
+<FieldWrapper
+  currentValue={book.title || undefined}
+  disabled={isDisabled("title")}
+  field="title"
+  onUseCurrent={() => setTitle(book.title)}
+  status={defaults.title.status}
+>
+  <Input
+    disabled={isDisabled("title")}
+    onChange={(e) => setTitle(e.target.value)}
+    value={title}
+  />
+</FieldWrapper>
+
+{/* Subtitle */}
+<FieldWrapper
+  currentValue={book.subtitle || undefined}
+  disabled={isDisabled("subtitle")}
+  field="subtitle"
+  onUseCurrent={() => setSubtitle(book.subtitle ?? "")}
+  status={defaults.subtitle.status}
+>
+  <Input
+    disabled={isDisabled("subtitle")}
+    onChange={(e) => setSubtitle(e.target.value)}
+    value={subtitle}
+  />
+</FieldWrapper>
+```
+
+Insert the button between the two `FieldWrapper` blocks so the rendered output becomes:
+
+```tsx
+{/* Title */}
+<FieldWrapper
+  currentValue={book.title || undefined}
+  disabled={isDisabled("title")}
+  field="title"
+  onUseCurrent={() => setTitle(book.title)}
+  status={defaults.title.status}
+>
+  <Input
+    disabled={isDisabled("title")}
+    onChange={(e) => setTitle(e.target.value)}
+    value={title}
+  />
+</FieldWrapper>
+
+{!isDisabled("title") && !isDisabled("subtitle") && (
+  <ExtractSubtitleButton
+    onExtract={(t, s) => {
+      setTitle(t);
+      setSubtitle(s);
+    }}
+    title={title}
+  />
+)}
+
+{/* Subtitle */}
+<FieldWrapper
+  currentValue={book.subtitle || undefined}
+  disabled={isDisabled("subtitle")}
+  field="subtitle"
+  onUseCurrent={() => setSubtitle(book.subtitle ?? "")}
+  status={defaults.subtitle.status}
+>
+  <Input
+    disabled={isDisabled("subtitle")}
+    onChange={(e) => setSubtitle(e.target.value)}
+    value={subtitle}
+  />
+</FieldWrapper>
+```
+
+- [ ] **Step 3: Manually verify in the dev server**
+
+With `mise start` running, trigger the Identify flow on a book. When a metadata provider returns a combined title (or if you edit the title field in the review form to include a `:`), confirm:
+
+- "Extract subtitle" appears between the Title and Subtitle rows.
+- Clicking it populates subtitle from the title's right-hand side and trims the title.
+- The button hides after a successful extraction (no more `:`).
+- If title editing is disabled (`isDisabled("title") === true`) or subtitle editing is disabled, the button is not rendered.
+
+- [ ] **Step 4: Run the frontend lint and typecheck**
+
+Run:
+
+```bash
+pnpm lint:eslint && pnpm lint:types
+```
+
+Expected: clean exit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/IdentifyReviewForm.tsx
+git commit -m "[Frontend] Wire ExtractSubtitleButton into IdentifyReviewForm"
+```
+
+---
+
+### Task 7: Final validation
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run the full check suite**
+
+Run:
+
+```bash
+mise check:quiet
+```
+
+Expected: one-line summary with all checks passing (Go tests, Go lint, JS tests, JS lint).
+
+- [ ] **Step 2: If anything fails, fix and recommit**
+
+For any failing step, read its output, fix the underlying cause, and create a new commit describing the fix. Do not proceed until `mise check:quiet` is green.
+
+---
+
+## Self-Review Summary
+
+- **Spec coverage:**
+  - Shared helper with render-gate logic → Task 1-2.
+  - Shared button component with render-gate and callback → Task 3-4.
+  - BookEditDialog integration → Task 5.
+  - IdentifyReviewForm integration with `isDisabled` guards → Task 6.
+  - Unit tests for helper → Task 1.
+  - Component tests for button → Task 3.
+  - Final check suite → Task 7.
+  - Spec explicitly says no docs needed → not in plan, correct.
+- **No placeholders** — all code steps show full code; all commands are exact.
+- **Type consistency** — helper signature `{ title: string; subtitle: string } | null` is used identically in the button component and all test assertions. Component props name `title` / `onExtract` match across tests, implementation, and both consumer call sites.

--- a/docs/superpowers/specs/2026-04-23-extract-subtitle-design.md
+++ b/docs/superpowers/specs/2026-04-23-extract-subtitle-design.md
@@ -1,0 +1,179 @@
+# Extract Subtitle from Title
+
+## Problem
+
+Book metadata often combines a book's subtitle into the title with a colon — e.g. `"Why We Sleep: Unlocking the Power of Sleep and Dreams"`. When this happens, editing the book manually is tedious: copy the part after the colon, delete it (and the colon) from the title, click into the subtitle field, paste.
+
+This isn't something we can automate unconditionally — plenty of legitimate titles contain colons, for example series titling like `"Star Wars: Dark Force Rising"`. But because the combined-title case is common, a one-click "Extract subtitle" affordance on the edit form is a big quality-of-life improvement.
+
+## Goals
+
+- Give users a one-click way to split a combined `"Title: Subtitle"` string into the separate title and subtitle fields while editing a book.
+- Make the affordance consistent across both places where a user can edit these fields: the book edit dialog and the identify-review form.
+- Keep the change narrow — no new config, no API change, no schema change.
+
+## Non-goals
+
+- **No automatic splitting.** The split must remain an explicit user action.
+- **No scan-time or identify-time auto-splitting.** This is strictly a UI helper for manual editing.
+- **No heuristics for detecting "is this a series prefix vs. a subtitle?"** — the user decides by clicking (or not).
+
+## UX
+
+### Visibility
+
+The "Extract subtitle" control is rendered **only** when the current title string contains a `:` with non-empty content on both sides (so `":foo"`, `"foo:"`, `":"` alone don't show the button). If the user clicks it, the title no longer has a colon, so the button disappears.
+
+### Placement
+
+Below the title input, right-aligned, muted link-style text. Matches the existing "Clear all" affordance pattern at `app/components/library/BookEditDialog.tsx:542`:
+
+```
+text-xs text-muted-foreground hover:text-foreground cursor-pointer
+```
+
+Placed below (not above) because in `IdentifyReviewForm`, the top-right of the title row is occupied by the "Changed" status badge and the row's right side is occupied by the "Use current" action. Below-right is the only location consistent across both forms.
+
+Visual sketch:
+
+```
+Title
+┌──────────────────────────────────────┐
+│ Why We Sleep: Unlocking the Power... │
+└──────────────────────────────────────┘
+                       Extract subtitle
+```
+
+### Click behavior
+
+- Split on **first** `:`.
+- Trim whitespace on both sides.
+- Set the title field to the left side.
+- Set the subtitle field to the right side, **overwriting** any existing subtitle value.
+
+Overwriting silently (rather than confirming or hiding when subtitle is non-empty) is fine because:
+
+1. The form shows both fields on screen — the user immediately sees the result.
+2. Both forms have unsaved-changes protection — a wrong click can be undone by Cancel.
+3. A confirmation step adds friction to what should be a one-click action.
+
+### Multiple colons
+
+The split always happens on the **first** colon. Any remaining colons stay in the subtitle. This is almost always correct:
+
+- `"Atomic Habits: An Easy & Proven Way to Build Good Habits: Tiny Changes, Remarkable Results"` → title `"Atomic Habits"`, subtitle `"An Easy & Proven Way… : Tiny Changes…"`
+- `"Star Wars: Thrawn: Alliances"` → title `"Star Wars"`, subtitle `"Thrawn: Alliances"`
+
+If the user disagrees with the split, they can edit further manually or hit Cancel.
+
+## Implementation
+
+### 1. Shared split helper
+
+New file `app/utils/extractSubtitle.ts`:
+
+```ts
+export function extractSubtitleFromTitle(
+  title: string,
+): { title: string; subtitle: string } | null {
+  const idx = title.indexOf(":");
+  if (idx === -1) return null;
+  const newTitle = title.slice(0, idx).trim();
+  const newSubtitle = title.slice(idx + 1).trim();
+  if (!newTitle || !newSubtitle) return null;
+  return { title: newTitle, subtitle: newSubtitle };
+}
+```
+
+Returning `null` when the split would produce an empty side (leading `:`, trailing `:`, or a bare `:`) doubles as the "should we render the button?" check — the consuming component can render iff the helper returns non-null.
+
+### 2. Shared button component
+
+New file `app/components/library/ExtractSubtitleButton.tsx`:
+
+```tsx
+interface Props {
+  title: string;
+  onExtract: (title: string, subtitle: string) => void;
+}
+
+export function ExtractSubtitleButton({ title, onExtract }: Props) {
+  const split = extractSubtitleFromTitle(title);
+  if (!split) return null;
+  return (
+    <div className="flex justify-end">
+      <button
+        type="button"
+        className="text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+        onClick={() => onExtract(split.title, split.subtitle)}
+      >
+        Extract subtitle
+      </button>
+    </div>
+  );
+}
+```
+
+### 3. BookEditDialog integration
+
+In `app/components/library/BookEditDialog.tsx`, inside the Title `<div className="space-y-2">` block (around lines 491-499), append the button after the `<Input>`:
+
+```tsx
+<ExtractSubtitleButton
+  title={title}
+  onExtract={(t, s) => {
+    setTitle(t);
+    setSubtitle(s);
+  }}
+/>
+```
+
+### 4. IdentifyReviewForm integration
+
+In `app/components/library/IdentifyReviewForm.tsx`, after the title `FieldWrapper` block (around lines 856-869), add the same button. The form already has `setTitle` and `setSubtitle` state setters at lines 570-571.
+
+The button sits between the Title FieldWrapper and the Subtitle FieldWrapper. `isDisabled("title")` should short-circuit rendering — if title editing is disabled for this field, the button should not appear. The `ExtractSubtitleButton` component itself doesn't need to know about this; the caller passes the button only when editing is allowed, e.g.:
+
+```tsx
+{!isDisabled("title") && !isDisabled("subtitle") && (
+  <ExtractSubtitleButton
+    title={title}
+    onExtract={(t, s) => {
+      setTitle(t);
+      setSubtitle(s);
+    }}
+  />
+)}
+```
+
+## Testing
+
+### Unit tests for `extractSubtitleFromTitle`
+
+`app/utils/extractSubtitle.test.ts`:
+
+- No colon → returns `null`.
+- Leading colon (`":foo"`) → returns `null`.
+- Trailing colon (`"foo:"`) → returns `null`.
+- Bare colon (`":"`) → returns `null`.
+- Simple split (`"A: B"`) → `{ title: "A", subtitle: "B" }`.
+- Surrounding whitespace (`"  Foo  :  Bar  "`) → `{ title: "Foo", subtitle: "Bar" }`.
+- Multiple colons (`"Foo: Bar: Baz"`) → `{ title: "Foo", subtitle: "Bar: Baz" }` (first colon wins).
+- Empty string → returns `null`.
+
+### Component tests for `ExtractSubtitleButton`
+
+`app/components/library/ExtractSubtitleButton.test.tsx`:
+
+- Renders nothing when `title` has no colon.
+- Renders button when `title` has a splittable colon.
+- Fires `onExtract` with the correct split values on click.
+
+## Docs
+
+No user-facing docs need updating. This is a small UI affordance — no new config option, no API change, no change to user-facing metadata semantics, no change in scanner or identify-flow behavior.
+
+## Out of scope / follow-ups
+
+- Applying the same logic automatically at scan-time or identify-time. Intentionally out of scope — we don't want to risk wrongly splitting a series-prefix title like `"Star Wars: Dark Force Rising"`.
+- A similar affordance elsewhere (file-level metadata edit, bulk edit, etc.) — can be added later if needed.


### PR DESCRIPTION
## Summary
- Adds a small "Extract subtitle" link below the title input in both `BookEditDialog` and `IdentifyReviewForm` that splits a combined "Title: Subtitle" string into the title and subtitle fields with a single click.
- The button is render-gated — it only appears when the title contains a `:` with non-empty content on both sides. Splits on the first colon only, so legitimate series titles like "Star Wars: Thrawn: Alliances" cleanly become title "Star Wars" / subtitle "Thrawn: Alliances".
- In the Identify review form, the button is additionally hidden when either title or subtitle editing is disabled, and wrapped in a tight `space-y-1.5` container so it docks under the title input instead of inheriting the form's larger row spacing.

## Test plan
- Open a book and click Edit. Set the title to `Why We Sleep: Unlocking the Power of Sleep and Dreams` and confirm an "Extract subtitle" link appears below the input. Click it — title becomes `Why We Sleep`, subtitle becomes `Unlocking the Power of Sleep and Dreams`, and the link disappears. Save and verify persistence; cancel on a fresh change and verify Unsaved Changes protection still works.
- Clear the colon from the title and confirm the link hides. Enter a title with only a leading or trailing colon (`:Foo`, `Foo:`) and confirm the link stays hidden.
- Enter a title with multiple colons (`Star Wars: Thrawn: Alliances`) and confirm the first-colon split is applied.
- Run the Identify flow on a book whose metadata provider returns a combined title. Confirm the button appears between Title and Subtitle rows with tight spacing (not the full row gap), and clicking it splits as expected.
- Confirm that when the identify form disables the title or subtitle field, the button disappears.
- `mise check:quiet` passes locally.