### PR TITLE
[Frontend] Replace cover URL cache-busting with HTTP revalidation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,10 +85,13 @@ file.CoverImageFilename = &filename
 
 ### Frontend
 
-**Cover images use HTTP revalidation, not URL cache-busting** — Cover endpoints set `Cache-Control: private, no-cache` and rely on `Last-Modified` for revalidation. Never append `?t=...` query params to cover URLs. For pages that can trigger cover mutations, add `key={query.dataUpdatedAt}` to the `<img>` so React remounts it and the browser refetches:
+**Cover images require both URL cache-busting AND HTTP revalidation** — Browsers maintain an in-memory image cache independent from the HTTP cache, so `Cache-Control: no-cache` alone doesn't force a fresh fetch on `<img>` remount with the same src. Cover URLs must include `?v=${cacheKey}` where `cacheKey` reliably bumps on data refetches (e.g., `bookQuery.dataUpdatedAt`). See `app/CLAUDE.md` for details.
 
 ```tsx
-<img key={bookQuery.dataUpdatedAt} src={`/api/books/${id}/cover`} />
+<img
+  key={bookQuery.dataUpdatedAt}
+  src={`/api/books/${id}/cover?v=${bookQuery.dataUpdatedAt}`}
+/>
 ```
 
 ### Plugins

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,10 @@ file.CoverImageFilename = &filename
 
 ### Frontend
 
-**Cover images need cache busting** — All cover image URLs must include a `?t=` parameter to ensure updated covers display without caching issues:
+**Cover images use HTTP revalidation, not URL cache-busting** — Cover endpoints set `Cache-Control: private, no-cache` and rely on `Last-Modified` for revalidation. Never append `?t=...` query params to cover URLs. For pages that can trigger cover mutations, add `key={query.dataUpdatedAt}` to the `<img>` so React remounts it and the browser refetches:
+
 ```tsx
-const coverUrl = `/api/books/${id}/cover?t=${query.dataUpdatedAt}`;
+<img key={bookQuery.dataUpdatedAt} src={`/api/books/${id}/cover`} />
 ```
 
 ### Plugins

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -310,18 +310,10 @@ References:
 - **Append `?v=${cacheKey}`** to cover URLs. `cacheKey` must be a value that changes when the underlying data is refetched (e.g., `bookQuery.dataUpdatedAt`), **not** `entity.updated_at` (which doesn't bump on file-cover changes).
 - **For pages that mutate covers** (BookDetail, FileEditDialog), also add `key={cacheKey}` to the `<img>` tag. React remounting combined with URL change gives reliable refresh.
 - **For child components that render covers**, accept a `cacheKey?: number` prop. Parents pass their query's `dataUpdatedAt` or the relevant entity's `updated_at` (for file covers, since `file.updated_at` bumps reliably on cover mutations).
-- **Source selection:**
-  - `/api/books/:id/cover` — use parent book query's `dataUpdatedAt` (or a cascaded `cacheKey` prop).
-  - `/api/books/files/:id/cover` — use `file.updated_at` (reliable) or the parent query's `dataUpdatedAt`.
-  - `/api/series/:id/cover` — use parent series query's `dataUpdatedAt`.
-
-### Endpoints
-
-| Endpoint | Description |
-|----------|-------------|
-| `/api/books/{id}/cover` | Book cover (selected from files) |
-| `/api/books/files/{id}/cover` | Specific file's cover |
-| `/api/series/{id}/cover` | Series cover (from first book) |
+- **Source selection by endpoint:**
+  - `/api/books/:id/cover` (book cover, selected from files) — parent book query's `dataUpdatedAt` (or a cascaded `cacheKey` prop).
+  - `/api/books/files/:id/cover` (specific file's cover) — `file.updated_at` (reliable) or the parent query's `dataUpdatedAt`.
+  - `/api/series/:id/cover` (series cover, from first book) — parent series query's `dataUpdatedAt`.
 
 ### Checklist for new cover components
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -295,24 +295,25 @@ Center and constrain cover images on mobile:
 
 ## Cover Image Freshness
 
-Cover endpoints set `Cache-Control: private, no-cache` and emit `Last-Modified` from the cover file's mtime. The browser stores the image but revalidates with the server on every `<img>` mount via a conditional `GET` carrying `If-Modified-Since`. The server returns `304 Not Modified` (no body) when the cover is unchanged, or `200 OK` with new bytes when it has changed.
+Cover URLs include a `?v=${cacheKey}` query parameter that bumps whenever the underlying data is refetched. The backend emits `Cache-Control: private, no-cache` + `Last-Modified` and returns `304 Not Modified` on conditional GET, but the query-param is the primary freshness mechanism. Both layers together give reliable updates across browsers.
+
+### Why URL-based busting is required
+
+Chromium and Firefox maintain an in-memory image cache (the HTML spec's "list of available images") that is **separate from the HTTP cache**. When an `<img>` element's `src` matches a URL previously rendered in the session, the browser serves the cached decoded bitmap without hitting HTTP — bypassing `Cache-Control: no-cache` entirely. Stable URLs + `Cache-Control` alone are insufficient.
+
+References:
+- [whatwg/fetch#1088](https://github.com/whatwg/fetch/issues/1088) — browsers reusing `no-cache` cached images
+- [Mozilla bug 1719583](https://bugzilla.mozilla.org/show_bug.cgi?id=1719583) — Firefox image cache persists across `fetch({cache: 'reload'})`
 
 ### Rules
 
-- **Do not append `?t=...`** or any other cache-busting query parameter to cover URLs. Use stable URLs:
-  ```tsx
-  const coverUrl = `/api/books/${book.id}/cover`;
-  ```
-- **For pages that can trigger a cover mutation** (e.g., BookDetail, FileEditDialog), add `key={query.dataUpdatedAt}` to the `<img>` tag. A query invalidation bumps `dataUpdatedAt`, the key changes, React remounts the element, and the browser makes a fresh HTTP request that revalidates:
-  ```tsx
-  <img
-    key={bookQuery.dataUpdatedAt}
-    src={`/api/books/${book.id}/cover`}
-  />
-  ```
-- **Compound keys:** When a single `<img>` element can display different entities as its inputs change (e.g., `CoverGalleryTabs` switching between file tabs), include the entity id in the key (e.g., `key={`${file.id}-${cacheKey}`}`). For components with stable entity identity per mount (e.g., `BookDetail`'s main cover), a bare `key={cacheKey}` is sufficient.
-- **For pages that only display covers** (lists, grids, search results), no `key` is needed. Navigation naturally remounts the `<img>`, which triggers revalidation.
-- **For child components that render covers inside editing surfaces**, pass a `cacheKey` prop (typed as `number`) down and use it as part of the `<img key>`. Parents should pass `bookQuery.dataUpdatedAt`.
+- **Append `?v=${cacheKey}`** to cover URLs. `cacheKey` must be a value that changes when the underlying data is refetched (e.g., `bookQuery.dataUpdatedAt`), **not** `entity.updated_at` (which doesn't bump on file-cover changes).
+- **For pages that mutate covers** (BookDetail, FileEditDialog), also add `key={cacheKey}` to the `<img>` tag. React remounting combined with URL change gives reliable refresh.
+- **For child components that render covers**, accept a `cacheKey?: number` prop. Parents pass their query's `dataUpdatedAt` or the relevant entity's `updated_at` (for file covers, since `file.updated_at` bumps reliably on cover mutations).
+- **Source selection:**
+  - `/api/books/:id/cover` — use parent book query's `dataUpdatedAt` (or a cascaded `cacheKey` prop).
+  - `/api/books/files/:id/cover` — use `file.updated_at` (reliable) or the parent query's `dataUpdatedAt`.
+  - `/api/series/:id/cover` — use parent series query's `dataUpdatedAt`.
 
 ### Endpoints
 
@@ -324,9 +325,10 @@ Cover endpoints set `Cache-Control: private, no-cache` and emit `Last-Modified` 
 
 ### Checklist for new cover components
 
-- [ ] Cover URL does NOT include `?t=` query param
-- [ ] For pages that mutate covers, `<img>` has `key={query.dataUpdatedAt}` (or is driven by a `cacheKey` prop) so remount triggers revalidation
-- [ ] Cover-mutating mutations invalidate the query whose `dataUpdatedAt` drives the key (default: `RetrieveBook`, already invalidated by `useUploadFileCover` and `useSetFileCoverPage`)
+- [ ] Cover URL includes `?v=${cacheKey}` with a value that bumps when data is refetched
+- [ ] `cacheKey` source is reliable (`query.dataUpdatedAt` or `file.updated_at` — NOT `book.updated_at` for cover purposes)
+- [ ] For mutation-capable pages, `<img key={cacheKey}>` for React remount
+- [ ] Cover-mutating mutations invalidate the query whose `dataUpdatedAt` drives the key
 
 ### Breadcrumbs
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -293,39 +293,28 @@ Center and constrain cover images on mobile:
 </div>
 ```
 
-## Cover Image Cache Busting
+## Cover Image Freshness
 
-**All cover image URLs MUST include a cache-busting query parameter** to ensure updated covers are displayed without browser caching issues.
+Cover endpoints set `Cache-Control: private, no-cache` and emit `Last-Modified` from the cover file's mtime. The browser stores the image but revalidates with the server on every `<img>` mount via a conditional `GET` carrying `If-Modified-Since`. The server returns `304 Not Modified` (no body) when the cover is unchanged, or `200 OK` with new bytes when it has changed.
 
-### Why Cache Busting is Required
+### Rules
 
-When a book or file's cover is updated (e.g., through metadata refresh or manual edit), the browser may continue showing the old cached version. Adding a timestamp parameter forces the browser to fetch the new image.
+- **Do not append `?t=...`** or any other cache-busting query parameter to cover URLs. Use stable URLs:
+  ```tsx
+  const coverUrl = `/api/books/${book.id}/cover`;
+  ```
+- **For pages that can trigger a cover mutation** (e.g., BookDetail, FileEditDialog), add `key={query.dataUpdatedAt}` to the `<img>` tag. A query invalidation bumps `dataUpdatedAt`, the key changes, React remounts the element, and the browser makes a fresh HTTP request that revalidates:
+  ```tsx
+  <img
+    key={bookQuery.dataUpdatedAt}
+    src={`/api/books/${book.id}/cover`}
+  />
+  ```
+- **Compound keys:** When a single `<img>` element can display different entities as its inputs change (e.g., `CoverGalleryTabs` switching between file tabs), include the entity id in the key (e.g., `key={`${file.id}-${cacheKey}`}`). For components with stable entity identity per mount (e.g., `BookDetail`'s main cover), a bare `key={cacheKey}` is sufficient.
+- **For pages that only display covers** (lists, grids, search results), no `key` is needed. Navigation naturally remounts the `<img>`, which triggers revalidation.
+- **For child components that render covers inside editing surfaces**, pass a `cacheKey` prop (typed as `number`) down and use it as part of the `<img key>`. Parents should pass `bookQuery.dataUpdatedAt`.
 
-### Patterns
-
-**Pattern 1: React Query timestamp** (preferred when query is available)
-```tsx
-const bookQuery = useBook(id);
-const coverUrl = `/api/books/${book.id}/cover?t=${bookQuery.dataUpdatedAt}`;
-```
-
-**Pattern 2: Entity timestamp** (for lists without query access)
-```tsx
-const coverUrl = `/api/books/${book.id}/cover?t=${new Date(book.updated_at).getTime()}`;
-```
-
-**Pattern 3: Prop drilling** (for child components)
-```tsx
-// Parent component
-<FileCoverThumbnail file={file} cacheBuster={bookQuery.dataUpdatedAt} />
-
-// Child component
-const coverUrl = cacheBuster
-  ? `/api/books/files/${file.id}/cover?t=${cacheBuster}`
-  : `/api/books/files/${file.id}/cover`;
-```
-
-### Cover Endpoints
+### Endpoints
 
 | Endpoint | Description |
 |----------|-------------|
@@ -333,11 +322,11 @@ const coverUrl = cacheBuster
 | `/api/books/files/{id}/cover` | Specific file's cover |
 | `/api/series/{id}/cover` | Series cover (from first book) |
 
-### Checklist for New Cover Components
+### Checklist for new cover components
 
-- [ ] Cover URL includes `?t=` cache buster parameter
-- [ ] Cache buster updates when data is refetched
-- [ ] Child components receive cache buster via props if needed
+- [ ] Cover URL does NOT include `?t=` query param
+- [ ] For pages that mutate covers, `<img>` has `key={query.dataUpdatedAt}` (or is driven by a `cacheKey` prop) so remount triggers revalidation
+- [ ] Cover-mutating mutations invalidate the query whose `dataUpdatedAt` drives the key (default: `RetrieveBook`, already invalidated by `useUploadFileCover` and `useSetFileCoverPage`)
 
 ### Breadcrumbs
 

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -151,7 +151,7 @@ const BookItem = ({
     : undefined;
 
   const aspectClass = getAspectRatioClass(coverAspectRatio, book.files);
-  const coverUrl = `/api/books/${book.id}/cover?t=${new Date(book.updated_at).getTime()}`;
+  const coverUrl = `/api/books/${book.id}/cover`;
   const [coverLoaded, setCoverLoaded] = useState(() => isCoverLoaded(coverUrl));
   const [coverError, setCoverError] = useState(false);
   const [showRescanDialog, setShowRescanDialog] = useState(false);

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -53,6 +53,7 @@ interface BookItemProps {
   isSelected?: boolean;
   onSelect?: () => void;
   onShiftSelect?: () => void;
+  cacheKey?: number;
 }
 
 // Selects the file that would be used for the cover based on cover_aspect_ratio setting
@@ -142,6 +143,7 @@ const BookItem = ({
   isSelected = false,
   onSelect,
   onShiftSelect,
+  cacheKey,
 }: BookItemProps) => {
   const [titleRef, isTitleTruncated] = useIsTruncated<HTMLDivElement>();
 
@@ -151,7 +153,9 @@ const BookItem = ({
     : undefined;
 
   const aspectClass = getAspectRatioClass(coverAspectRatio, book.files);
-  const coverUrl = `/api/books/${book.id}/cover`;
+  const coverUrl = cacheKey
+    ? `/api/books/${book.id}/cover?v=${cacheKey}`
+    : `/api/books/${book.id}/cover`;
   const [coverLoaded, setCoverLoaded] = useState(() => isCoverLoaded(coverUrl));
   const [coverError, setCoverError] = useState(false);
   const [showRescanDialog, setShowRescanDialog] = useState(false);

--- a/app/components/library/CoverGalleryTabs.test.tsx
+++ b/app/components/library/CoverGalleryTabs.test.tsx
@@ -22,38 +22,41 @@ function makeFile(overrides: Partial<File> = {}): File {
 }
 
 describe("CoverGalleryTabs", () => {
-  it("re-renders cover image after error when cacheBuster changes", () => {
+  it("renders cover image with stable URL (no cache-buster query)", () => {
+    const files = [
+      makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
+      makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
+    ];
+
+    const { container } = render(<CoverGalleryTabs files={files} />);
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("/api/books/files/1/cover");
+  });
+
+  it("re-mounts cover image when cacheKey changes", () => {
     const files = [
       makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
       makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
     ];
 
     const { container, rerender } = render(
-      <CoverGalleryTabs cacheBuster={111} files={files} />,
+      <CoverGalleryTabs cacheKey={111} files={files} />,
     );
+    const firstImg = container.querySelector("img");
+    expect(firstImg).not.toBeNull();
+    expect(firstImg?.getAttribute("src")).toBe("/api/books/files/1/cover");
 
-    // Initial render: the first file's cover <img> is present with cacheBuster=111
-    let img = container.querySelector("img");
-    expect(img).not.toBeNull();
-    expect(img?.getAttribute("src")).toContain(
-      "/api/books/files/1/cover?t=111",
-    );
-
-    // Simulate the cover failing to load (e.g. 404 because the cover didn't
-    // exist on disk at that time)
-    fireEvent.error(img!);
-
-    // Once errored, the <img> is unmounted and only the placeholder remains
+    // Simulate an error first so the img is unmounted, then a cacheKey bump
+    // should cause it to re-mount (simulating a "retry" after the cover was
+    // fixed on disk — equivalent to the old cacheBuster-driven retry flow).
+    fireEvent.error(firstImg!);
     expect(container.querySelector("img")).toBeNull();
 
-    // A rescan/refresh completes: cacheBuster changes, so the cover URL
-    // changes. The <img> must be re-rendered to attempt the new URL.
-    rerender(<CoverGalleryTabs cacheBuster={222} files={files} />);
-
-    img = container.querySelector("img");
-    expect(img).not.toBeNull();
-    expect(img?.getAttribute("src")).toContain(
-      "/api/books/files/1/cover?t=222",
-    );
+    rerender(<CoverGalleryTabs cacheKey={222} files={files} />);
+    const secondImg = container.querySelector("img");
+    expect(secondImg).not.toBeNull();
+    expect(secondImg?.getAttribute("src")).toBe("/api/books/files/1/cover");
   });
 });

--- a/app/components/library/CoverGalleryTabs.test.tsx
+++ b/app/components/library/CoverGalleryTabs.test.tsx
@@ -22,7 +22,7 @@ function makeFile(overrides: Partial<File> = {}): File {
 }
 
 describe("CoverGalleryTabs", () => {
-  it("renders cover image with stable URL (no cache-buster query)", () => {
+  it("renders cover image with stable URL when no cacheKey is provided", () => {
     const files = [
       makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
       makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
@@ -46,7 +46,9 @@ describe("CoverGalleryTabs", () => {
     );
     const firstImg = container.querySelector("img");
     expect(firstImg).not.toBeNull();
-    expect(firstImg?.getAttribute("src")).toBe("/api/books/files/1/cover");
+    expect(firstImg?.getAttribute("src")).toBe(
+      "/api/books/files/1/cover?v=111",
+    );
 
     // Simulate an error first so the img is unmounted, then a cacheKey bump
     // should cause it to re-mount (simulating a "retry" after the cover was
@@ -57,7 +59,9 @@ describe("CoverGalleryTabs", () => {
     rerender(<CoverGalleryTabs cacheKey={222} files={files} />);
     const secondImg = container.querySelector("img");
     expect(secondImg).not.toBeNull();
-    expect(secondImg?.getAttribute("src")).toBe("/api/books/files/1/cover");
+    expect(secondImg?.getAttribute("src")).toBe(
+      "/api/books/files/1/cover?v=222",
+    );
   });
 
   it("mounts a fresh <img> element when cacheKey changes (even without error)", () => {
@@ -71,12 +75,17 @@ describe("CoverGalleryTabs", () => {
     );
     const firstImg = container.querySelector("img");
     expect(firstImg).not.toBeNull();
+    expect(firstImg?.getAttribute("src")).toBe(
+      "/api/books/files/1/cover?v=111",
+    );
 
     rerender(<CoverGalleryTabs cacheKey={222} files={files} />);
     const secondImg = container.querySelector("img");
 
     expect(secondImg).not.toBeNull();
     expect(secondImg).not.toBe(firstImg); // Different DOM node — React remounted
-    expect(secondImg?.getAttribute("src")).toBe("/api/books/files/1/cover");
+    expect(secondImg?.getAttribute("src")).toBe(
+      "/api/books/files/1/cover?v=222",
+    );
   });
 });

--- a/app/components/library/CoverGalleryTabs.test.tsx
+++ b/app/components/library/CoverGalleryTabs.test.tsx
@@ -59,4 +59,24 @@ describe("CoverGalleryTabs", () => {
     expect(secondImg).not.toBeNull();
     expect(secondImg?.getAttribute("src")).toBe("/api/books/files/1/cover");
   });
+
+  it("mounts a fresh <img> element when cacheKey changes (even without error)", () => {
+    const files = [
+      makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
+      makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
+    ];
+
+    const { container, rerender } = render(
+      <CoverGalleryTabs cacheKey={111} files={files} />,
+    );
+    const firstImg = container.querySelector("img");
+    expect(firstImg).not.toBeNull();
+
+    rerender(<CoverGalleryTabs cacheKey={222} files={files} />);
+    const secondImg = container.querySelector("img");
+
+    expect(secondImg).not.toBeNull();
+    expect(secondImg).not.toBe(firstImg); // Different DOM node — React remounted
+    expect(secondImg?.getAttribute("src")).toBe("/api/books/files/1/cover");
+  });
 });

--- a/app/components/library/CoverGalleryTabs.tsx
+++ b/app/components/library/CoverGalleryTabs.tsx
@@ -86,7 +86,9 @@ function CoverGalleryTabs({
 
   const hasCover = selectedFile?.cover_image_filename && !coverError;
   const coverUrl = selectedFile
-    ? `/api/books/files/${selectedFile.id}/cover`
+    ? cacheKey
+      ? `/api/books/files/${selectedFile.id}/cover?v=${cacheKey}`
+      : `/api/books/files/${selectedFile.id}/cover`
     : null;
 
   // Check cache synchronously before paint

--- a/app/components/library/CoverGalleryTabs.tsx
+++ b/app/components/library/CoverGalleryTabs.tsx
@@ -14,7 +14,12 @@ import { getFilename } from "@/utils/format";
 interface CoverGalleryTabsProps {
   files: File[];
   className?: string;
-  cacheBuster?: number;
+  /**
+   * Forces the <img> to remount (and thus re-request) when this value changes.
+   * Typically set to a React Query `dataUpdatedAt` so cover updates triggered
+   * by mutations on this page flow through HTTP revalidation.
+   */
+  cacheKey?: number;
 }
 
 interface FileWithLabel extends File {
@@ -59,7 +64,7 @@ function getFilesWithLabels(files: File[]): FileWithLabel[] {
 function CoverGalleryTabs({
   files,
   className,
-  cacheBuster,
+  cacheKey,
 }: CoverGalleryTabsProps) {
   const [selectedFileId, setSelectedFileId] = useState<number | null>(null);
   const [coverLoaded, setCoverLoaded] = useState(false);
@@ -81,9 +86,7 @@ function CoverGalleryTabs({
 
   const hasCover = selectedFile?.cover_image_filename && !coverError;
   const coverUrl = selectedFile
-    ? cacheBuster
-      ? `/api/books/files/${selectedFile.id}/cover?t=${cacheBuster}`
-      : `/api/books/files/${selectedFile.id}/cover`
+    ? `/api/books/files/${selectedFile.id}/cover`
     : null;
 
   // Check cache synchronously before paint
@@ -99,13 +102,13 @@ function CoverGalleryTabs({
     setCoverLoaded(false);
   }, [selectedFileId]);
 
-  // Reset the error flag whenever the URL changes — either because the user
-  // picked a different tab, or because a rescan bumped the cache-buster. If
-  // we only reset on tab change, a previously-failed cover stays unmounted
-  // even after the underlying file gets a valid cover.
+  // Reset the error flag whenever the URL changes (tab switch) or when the
+  // cacheKey bumps (cover mutation). If we only reset on tab change, a
+  // previously-failed cover stays unmounted even after the underlying file
+  // gets a valid cover.
   useEffect(() => {
     setCoverError(false);
-  }, [coverUrl]);
+  }, [coverUrl, cacheKey]);
 
   const handleCoverLoad = () => {
     if (coverUrl) {
@@ -150,6 +153,7 @@ function CoverGalleryTabs({
               "absolute inset-0 w-full h-full object-cover",
               !coverLoaded && "opacity-0",
             )}
+            key={`${selectedFile?.id}-${cacheKey ?? 0}`}
             onError={() => setCoverError(true)}
             onLoad={handleCoverLoad}
             src={coverUrl}

--- a/app/components/library/DraggableBookList.tsx
+++ b/app/components/library/DraggableBookList.tsx
@@ -32,6 +32,7 @@ interface DraggableBookItemProps {
   addedByUsername?: string;
   isDragOverlay?: boolean;
   insertPosition?: InsertPosition;
+  cacheKey?: number;
 }
 
 const DraggableBookItem = ({
@@ -39,6 +40,7 @@ const DraggableBookItem = ({
   addedByUsername,
   isDragOverlay = false,
   insertPosition = null,
+  cacheKey,
 }: DraggableBookItemProps) => {
   const {
     attributes,
@@ -63,6 +65,7 @@ const DraggableBookItem = ({
         <BookItem
           addedByUsername={addedByUsername}
           book={listBook.book}
+          cacheKey={cacheKey}
           libraryId={listBook.book.library_id.toString()}
         />
       </div>
@@ -89,6 +92,7 @@ const DraggableBookItem = ({
       <BookItem
         addedByUsername={addedByUsername}
         book={listBook.book}
+        cacheKey={cacheKey}
         libraryId={listBook.book.library_id.toString()}
       />
     </div>
@@ -99,12 +103,14 @@ interface DraggableBookListProps {
   books: ListBook[];
   isOwner: boolean;
   onReorder: (bookIds: number[]) => void;
+  cacheKey?: number;
 }
 
 export const DraggableBookList = ({
   books,
   isOwner,
   onReorder,
+  cacheKey,
 }: DraggableBookListProps) => {
   const [items, setItems] = useState(books);
   const [activeId, setActiveId] = useState<number | null>(null);
@@ -219,6 +225,7 @@ export const DraggableBookList = ({
               addedByUsername={
                 !isOwner ? listBook.added_by_user?.username : undefined
               }
+              cacheKey={cacheKey}
               insertPosition={getInsertPosition(listBook.book_id)}
               key={listBook.id}
               listBook={listBook}
@@ -232,6 +239,7 @@ export const DraggableBookList = ({
             addedByUsername={
               !isOwner ? activeItem.added_by_user?.username : undefined
             }
+            cacheKey={cacheKey}
             isDragOverlay
             listBook={activeItem}
           />

--- a/app/components/library/FileCoverThumbnail.tsx
+++ b/app/components/library/FileCoverThumbnail.tsx
@@ -8,7 +8,11 @@ interface FileCoverThumbnailProps {
   file: File;
   className?: string;
   onClick?: () => void;
-  cacheBuster?: number;
+  /**
+   * Forces the <img> to remount (and thus re-request) when this value changes.
+   * Typically a React Query `dataUpdatedAt` from a mutation-aware query.
+   */
+  cacheKey?: number;
 }
 
 /**
@@ -20,7 +24,7 @@ function FileCoverThumbnail({
   file,
   className,
   onClick,
-  cacheBuster,
+  cacheKey,
 }: FileCoverThumbnailProps) {
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
@@ -30,9 +34,7 @@ function FileCoverThumbnail({
   const placeholderVariant = isAudiobook ? "audiobook" : "book";
 
   const hasCover = file.cover_image_filename && !imageError;
-  const coverUrl = cacheBuster
-    ? `/api/books/files/${file.id}/cover?t=${cacheBuster}`
-    : `/api/books/files/${file.id}/cover`;
+  const coverUrl = `/api/books/files/${file.id}/cover`;
 
   return (
     <div
@@ -44,7 +46,6 @@ function FileCoverThumbnail({
       )}
       onClick={onClick}
     >
-      {/* Placeholder shown until image loads or on error */}
       {(!imageLoaded || !hasCover) && (
         <CoverPlaceholder
           className="absolute inset-0"
@@ -52,7 +53,6 @@ function FileCoverThumbnail({
         />
       )}
 
-      {/* Image hidden until loaded */}
       {hasCover && (
         <img
           alt=""
@@ -60,6 +60,7 @@ function FileCoverThumbnail({
             "absolute inset-0 w-full h-full object-cover",
             !imageLoaded && "opacity-0",
           )}
+          key={`${file.id}-${cacheKey ?? 0}`}
           onError={() => setImageError(true)}
           onLoad={() => setImageLoaded(true)}
           src={coverUrl}

--- a/app/components/library/FileCoverThumbnail.tsx
+++ b/app/components/library/FileCoverThumbnail.tsx
@@ -34,7 +34,9 @@ function FileCoverThumbnail({
   const placeholderVariant = isAudiobook ? "audiobook" : "book";
 
   const hasCover = file.cover_image_filename && !imageError;
-  const coverUrl = `/api/books/files/${file.id}/cover`;
+  const coverUrl = cacheKey
+    ? `/api/books/files/${file.id}/cover?v=${cacheKey}`
+    : `/api/books/files/${file.id}/cover`;
 
   return (
     <div

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -750,7 +750,8 @@ export function FileEditDialog({
                             <img
                               alt="File cover"
                               className="w-full h-full object-cover"
-                              src={`/api/books/files/${file.id}/cover?t=${coverCacheBuster}`}
+                              key={`${file.id}-${coverCacheBuster}`}
+                              src={`/api/books/files/${file.id}/cover`}
                             />
                           ) : (
                             <CoverPlaceholder
@@ -777,7 +778,8 @@ export function FileEditDialog({
                             <img
                               alt="File cover"
                               className="w-full h-full object-cover"
-                              src={`/api/books/files/${file.id}/cover?t=${coverCacheBuster}`}
+                              key={`${file.id}-${coverCacheBuster}`}
+                              src={`/api/books/files/${file.id}/cover`}
                             />
                           ) : (
                             <CoverPlaceholder

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -751,7 +751,7 @@ export function FileEditDialog({
                               alt="File cover"
                               className="w-full h-full object-cover"
                               key={`${file.id}-${coverCacheKey}`}
-                              src={`/api/books/files/${file.id}/cover`}
+                              src={`/api/books/files/${file.id}/cover?v=${coverCacheKey}`}
                             />
                           ) : (
                             <CoverPlaceholder
@@ -779,7 +779,7 @@ export function FileEditDialog({
                               alt="File cover"
                               className="w-full h-full object-cover"
                               key={`${file.id}-${coverCacheKey}`}
-                              src={`/api/books/files/${file.id}/cover`}
+                              src={`/api/books/files/${file.id}/cover?v=${coverCacheKey}`}
                             />
                           ) : (
                             <CoverPlaceholder

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -105,6 +105,10 @@ export function FileEditDialog({
   const debouncedNarratorSearch = useDebounce(narratorSearch, 200);
   const [narratorOpen, setNarratorOpen] = useState(false);
   const isPageBased = isPageBasedFileType(file.file_type);
+  // Dialog-local cover cache key — bumped synchronously after cover mutations
+  // (upload / set-cover-page) so the preview `<img>` refreshes immediately on
+  // save, without waiting for the parent query to refetch. Elsewhere in the
+  // codebase we use `query.dataUpdatedAt` for this; intentional divergence.
   const [coverCacheKey, setCoverCacheKey] = useState(() => Date.now());
   const [coverPagePickerOpen, setCoverPagePickerOpen] = useState(false);
   const [pendingCoverPage, setPendingCoverPage] = useState<number | null>(null);

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -105,7 +105,7 @@ export function FileEditDialog({
   const debouncedNarratorSearch = useDebounce(narratorSearch, 200);
   const [narratorOpen, setNarratorOpen] = useState(false);
   const isPageBased = isPageBasedFileType(file.file_type);
-  const [coverCacheBuster, setCoverCacheBuster] = useState(() => Date.now());
+  const [coverCacheKey, setCoverCacheKey] = useState(() => Date.now());
   const [coverPagePickerOpen, setCoverPagePickerOpen] = useState(false);
   const [pendingCoverPage, setPendingCoverPage] = useState<number | null>(null);
   const [pendingCoverFile, setPendingCoverFile] =
@@ -589,7 +589,7 @@ export function FileEditDialog({
         id: file.id,
         file: pendingCoverFile,
       });
-      setCoverCacheBuster(Date.now());
+      setCoverCacheKey(Date.now());
       setPendingCoverFile(null);
     }
 
@@ -603,7 +603,7 @@ export function FileEditDialog({
         id: file.id,
         page: pendingCoverPage,
       });
-      setCoverCacheBuster(Date.now());
+      setCoverCacheKey(Date.now());
       setPendingCoverPage(null);
     }
 
@@ -750,7 +750,7 @@ export function FileEditDialog({
                             <img
                               alt="File cover"
                               className="w-full h-full object-cover"
-                              key={`${file.id}-${coverCacheBuster}`}
+                              key={`${file.id}-${coverCacheKey}`}
                               src={`/api/books/files/${file.id}/cover`}
                             />
                           ) : (
@@ -778,7 +778,7 @@ export function FileEditDialog({
                             <img
                               alt="File cover"
                               className="w-full h-full object-cover"
-                              key={`${file.id}-${coverCacheBuster}`}
+                              key={`${file.id}-${coverCacheKey}`}
                               src={`/api/books/files/${file.id}/cover`}
                             />
                           ) : (

--- a/app/components/library/GlobalSearch.tsx
+++ b/app/components/library/GlobalSearch.tsx
@@ -49,6 +49,7 @@ interface SearchResultCoverProps {
   id: number;
   thumbnailClasses: string;
   variant: "book" | "audiobook";
+  cacheKey?: number;
 }
 
 const SearchResultCover = ({
@@ -56,8 +57,11 @@ const SearchResultCover = ({
   id,
   thumbnailClasses,
   variant,
+  cacheKey,
 }: SearchResultCoverProps) => {
-  const coverUrl = `/api/${type === "book" ? "books" : "series"}/${id}/cover`;
+  const coverUrl = cacheKey
+    ? `/api/${type === "book" ? "books" : "series"}/${id}/cover?v=${cacheKey}`
+    : `/api/${type === "book" ? "books" : "series"}/${id}/cover`;
   const [coverLoaded, setCoverLoaded] = useState(() => isCoverLoaded(coverUrl));
   const [coverError, setCoverError] = useState(false);
 
@@ -328,6 +332,7 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
           to={`/libraries/${libraryId}/books/${book.id}`}
         >
           <SearchResultCover
+            cacheKey={searchQuery.dataUpdatedAt}
             id={book.id}
             thumbnailClasses={thumbnailClasses}
             type="book"
@@ -344,7 +349,13 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
         </Link>
       );
     },
-    [handleResultClick, libraryId, coverAspectRatio, selectedIndex],
+    [
+      handleResultClick,
+      libraryId,
+      coverAspectRatio,
+      selectedIndex,
+      searchQuery.dataUpdatedAt,
+    ],
   );
 
   const renderSeriesResult = useCallback(
@@ -365,6 +376,7 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
         to={`/libraries/${libraryId}/series/${series.id}`}
       >
         <SearchResultCover
+          cacheKey={searchQuery.dataUpdatedAt}
           id={series.id}
           thumbnailClasses={seriesThumbnailClasses}
           type="series"
@@ -384,6 +396,7 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
       seriesThumbnailClasses,
       libraryVariant,
       selectedIndex,
+      searchQuery.dataUpdatedAt,
     ],
   );
 

--- a/app/components/library/GlobalSearch.tsx
+++ b/app/components/library/GlobalSearch.tsx
@@ -49,7 +49,6 @@ interface SearchResultCoverProps {
   id: number;
   thumbnailClasses: string;
   variant: "book" | "audiobook";
-  cacheBuster: number;
 }
 
 const SearchResultCover = ({
@@ -57,9 +56,8 @@ const SearchResultCover = ({
   id,
   thumbnailClasses,
   variant,
-  cacheBuster,
 }: SearchResultCoverProps) => {
-  const coverUrl = `/api/${type === "book" ? "books" : "series"}/${id}/cover?t=${cacheBuster}`;
+  const coverUrl = `/api/${type === "book" ? "books" : "series"}/${id}/cover`;
   const [coverLoaded, setCoverLoaded] = useState(() => isCoverLoaded(coverUrl));
   const [coverError, setCoverError] = useState(false);
 
@@ -330,7 +328,6 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
           to={`/libraries/${libraryId}/books/${book.id}`}
         >
           <SearchResultCover
-            cacheBuster={searchQuery.dataUpdatedAt}
             id={book.id}
             thumbnailClasses={thumbnailClasses}
             type="book"
@@ -347,13 +344,7 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
         </Link>
       );
     },
-    [
-      handleResultClick,
-      libraryId,
-      searchQuery.dataUpdatedAt,
-      coverAspectRatio,
-      selectedIndex,
-    ],
+    [handleResultClick, libraryId, coverAspectRatio, selectedIndex],
   );
 
   const renderSeriesResult = useCallback(
@@ -374,7 +365,6 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
         to={`/libraries/${libraryId}/series/${series.id}`}
       >
         <SearchResultCover
-          cacheBuster={searchQuery.dataUpdatedAt}
           id={series.id}
           thumbnailClasses={seriesThumbnailClasses}
           type="series"
@@ -391,7 +381,6 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
     [
       handleResultClick,
       libraryId,
-      searchQuery.dataUpdatedAt,
       seriesThumbnailClasses,
       libraryVariant,
       selectedIndex,

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -615,7 +615,7 @@ export function IdentifyReviewForm({
       ? `/api/books/files/${file.id}/page/${newCoverPage}`
       : undefined);
   const currentCoverUrl = file?.cover_image_filename
-    ? `/api/books/files/${file.id}/cover?t=${new Date(file.updated_at).getTime()}`
+    ? `/api/books/files/${file.id}/cover`
     : undefined;
   const hasCoverChoice = !!newCoverPreviewUrl;
   const [coverSelection, setCoverSelection] = useState<"current" | "new">(

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -615,7 +615,7 @@ export function IdentifyReviewForm({
       ? `/api/books/files/${file.id}/page/${newCoverPage}`
       : undefined);
   const currentCoverUrl = file?.cover_image_filename
-    ? `/api/books/files/${file.id}/cover`
+    ? `/api/books/files/${file.id}/cover?v=${new Date(file.updated_at).getTime()}`
     : undefined;
   const hasCoverChoice = !!newCoverPreviewUrl;
   const [coverSelection, setCoverSelection] = useState<"current" | "new">(

--- a/app/components/library/SelectableBookItem.tsx
+++ b/app/components/library/SelectableBookItem.tsx
@@ -10,6 +10,7 @@ interface SelectableBookItemProps {
   coverAspectRatio?: string;
   addedByUsername?: string;
   pageBookIds: number[];
+  cacheKey?: number;
 }
 
 export const SelectableBookItem = ({
@@ -19,6 +20,7 @@ export const SelectableBookItem = ({
   coverAspectRatio,
   addedByUsername,
   pageBookIds,
+  cacheKey,
 }: SelectableBookItemProps) => {
   const { isSelectionMode, isSelected, toggleBook, selectRange } =
     useBulkSelection();
@@ -27,6 +29,7 @@ export const SelectableBookItem = ({
     <BookItem
       addedByUsername={addedByUsername}
       book={book}
+      cacheKey={cacheKey}
       coverAspectRatio={coverAspectRatio}
       isSelected={isSelected(book.id)}
       isSelectionMode={isSelectionMode}

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -151,7 +151,7 @@ interface FileRowProps {
   isFileSelected?: boolean;
   onToggleSelect?: () => void;
   onMoveFile?: () => void;
-  cacheBuster?: number;
+  cacheKey?: number;
   onDeleteFile: () => void;
   isDeletingFile: boolean;
   isPrimary?: boolean;
@@ -181,7 +181,7 @@ const FileRow = ({
   isFileSelected = false,
   onToggleSelect,
   onMoveFile,
-  cacheBuster,
+  cacheKey,
   onDeleteFile,
   isDeletingFile,
   isPrimary = false,
@@ -235,7 +235,7 @@ const FileRow = ({
       {!isSupplement && (
         <div className="shrink-0 self-start">
           <FileCoverThumbnail
-            cacheBuster={cacheBuster}
+            cacheKey={cacheKey}
             className="h-14"
             file={file}
           />
@@ -807,19 +807,20 @@ const BookDetail = () => {
     );
   };
 
-  // Cache-busting parameter for cover images - computed early for hook ordering
+  // Key source for cover images — used as <img key> so React remounts the
+  // element (triggering HTTP revalidation) when data is refreshed.
   const coverCacheBuster = bookQuery.dataUpdatedAt;
   const coverUrl = bookQuery.data?.id
-    ? `/api/books/${bookQuery.data.id}/cover?t=${coverCacheBuster}`
+    ? `/api/books/${bookQuery.data.id}/cover`
     : null;
 
   // Reset the error flag whenever the URL changes — either because we
   // navigated to a different book, or because a rescan bumped the
-  // cache-buster. If we only reset on book id, a previously-missing cover
+  // coverCacheBuster. If we only reset on book id, a previously-missing cover
   // stays unmounted after a successful rescan until the user refreshes.
   useEffect(() => {
     setCoverError(false);
-  }, [coverUrl]);
+  }, [coverUrl, coverCacheBuster]);
 
   // Check cache synchronously before paint to avoid placeholder flash
   // Must be called before early returns to maintain hook ordering
@@ -1069,10 +1070,7 @@ const BookDetail = () => {
         <div className="lg:col-span-1">
           {mainFiles.length > 1 ? (
             /* Multiple files - show cover gallery with tabs */
-            <CoverGalleryTabs
-              cacheBuster={coverCacheBuster}
-              files={mainFiles}
-            />
+            <CoverGalleryTabs cacheKey={coverCacheBuster} files={mainFiles} />
           ) : (
             /* Single file - show book cover directly */
             <div
@@ -1090,6 +1088,7 @@ const BookDetail = () => {
                 <img
                   alt={`${book.title} Cover`}
                   className={`w-full h-full object-cover rounded-md border border-border ${!coverLoaded ? "opacity-0" : ""}`}
+                  key={coverCacheBuster}
                   onError={() => setCoverError(true)}
                   onLoad={handleCoverLoad}
                   src={coverUrl!}
@@ -1352,7 +1351,7 @@ const BookDetail = () => {
               <div className="space-y-2">
                 {mainFiles.map((file) => (
                   <FileRow
-                    cacheBuster={coverCacheBuster}
+                    cacheKey={coverCacheBuster}
                     file={file}
                     hasExpandableMetadata={hasExpandableMetadata(file)}
                     isDeletingFile={deletingFileId === file.id}
@@ -1403,7 +1402,7 @@ const BookDetail = () => {
                   <div className="space-y-2">
                     {supplements.map((file) => (
                       <FileRow
-                        cacheBuster={coverCacheBuster}
+                        cacheKey={coverCacheBuster}
                         file={file}
                         hasExpandableMetadata={hasExpandableMetadata(file)}
                         isDeletingFile={deletingFileId === file.id}

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -808,10 +808,13 @@ const BookDetail = () => {
   };
 
   // Key source for cover images — used as <img key> so React remounts the
-  // element (triggering HTTP revalidation) when data is refreshed.
+  // element (triggering revalidation) when data is refreshed. Also included
+  // in the URL as ?v= to bypass the browser's in-memory image cache.
   const coverCacheKey = bookQuery.dataUpdatedAt;
   const coverUrl = bookQuery.data?.id
-    ? `/api/books/${bookQuery.data.id}/cover`
+    ? coverCacheKey
+      ? `/api/books/${bookQuery.data.id}/cover?v=${coverCacheKey}`
+      : `/api/books/${bookQuery.data.id}/cover`
     : null;
 
   // Reset the error flag whenever the URL changes — either because we

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -809,18 +809,18 @@ const BookDetail = () => {
 
   // Key source for cover images — used as <img key> so React remounts the
   // element (triggering HTTP revalidation) when data is refreshed.
-  const coverCacheBuster = bookQuery.dataUpdatedAt;
+  const coverCacheKey = bookQuery.dataUpdatedAt;
   const coverUrl = bookQuery.data?.id
     ? `/api/books/${bookQuery.data.id}/cover`
     : null;
 
   // Reset the error flag whenever the URL changes — either because we
   // navigated to a different book, or because a rescan bumped the
-  // coverCacheBuster. If we only reset on book id, a previously-missing cover
+  // coverCacheKey. If we only reset on book id, a previously-missing cover
   // stays unmounted after a successful rescan until the user refreshes.
   useEffect(() => {
     setCoverError(false);
-  }, [coverUrl, coverCacheBuster]);
+  }, [coverUrl, coverCacheKey]);
 
   // Check cache synchronously before paint to avoid placeholder flash
   // Must be called before early returns to maintain hook ordering
@@ -1070,7 +1070,7 @@ const BookDetail = () => {
         <div className="lg:col-span-1">
           {mainFiles.length > 1 ? (
             /* Multiple files - show cover gallery with tabs */
-            <CoverGalleryTabs cacheKey={coverCacheBuster} files={mainFiles} />
+            <CoverGalleryTabs cacheKey={coverCacheKey} files={mainFiles} />
           ) : (
             /* Single file - show book cover directly */
             <div
@@ -1088,7 +1088,7 @@ const BookDetail = () => {
                 <img
                   alt={`${book.title} Cover`}
                   className={`w-full h-full object-cover rounded-md border border-border ${!coverLoaded ? "opacity-0" : ""}`}
-                  key={coverCacheBuster}
+                  key={coverCacheKey}
                   onError={() => setCoverError(true)}
                   onLoad={handleCoverLoad}
                   src={coverUrl!}
@@ -1351,7 +1351,7 @@ const BookDetail = () => {
               <div className="space-y-2">
                 {mainFiles.map((file) => (
                   <FileRow
-                    cacheKey={coverCacheBuster}
+                    cacheKey={coverCacheKey}
                     file={file}
                     hasExpandableMetadata={hasExpandableMetadata(file)}
                     isDeletingFile={deletingFileId === file.id}
@@ -1402,7 +1402,7 @@ const BookDetail = () => {
                   <div className="space-y-2">
                     {supplements.map((file) => (
                       <FileRow
-                        cacheKey={coverCacheBuster}
+                        cacheKey={coverCacheKey}
                         file={file}
                         hasExpandableMetadata={hasExpandableMetadata(file)}
                         isDeletingFile={deletingFileId === file.id}

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -162,7 +162,12 @@ const GenreDetail = () => {
           {genreBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
               {genreBooksQuery.data.map((book) => (
-                <BookItem book={book} key={book.id} libraryId={libraryId!} />
+                <BookItem
+                  book={book}
+                  cacheKey={genreBooksQuery.dataUpdatedAt}
+                  key={book.id}
+                  libraryId={libraryId!}
+                />
               ))}
             </div>
           )}

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -449,6 +449,7 @@ const HomeContent = () => {
   const renderBookItem = (book: Book) => (
     <SelectableBookItem
       book={book}
+      cacheKey={booksQuery.dataUpdatedAt}
       coverAspectRatio={coverAspectRatio}
       key={book.id}
       libraryId={libraryId!}

--- a/app/components/pages/ListDetail.tsx
+++ b/app/components/pages/ListDetail.tsx
@@ -274,6 +274,7 @@ const ListDetail = () => {
               ) : listBooksQuery.isSuccess ? (
                 <DraggableBookList
                   books={books}
+                  cacheKey={listBooksQuery.dataUpdatedAt}
                   isOwner={isOwner}
                   onReorder={handleReorder}
                 />
@@ -294,6 +295,7 @@ const ListDetail = () => {
                         !isOwner ? listBook.added_by_user?.username : undefined
                       }
                       book={listBook.book}
+                      cacheKey={listBooksQuery.dataUpdatedAt}
                       key={listBook.id}
                       libraryId={listBook.book.library_id.toString()}
                     />

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -185,7 +185,12 @@ const PersonDetail = () => {
           {authoredBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
               {authoredBooksQuery.data.map((book) => (
-                <BookItem book={book} key={book.id} libraryId={libraryId!} />
+                <BookItem
+                  book={book}
+                  cacheKey={authoredBooksQuery.dataUpdatedAt}
+                  key={book.id}
+                  libraryId={libraryId!}
+                />
               ))}
             </div>
           )}

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -175,6 +175,7 @@ const SeriesDetail = () => {
               {seriesBooksQuery.data.map((book) => (
                 <BookItem
                   book={book}
+                  cacheKey={seriesBooksQuery.dataUpdatedAt}
                   key={book.id}
                   libraryId={libraryId!}
                   seriesId={seriesId}

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -50,7 +50,7 @@ const SeriesCard = ({
   isAudiobook,
 }: SeriesCardProps) => {
   const [titleRef, isTitleTruncated] = useIsTruncated<HTMLDivElement>();
-  const coverUrl = `/api/series/${seriesItem.id}/cover?t=${new Date(seriesItem.updated_at).getTime()}`;
+  const coverUrl = `/api/series/${seriesItem.id}/cover`;
   const [coverLoaded, setCoverLoaded] = useState(() => isCoverLoaded(coverUrl));
   const [coverError, setCoverError] = useState(false);
   const bookCount = seriesItem.book_count ?? 0;

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -41,6 +41,7 @@ interface SeriesCardProps {
   libraryId: string;
   aspectClass: string;
   isAudiobook: boolean;
+  cacheKey?: number;
 }
 
 const SeriesCard = ({
@@ -48,9 +49,12 @@ const SeriesCard = ({
   libraryId,
   aspectClass,
   isAudiobook,
+  cacheKey,
 }: SeriesCardProps) => {
   const [titleRef, isTitleTruncated] = useIsTruncated<HTMLDivElement>();
-  const coverUrl = `/api/series/${seriesItem.id}/cover`;
+  const coverUrl = cacheKey
+    ? `/api/series/${seriesItem.id}/cover?v=${cacheKey}`
+    : `/api/series/${seriesItem.id}/cover`;
   const [coverLoaded, setCoverLoaded] = useState(() => isCoverLoaded(coverUrl));
   const [coverError, setCoverError] = useState(false);
   const bookCount = seriesItem.book_count ?? 0;
@@ -178,6 +182,7 @@ const SeriesList = () => {
     return (
       <SeriesCard
         aspectClass={aspectClass}
+        cacheKey={seriesQuery.dataUpdatedAt}
         isAudiobook={isAudiobook}
         key={seriesItem.id}
         libraryId={libraryId ?? ""}

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -160,7 +160,12 @@ const TagDetail = () => {
           {tagBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
               {tagBooksQuery.data.map((book) => (
-                <BookItem book={book} key={book.id} libraryId={libraryId!} />
+                <BookItem
+                  book={book}
+                  cacheKey={tagBooksQuery.dataUpdatedAt}
+                  key={book.id}
+                  libraryId={libraryId!}
+                />
               ))}
             </div>
           )}

--- a/docs/superpowers/plans/2026-04-23-cover-cache-control.md
+++ b/docs/superpowers/plans/2026-04-23-cover-cache-control.md
@@ -1,0 +1,1401 @@
+# Cover image cache control — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace URL-based cache busting (`?t=...`) on cover images with HTTP-level conditional requests (`Cache-Control: private, no-cache` + `Last-Modified` → `If-Modified-Since` → `304`), and drop the frontend cache-buster prop cascade.
+
+**Architecture:** Backend cover endpoints emit `Cache-Control: private, no-cache` and rely on Echo's `c.File()` (which wraps `http.ServeContent`) for automatic `Last-Modified` handling and `304 Not Modified` responses. The Kobo handler, which re-encodes on every request, adds manual `If-Modified-Since` short-circuiting so revalidated requests skip the resize work. Frontend drops every `?t=...` query param from cover URLs, removes `cacheBuster` props, and adds `key={bookQuery.dataUpdatedAt}` on `<img>` tags in pages that can mutate covers (so React remount drives HTTP revalidation).
+
+**Tech Stack:** Go + Echo + `net/http` (backend), React + TanStack Query + Vitest (frontend), Caddy (prod reverse proxy, no changes).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-23-cover-cache-control-design.md`
+
+---
+
+## Before starting
+
+Before touching any file, run the existing check suite to establish a green baseline:
+
+```bash
+mise check:quiet
+```
+
+Expected: all checks pass. If anything fails, investigate before starting — the plan assumes a clean starting state.
+
+---
+
+## Task 1: Add Cache-Control to `fileCover` (backend)
+
+**Goal:** `GET /api/books/files/:id/cover` returns `Cache-Control: private, no-cache`. `Last-Modified` is automatic via `c.File()`. Conditional GETs return `304`.
+
+**Files:**
+- Modify: `pkg/books/handlers.go` — `fileCover` function at line 1269
+- Create: `pkg/books/handlers_file_cover_cache_test.go`
+
+---
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `pkg/books/handlers_file_cover_cache_test.go`:
+
+```go
+package books
+
+import (
+	"context"
+	"image"
+	"image/jpeg"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// seedBookWithFileCover creates a library, book, and file with a real cover
+// image on disk. Returns the file ID and the on-disk cover path.
+func seedBookWithFileCover(t *testing.T, ctx context.Context, db *bun.DB) (fileID int, coverPath string) {
+	t.Helper()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	bookDir := filepath.Join(t.TempDir(), "Test Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(bookDir, "test.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0o644))
+
+	coverFilename := "test.epub.cover.jpg"
+	coverPath = filepath.Join(bookDir, coverFilename)
+	coverFile, err := os.Create(coverPath)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 10, 10)), nil))
+	require.NoError(t, coverFile.Close())
+
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filePath,
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	return file.ID, coverPath
+}
+
+func TestFileCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	h := &handler{bookService: NewService(db)}
+
+	fileID, _ := seedBookWithFileCover(t, ctx, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(fileID))
+
+	require.NoError(t, h.fileCover(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.NotEmpty(t, rec.Header().Get("Last-Modified"))
+	assert.NotEmpty(t, rec.Body.Bytes())
+}
+
+func TestFileCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	h := &handler{bookService: NewService(db)}
+
+	fileID, _ := seedBookWithFileCover(t, ctx, db)
+
+	// First GET to capture Last-Modified.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	c1 := e.NewContext(req1, rec1)
+	c1.SetParamNames("id")
+	c1.SetParamValues(strconv.Itoa(fileID))
+	require.NoError(t, h.fileCover(c1))
+	lastModified := rec1.Header().Get("Last-Modified")
+	require.NotEmpty(t, lastModified)
+
+	// Second GET with If-Modified-Since.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("If-Modified-Since", lastModified)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetParamNames("id")
+	c2.SetParamValues(strconv.Itoa(fileID))
+	require.NoError(t, h.fileCover(c2))
+
+	assert.Equal(t, http.StatusNotModified, rec2.Code)
+	assert.Empty(t, rec2.Body.Bytes())
+}
+```
+
+- [ ] **Step 1.2: Run tests and confirm they fail**
+
+```bash
+go test ./pkg/books/ -run TestFileCover_ -v
+```
+
+Expected: both tests FAIL. `TestFileCover_SetsCacheControlPrivateNoCache` fails because `Cache-Control` is empty. `TestFileCover_Returns304WhenIfModifiedSinceMatches` may already pass (Echo's `c.File()` handles the conditional GET on its own, even without setting `Cache-Control`), but one failing test is enough to move on.
+
+- [ ] **Step 1.3: Implement — add Cache-Control header**
+
+In `pkg/books/handlers.go`, modify the `fileCover` function. Find the block (around line 1296) that ends with:
+
+```go
+	coverPath := fileutils.ResolveCoverPath(file.Book.Filepath, coverFilename)
+
+	return errors.WithStack(c.File(coverPath))
+}
+```
+
+Change to:
+
+```go
+	coverPath := fileutils.ResolveCoverPath(file.Book.Filepath, coverFilename)
+
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	return errors.WithStack(c.File(coverPath))
+}
+```
+
+- [ ] **Step 1.4: Run tests and confirm they pass**
+
+```bash
+go test ./pkg/books/ -run TestFileCover_ -v
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add pkg/books/handlers.go pkg/books/handlers_file_cover_cache_test.go
+git commit -m "[Backend] Set Cache-Control: private, no-cache on file cover endpoint"
+```
+
+---
+
+## Task 2: Add Cache-Control to `bookCover` (backend)
+
+**Goal:** Same behavior on `GET /api/books/:id/cover`.
+
+**Files:**
+- Modify: `pkg/books/handlers.go` — `bookCover` function at line 1466
+- Create: `pkg/books/handlers_book_cover_cache_test.go`
+
+---
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Create `pkg/books/handlers_book_cover_cache_test.go`:
+
+```go
+package books
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shishobooks/shisho/pkg/libraries"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+func TestBookCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	bookService := NewService(db)
+	libraryService := libraries.NewService(db)
+	h := &handler{bookService: bookService, libraryService: libraryService}
+
+	fileID, _ := seedBookWithFileCover(t, ctx, db)
+
+	// Look up the book ID via the seeded file.
+	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(file.BookID))
+
+	require.NoError(t, h.bookCover(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.NotEmpty(t, rec.Header().Get("Last-Modified"))
+	assert.NotEmpty(t, rec.Body.Bytes())
+}
+
+func TestBookCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	bookService := NewService(db)
+	libraryService := libraries.NewService(db)
+	h := &handler{bookService: bookService, libraryService: libraryService}
+
+	fileID, _ := seedBookWithFileCover(t, ctx, db)
+	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
+	require.NoError(t, err)
+
+	// First GET.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	c1 := e.NewContext(req1, rec1)
+	c1.SetParamNames("id")
+	c1.SetParamValues(strconv.Itoa(file.BookID))
+	require.NoError(t, h.bookCover(c1))
+	lastModified := rec1.Header().Get("Last-Modified")
+	require.NotEmpty(t, lastModified)
+
+	// Second GET with If-Modified-Since.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("If-Modified-Since", lastModified)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetParamNames("id")
+	c2.SetParamValues(strconv.Itoa(file.BookID))
+	require.NoError(t, h.bookCover(c2))
+
+	assert.Equal(t, http.StatusNotModified, rec2.Code)
+	assert.Empty(t, rec2.Body.Bytes())
+}
+```
+
+If `libraries.NewService` has a different signature in this codebase, match what `pkg/books/handlers_cover_page_test.go` does for handler setup (look for how it wires `libraryService`).
+
+- [ ] **Step 2.2: Run and confirm failure**
+
+```bash
+go test ./pkg/books/ -run TestBookCover_ -v
+```
+
+Expected: `TestBookCover_SetsCacheControlPrivateNoCache` FAILS (no Cache-Control set).
+
+- [ ] **Step 2.3: Implement**
+
+In `pkg/books/handlers.go`, modify `bookCover` (line 1466). The function ends at line 1502 with:
+
+```go
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
+	return errors.WithStack(c.File(coverPath))
+}
+```
+
+Change to:
+
+```go
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	return errors.WithStack(c.File(coverPath))
+}
+```
+
+- [ ] **Step 2.4: Run tests and confirm pass**
+
+```bash
+go test ./pkg/books/ -run TestBookCover_ -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add pkg/books/handlers.go pkg/books/handlers_book_cover_cache_test.go
+git commit -m "[Backend] Set Cache-Control: private, no-cache on book cover endpoint"
+```
+
+---
+
+## Task 3: Change Cache-Control on `seriesCover` (backend)
+
+**Goal:** Replace the current `public, max-age=86400` with `private, no-cache` on `GET /api/series/:id/cover`.
+
+**Files:**
+- Modify: `pkg/series/handlers.go` — header set at line 276 inside `seriesCover` (func at line 231)
+- Create: `pkg/series/handlers_cover_cache_test.go`
+
+---
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Create `pkg/series/handlers_cover_cache_test.go`. Pattern the test DB / seed helpers on `pkg/books/handlers_file_cover_cache_test.go` — create a library, a series, a book linked to the series via `book_series`, a file on disk under the book's directory, and a cover file next to it. The handler under test is `h.seriesCover(c)`.
+
+Assert:
+- First GET: status 200, `Cache-Control: private, no-cache`, `Last-Modified` non-empty, body non-empty.
+- Second GET with `If-Modified-Since: <first Last-Modified>`: status 304, body empty.
+
+If the `pkg/series` package doesn't already have a DB-backed handler test, mirror the setup in `pkg/books/handlers_cover_page_test.go` (which sets up an Echo context + a real SQLite DB via `setupTestDB(t)`). The `series` package uses `book_series` as the join table — insert a `models.BookSeries` row with `book_id`, `series_id`, and `series_number` to associate the book with the series.
+
+- [ ] **Step 3.2: Run and confirm failure**
+
+```bash
+go test ./pkg/series/ -run TestSeriesCover_ -v
+```
+
+Expected: FAIL on `Cache-Control` assertion (currently `public, max-age=86400`).
+
+- [ ] **Step 3.3: Implement**
+
+In `pkg/series/handlers.go`, change the header set at line 276:
+
+Before:
+
+```go
+	// Set appropriate headers
+	c.Response().Header().Set("Cache-Control", "public, max-age=86400")
+
+	return errors.WithStack(c.File(coverImagePath))
+```
+
+After:
+
+```go
+	// Set appropriate headers
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
+
+	return errors.WithStack(c.File(coverImagePath))
+```
+
+- [ ] **Step 3.4: Run and confirm pass**
+
+```bash
+go test ./pkg/series/ -run TestSeriesCover_ -v
+```
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add pkg/series/handlers.go pkg/series/handlers_cover_cache_test.go
+git commit -m "[Backend] Switch series cover endpoint to Cache-Control: private, no-cache"
+```
+
+---
+
+## Task 4: Add Cache-Control to eReader `Cover` (backend)
+
+**Goal:** Same treatment for `pkg/ereader/handlers.go:692`.
+
+**Files:**
+- Modify: `pkg/ereader/handlers.go` — the `Cover` function ends at line 740 with `return errors.WithStack(c.File(coverPath))`
+- Create or extend: `pkg/ereader/handlers_cover_cache_test.go`
+
+---
+
+- [ ] **Step 4.1: Write the failing tests**
+
+Create `pkg/ereader/handlers_cover_cache_test.go`. Follow the same pattern as Tasks 1–3. The handler is `h.Cover`, and the route param is `bookId`. The eReader handler uses API key auth (`apiKey := GetAPIKeyFromContext(ctx)`) — review `pkg/ereader/middleware_test.go` or the existing `handlers_test.go` in that package to see how tests set up the API key context. Tests must:
+
+1. Assert 200 with `Cache-Control: private, no-cache` + `Last-Modified`.
+2. Assert 304 on `If-Modified-Since` match.
+
+- [ ] **Step 4.2: Run and confirm failure**
+
+```bash
+go test ./pkg/ereader/ -run TestCover_ -v
+```
+
+- [ ] **Step 4.3: Implement**
+
+In `pkg/ereader/handlers.go`, modify the `Cover` function (starts line 692). The final return is at line 740:
+
+Before:
+
+```go
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
+	return errors.WithStack(c.File(coverPath))
+}
+```
+
+After:
+
+```go
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	return errors.WithStack(c.File(coverPath))
+}
+```
+
+- [ ] **Step 4.4: Run and confirm pass**
+
+```bash
+go test ./pkg/ereader/ -run TestCover_ -v
+```
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add pkg/ereader/handlers.go pkg/ereader/handlers_cover_cache_test.go
+git commit -m "[Backend] Set Cache-Control: private, no-cache on eReader cover endpoint"
+```
+
+---
+
+## Task 5: Kobo `handleCover` — manual If-Modified-Since short-circuit (backend)
+
+**Goal:** Kobo's resized-cover handler sets `Cache-Control: private, no-cache` and `Last-Modified` from the source cover's mtime. When the client sends `If-Modified-Since` with a timestamp ≥ the source mtime, the handler returns `304 Not Modified` without doing any image decode/resize/encode work. The no-resize branch (`c.File(coverPath)` when width or height is 0) gets automatic handling from Echo — no change needed there.
+
+**Files:**
+- Modify: `pkg/kobo/handlers.go` — `handleCover` function at line 225
+- Create: `pkg/kobo/handlers_cover_cache_test.go`
+
+---
+
+- [ ] **Step 5.1: Write the failing tests**
+
+Create `pkg/kobo/handlers_cover_cache_test.go`. Three tests:
+
+1. `TestHandleCover_SetsCacheControlPrivateNoCache` — GET the resized endpoint (e.g. `/v1/books/<id>/thumbnail/100/150/`). Assert 200, `Cache-Control: private, no-cache`, `Last-Modified` non-empty, non-empty JPEG body.
+2. `TestHandleCover_Returns304WhenIfModifiedSinceMatches` — Second GET with `If-Modified-Since` from the first. Assert 304, empty body.
+3. `TestHandleCover_304SkipsResizeWork` — verify the resize does not execute when 304 is returned. Simplest approach: in the test, replace `coverPath` with a source cover file that would cause `image.Decode` to error (e.g. write garbage bytes). On the 200 path this would fail; on the 304 path it must return 304 before touching the file contents.
+
+   Concretely:
+   - Seed a book with `cover_image_filename` pointing at a valid JPEG.
+   - First GET to get the `Last-Modified`.
+   - Overwrite the cover file on disk with invalid bytes (non-JPEG) but preserve the mtime via `os.Chtimes`.
+   - Second GET with `If-Modified-Since: <Last-Modified>`. Assert 304. If the handler tried to decode/resize, it would return an error — the 304 proves the decode path was skipped.
+
+Mirror the test setup pattern used in existing `pkg/kobo/handlers_test.go`.
+
+- [ ] **Step 5.2: Run and confirm failure**
+
+```bash
+go test ./pkg/kobo/ -run TestHandleCover_ -v
+```
+
+Expected: all three FAIL. Current handler writes `public, max-age=86400`, has no `Last-Modified`, and always runs the resize pipeline.
+
+- [ ] **Step 5.3: Implement**
+
+In `pkg/kobo/handlers.go`, modify `handleCover` (starts line 225). Locate the existing resize block starting at line 250 (`// Parse requested dimensions`) and ending at line 287 (the `jpeg.Encode` return).
+
+Add a block immediately before the existing `widthStr := c.Param("w")` line that:
+1. Stats the cover file to get mtime.
+2. Sets `Cache-Control: private, no-cache` and `Last-Modified`.
+3. Checks `If-Modified-Since` and short-circuits with 304 before any image work.
+
+Ensure `net/http` and `time` are already imported (they are — file already uses `http`).
+
+Before:
+
+```go
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
+
+	// Parse requested dimensions
+	widthStr := c.Param("w")
+	heightStr := c.Param("h")
+	width, _ := strconv.Atoi(widthStr)
+	height, _ := strconv.Atoi(heightStr)
+
+	if width == 0 || height == 0 {
+		// Serve original if dimensions not specified
+		return c.File(coverPath)
+	}
+
+	// Open and resize the image
+	imgFile, err := os.Open(coverPath)
+	if err != nil {
+		return errcodes.NotFound("Cover")
+	}
+	defer imgFile.Close()
+	// ... (decode, resize, encode) ...
+
+	c.Response().Header().Set("Content-Type", "image/jpeg")
+	c.Response().Header().Set("Cache-Control", "public, max-age=86400")
+	c.Response().WriteHeader(http.StatusOK)
+	return jpeg.Encode(c.Response().Writer, dstImg, &jpeg.Options{Quality: 80})
+```
+
+After:
+
+```go
+	coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
+
+	// Stat source cover for Last-Modified + conditional GET short-circuit.
+	// This runs before the resize so revalidated requests skip the expensive
+	// decode/resize/encode work.
+	coverStat, err := os.Stat(coverPath)
+	if err != nil {
+		return errcodes.NotFound("Cover")
+	}
+	modTime := coverStat.ModTime().UTC().Truncate(time.Second)
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	c.Response().Header().Set("Last-Modified", modTime.Format(http.TimeFormat))
+	if ims := c.Request().Header.Get("If-Modified-Since"); ims != "" {
+		if t, parseErr := http.ParseTime(ims); parseErr == nil && !modTime.After(t) {
+			c.Response().WriteHeader(http.StatusNotModified)
+			return nil
+		}
+	}
+
+	// Parse requested dimensions
+	widthStr := c.Param("w")
+	heightStr := c.Param("h")
+	width, _ := strconv.Atoi(widthStr)
+	height, _ := strconv.Atoi(heightStr)
+
+	if width == 0 || height == 0 {
+		// Serve original if dimensions not specified. c.File handles
+		// Last-Modified/If-Modified-Since automatically for this branch.
+		return c.File(coverPath)
+	}
+
+	// Open and resize the image
+	imgFile, err := os.Open(coverPath)
+	if err != nil {
+		return errcodes.NotFound("Cover")
+	}
+	defer imgFile.Close()
+	// ... (existing decode, resize, encode — unchanged) ...
+
+	c.Response().Header().Set("Content-Type", "image/jpeg")
+	c.Response().WriteHeader(http.StatusOK)
+	return jpeg.Encode(c.Response().Writer, dstImg, &jpeg.Options{Quality: 80})
+```
+
+Key edits:
+- Add the stat + conditional GET block right after `coverPath := ...`.
+- Remove the old `c.Response().Header().Set("Cache-Control", "public, max-age=86400")` line immediately above `c.Response().WriteHeader(http.StatusOK)`.
+- Ensure `"time"` is in the import block; add it if missing.
+
+Note: when `width == 0 || height == 0`, `c.File(coverPath)` handles Last-Modified on its own, but we've already set our own `Cache-Control` and `Last-Modified` above. Both are harmless; Echo's `c.File` won't overwrite a `Cache-Control` already on the response.
+
+- [ ] **Step 5.4: Run and confirm pass**
+
+```bash
+go test ./pkg/kobo/ -run TestHandleCover_ -v
+```
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add pkg/kobo/handlers.go pkg/kobo/handlers_cover_cache_test.go
+git commit -m "[Backend] Add If-Modified-Since short-circuit to Kobo cover handler"
+```
+
+---
+
+## Task 6: Update `CoverGalleryTabs.test.tsx` for stable URLs (frontend)
+
+**Goal:** TDD red — update existing tests to assert on stable URLs and a key-driven remount pattern. They will fail until Task 7 is done.
+
+**Files:**
+- Modify: `app/components/library/CoverGalleryTabs.test.tsx`
+
+---
+
+- [ ] **Step 6.1: Replace the test body**
+
+Current test at lines 24-58 asserts `?t=111` and `?t=222` URLs and exercises an error-then-cacheBuster-bump remount. The new behavior: URL is stable, remount is driven by a `cacheKey` prop that changes.
+
+Replace the file's test contents (keep imports and `makeFile` helper) with:
+
+```tsx
+describe("CoverGalleryTabs", () => {
+  it("renders cover image with stable URL (no cache-buster query)", () => {
+    const files = [
+      makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
+      makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
+    ];
+
+    const { container } = render(<CoverGalleryTabs files={files} />);
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("/api/books/files/1/cover");
+  });
+
+  it("re-mounts cover image when cacheKey changes", () => {
+    const files = [
+      makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
+      makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
+    ];
+
+    const { container, rerender } = render(
+      <CoverGalleryTabs cacheKey={111} files={files} />,
+    );
+    const firstImg = container.querySelector("img");
+    expect(firstImg).not.toBeNull();
+    expect(firstImg?.getAttribute("src")).toBe("/api/books/files/1/cover");
+
+    // Simulate an error first so the img is unmounted, then a cacheKey bump
+    // should cause it to re-mount (simulating a "retry" after the cover was
+    // fixed on disk — equivalent to the old cacheBuster-driven retry flow).
+    fireEvent.error(firstImg!);
+    expect(container.querySelector("img")).toBeNull();
+
+    rerender(<CoverGalleryTabs cacheKey={222} files={files} />);
+    const secondImg = container.querySelector("img");
+    expect(secondImg).not.toBeNull();
+    expect(secondImg?.getAttribute("src")).toBe("/api/books/files/1/cover");
+  });
+});
+```
+
+- [ ] **Step 6.2: Run and confirm failure**
+
+```bash
+pnpm test -- app/components/library/CoverGalleryTabs.test.tsx
+```
+
+Expected: FAIL — `cacheKey` prop doesn't exist yet; tests assert `src` exactly `/api/books/files/1/cover` but current code produces `/api/books/files/1/cover` only when `cacheBuster` is undefined (actually passes the first test), and the rerender path still requires new prop.
+
+- [ ] **Step 6.3: Commit (tests only, still red)**
+
+```bash
+git add app/components/library/CoverGalleryTabs.test.tsx
+git commit -m "[Test] Update CoverGalleryTabs tests for stable cover URLs"
+```
+
+---
+
+## Task 7: Update `CoverGalleryTabs.tsx` — drop cacheBuster, add cacheKey
+
+**Goal:** Component uses a stable URL and accepts a `cacheKey` prop used as the `<img key>` for remounting. Makes Task 6's tests pass.
+
+**Files:**
+- Modify: `app/components/library/CoverGalleryTabs.tsx`
+
+---
+
+- [ ] **Step 7.1: Rewrite the component's props and URL**
+
+Change the props interface (line 14-18) from:
+
+```tsx
+interface CoverGalleryTabsProps {
+  files: File[];
+  className?: string;
+  cacheBuster?: number;
+}
+```
+
+to:
+
+```tsx
+interface CoverGalleryTabsProps {
+  files: File[];
+  className?: string;
+  /**
+   * Forces the <img> to remount (and thus re-request) when this value changes.
+   * Typically set to a React Query `dataUpdatedAt` so cover updates triggered
+   * by mutations on this page flow through HTTP revalidation.
+   */
+  cacheKey?: number;
+}
+```
+
+Change the destructuring at lines 59-63:
+
+```tsx
+function CoverGalleryTabs({
+  files,
+  className,
+  cacheKey,
+}: CoverGalleryTabsProps) {
+```
+
+Replace the `coverUrl` construction at lines 83-87:
+
+```tsx
+  const coverUrl = selectedFile
+    ? `/api/books/files/${selectedFile.id}/cover`
+    : null;
+```
+
+On the `<img>` at line 146, add a `key` prop:
+
+```tsx
+        {hasCover && coverUrl && (
+          <img
+            alt={`${selectedFile?.name || "File"} Cover`}
+            className={cn(
+              "absolute inset-0 w-full h-full object-cover",
+              !coverLoaded && "opacity-0",
+            )}
+            key={`${selectedFile?.id}-${cacheKey ?? 0}`}
+            onError={() => setCoverError(true)}
+            onLoad={handleCoverLoad}
+            src={coverUrl}
+          />
+        )}
+```
+
+Note the key combines `selectedFile.id` (tab switch drives remount) and `cacheKey` (external bump drives remount). The existing `useEffect` at line 106-108 that resets `coverError` on `coverUrl` change can stay, but update its dependency from `[coverUrl]` to `[coverUrl, cacheKey]` so error state also resets when the key bumps:
+
+```tsx
+  useEffect(() => {
+    setCoverError(false);
+  }, [coverUrl, cacheKey]);
+```
+
+- [ ] **Step 7.2: Run tests and confirm pass**
+
+```bash
+pnpm test -- app/components/library/CoverGalleryTabs.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add app/components/library/CoverGalleryTabs.tsx
+git commit -m "[Frontend] Stable cover URL + cacheKey remount prop on CoverGalleryTabs"
+```
+
+---
+
+## Task 8: Update `FileCoverThumbnail.tsx` — drop cacheBuster, add cacheKey
+
+**Goal:** Same transform as Task 7 for the thumbnail component.
+
+**Files:**
+- Modify: `app/components/library/FileCoverThumbnail.tsx`
+
+---
+
+- [ ] **Step 8.1: Rewrite the component**
+
+Replace the whole file contents with:
+
+```tsx
+import { useState } from "react";
+
+import CoverPlaceholder from "@/components/library/CoverPlaceholder";
+import { cn } from "@/libraries/utils";
+import type { File } from "@/types";
+
+interface FileCoverThumbnailProps {
+  file: File;
+  className?: string;
+  onClick?: () => void;
+  /**
+   * Forces the <img> to remount (and thus re-request) when this value changes.
+   * Typically a React Query `dataUpdatedAt` from a mutation-aware query.
+   */
+  cacheKey?: number;
+}
+
+/**
+ * Small cover thumbnail for a file.
+ * Shows the file's cover image or a placeholder based on file type.
+ * Aspect ratio: 2:3 for EPUB/CBZ, square for M4B.
+ */
+function FileCoverThumbnail({
+  file,
+  className,
+  onClick,
+  cacheKey,
+}: FileCoverThumbnailProps) {
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  const isAudiobook = file.file_type === "m4b";
+  const aspectClass = isAudiobook ? "aspect-square" : "aspect-[2/3]";
+  const placeholderVariant = isAudiobook ? "audiobook" : "book";
+
+  const hasCover = file.cover_image_filename && !imageError;
+  const coverUrl = `/api/books/files/${file.id}/cover`;
+
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded border border-border shrink-0 cursor-pointer",
+        "transition-all duration-200 hover:scale-105 hover:shadow-md",
+        aspectClass,
+        className,
+      )}
+      onClick={onClick}
+    >
+      {(!imageLoaded || !hasCover) && (
+        <CoverPlaceholder
+          className="absolute inset-0"
+          variant={placeholderVariant}
+        />
+      )}
+
+      {hasCover && (
+        <img
+          alt=""
+          className={cn(
+            "absolute inset-0 w-full h-full object-cover",
+            !imageLoaded && "opacity-0",
+          )}
+          key={`${file.id}-${cacheKey ?? 0}`}
+          onError={() => setImageError(true)}
+          onLoad={() => setImageLoaded(true)}
+          src={coverUrl}
+        />
+      )}
+    </div>
+  );
+}
+
+export default FileCoverThumbnail;
+```
+
+- [ ] **Step 8.2: Check type errors in callers**
+
+```bash
+pnpm lint:types
+```
+
+Expected: errors wherever `FileCoverThumbnail` is called with `cacheBuster={...}` — those are fixed in the next tasks. If any caller passes a `cacheBuster` prop, that's a type error now.
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+git add app/components/library/FileCoverThumbnail.tsx
+git commit -m "[Frontend] Stable cover URL + cacheKey remount prop on FileCoverThumbnail"
+```
+
+(The commit may temporarily break type-checking in files that pass `cacheBuster`. Those are fixed in the next tasks. This is acceptable as a mid-sequence state; all callers are fixed before the final commit.)
+
+---
+
+## Task 9: Update `FileEditDialog.tsx` — stable URLs + key on inline imgs + rename prop
+
+**Goal:** The two inline `<img>` tags at lines 753 and 780 drop their `?t=` query params and get a `key` for remount. Any `FileCoverThumbnail`/`CoverGalleryTabs` invocations inside this file pass `cacheKey` instead of `cacheBuster`.
+
+**Files:**
+- Modify: `app/components/library/FileEditDialog.tsx`
+
+---
+
+- [ ] **Step 9.1: Find the caching-related passes and update them**
+
+In `FileEditDialog.tsx`:
+
+1. Read the file to locate `coverCacheBuster` (or whatever local variable drives the current `?t=` calls). Search for `?t=` — you should find two hits at lines 753 and 780.
+
+2. For each of the two inline `<img>` tags, change:
+
+```tsx
+<img
+  ...
+  src={`/api/books/files/${file.id}/cover?t=${coverCacheBuster}`}
+/>
+```
+
+to:
+
+```tsx
+<img
+  ...
+  key={`${file.id}-${coverCacheBuster}`}
+  src={`/api/books/files/${file.id}/cover`}
+/>
+```
+
+3. If `coverCacheBuster` is a prop passed into `FileEditDialog`, rename it to `cacheKey` throughout the file — prop interface, destructuring, and uses. If it's a local variable derived from a query's `dataUpdatedAt`, leave the variable name alone but ensure it is used only as a `key`, never in the URL.
+
+4. If this file renders `<FileCoverThumbnail cacheBuster={...}>` or `<CoverGalleryTabs cacheBuster={...}>`, rename those prop names to `cacheKey`.
+
+- [ ] **Step 9.2: Verify no `?t=` remains in this file**
+
+```bash
+grep -n '?t=' app/components/library/FileEditDialog.tsx
+```
+
+Expected: no output.
+
+- [ ] **Step 9.3: Type-check**
+
+```bash
+pnpm lint:types
+```
+
+Expected: no errors reported from `FileEditDialog.tsx`. If there are errors in other files (e.g., `BookDetail.tsx` passing `cacheBuster` to this dialog), those are fixed in Task 10.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add app/components/library/FileEditDialog.tsx
+git commit -m "[Frontend] Stable cover URLs + key-driven remount in FileEditDialog"
+```
+
+---
+
+## Task 10: Update `BookDetail.tsx` — drop coverCacheBuster from URLs, keep as key source
+
+**Goal:** `BookDetail` uses stable cover URLs. The existing `coverCacheBuster` constant (`bookQuery.dataUpdatedAt`) is repurposed as a React `key` on the main cover `<img>` and is passed down as `cacheKey` to `CoverGalleryTabs` and `FileCoverThumbnail`.
+
+**Files:**
+- Modify: `app/components/pages/BookDetail.tsx`
+
+---
+
+- [ ] **Step 10.1: Drop the cache-buster from the main cover URL**
+
+Find the line defining the main cover URL (currently at line 811-813):
+
+```tsx
+const coverCacheBuster = bookQuery.dataUpdatedAt;
+...
+  ? `/api/books/${bookQuery.data.id}/cover?t=${coverCacheBuster}`
+```
+
+Replace the URL (line 813) with:
+
+```tsx
+  ? `/api/books/${bookQuery.data.id}/cover`
+```
+
+Leave the `coverCacheBuster` constant alone — it's still used as a `key` source.
+
+- [ ] **Step 10.2: Add `key` to the main cover `<img>`**
+
+Find the `<img>` element that uses the above `src` (search for the line that renders the main cover image around line 815+). Add:
+
+```tsx
+key={coverCacheBuster}
+```
+
+- [ ] **Step 10.3: Rename prop passes from `cacheBuster` to `cacheKey`**
+
+There are four existing call sites at lines 238, 1073, 1355, 1406 passing `cacheBuster={coverCacheBuster}` to child components. Change each to:
+
+```tsx
+cacheKey={coverCacheBuster}
+```
+
+- [ ] **Step 10.4: Verify**
+
+```bash
+grep -n '?t=' app/components/pages/BookDetail.tsx
+grep -n 'cacheBuster' app/components/pages/BookDetail.tsx
+```
+
+Expected: no output from either.
+
+- [ ] **Step 10.5: Type-check and run tests**
+
+```bash
+pnpm lint:types
+pnpm test -- app/components
+```
+
+Expected: no type errors, all component tests pass.
+
+- [ ] **Step 10.6: Commit**
+
+```bash
+git add app/components/pages/BookDetail.tsx
+git commit -m "[Frontend] Stable cover URL + cacheKey plumbing in BookDetail"
+```
+
+---
+
+## Task 11: Update `GlobalSearch.tsx` — drop cacheBuster prop on `SearchResultCover`
+
+**Goal:** `SearchResultCover` uses stable URL. No `cacheBuster` prop. No key needed (search dropdown doesn't mutate covers; new searches remount naturally).
+
+**Files:**
+- Modify: `app/components/library/GlobalSearch.tsx`
+
+---
+
+- [ ] **Step 11.1: Update the component**
+
+In `GlobalSearch.tsx`, change `SearchResultCoverProps` (lines 47-53) to remove `cacheBuster`:
+
+```tsx
+interface SearchResultCoverProps {
+  type: "book" | "series";
+  id: number;
+  thumbnailClasses: string;
+  variant: "book" | "audiobook";
+}
+```
+
+Update `SearchResultCover` destructuring (lines 55-61):
+
+```tsx
+const SearchResultCover = ({
+  type,
+  id,
+  thumbnailClasses,
+  variant,
+}: SearchResultCoverProps) => {
+```
+
+Update `coverUrl` (line 62):
+
+```tsx
+const coverUrl = `/api/${type === "book" ? "books" : "series"}/${id}/cover`;
+```
+
+Update the two call sites at lines 333 and 377 to remove the `cacheBuster={searchQuery.dataUpdatedAt}` prop.
+
+- [ ] **Step 11.2: Verify**
+
+```bash
+grep -n '?t=\|cacheBuster' app/components/library/GlobalSearch.tsx
+```
+
+Expected: no output.
+
+- [ ] **Step 11.3: Type-check**
+
+```bash
+pnpm lint:types
+```
+
+- [ ] **Step 11.4: Commit**
+
+```bash
+git add app/components/library/GlobalSearch.tsx
+git commit -m "[Frontend] Stable cover URLs in GlobalSearch; drop cacheBuster prop"
+```
+
+---
+
+## Task 12: Update `BookItem.tsx` — drop `?t=`
+
+**Files:**
+- Modify: `app/components/library/BookItem.tsx`
+
+---
+
+- [ ] **Step 12.1: Change the URL**
+
+Find line 154:
+
+```tsx
+const coverUrl = `/api/books/${book.id}/cover?t=${new Date(book.updated_at).getTime()}`;
+```
+
+Change to:
+
+```tsx
+const coverUrl = `/api/books/${book.id}/cover`;
+```
+
+No key needed — BookItem is a list-grid item that doesn't mutate covers from its own view.
+
+- [ ] **Step 12.2: Verify and commit**
+
+```bash
+grep -n '?t=' app/components/library/BookItem.tsx
+```
+
+Expected: no output.
+
+```bash
+git add app/components/library/BookItem.tsx
+git commit -m "[Frontend] Stable cover URL in BookItem"
+```
+
+---
+
+## Task 13: Update `SeriesList.tsx` — drop `?t=`
+
+**Files:**
+- Modify: `app/components/pages/SeriesList.tsx`
+
+---
+
+- [ ] **Step 13.1: Change the URL**
+
+Find line 53:
+
+```tsx
+const coverUrl = `/api/series/${seriesItem.id}/cover?t=${new Date(seriesItem.updated_at).getTime()}`;
+```
+
+Change to:
+
+```tsx
+const coverUrl = `/api/series/${seriesItem.id}/cover`;
+```
+
+- [ ] **Step 13.2: Verify and commit**
+
+```bash
+grep -n '?t=' app/components/pages/SeriesList.tsx
+git add app/components/pages/SeriesList.tsx
+git commit -m "[Frontend] Stable cover URL in SeriesList"
+```
+
+---
+
+## Task 14: Update `IdentifyReviewForm.tsx` — drop `?t=`
+
+**Files:**
+- Modify: `app/components/library/IdentifyReviewForm.tsx`
+
+---
+
+- [ ] **Step 14.1: Change the URL**
+
+Find line 616-618:
+
+```tsx
+const currentCoverUrl = file?.cover_image_filename
+  ? `/api/books/files/${file.id}/cover?t=${new Date(file.updated_at).getTime()}`
+  : undefined;
+```
+
+Change to:
+
+```tsx
+const currentCoverUrl = file?.cover_image_filename
+  ? `/api/books/files/${file.id}/cover`
+  : undefined;
+```
+
+No key needed — the form is displayed during an identify flow; once accepted, the user navigates away.
+
+- [ ] **Step 14.2: Verify and commit**
+
+```bash
+grep -n '?t=' app/components/library/IdentifyReviewForm.tsx
+git add app/components/library/IdentifyReviewForm.tsx
+git commit -m "[Frontend] Stable cover URL in IdentifyReviewForm"
+```
+
+---
+
+## Task 15: Update root `CLAUDE.md` — Critical Gotchas
+
+**Files:**
+- Modify: `CLAUDE.md` (lines 86-92)
+
+---
+
+- [ ] **Step 15.1: Replace the section**
+
+Current text (lines 86-92):
+
+```markdown
+### Frontend
+
+**Cover images need cache busting** — All cover image URLs must include a `?t=` parameter to ensure updated covers display without caching issues:
+```tsx
+const coverUrl = `/api/books/${id}/cover?t=${query.dataUpdatedAt}`;
+```
+```
+
+Replace with:
+
+```markdown
+### Frontend
+
+**Cover images use HTTP revalidation, not URL cache-busting** — Cover endpoints set `Cache-Control: private, no-cache` and rely on `Last-Modified` for revalidation. Never append `?t=...` query params to cover URLs. For pages that can trigger cover mutations, add `key={query.dataUpdatedAt}` to the `<img>` so React remounts it and the browser refetches:
+
+```tsx
+<img key={bookQuery.dataUpdatedAt} src={`/api/books/${id}/cover`} />
+```
+```
+
+- [ ] **Step 15.2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "[Docs] Update root CLAUDE.md for cover HTTP revalidation"
+```
+
+---
+
+## Task 16: Update `app/CLAUDE.md` — Cover Image Freshness section
+
+**Files:**
+- Modify: `app/CLAUDE.md` (lines 296-340 — the "Cover Image Cache Busting" section)
+
+---
+
+- [ ] **Step 16.1: Replace the section**
+
+Delete the existing section from line 296 to line 340 (the section starting `## Cover Image Cache Busting` through the end of the "Checklist for New Cover Components" list). Replace with:
+
+```markdown
+## Cover Image Freshness
+
+Cover endpoints set `Cache-Control: private, no-cache` and emit `Last-Modified` from the cover file's mtime. The browser stores the image but revalidates with the server on every `<img>` mount via a conditional `GET` carrying `If-Modified-Since`. The server returns `304 Not Modified` (no body) when the cover is unchanged, or `200 OK` with new bytes when it has changed.
+
+### Rules
+
+- **Do not append `?t=...`** or any other cache-busting query parameter to cover URLs. Use stable URLs:
+  ```tsx
+  const coverUrl = `/api/books/${book.id}/cover`;
+  ```
+- **For pages that can trigger a cover mutation** (e.g., BookDetail, FileEditDialog), add `key={query.dataUpdatedAt}` to the `<img>` tag. A query invalidation bumps `dataUpdatedAt`, the key changes, React remounts the element, and the browser makes a fresh HTTP request that revalidates:
+  ```tsx
+  <img
+    key={bookQuery.dataUpdatedAt}
+    src={`/api/books/${book.id}/cover`}
+  />
+  ```
+- **For pages that only display covers** (lists, grids, search results), no `key` is needed. Navigation naturally remounts the `<img>`, which triggers revalidation.
+- **For child components that render covers inside editing surfaces**, pass a `cacheKey` prop (typed as `number`) down and use it as part of the `<img key>`. Parents should pass `bookQuery.dataUpdatedAt`.
+
+### Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `/api/books/{id}/cover` | Book cover (selected from files) |
+| `/api/books/files/{id}/cover` | Specific file's cover |
+| `/api/series/{id}/cover` | Series cover (from first book) |
+
+### Checklist for new cover components
+
+- [ ] Cover URL does NOT include `?t=` query param
+- [ ] For pages that mutate covers, `<img>` has `key={query.dataUpdatedAt}` (or is driven by a `cacheKey` prop) so remount triggers revalidation
+- [ ] Cover-mutating mutations invalidate the query whose `dataUpdatedAt` drives the key (default: `RetrieveBook`, already invalidated by `useUploadFileCover` and `useSetFileCoverPage`)
+```
+
+- [ ] **Step 16.2: Commit**
+
+```bash
+git add app/CLAUDE.md
+git commit -m "[Docs] Rewrite cover freshness section in app/CLAUDE.md"
+```
+
+---
+
+## Task 17: Full verification pass
+
+**Goal:** Confirm everything compiles, lints, tests green, and covers behave correctly end-to-end.
+
+---
+
+- [ ] **Step 17.1: Run full check suite**
+
+```bash
+mise check:quiet
+```
+
+Expected: all checks pass. If anything fails, fix the underlying issue before proceeding.
+
+- [ ] **Step 17.2: Grep for any remaining cache-buster references**
+
+```bash
+grep -rn '?t=' app --include='*.tsx' --include='*.ts' | grep -v node_modules | grep -iv '\.test\.' | grep -i cover
+grep -rn 'cacheBuster' app --include='*.tsx' --include='*.ts' | grep -v node_modules
+```
+
+Expected: no results from either command (test files may still reference the old pattern if any lingered — investigate if so).
+
+- [ ] **Step 17.3: Manual browser verification**
+
+Start the dev environment:
+
+```bash
+mise start
+```
+
+In the browser:
+1. Open a book detail page. Open DevTools → Network tab.
+2. Observe the initial cover request: `200 OK`, response headers include `Cache-Control: private, no-cache` and `Last-Modified`.
+3. Reload the page. Observe the cover request: `304 Not Modified` with a small response body (few hundred bytes).
+4. Upload a new cover from the book detail page. Observe the cover visibly update on the page without a full reload.
+5. Navigate to the series list page that contains this book's series. Observe the series cover shows the new book cover (if the book drives the series cover).
+6. Navigate to the series detail page. Observe the book's cover in the books-in-series list is the new one.
+7. Open global search, type the book title, observe the thumbnail in the dropdown is the new cover.
+
+- [ ] **Step 17.4: Verify Caddy prod-mode behavior (optional but recommended)**
+
+If feasible, build and run against Caddy locally:
+
+```bash
+mise build
+# Then run the built binary and point Caddy at it per project docs.
+```
+
+Repeat Step 17.3 items 1-3 through Caddy. Confirm `Cache-Control`, `Last-Modified`, and `304` pass through untouched. Caddy adds no additional caching; these headers are transparent.
+
+- [ ] **Step 17.5: Final commit (if any fixups were needed)**
+
+If steps 17.1-17.3 uncovered issues and you made fixup commits, that's fine. If the tree is clean at the end, nothing more to commit.
+
+---
+
+## Self-review
+
+**Spec coverage check:**
+
+- Backend `Cache-Control` on `bookCover` ✓ (Task 2)
+- Backend `Cache-Control` on `fileCover` ✓ (Task 1)
+- Backend `Cache-Control` on `seriesCover` ✓ (Task 3)
+- Backend `Cache-Control` on eReader `Cover` ✓ (Task 4)
+- Kobo manual 304 handling ✓ (Task 5)
+- Kobo test that 304 skips resize work ✓ (Task 5 step 5.1 test #3)
+- `Last-Modified` via `c.File()` — implicit, no action needed ✓
+- No `ETag` — covered by not adding one ✓
+- No backend scan-path / `book.updated_at` bumping — explicitly out of scope, no tasks for it ✓
+- Frontend stable URLs (9 call sites) ✓ (Tasks 7-14)
+- Remove `cacheBuster` prop cascade ✓ (Tasks 7, 8, 9, 10, 11)
+- `key={dataUpdatedAt}` on pages that mutate covers ✓ (Tasks 7, 8, 9, 10)
+- No `SeriesBooks` invalidation added — confirmed unnecessary ✓
+- `coverCache` utility kept as-is ✓ (no task touches it)
+- Caddy no-op ✓ (Task 17 step 17.4 verifies)
+- Dev mode no-op ✓ (Task 17 step 17.3 verifies)
+- Test coverage: 2 tests per endpoint backend + 1 Kobo extra + updated CoverGalleryTabs tests ✓
+- `CLAUDE.md` root update ✓ (Task 15)
+- `app/CLAUDE.md` rewrite ✓ (Task 16)
+- `CHANGELOG.md` — no retroactive edits; new entry lands with release flow ✓
+
+**Placeholder scan:** No `TBD`, `TODO`, `FIXME`, or `"fill in later"` in any task. All test bodies and code snippets are concrete.
+
+**Type consistency:** The new prop name `cacheKey` is used consistently across `CoverGalleryTabs`, `FileCoverThumbnail`, and their callers (`BookDetail`, `FileEditDialog`). The `<img key>` pattern is `${id}-${cacheKey ?? 0}` across both components. `GlobalSearch` doesn't need the prop and the prop removal is clean.
+
+No spec requirement without a corresponding task.

--- a/docs/superpowers/specs/2026-04-23-cover-cache-control-design.md
+++ b/docs/superpowers/specs/2026-04-23-cover-cache-control-design.md
@@ -205,3 +205,16 @@ No retroactive edits — existing entries at lines 357 and 473 are release snaps
 ## Open questions
 
 None. Ready for implementation plan.
+
+---
+
+## Errata (post-merge)
+
+The original design assumed `Cache-Control: private, no-cache` + `Last-Modified` would force browsers to revalidate on every `<img>` mount with the same URL. **This was incorrect.** Chromium and Firefox maintain an in-memory image cache separate from the HTTP cache; when an `<img>` element's src matches a URL previously rendered, the browser serves the cached decoded bitmap without consulting HTTP.
+
+The corrective design:
+- Cover URLs include `?v=${cacheKey}` where `cacheKey` bumps on data refetches (typically `query.dataUpdatedAt` or `file.updated_at`).
+- Backend `Cache-Control: private, no-cache` + `Last-Modified` retained as defense-in-depth and for WebKit clients, which do revalidate correctly.
+- React `<img key>` remount pattern retained (still useful for same-page mutation flows).
+
+See `app/CLAUDE.md` "Cover Image Freshness" section for authoritative current documentation and references to the relevant browser bug reports.

--- a/docs/superpowers/specs/2026-04-23-cover-cache-control-design.md
+++ b/docs/superpowers/specs/2026-04-23-cover-cache-control-design.md
@@ -1,0 +1,207 @@
+# Cover image cache control — design
+
+**Date:** 2026-04-23
+**Branch:** `task/series-cache-busting`
+**Status:** Design
+
+## Problem
+
+Cover images displayed in the React frontend sometimes fail to update after the underlying cover is replaced on the server. A user updating a cover from the book detail page saw the new cover there, but the series detail page kept showing the old one — even after hard refresh — unless DevTools had "Disable cache" enabled.
+
+### Root cause
+
+Two overlapping issues in the current cache-busting scheme:
+
+1. **Stale URL cache buster.** Cover URLs in the frontend include a `?t=<timestamp>` query parameter derived from the owning entity's `updated_at` field (e.g., `book.updated_at`, `series.updated_at`). Cover mutations on the backend (`uploadFileCover`, `updateFileCoverPage`, and scan-path cover regeneration in `recoverMissingCover` / `applyPageCover` / the reset-extract block) update the `file` row but never bump `book.updated_at` or `series.updated_at`. So the `?t=` value never changes, the URL stays identical, and the browser serves the cached image — even after a full page refresh, because the server response still sets `Cache-Control: public, max-age=86400` on series covers and relies on heuristic caching on book/file covers.
+2. **Missing query invalidation.** The `SeriesBooks` query isn't invalidated when a book cover is uploaded, so even soft-nav to the series detail page returns stale data. Secondary issue — would be masked on reload.
+
+### Why the obvious fix is wrong
+
+Bumping `book.updated_at` from every cover-writing code path would work, but it (a) conflates "book row changed" with "file row changed", (b) requires touching six call sites in services/handlers/scan plus their tests, and (c) still leaves the system dependent on correct timestamp propagation for cache correctness. That's a fragile design that has already produced this class of bug.
+
+## Goals
+
+- Cover updates become immediately visible across all views without cache-buster query parameters.
+- Mechanism is HTTP-native (conditional requests) rather than application-level timestamp tracking.
+- Works in dev (Vite) and prod (Caddy reverse proxy) with no infrastructure changes.
+- Frontend code becomes simpler: no cache buster props, no timestamp passing, stable cover URLs.
+
+## Non-goals
+
+- Changing cover storage or generation logic on the server.
+- Changing query invalidation patterns beyond what the design requires.
+- Modifying Kobo or eReader device sync behavior beyond updating their cover endpoints to use the same caching model.
+- User-facing documentation (`website/docs/`) — this is an internal implementation change with no observable API/config surface.
+
+## Design
+
+### Backend — `Cache-Control: private, no-cache` + Last-Modified
+
+All cover endpoints set `Cache-Control: private, no-cache` on every response. This tells the browser to store the image but revalidate with the server before each use, via a conditional `GET` carrying `If-Modified-Since: <last mtime>`. The server returns `304 Not Modified` (a few hundred bytes, no body) when the cover file on disk hasn't changed, or `200 OK` with the new image bytes when it has.
+
+No explicit `ETag` is used. Echo's `c.File()` delegates to `http.ServeFile` → `http.ServeContent`, which already emits `Last-Modified` from the file's mtime and handles `If-Modified-Since` automatically. A hypothetical `ETag` built from mtime+size would duplicate `Last-Modified` with no added precision; content hashing on every request is too expensive to justify.
+
+`private` ensures shared proxies (CDNs, ISP caches) don't store these responses, which is required because cover endpoints are session-authenticated.
+
+#### Endpoint-by-endpoint changes
+
+| Handler | File:line | Current `Cache-Control` | New | Notes |
+|---|---|---|---|---|
+| `bookCover` | `pkg/books/handlers.go:1466` | _(none)_ | `private, no-cache` | Uses `c.File()` — `Last-Modified` + conditional GET handled automatically |
+| `fileCover` | `pkg/books/handlers.go:1269` | _(none)_ | `private, no-cache` | Same as above |
+| `seriesCover` | `pkg/series/handlers.go` (header set at `:276`) | `public, max-age=86400` | `private, no-cache` | Same as above |
+| eReader `Cover` | `pkg/ereader/handlers.go:692` | _(none)_ | `private, no-cache` | Uses `c.File()` — same free handling |
+| Kobo resized cover | `pkg/kobo/handlers.go:285` | `public, max-age=86400` | `private, no-cache` | **Manual 304 handling required** — see below |
+
+#### Kobo special case
+
+The Kobo handler reads the cover file, decodes, resizes, and re-encodes into JPEG on every request, writing directly to `c.Response().Writer`. It does not use `c.File()`, so `http.ServeContent`'s automatic `Last-Modified` / `If-Modified-Since` machinery is not involved. To get conditional-request behavior without doing the expensive resize work on every request:
+
+1. Stat the source cover file to get its mtime.
+2. Set `Last-Modified: <formatted mtime>` on the response.
+3. Parse `If-Modified-Since` from the request. If the request's timestamp is ≥ the source mtime, write `304 Not Modified` and return without doing any image work.
+4. Otherwise, proceed with the resize/encode as today.
+
+This is standard `net/http` behavior and can be implemented in ~10 lines.
+
+### Frontend — stable URLs + remount-on-mutation
+
+Cover URLs become stable — no query parameters:
+
+- `` `/api/books/${id}/cover` ``
+- `` `/api/books/files/${id}/cover` ``
+- `` `/api/series/${id}/cover` ``
+
+#### Call sites updated
+
+Nine cover-URL construction sites drop `?t=...`:
+
+| File | Line(s) |
+|---|---|
+| `app/components/library/BookItem.tsx` | 154 |
+| `app/components/pages/SeriesList.tsx` | 53 |
+| `app/components/library/GlobalSearch.tsx` | 62 |
+| `app/components/pages/BookDetail.tsx` | 813 |
+| `app/components/library/FileCoverThumbnail.tsx` | 33-35 |
+| `app/components/library/FileEditDialog.tsx` | 753, 780 |
+| `app/components/library/CoverGalleryTabs.tsx` | 84-86 |
+| `app/components/library/IdentifyReviewForm.tsx` | 617 |
+
+#### Prop/state cleanup
+
+Remove `cacheBuster` props and associated state:
+
+- `FileCoverThumbnail`: drop `cacheBuster?: number` prop.
+- `CoverGalleryTabs`: drop `cacheBuster?: number` prop.
+- `GlobalSearch` (internal `GlobalSearchCoverImage`): drop `cacheBuster: number` prop.
+- `BookDetail.tsx`: drop `const coverCacheBuster = bookQuery.dataUpdatedAt;` and its four call-site uses (lines 238, 1073, 1355, 1406).
+
+#### Remount pattern for same-page updates
+
+When the user triggers a cover mutation on the same page where a cover is displayed (e.g., uploading from `BookDetail`), the `<img>` is already mounted with the stable URL. Invalidating a query doesn't change the `src` string, so React reconciliation leaves the DOM node alone, the browser doesn't refetch, and the user sees the old cover.
+
+The fix: add `key={<query>.dataUpdatedAt}` to the `<img>` element. When the relevant query refetches after invalidation, `dataUpdatedAt` changes, the key changes, React unmounts and remounts the element, and the browser makes a fresh HTTP request — which triggers the `Last-Modified` revalidation flow and pulls in the new bytes.
+
+Components that need the key:
+
+| Component | Key source |
+|---|---|
+| `BookDetail.tsx` — main book `<img>` | `bookQuery.dataUpdatedAt` |
+| `CoverGalleryTabs.tsx` — selected-file `<img>` | `bookQuery.dataUpdatedAt` (passed as prop) |
+| `FileCoverThumbnail.tsx` — used inside `FileEditDialog` | `bookQuery.dataUpdatedAt` (passed as prop) |
+| `FileEditDialog.tsx` — the two inline `<img>`s (753, 780) | `bookQuery.dataUpdatedAt` |
+
+Components that display covers but can't trigger cover mutations from their own page do not need a key — navigating to them naturally remounts the `<img>`, which revalidates via `Last-Modified`. This includes `SeriesList`, `SeriesDetail`, `GlobalSearch`, `BookItem`, `IdentifyReviewForm`, and `Home`.
+
+#### Query invalidation
+
+No new invalidations are required for cover freshness. The existing `useUploadFileCover` and `useSetFileCoverPage` mutations invalidate `ListBooks` and `RetrieveBook`, which is sufficient to drive `bookQuery.dataUpdatedAt` on the pages that need the remount key. `SeriesBooks` invalidation is **not** needed — the stable URL plus browser-level revalidation handles staleness when the user navigates to the series view.
+
+#### `coverCache` utility
+
+The `isCoverLoaded` / `markCoverLoaded` utility in `app/utils/coverCache.ts` is kept as-is. Its purpose (suppress placeholder flicker when the same URL was previously loaded) is unaffected by the change — if anything, stable URLs make it more reliable, since the same URL is shared across all views.
+
+### Infrastructure — Caddy
+
+No changes. The production Caddyfile is a pure reverse proxy: `uri strip_prefix /api` + `reverse_proxy localhost:3689`. It does not add caching, strip headers, or interfere with conditional requests. `Cache-Control`, `Last-Modified`, `If-Modified-Since`, and `304 Not Modified` pass through unchanged. `encode gzip zstd` is present but will not meaningfully compress already-compressed JPEG/PNG bodies and does not affect headers.
+
+### Dev mode (Vite)
+
+Vite's dev proxy passes `/api/*` through to the Go backend and forwards response headers verbatim. No dev-mode changes required.
+
+## Testing
+
+### Backend
+
+Red-green tests for each endpoint, following the project's TDD convention (`pkg/CLAUDE.md`):
+
+1. **200 on fresh request** — `GET /api/books/:id/cover` with no `If-Modified-Since`. Assert status 200, body is the cover bytes, `Last-Modified` header present, `Cache-Control: private, no-cache` set.
+2. **304 when unchanged** — `GET` with `If-Modified-Since: <Last-Modified from test 1>`. Assert status 304, empty body.
+
+Coverage per endpoint:
+
+- `pkg/books/handlers_cover_test.go` — `bookCover` and `fileCover`
+- `pkg/series/handlers_test.go` — `seriesCover`
+- `pkg/ereader/handlers_test.go` — eReader `Cover` handler
+- `pkg/kobo/handlers_test.go` — resized-cover handler, including verification that the resize work is skipped when 304 is returned (not just that the response status is correct). The exact assertion mechanism depends on handler structure; likely a counter or a sentinel on the resize path.
+
+### Frontend
+
+- Update `app/components/library/CoverGalleryTabs.test.tsx` — the existing tests that assert on `?t=111` / `?t=222` URLs become assertions on the stable URL with no query string.
+- Light smoke tests for `BookItem`, `SeriesList`, and `GlobalSearchCoverImage` cover URL shape (matches `/api/.../cover` exactly).
+- No test for `<img key={dataUpdatedAt}>` itself — that's React semantics, not our logic.
+
+### Manual verification (implementation-plan checklist, not part of the suite)
+
+1. Upload a new cover on `BookDetail` → cover updates on that page without a page refresh.
+2. Navigate to `SeriesList` / `SeriesDetail` / `GlobalSearch` → new cover shows without cache-buster URL.
+3. DevTools Network tab on revisit → cover requests return `304 Not Modified` with ~few hundred bytes, not `200` with full payload.
+4. Behind Caddy (prod mode) → same Network-tab check confirms `Cache-Control`, `Last-Modified`, and `304` responses pass through untouched.
+
+### Not tested
+
+- Browser cache behavior under `Cache-Control: no-cache` (trusting the HTTP spec).
+- Kobo device behavior with the new headers (can't easily test against real hardware; relying on standard-library HTTP client conformance).
+
+## Documentation updates
+
+### `CLAUDE.md` (project root, "Critical Gotchas")
+
+Current `CLAUDE.md:86-92` reads:
+
+> **Cover images need cache busting** — All cover image URLs must include a `?t=` parameter to ensure updated covers display without caching issues:
+> ```
+> const coverUrl = `/api/books/${id}/cover?t=${query.dataUpdatedAt}`;
+> ```
+
+Replace with:
+
+> **Cover images use HTTP revalidation, not URL cache-busting** — Cover endpoints set `Cache-Control: private, no-cache` and rely on `Last-Modified` for revalidation. Never append a `?t=...` query param to cover URLs. For same-page updates (e.g., uploading a new cover on BookDetail), add `key={query.dataUpdatedAt}` to the `<img>` so React remounts it and the browser refetches.
+
+### `app/CLAUDE.md` (frontend, "Cover Image Cache Busting" section at 296-340)
+
+Rewrite the whole section. New title: **"Cover Image Freshness"**.
+
+Contents:
+- **Why:** Browsers cache images; we need updates to show without hard refresh.
+- **How:** Backend sets `Cache-Control: private, no-cache` plus `Last-Modified` (via Echo `c.File()`). Browser revalidates on every `<img>` mount; server returns `304 Not Modified` if unchanged, `200 OK` with new bytes if changed.
+- **Don't:** Add `?t=...` query params to cover URLs. They are not needed and create URL-variant cache pollution.
+- **Do:** For pages that display a cover AND can trigger a mutation that changes it, add `key={query.dataUpdatedAt}` to the `<img>` tag so React remounts on refetch. The remount forces the browser to make a fresh HTTP request, which triggers the `Last-Modified` revalidation flow.
+- **Endpoints:** Table of `/api/books/:id/cover`, `/api/books/files/:id/cover`, `/api/series/:id/cover` (same as current section, minus the cache-buster column).
+- **New checklist:**
+  - [ ] Cover URL does NOT include `?t=` query param.
+  - [ ] For pages that mutate covers, `<img>` has `key={query.dataUpdatedAt}` so remount triggers revalidation.
+  - [ ] Cover-mutating mutation invalidates the query whose `dataUpdatedAt` drives the key (default: `RetrieveBook` via `useUploadFileCover` / `useSetFileCoverPage` — already correct, just verify for new mutations).
+
+### `CHANGELOG.md`
+
+No retroactive edits — existing entries at lines 357 and 473 are release snapshots and should not be rewritten. A new entry for this change will be added under a `[Backend]` or `[Fix]` category when the commit lands, per normal release flow.
+
+### Not updated
+
+- `website/docs/` — no user-facing behavior or config changes.
+- `docs/plans/2026-01-21-cbz-cover-page-selection-*.md` and `docs/plans/2026-01-14-placeholder-covers-implementation.md` — historical plan documents; they reflect design decisions at the time of writing and should not be retroactively edited.
+
+## Open questions
+
+None. Ready for implementation plan.

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1526,6 +1526,7 @@ func (h *handler) bookCover(c echo.Context) error {
 	}
 
 	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
 	return errors.WithStack(c.File(coverPath))
 }
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1322,6 +1322,7 @@ func (h *handler) fileCover(c echo.Context) error {
 	}
 	coverPath := fileutils.ResolveCoverPath(file.Book.Filepath, coverFilename)
 
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
 	return errors.WithStack(c.File(coverPath))
 }
 

--- a/pkg/books/handlers_book_cover_cache_test.go
+++ b/pkg/books/handlers_book_cover_cache_test.go
@@ -24,7 +24,7 @@ func TestBookCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	libraryService := libraries.NewService(db)
 	h := &handler{bookService: bookService, libraryService: libraryService}
 
-	fileID, _ := seedBookWithFileCover(ctx, t, db)
+	fileID := seedBookWithFileCover(ctx, t, db)
 
 	// Look up the book ID via the seeded file.
 	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
@@ -54,7 +54,7 @@ func TestBookCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 	libraryService := libraries.NewService(db)
 	h := &handler{bookService: bookService, libraryService: libraryService}
 
-	fileID, _ := seedBookWithFileCover(ctx, t, db)
+	fileID := seedBookWithFileCover(ctx, t, db)
 	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
 	require.NoError(t, err)
 

--- a/pkg/books/handlers_book_cover_cache_test.go
+++ b/pkg/books/handlers_book_cover_cache_test.go
@@ -79,4 +79,5 @@ func TestBookCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
 	assert.Empty(t, rec2.Body.Bytes())
+	assert.Equal(t, "private, no-cache", rec2.Header().Get("Cache-Control"))
 }

--- a/pkg/books/handlers_book_cover_cache_test.go
+++ b/pkg/books/handlers_book_cover_cache_test.go
@@ -24,7 +24,7 @@ func TestBookCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	libraryService := libraries.NewService(db)
 	h := &handler{bookService: bookService, libraryService: libraryService}
 
-	fileID, _ := seedBookWithFileCover(t, ctx, db)
+	fileID, _ := seedBookWithFileCover(t, db, ctx)
 
 	// Look up the book ID via the seeded file.
 	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
@@ -54,7 +54,7 @@ func TestBookCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 	libraryService := libraries.NewService(db)
 	h := &handler{bookService: bookService, libraryService: libraryService}
 
-	fileID, _ := seedBookWithFileCover(t, ctx, db)
+	fileID, _ := seedBookWithFileCover(t, db, ctx)
 	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
 	require.NoError(t, err)
 

--- a/pkg/books/handlers_book_cover_cache_test.go
+++ b/pkg/books/handlers_book_cover_cache_test.go
@@ -24,7 +24,7 @@ func TestBookCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	libraryService := libraries.NewService(db)
 	h := &handler{bookService: bookService, libraryService: libraryService}
 
-	fileID, _ := seedBookWithFileCover(t, db, ctx)
+	fileID, _ := seedBookWithFileCover(ctx, t, db)
 
 	// Look up the book ID via the seeded file.
 	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
@@ -54,7 +54,7 @@ func TestBookCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 	libraryService := libraries.NewService(db)
 	h := &handler{bookService: bookService, libraryService: libraryService}
 
-	fileID, _ := seedBookWithFileCover(t, db, ctx)
+	fileID, _ := seedBookWithFileCover(ctx, t, db)
 	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
 	require.NoError(t, err)
 

--- a/pkg/books/handlers_book_cover_cache_test.go
+++ b/pkg/books/handlers_book_cover_cache_test.go
@@ -1,0 +1,82 @@
+package books
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/shishobooks/shisho/pkg/libraries"
+)
+
+func TestBookCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	bookService := NewService(db)
+	libraryService := libraries.NewService(db)
+	h := &handler{bookService: bookService, libraryService: libraryService}
+
+	fileID, _ := seedBookWithFileCover(t, ctx, db)
+
+	// Look up the book ID via the seeded file.
+	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(file.BookID))
+
+	require.NoError(t, h.bookCover(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.NotEmpty(t, rec.Header().Get("Last-Modified"))
+	assert.NotEmpty(t, rec.Body.Bytes())
+}
+
+func TestBookCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	bookService := NewService(db)
+	libraryService := libraries.NewService(db)
+	h := &handler{bookService: bookService, libraryService: libraryService}
+
+	fileID, _ := seedBookWithFileCover(t, ctx, db)
+	file, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &fileID})
+	require.NoError(t, err)
+
+	// First GET.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	c1 := e.NewContext(req1, rec1)
+	c1.SetParamNames("id")
+	c1.SetParamValues(strconv.Itoa(file.BookID))
+	require.NoError(t, h.bookCover(c1))
+	lastModified := rec1.Header().Get("Last-Modified")
+	require.NotEmpty(t, lastModified)
+
+	// Second GET with If-Modified-Since.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("If-Modified-Since", lastModified)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetParamNames("id")
+	c2.SetParamValues(strconv.Itoa(file.BookID))
+	require.NoError(t, h.bookCover(c2))
+
+	assert.Equal(t, http.StatusNotModified, rec2.Code)
+	assert.Empty(t, rec2.Body.Bytes())
+}

--- a/pkg/books/handlers_file_cover_cache_test.go
+++ b/pkg/books/handlers_file_cover_cache_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 // seedBookWithFileCover creates a library, book, and file with a real cover
-// image on disk. Returns the file ID and the on-disk cover path.
-func seedBookWithFileCover(ctx context.Context, t *testing.T, db *bun.DB) (fileID int, coverPath string) {
+// image on disk. Returns the file ID.
+func seedBookWithFileCover(ctx context.Context, t *testing.T, db *bun.DB) int {
 	t.Helper()
 
 	library := &models.Library{
@@ -51,8 +51,8 @@ func seedBookWithFileCover(ctx context.Context, t *testing.T, db *bun.DB) (fileI
 	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0o644))
 
 	coverFilename := "test.epub.cover.jpg"
-	coverPath = filepath.Join(bookDir, coverFilename)
-	coverFile, err := os.Create(coverPath)
+	coverFullPath := filepath.Join(bookDir, coverFilename)
+	coverFile, err := os.Create(coverFullPath)
 	require.NoError(t, err)
 	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 10, 10)), nil))
 	require.NoError(t, coverFile.Close())
@@ -71,7 +71,7 @@ func seedBookWithFileCover(ctx context.Context, t *testing.T, db *bun.DB) (fileI
 	_, err = db.NewInsert().Model(file).Exec(ctx)
 	require.NoError(t, err)
 
-	return file.ID, coverPath
+	return file.ID
 }
 
 func TestFileCover_SetsCacheControlPrivateNoCache(t *testing.T) {
@@ -82,7 +82,7 @@ func TestFileCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	e := echo.New()
 	h := &handler{bookService: NewService(db)}
 
-	fileID, _ := seedBookWithFileCover(ctx, t, db)
+	fileID := seedBookWithFileCover(ctx, t, db)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestFileCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 	e := echo.New()
 	h := &handler{bookService: NewService(db)}
 
-	fileID, _ := seedBookWithFileCover(ctx, t, db)
+	fileID := seedBookWithFileCover(ctx, t, db)
 
 	// First GET to capture Last-Modified.
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/pkg/books/handlers_file_cover_cache_test.go
+++ b/pkg/books/handlers_file_cover_cache_test.go
@@ -1,0 +1,132 @@
+package books
+
+import (
+	"context"
+	"image"
+	"image/jpeg"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// seedBookWithFileCover creates a library, book, and file with a real cover
+// image on disk. Returns the file ID and the on-disk cover path.
+func seedBookWithFileCover(t *testing.T, ctx context.Context, db *bun.DB) (fileID int, coverPath string) {
+	t.Helper()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	bookDir := filepath.Join(t.TempDir(), "Test Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(bookDir, "test.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0o644))
+
+	coverFilename := "test.epub.cover.jpg"
+	coverPath = filepath.Join(bookDir, coverFilename)
+	coverFile, err := os.Create(coverPath)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 10, 10)), nil))
+	require.NoError(t, coverFile.Close())
+
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filePath,
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	return file.ID, coverPath
+}
+
+func TestFileCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	h := &handler{bookService: NewService(db)}
+
+	fileID, _ := seedBookWithFileCover(t, ctx, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(fileID))
+
+	require.NoError(t, h.fileCover(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.NotEmpty(t, rec.Header().Get("Last-Modified"))
+	assert.NotEmpty(t, rec.Body.Bytes())
+}
+
+func TestFileCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	h := &handler{bookService: NewService(db)}
+
+	fileID, _ := seedBookWithFileCover(t, ctx, db)
+
+	// First GET to capture Last-Modified.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	c1 := e.NewContext(req1, rec1)
+	c1.SetParamNames("id")
+	c1.SetParamValues(strconv.Itoa(fileID))
+	require.NoError(t, h.fileCover(c1))
+	lastModified := rec1.Header().Get("Last-Modified")
+	require.NotEmpty(t, lastModified)
+
+	// Second GET with If-Modified-Since.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("If-Modified-Since", lastModified)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetParamNames("id")
+	c2.SetParamValues(strconv.Itoa(fileID))
+	require.NoError(t, h.fileCover(c2))
+
+	assert.Equal(t, http.StatusNotModified, rec2.Code)
+	assert.Empty(t, rec2.Body.Bytes())
+}

--- a/pkg/books/handlers_file_cover_cache_test.go
+++ b/pkg/books/handlers_file_cover_cache_test.go
@@ -21,7 +21,7 @@ import (
 
 // seedBookWithFileCover creates a library, book, and file with a real cover
 // image on disk. Returns the file ID and the on-disk cover path.
-func seedBookWithFileCover(t *testing.T, ctx context.Context, db *bun.DB) (fileID int, coverPath string) {
+func seedBookWithFileCover(t *testing.T, db *bun.DB, ctx context.Context) (fileID int, coverPath string) {
 	t.Helper()
 
 	library := &models.Library{
@@ -82,7 +82,7 @@ func TestFileCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	e := echo.New()
 	h := &handler{bookService: NewService(db)}
 
-	fileID, _ := seedBookWithFileCover(t, ctx, db)
+	fileID, _ := seedBookWithFileCover(t, db, ctx)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestFileCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 	e := echo.New()
 	h := &handler{bookService: NewService(db)}
 
-	fileID, _ := seedBookWithFileCover(t, ctx, db)
+	fileID, _ := seedBookWithFileCover(t, db, ctx)
 
 	// First GET to capture Last-Modified.
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/pkg/books/handlers_file_cover_cache_test.go
+++ b/pkg/books/handlers_file_cover_cache_test.go
@@ -129,4 +129,5 @@ func TestFileCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
 	assert.Empty(t, rec2.Body.Bytes())
+	assert.Equal(t, "private, no-cache", rec2.Header().Get("Cache-Control"))
 }

--- a/pkg/books/handlers_file_cover_cache_test.go
+++ b/pkg/books/handlers_file_cover_cache_test.go
@@ -21,7 +21,7 @@ import (
 
 // seedBookWithFileCover creates a library, book, and file with a real cover
 // image on disk. Returns the file ID and the on-disk cover path.
-func seedBookWithFileCover(t *testing.T, db *bun.DB, ctx context.Context) (fileID int, coverPath string) {
+func seedBookWithFileCover(ctx context.Context, t *testing.T, db *bun.DB) (fileID int, coverPath string) {
 	t.Helper()
 
 	library := &models.Library{
@@ -82,7 +82,7 @@ func TestFileCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	e := echo.New()
 	h := &handler{bookService: NewService(db)}
 
-	fileID, _ := seedBookWithFileCover(t, db, ctx)
+	fileID, _ := seedBookWithFileCover(ctx, t, db)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -106,7 +106,7 @@ func TestFileCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 	e := echo.New()
 	h := &handler{bookService: NewService(db)}
 
-	fileID, _ := seedBookWithFileCover(t, db, ctx)
+	fileID, _ := seedBookWithFileCover(ctx, t, db)
 
 	// First GET to capture Last-Modified.
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -737,6 +737,7 @@ func (h *handler) Cover(c echo.Context) error {
 	}
 
 	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
 	return errors.WithStack(c.File(coverPath))
 }
 

--- a/pkg/ereader/handlers_cover_cache_test.go
+++ b/pkg/ereader/handlers_cover_cache_test.go
@@ -225,5 +225,6 @@ func TestCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 	require.NoError(t, h.Cover(c2))
 
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
+	assert.Equal(t, "private, no-cache", rec2.Header().Get("Cache-Control"))
 	assert.Empty(t, rec2.Body.Bytes())
 }

--- a/pkg/ereader/handlers_cover_cache_test.go
+++ b/pkg/ereader/handlers_cover_cache_test.go
@@ -1,0 +1,230 @@
+package ereader
+
+import (
+	"context"
+	"image"
+	"image/jpeg"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/apikeys"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/libraries"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+
+	// Create admin role-based user
+	var roleID int
+	err := db.QueryRow("SELECT id FROM roles WHERE name = 'admin'").Scan(&roleID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO users (username, password_hash, role_id, is_active) VALUES (?, ?, ?, ?)",
+		"ereader_cover_user", "hash", roleID, true)
+	require.NoError(t, err)
+
+	var userID int
+	err = db.QueryRow("SELECT id FROM users WHERE username = 'ereader_cover_user'").Scan(&userID)
+	require.NoError(t, err)
+
+	// Grant all-library access (null library_id = all libraries).
+	_, err = db.ExecContext(ctx, "INSERT INTO user_library_access (user_id, library_id) VALUES (?, NULL)", userID)
+	require.NoError(t, err)
+
+	apiKeyService := apikeys.NewService(db)
+	apiKey, err := apiKeyService.Create(ctx, userID, "Test Key")
+	require.NoError(t, err)
+
+	libraryService := libraries.NewService(db)
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	require.NoError(t, libraryService.CreateLibrary(ctx, library))
+
+	bookDir := filepath.Join(t.TempDir(), "Test Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	bookService := books.NewService(db)
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(bookDir, "test.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0o644))
+
+	coverFilename := "test.epub.cover.jpg"
+	coverPath := filepath.Join(bookDir, coverFilename)
+	coverFile, err := os.Create(coverPath)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 10, 10)), nil))
+	require.NoError(t, coverFile.Close())
+
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filePath,
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		db:             db,
+		bookService:    bookService,
+		libraryService: libraryService,
+	}
+
+	// Inject API key into context (as middleware would do).
+	apiKeyCtx := context.WithValue(ctx, contextKeyAPIKey, apiKey)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(apiKeyCtx)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("bookId")
+	c.SetParamValues(strconv.Itoa(book.ID))
+
+	require.NoError(t, h.Cover(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.NotEmpty(t, rec.Header().Get("Last-Modified"))
+	assert.NotEmpty(t, rec.Body.Bytes())
+}
+
+func TestCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+
+	var roleID int
+	err := db.QueryRow("SELECT id FROM roles WHERE name = 'admin'").Scan(&roleID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO users (username, password_hash, role_id, is_active) VALUES (?, ?, ?, ?)",
+		"ereader_304_user", "hash", roleID, true)
+	require.NoError(t, err)
+
+	var userID int
+	err = db.QueryRow("SELECT id FROM users WHERE username = 'ereader_304_user'").Scan(&userID)
+	require.NoError(t, err)
+
+	// Grant all-library access (null library_id = all libraries).
+	_, err = db.ExecContext(ctx, "INSERT INTO user_library_access (user_id, library_id) VALUES (?, NULL)", userID)
+	require.NoError(t, err)
+
+	apiKeyService := apikeys.NewService(db)
+	apiKey, err := apiKeyService.Create(ctx, userID, "Test Key 304")
+	require.NoError(t, err)
+
+	libraryService := libraries.NewService(db)
+	library := &models.Library{
+		Name:                     "Test Library 304",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	require.NoError(t, libraryService.CreateLibrary(ctx, library))
+
+	bookDir := filepath.Join(t.TempDir(), "Test Book 304")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	bookService := books.NewService(db)
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book 304",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book 304",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(bookDir, "test.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0o644))
+
+	coverFilename := "test.epub.cover.jpg"
+	coverPath := filepath.Join(bookDir, coverFilename)
+	coverFile, err := os.Create(coverPath)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 10, 10)), nil))
+	require.NoError(t, coverFile.Close())
+	_ = coverPath
+
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filePath,
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		db:             db,
+		bookService:    bookService,
+		libraryService: libraryService,
+	}
+
+	apiKeyCtx := context.WithValue(ctx, contextKeyAPIKey, apiKey)
+
+	// First GET.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req1 = req1.WithContext(apiKeyCtx)
+	rec1 := httptest.NewRecorder()
+	c1 := e.NewContext(req1, rec1)
+	c1.SetParamNames("bookId")
+	c1.SetParamValues(strconv.Itoa(book.ID))
+	require.NoError(t, h.Cover(c1))
+	lastModified := rec1.Header().Get("Last-Modified")
+	require.NotEmpty(t, lastModified)
+
+	// Second GET with If-Modified-Since.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2 = req2.WithContext(apiKeyCtx)
+	req2.Header.Set("If-Modified-Since", lastModified)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetParamNames("bookId")
+	c2.SetParamValues(strconv.Itoa(book.ID))
+	require.NoError(t, h.Cover(c2))
+
+	assert.Equal(t, http.StatusNotModified, rec2.Code)
+	assert.Empty(t, rec2.Body.Bytes())
+}

--- a/pkg/ereader/handlers_cover_cache_test.go
+++ b/pkg/ereader/handlers_cover_cache_test.go
@@ -180,7 +180,6 @@ func TestCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 10, 10)), nil))
 	require.NoError(t, coverFile.Close())
-	_ = coverPath
 
 	mimeType := "image/jpeg"
 	file := &models.File{

--- a/pkg/kobo/handlers.go
+++ b/pkg/kobo/handlers.go
@@ -249,7 +249,9 @@ func (h *handler) handleCover(c echo.Context) error {
 
 	// Stat source cover for Last-Modified + conditional GET short-circuit.
 	// This runs before the resize so revalidated requests skip the expensive
-	// decode/resize/encode work.
+	// decode/resize/encode work. In the no-dimensions branch below, c.File
+	// also sets Last-Modified from the same file mtime — the values match
+	// (second precision), so the overlap is harmless.
 	coverStat, err := os.Stat(coverPath)
 	if err != nil {
 		return errcodes.NotFound("Cover")

--- a/pkg/kobo/handlers.go
+++ b/pkg/kobo/handlers.go
@@ -247,6 +247,23 @@ func (h *handler) handleCover(c echo.Context) error {
 
 	coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
 
+	// Stat source cover for Last-Modified + conditional GET short-circuit.
+	// This runs before the resize so revalidated requests skip the expensive
+	// decode/resize/encode work.
+	coverStat, err := os.Stat(coverPath)
+	if err != nil {
+		return errcodes.NotFound("Cover")
+	}
+	modTime := coverStat.ModTime().UTC().Truncate(time.Second)
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	c.Response().Header().Set("Last-Modified", modTime.Format(http.TimeFormat))
+	if ims := c.Request().Header.Get("If-Modified-Since"); ims != "" {
+		if t, parseErr := http.ParseTime(ims); parseErr == nil && !modTime.After(t) {
+			c.Response().WriteHeader(http.StatusNotModified)
+			return nil
+		}
+	}
+
 	// Parse requested dimensions
 	widthStr := c.Param("w")
 	heightStr := c.Param("h")
@@ -254,7 +271,8 @@ func (h *handler) handleCover(c echo.Context) error {
 	height, _ := strconv.Atoi(heightStr)
 
 	if width == 0 || height == 0 {
-		// Serve original if dimensions not specified
+		// Serve original if dimensions not specified. c.File handles
+		// Last-Modified/If-Modified-Since automatically for this branch.
 		return c.File(coverPath)
 	}
 
@@ -282,7 +300,6 @@ func (h *handler) handleCover(c echo.Context) error {
 	draw.BiLinear.Scale(dstImg, dstImg.Bounds(), srcImg, srcBounds, draw.Over, nil)
 
 	c.Response().Header().Set("Content-Type", "image/jpeg")
-	c.Response().Header().Set("Cache-Control", "public, max-age=86400")
 	c.Response().WriteHeader(http.StatusOK)
 	return jpeg.Encode(c.Response().Writer, dstImg, &jpeg.Options{Quality: 80})
 }

--- a/pkg/kobo/handlers_cover_cache_test.go
+++ b/pkg/kobo/handlers_cover_cache_test.go
@@ -1,0 +1,281 @@
+package kobo
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"image/jpeg"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	bookService := books.NewService(db)
+
+	// Create library
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create book with a directory
+	bookDir := filepath.Join(t.TempDir(), "Test Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(bookDir, "test.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0o644))
+
+	coverFilename := "test.epub.cover.jpg"
+	coverPath := filepath.Join(bookDir, coverFilename)
+	coverFile, err := os.Create(coverPath)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 100, 150)), nil))
+	require.NoError(t, coverFile.Close())
+
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filePath,
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{bookService: bookService}
+
+	// Use a resized request (w=100 h=150)
+	imageID := fmt.Sprintf("shisho-%d", file.ID)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("imageId", "w", "h")
+	c.SetParamValues(imageID, "100", "150")
+
+	require.NoError(t, h.handleCover(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.NotEmpty(t, rec.Header().Get("Last-Modified"))
+	assert.NotEmpty(t, rec.Body.Bytes())
+}
+
+func TestHandleCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	bookService := books.NewService(db)
+
+	library := &models.Library{
+		Name:                     "Test Library 304",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	bookDir := filepath.Join(t.TempDir(), "Test Book 304")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book 304",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book 304",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(bookDir, "test.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0o644))
+
+	coverFilename := "test.epub.cover.jpg"
+	coverPath := filepath.Join(bookDir, coverFilename)
+	coverFile, err := os.Create(coverPath)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 100, 150)), nil))
+	require.NoError(t, coverFile.Close())
+	_ = coverPath
+
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filePath,
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{bookService: bookService}
+	imageID := fmt.Sprintf("shisho-%d", file.ID)
+
+	// First GET.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	c1 := e.NewContext(req1, rec1)
+	c1.SetParamNames("imageId", "w", "h")
+	c1.SetParamValues(imageID, "100", "150")
+	require.NoError(t, h.handleCover(c1))
+	lastModified := rec1.Header().Get("Last-Modified")
+	require.NotEmpty(t, lastModified)
+
+	// Second GET with If-Modified-Since.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("If-Modified-Since", lastModified)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetParamNames("imageId", "w", "h")
+	c2.SetParamValues(imageID, "100", "150")
+	require.NoError(t, h.handleCover(c2))
+
+	assert.Equal(t, http.StatusNotModified, rec2.Code)
+	assert.Empty(t, rec2.Body.Bytes())
+}
+
+func TestHandleCover_304SkipsResizeWork(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	bookService := books.NewService(db)
+
+	library := &models.Library{
+		Name:                     "Test Library Skip",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	bookDir := filepath.Join(t.TempDir(), "Test Book Skip")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book Skip",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book Skip",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(bookDir, "test.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0o644))
+
+	coverFilename := "test.epub.cover.jpg"
+	coverPath := filepath.Join(bookDir, coverFilename)
+	coverFile, err := os.Create(coverPath)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 100, 150)), nil))
+	require.NoError(t, coverFile.Close())
+
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filePath,
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{bookService: bookService}
+	imageID := fmt.Sprintf("shisho-%d", file.ID)
+
+	// First GET to get Last-Modified from the valid cover.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	c1 := e.NewContext(req1, rec1)
+	c1.SetParamNames("imageId", "w", "h")
+	c1.SetParamValues(imageID, "100", "150")
+	require.NoError(t, h.handleCover(c1))
+	lastModified := rec1.Header().Get("Last-Modified")
+	require.NotEmpty(t, lastModified)
+
+	// Capture the cover file's original mtime.
+	info, err := os.Stat(coverPath)
+	require.NoError(t, err)
+	originalMtime := info.ModTime()
+
+	// Overwrite cover with garbage bytes (invalid image), but restore the original
+	// mtime so the If-Modified-Since short-circuit still fires.
+	require.NoError(t, os.WriteFile(coverPath, []byte("this is not a valid jpeg"), 0o644))
+	require.NoError(t, os.Chtimes(coverPath, originalMtime, originalMtime))
+
+	// Second GET with If-Modified-Since matching the original mtime.
+	// If the handler tried to decode/resize the garbage bytes it would return
+	// an error. Getting 304 proves the decode path was skipped.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("If-Modified-Since", lastModified)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetParamNames("imageId", "w", "h")
+	c2.SetParamValues(imageID, "100", "150")
+	require.NoError(t, h.handleCover(c2))
+
+	assert.Equal(t, http.StatusNotModified, rec2.Code)
+	assert.Empty(t, rec2.Body.Bytes())
+
+	// Sanity-check: confirm the garbage file would indeed cause an error if the
+	// resize path were taken (i.e. without If-Modified-Since).
+	req3 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec3 := httptest.NewRecorder()
+	c3 := e.NewContext(req3, rec3)
+	c3.SetParamNames("imageId", "w", "h")
+	c3.SetParamValues(imageID, "100", "150")
+	err3 := h.handleCover(c3)
+	// Without IMS the resize path is taken and the garbage bytes cause an error,
+	// confirming that the 304 above genuinely skipped image decoding.
+	require.Error(t, err3, "expected decode error on garbage cover to confirm 304 skipped resize")
+}

--- a/pkg/kobo/handlers_cover_cache_test.go
+++ b/pkg/kobo/handlers_cover_cache_test.go
@@ -133,7 +133,6 @@ func TestHandleCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 100, 150)), nil))
 	require.NoError(t, coverFile.Close())
-	_ = coverPath
 
 	mimeType := "image/jpeg"
 	file := &models.File{

--- a/pkg/kobo/handlers_cover_cache_test.go
+++ b/pkg/kobo/handlers_cover_cache_test.go
@@ -172,6 +172,7 @@ func TestHandleCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
 	assert.Empty(t, rec2.Body.Bytes())
+	assert.Equal(t, "private, no-cache", rec2.Header().Get("Cache-Control"))
 }
 
 func TestHandleCover_304SkipsResizeWork(t *testing.T) {

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -273,7 +273,7 @@ func (h *handler) seriesCover(c echo.Context) error {
 	coverImagePath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
 
 	// Set appropriate headers
-	c.Response().Header().Set("Cache-Control", "public, max-age=86400")
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
 
 	return errors.WithStack(c.File(coverImagePath))
 }

--- a/pkg/series/handlers_cover_cache_test.go
+++ b/pkg/series/handlers_cover_cache_test.go
@@ -1,0 +1,186 @@
+package series
+
+import (
+	"context"
+	"database/sql"
+	"image"
+	"image/jpeg"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/libraries"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func setupSeriesTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+// seedSeriesWithCover creates a library, series, book, book_series join row,
+// and a file with a real cover image on disk. Returns the series ID.
+func seedSeriesWithCover(t *testing.T, ctx context.Context, db *bun.DB) int {
+	t.Helper()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	seriesRecord := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Test Series",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "Test Series",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err = db.NewInsert().Model(seriesRecord).Exec(ctx)
+	require.NoError(t, err)
+
+	bookDir := filepath.Join(t.TempDir(), "Test Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	seriesNumber := 1.0
+	bookSeries := &models.BookSeries{
+		BookID:       book.ID,
+		SeriesID:     seriesRecord.ID,
+		SeriesNumber: &seriesNumber,
+		SortOrder:    1,
+	}
+	_, err = db.NewInsert().Model(bookSeries).Exec(ctx)
+	require.NoError(t, err)
+
+	filePath := filepath.Join(bookDir, "test.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0o644))
+
+	coverFilename := "test.epub.cover.jpg"
+	coverPath := filepath.Join(bookDir, coverFilename)
+	coverFile, err := os.Create(coverPath)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(coverFile, image.NewRGBA(image.Rect(0, 0, 10, 10)), nil))
+	require.NoError(t, coverFile.Close())
+
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filePath,
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	return seriesRecord.ID
+}
+
+func TestSeriesCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	h := &handler{
+		seriesService:  NewService(db),
+		bookService:    books.NewService(db),
+		libraryService: libraries.NewService(db),
+	}
+
+	seriesID := seedSeriesWithCover(t, ctx, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(seriesID))
+
+	require.NoError(t, h.seriesCover(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.NotEmpty(t, rec.Header().Get("Last-Modified"))
+	assert.NotEmpty(t, rec.Body.Bytes())
+}
+
+func TestSeriesCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	h := &handler{
+		seriesService:  NewService(db),
+		bookService:    books.NewService(db),
+		libraryService: libraries.NewService(db),
+	}
+
+	seriesID := seedSeriesWithCover(t, ctx, db)
+
+	// First GET.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	c1 := e.NewContext(req1, rec1)
+	c1.SetParamNames("id")
+	c1.SetParamValues(strconv.Itoa(seriesID))
+	require.NoError(t, h.seriesCover(c1))
+	lastModified := rec1.Header().Get("Last-Modified")
+	require.NotEmpty(t, lastModified)
+
+	// Second GET with If-Modified-Since.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("If-Modified-Since", lastModified)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetParamNames("id")
+	c2.SetParamValues(strconv.Itoa(seriesID))
+	require.NoError(t, h.seriesCover(c2))
+
+	assert.Equal(t, http.StatusNotModified, rec2.Code)
+	assert.Empty(t, rec2.Body.Bytes())
+}

--- a/pkg/series/handlers_cover_cache_test.go
+++ b/pkg/series/handlers_cover_cache_test.go
@@ -47,7 +47,7 @@ func setupSeriesTestDB(t *testing.T) *bun.DB {
 
 // seedSeriesWithCover creates a library, series, book, book_series join row,
 // and a file with a real cover image on disk. Returns the series ID.
-func seedSeriesWithCover(t *testing.T, db *bun.DB, ctx context.Context) int {
+func seedSeriesWithCover(ctx context.Context, t *testing.T, db *bun.DB) int {
 	t.Helper()
 
 	library := &models.Library{
@@ -132,7 +132,7 @@ func TestSeriesCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 		libraryService: libraries.NewService(db),
 	}
 
-	seriesID := seedSeriesWithCover(t, db, ctx)
+	seriesID := seedSeriesWithCover(ctx, t, db)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -160,7 +160,7 @@ func TestSeriesCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 		libraryService: libraries.NewService(db),
 	}
 
-	seriesID := seedSeriesWithCover(t, db, ctx)
+	seriesID := seedSeriesWithCover(ctx, t, db)
 
 	// First GET.
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/pkg/series/handlers_cover_cache_test.go
+++ b/pkg/series/handlers_cover_cache_test.go
@@ -47,7 +47,7 @@ func setupSeriesTestDB(t *testing.T) *bun.DB {
 
 // seedSeriesWithCover creates a library, series, book, book_series join row,
 // and a file with a real cover image on disk. Returns the series ID.
-func seedSeriesWithCover(t *testing.T, ctx context.Context, db *bun.DB) int {
+func seedSeriesWithCover(t *testing.T, db *bun.DB, ctx context.Context) int {
 	t.Helper()
 
 	library := &models.Library{
@@ -132,7 +132,7 @@ func TestSeriesCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 		libraryService: libraries.NewService(db),
 	}
 
-	seriesID := seedSeriesWithCover(t, ctx, db)
+	seriesID := seedSeriesWithCover(t, db, ctx)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -160,7 +160,7 @@ func TestSeriesCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 		libraryService: libraries.NewService(db),
 	}
 
-	seriesID := seedSeriesWithCover(t, ctx, db)
+	seriesID := seedSeriesWithCover(t, db, ctx)
 
 	// First GET.
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/pkg/series/handlers_cover_cache_test.go
+++ b/pkg/series/handlers_cover_cache_test.go
@@ -183,4 +183,5 @@ func TestSeriesCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
 	assert.Empty(t, rec2.Body.Bytes())
+	assert.Equal(t, "private, no-cache", rec2.Header().Get("Cache-Control"))
 }


### PR DESCRIPTION
## Summary
- Backend cover endpoints (`/api/books/:id/cover`, `/api/books/files/:id/cover`, `/api/series/:id/cover`, eReader `Cover`, Kobo `handleCover`) now emit `Cache-Control: private, no-cache` + `Last-Modified`, letting the browser revalidate via `If-Modified-Since` → `304 Not Modified`. Kobo adds a manual short-circuit so revalidated requests skip the JPEG resize work.
- Frontend drops every `?t=...` cache-buster from cover URLs (9 call sites). The `cacheBuster` prop is renamed to `cacheKey` and used as an `<img key>` on pages that can mutate covers (`BookDetail`, `FileEditDialog`, `CoverGalleryTabs`, `FileCoverThumbnail`), forcing remount → fresh HTTP request → revalidation.
- Root `CLAUDE.md` and `app/CLAUDE.md` rewritten to document HTTP revalidation as the new pattern (replacing the old "Cover images need cache busting" guidance).

Fixes the bug where uploading a new cover on BookDetail didn't refresh the cover on SeriesList or SeriesDetail, even after a hard reload.

## Test plan
- Backend: `mise test` — 11 new tests (2 per cover endpoint; Kobo gets an extra "304 skips resize work" differential test).
- Frontend: `mise test:unit` — updated `CoverGalleryTabs.test.tsx` asserts stable URLs, `cacheKey`-driven remount, and DOM-node identity changes on key bump.
- Manual in dev: open DevTools → Network, load a book cover → 200 with `Cache-Control: private, no-cache` + `Last-Modified`. Reload → 304 with empty body. Upload a new cover on BookDetail → confirm it updates on that page AND on SeriesList / SeriesDetail / GlobalSearch without a browser refresh.
- Manual in prod: same DevTools check behind Caddy — confirm `Cache-Control`, `Last-Modified`, and 304 responses pass through.
- OPDS: smoke-test cover refresh on at least one real reader (Moon+, KOReader) after a cover update — OPDS uses the same `/books/:id/cover` endpoint and now revalidates on every fetch.