### PR TITLE
[Feature] Add delete library action to admin settings

### DIFF
--- a/app/components/library/DeleteLibraryDialog.test.tsx
+++ b/app/components/library/DeleteLibraryDialog.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { DeleteLibraryDialog } from "./DeleteLibraryDialog";
+
+const mockDelete = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/queries/libraries", () => ({
+  useDeleteLibrary: () => ({
+    mutateAsync: mockDelete,
+    isPending: false,
+  }),
+}));
+
+const renderDialog = (
+  props: Partial<React.ComponentProps<typeof DeleteLibraryDialog>> = {},
+) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const onOpenChange = vi.fn();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DeleteLibraryDialog
+          library={{ id: 1, name: "My Library" }}
+          onOpenChange={onOpenChange}
+          open={true}
+          {...props}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  return { onOpenChange };
+};
+
+describe("DeleteLibraryDialog", () => {
+  it("disables the Delete button until the user types the exact library name", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderDialog();
+
+    const deleteButton = screen.getByRole("button", { name: /^Delete$/ });
+    expect(deleteButton).toBeDisabled();
+
+    const input = screen.getByLabelText(/Type the library name to confirm/i);
+    await user.type(input, "my library"); // wrong case
+    expect(deleteButton).toBeDisabled();
+
+    await user.clear(input);
+    await user.type(input, "My Library");
+    expect(deleteButton).toBeEnabled();
+  });
+
+  it("calls the delete mutation with the library id on confirm", async () => {
+    mockDelete.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderDialog();
+
+    await user.type(
+      screen.getByLabelText(/Type the library name to confirm/i),
+      "My Library",
+    );
+    await user.click(screen.getByRole("button", { name: /^Delete$/ }));
+
+    expect(mockDelete).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it("surfaces the three caveats in the warning banner", () => {
+    renderDialog();
+
+    expect(screen.getByText(/irreversible/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Files on disk will not be deleted/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Sidecar and metadata files will not be cleaned up/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/components/library/DeleteLibraryDialog.test.tsx
+++ b/app/components/library/DeleteLibraryDialog.test.tsx
@@ -1,7 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
+import { toast } from "sonner";
 import { describe, expect, it, vi } from "vitest";
 
 import { DeleteLibraryDialog } from "./DeleteLibraryDialog";
@@ -13,6 +14,13 @@ vi.mock("@/hooks/queries/libraries", () => ({
     mutateAsync: mockDelete,
     isPending: false,
   }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 const renderDialog = (
@@ -66,6 +74,23 @@ describe("DeleteLibraryDialog", () => {
     await user.click(screen.getByRole("button", { name: /^Delete$/ }));
 
     expect(mockDelete).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it("keeps the dialog open and shows an error toast when the mutation fails", async () => {
+    mockDelete.mockRejectedValueOnce(new Error("server exploded"));
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const { onOpenChange } = renderDialog();
+
+    await user.type(
+      screen.getByLabelText(/Type the library name to confirm/i),
+      "My Library",
+    );
+    await user.click(screen.getByRole("button", { name: /^Delete$/ }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("server exploded");
+    });
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 
   it("surfaces the three caveats in the warning banner", () => {

--- a/app/components/library/DeleteLibraryDialog.tsx
+++ b/app/components/library/DeleteLibraryDialog.tsx
@@ -1,0 +1,117 @@
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useDeleteLibrary } from "@/hooks/queries/libraries";
+
+interface DeleteLibraryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  library: { id: number; name: string };
+}
+
+export function DeleteLibraryDialog({
+  open,
+  onOpenChange,
+  library,
+}: DeleteLibraryDialogProps) {
+  const [typedName, setTypedName] = useState("");
+  const deleteMutation = useDeleteLibrary();
+  const navigate = useNavigate();
+
+  // Reset the typed value whenever the dialog reopens.
+  useEffect(() => {
+    if (open) setTypedName("");
+  }, [open]);
+
+  const canDelete = typedName === library.name && !deleteMutation.isPending;
+
+  const handleConfirm = async () => {
+    try {
+      await deleteMutation.mutateAsync({ id: library.id });
+      toast.success(`Library "${library.name}" deleted.`);
+      onOpenChange(false);
+      navigate("/settings/libraries");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Something went wrong.";
+      toast.error(msg);
+    }
+  };
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-md overflow-x-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-destructive shrink-0" />
+            Delete library
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Permanently delete this library from the database.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 min-w-0">
+          <div className="bg-destructive/10 border border-destructive/20 rounded-md p-3 text-sm text-destructive break-words space-y-2">
+            <p>This action is irreversible.</p>
+            <p>Files on disk will not be deleted.</p>
+            <p>
+              Sidecar and metadata files will not be cleaned up. You&apos;ll
+              need to remove them manually if desired.
+            </p>
+          </div>
+
+          <p className="text-sm">
+            Are you sure you want to delete{" "}
+            <span className="font-medium">&ldquo;{library.name}&rdquo;</span>?
+          </p>
+
+          <div className="space-y-2">
+            <Label htmlFor="delete-library-confirm">
+              Type the library name to confirm
+            </Label>
+            <Input
+              autoComplete="off"
+              id="delete-library-confirm"
+              onChange={(e) => setTypedName(e.target.value)}
+              placeholder={library.name}
+              value={typedName}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            disabled={deleteMutation.isPending}
+            onClick={() => onOpenChange(false)}
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!canDelete}
+            onClick={handleConfirm}
+            variant="destructive"
+          >
+            {deleteMutation.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/components/pages/LibrarySettings.tsx
+++ b/app/components/pages/LibrarySettings.tsx
@@ -421,37 +421,40 @@ const LibrarySettings = () => {
       </div>
 
       {canDeleteLibrary && libraryQuery.data && (
-        <section className="max-w-2xl mt-8 border border-destructive/40 rounded-md p-4 md:p-6">
-          <h2 className="text-base md:text-lg font-semibold text-destructive mb-1">
-            Danger Zone
-          </h2>
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-2">
-            <div className="min-w-0">
-              <p className="font-medium">Delete this library</p>
-              <p className="text-sm text-muted-foreground">
-                Permanently removes this library and all of its books, files,
-                and metadata from the database. Files on disk are not touched.
-              </p>
+        <>
+          <section className="max-w-2xl mt-8 border border-destructive/40 rounded-md p-4 md:p-6">
+            <h2 className="text-base md:text-lg font-semibold text-destructive mb-1">
+              Danger Zone
+            </h2>
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-2">
+              <div className="min-w-0">
+                <p className="font-medium">Delete this library</p>
+                <p className="text-sm text-muted-foreground">
+                  Permanently removes this library and all of its books, files,
+                  and metadata from the database. Files on disk are not touched.
+                </p>
+              </div>
+              <Button
+                className="shrink-0"
+                onClick={() => setDeleteDialogOpen(true)}
+                size="sm"
+                variant="destructive"
+              >
+                <Trash2 className="h-4 w-4 sm:mr-2" />
+                <span className="hidden sm:inline">Delete library</span>
+              </Button>
             </div>
-            <Button
-              className="shrink-0"
-              onClick={() => setDeleteDialogOpen(true)}
-              size="sm"
-              variant="destructive"
-            >
-              <Trash2 className="h-4 w-4 sm:mr-2" />
-              <span className="hidden sm:inline">Delete library</span>
-            </Button>
-          </div>
-        </section>
-      )}
+          </section>
 
-      {libraryQuery.data && (
-        <DeleteLibraryDialog
-          library={{ id: libraryQuery.data.id, name: libraryQuery.data.name }}
-          onOpenChange={setDeleteDialogOpen}
-          open={deleteDialogOpen}
-        />
+          <DeleteLibraryDialog
+            library={{
+              id: libraryQuery.data.id,
+              name: libraryQuery.data.name,
+            }}
+            onOpenChange={setDeleteDialogOpen}
+            open={deleteDialogOpen}
+          />
+        </>
       )}
 
       <UnsavedChangesDialog

--- a/app/components/pages/LibrarySettings.tsx
+++ b/app/components/pages/LibrarySettings.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
 
+import { DeleteLibraryDialog } from "@/components/library/DeleteLibraryDialog";
 import DirectoryPickerDialog from "@/components/library/DirectoryPickerDialog";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LibraryPluginsTab from "@/components/library/LibraryPluginsTab";
@@ -22,6 +23,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { UnsavedChangesDialog } from "@/components/ui/unsaved-changes-dialog";
 import { useLibrary, useUpdateLibrary } from "@/hooks/queries/libraries";
+import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import {
@@ -34,6 +36,8 @@ const LibrarySettings = () => {
   const { libraryId } = useParams<{ libraryId: string }>();
   const libraryQuery = useLibrary(libraryId);
   const updateLibraryMutation = useUpdateLibrary();
+  const { hasPermission } = useAuth();
+  const canDeleteLibrary = hasPermission("libraries", "write");
 
   usePageTitle(
     libraryQuery.data?.name
@@ -51,6 +55,7 @@ const LibrarySettings = () => {
   const [isInitialized, setIsInitialized] = useState(false);
   const [pluginsHaveChanges, setPluginsHaveChanges] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [pickerTargetIndex, setPickerTargetIndex] = useState<number | null>(
     null,
   );
@@ -414,6 +419,40 @@ const LibrarySettings = () => {
           </Button>
         </div>
       </div>
+
+      {canDeleteLibrary && libraryQuery.data && (
+        <section className="max-w-2xl mt-8 border border-destructive/40 rounded-md p-4 md:p-6">
+          <h2 className="text-base md:text-lg font-semibold text-destructive mb-1">
+            Danger Zone
+          </h2>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-2">
+            <div className="min-w-0">
+              <p className="font-medium">Delete this library</p>
+              <p className="text-sm text-muted-foreground">
+                Permanently removes this library and all of its books, files,
+                and metadata from the database. Files on disk are not touched.
+              </p>
+            </div>
+            <Button
+              className="shrink-0"
+              onClick={() => setDeleteDialogOpen(true)}
+              size="sm"
+              variant="destructive"
+            >
+              <Trash2 className="h-4 w-4 sm:mr-2" />
+              <span className="hidden sm:inline">Delete library</span>
+            </Button>
+          </div>
+        </section>
+      )}
+
+      {libraryQuery.data && (
+        <DeleteLibraryDialog
+          library={{ id: libraryQuery.data.id, name: libraryQuery.data.name }}
+          onOpenChange={setDeleteDialogOpen}
+          open={deleteDialogOpen}
+        />
+      )}
 
       <UnsavedChangesDialog
         onDiscard={proceedNavigation}

--- a/app/hooks/queries/libraries.ts
+++ b/app/hooks/queries/libraries.ts
@@ -14,6 +14,7 @@ import type {
 } from "@/types";
 
 import { QueryKey as BooksQueryKey } from "./books";
+import { QueryKey as LibrarySettingsQueryKey } from "./librarySettings";
 
 export enum QueryKey {
   RetrieveLibrary = "RetrieveLibrary",
@@ -107,6 +108,12 @@ export const useDeleteLibrary = () => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListLibraries] });
       queryClient.removeQueries({
         queryKey: [QueryKey.RetrieveLibrary, String(id)],
+      });
+      queryClient.removeQueries({
+        queryKey: [QueryKey.LibraryLanguages, id],
+      });
+      queryClient.removeQueries({
+        queryKey: [LibrarySettingsQueryKey.LibrarySettings, id],
       });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });

--- a/app/hooks/queries/libraries.ts
+++ b/app/hooks/queries/libraries.ts
@@ -13,6 +13,8 @@ import type {
   UpdateLibraryPayload,
 } from "@/types";
 
+import { QueryKey as BooksQueryKey } from "./books";
+
 export enum QueryKey {
   RetrieveLibrary = "RetrieveLibrary",
   ListLibraries = "ListLibraries",
@@ -90,6 +92,24 @@ export const useUpdateLibrary = () => {
     onSuccess: (data: Library) => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListLibraries] });
       queryClient.setQueryData([QueryKey.RetrieveLibrary, data.id], data);
+    },
+  });
+};
+
+export const useDeleteLibrary = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, ShishoAPIError, { id: number }>({
+    mutationFn: ({ id }) => {
+      return API.request("DELETE", `/libraries/${id}`);
+    },
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: [QueryKey.ListLibraries] });
+      queryClient.removeQueries({
+        queryKey: [QueryKey.RetrieveLibrary, String(id)],
+      });
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
     },
   });
 };

--- a/docs/superpowers/plans/2026-04-23-delete-library.md
+++ b/docs/superpowers/plans/2026-04-23-delete-library.md
@@ -1,0 +1,1378 @@
+# Delete Library Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a user-facing "Delete library" action to the library settings page, gated by `libraries:write`, that hard-deletes the library and all DB-resident content (rows + FTS) without touching files on disk.
+
+**Architecture:** New `DELETE /api/libraries/:id` endpoint. A service method runs job cancellation → FTS purge → `DELETE FROM libraries` inside a single transaction, relying on existing `ON DELETE CASCADE` FKs for child tables. The existing `OnLibraryChanged` callback is invoked after commit to refresh the filesystem monitor. The unused `deleted_at` soft-delete plumbing on libraries is removed in the same change.
+
+**Tech Stack:** Go 1.x, Echo, Bun ORM, SQLite FTS5; React 19, TanStack Query, TailwindCSS, Vitest; Docusaurus.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-delete-library-design.md`
+
+**Before you start each task:**
+- Read the spec section referenced in the task.
+- Read the root `CLAUDE.md`, `pkg/CLAUDE.md`, `app/CLAUDE.md`, and `website/CLAUDE.md` — they contain project conventions (JSON naming, test parallelism, doc casing, destructive-action UX) that are review failures if violated.
+- Use Red-Green-Refactor: every test must be observed failing before its implementation is written.
+
+**Commit messages** follow the project convention `[Category] Short description` — see root `CLAUDE.md`. This plan uses `[Backend]`, `[Fix]` (removing dead code), `[Frontend]`, and `[Docs]`.
+
+---
+
+## Task 1: Remove `deleted_at` soft-delete plumbing
+
+**Files:**
+- Create: `pkg/migrations/20260423000000_drop_libraries_deleted_at.go`
+- Modify: `pkg/models/library.go:16-28`
+- Modify: `pkg/libraries/service.go:18-25, 119-157`
+- Modify: `pkg/libraries/handlers.go:1-223`
+- Modify: `pkg/libraries/validators.go:11-24`
+
+This task removes the existing unused soft-delete code. The column is currently only toggled by the update handler via `params.Deleted`; no UI reads it, no background code honors it beyond the one list filter. Removing it in the same change keeps the model, migrations, and UI coherent.
+
+- [ ] **Step 1: Add migration to drop the `deleted_at` column**
+
+Create `pkg/migrations/20260423000000_drop_libraries_deleted_at.go`:
+
+```go
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE libraries DROP COLUMN deleted_at`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE libraries ADD COLUMN deleted_at TIMESTAMPTZ`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}
+```
+
+- [ ] **Step 2: Remove the `DeletedAt` field from the Library model**
+
+Edit `pkg/models/library.go` — delete the line `DeletedAt *time.Time \`json:"deleted_at,omitempty"\`` (line 27). If `time` is no longer referenced in the file, remove the import. After editing, the struct should end with the `LibraryPaths` field.
+
+- [ ] **Step 3: Remove `IncludeDeleted` from list options and the `deleted_at IS NULL` filter**
+
+In `pkg/libraries/service.go`:
+
+Replace the `ListLibrariesOptions` struct (currently at lines 18-25) with:
+
+```go
+type ListLibrariesOptions struct {
+	Limit      *int
+	Offset     *int
+	LibraryIDs []int // If set, only return libraries with these IDs
+
+	includeTotal bool
+}
+```
+
+In `listLibrariesWithTotal` (currently lines 119-157), delete the block:
+
+```go
+	if !opts.IncludeDeleted {
+		q = q.Where("deleted_at IS NULL")
+	}
+```
+
+- [ ] **Step 4: Remove the soft-delete branch in the update handler**
+
+In `pkg/libraries/handlers.go`:
+
+Remove the block (lines 194-201):
+
+```go
+	if params.Deleted != nil && (*params.Deleted && library.DeletedAt == nil || !*params.Deleted && library.DeletedAt != nil) {
+		if *params.Deleted {
+			library.DeletedAt = pointerutil.Time(time.Now())
+		} else {
+			library.DeletedAt = nil
+		}
+		opts.Columns = append(opts.Columns, "deleted_at")
+	}
+```
+
+In the same file, update the `onLibraryChanged` guard (currently line 218) — it currently fires for `opts.UpdateLibraryPaths || slices.Contains(opts.Columns, "deleted_at")`. Simplify to just `opts.UpdateLibraryPaths`:
+
+```go
+	if h.onLibraryChanged != nil && opts.UpdateLibraryPaths {
+		h.onLibraryChanged()
+	}
+```
+
+In the `list` handler (currently lines 109-143), remove `IncludeDeleted: params.Deleted` from the `opts` struct literal.
+
+Remove the now-unused imports from `pkg/libraries/handlers.go`:
+- `"slices"` (only used by the removed condition)
+- `"time"` (only used by `time.Now()` in the removed block)
+- `"github.com/robinjoseph08/golib/pointerutil"` (only used for `pointerutil.Time`)
+
+Verify by running `goimports -w pkg/libraries/handlers.go` or by letting the test build fail and catching unused-import errors.
+
+- [ ] **Step 5: Remove the `Deleted` field from update/list payloads**
+
+In `pkg/libraries/validators.go`:
+
+Remove the `Deleted` field from `ListLibrariesQuery`:
+
+```go
+type ListLibrariesQuery struct {
+	Limit  int `query:"limit" json:"limit,omitempty" default:"10" validate:"min=1,max=100"`
+	Offset int `query:"offset" json:"offset,omitempty" validate:"min=0"`
+}
+```
+
+Remove the `Deleted` field from `UpdateLibraryPayload`:
+
+```go
+type UpdateLibraryPayload struct {
+	Name                     *string  `json:"name,omitempty" validate:"omitempty,max=100"`
+	OrganizeFileStructure    *bool    `json:"organize_file_structure,omitempty"`
+	CoverAspectRatio         *string  `json:"cover_aspect_ratio,omitempty" validate:"omitempty,oneof=book audiobook book_fallback_audiobook audiobook_fallback_book"`
+	DownloadFormatPreference *string  `json:"download_format_preference,omitempty" validate:"omitempty,oneof=original kepub ask"`
+	LibraryPaths             []string `json:"library_paths,omitempty" validate:"omitempty,min=1,max=50,dive"`
+}
+```
+
+- [ ] **Step 6: Build and verify no remaining references to removed symbols**
+
+Run:
+
+```bash
+go build ./...
+grep -rn "DeletedAt\|IncludeDeleted\|params\.Deleted" pkg/
+```
+
+Expected: `go build` succeeds. `grep` returns no matches inside `pkg/libraries/`, `pkg/models/library.go`, or any caller. (Matches inside unrelated models like `Series.DeletedAt` are fine — series still has soft-delete; this task only touches Library.)
+
+- [ ] **Step 7: Run full Go test suite**
+
+Run: `mise test`
+
+Expected: all tests pass. Existing library tests (none yet) and callers that use `ListLibrariesOptions` compile and pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pkg/migrations/20260423000000_drop_libraries_deleted_at.go pkg/models/library.go pkg/libraries/service.go pkg/libraries/handlers.go pkg/libraries/validators.go
+git commit -m "[Fix] Remove unused deleted_at soft-delete from libraries"
+```
+
+---
+
+## Task 2: Write failing service test for DeleteLibrary — cascades + FTS purge + job cancellation
+
+**Files:**
+- Create: `pkg/libraries/service_test.go`
+
+This task establishes the red side of TDD. One test file, multiple test cases, all failing because `DeleteLibrary` doesn't exist yet. The tests exercise the full contract: row removal, CASCADE coverage, FTS purge, active-job cancellation, not-found error, and transactional atomicity.
+
+- [ ] **Step 1: Write the test file**
+
+Create `pkg/libraries/service_test.go`:
+
+```go
+package libraries
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func newTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { db.Close() })
+
+	return db
+}
+
+// seedLibraryWithContent creates a library with one book, one file, one series,
+// one person, one genre, one tag, and corresponding FTS entries. Returns the
+// library ID and the seeded entity IDs for assertions.
+type seededIDs struct {
+	LibraryID int
+	BookID    int
+	FileID    int
+	SeriesID  int
+	PersonID  int
+	GenreID   int
+	TagID     int
+}
+
+func seedLibraryWithContent(t *testing.T, ctx context.Context, db *bun.DB, name string) seededIDs {
+	t.Helper()
+
+	library := &models.Library{
+		Name:                     name,
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID: library.ID,
+		Title:     "Seeded Book",
+		Filepath:  "/tmp/seeded",
+	}
+	_, err = db.NewInsert().Model(book).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID: library.ID,
+		BookID:    book.ID,
+		Filepath:  "/tmp/seeded/book.epub",
+		FileType:  "epub",
+	}
+	_, err = db.NewInsert().Model(file).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	series := &models.Series{
+		LibraryID: library.ID,
+		Name:      "Seeded Series",
+	}
+	_, err = db.NewInsert().Model(series).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	person := &models.Person{
+		LibraryID: library.ID,
+		Name:      "Seeded Person",
+		SortName:  "Person, Seeded",
+	}
+	_, err = db.NewInsert().Model(person).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	genre := &models.Genre{
+		LibraryID: library.ID,
+		Name:      "Seeded Genre",
+	}
+	_, err = db.NewInsert().Model(genre).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	tag := &models.Tag{
+		LibraryID: library.ID,
+		Name:      "Seeded Tag",
+	}
+	_, err = db.NewInsert().Model(tag).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	// Seed minimal FTS rows directly (Index* methods have relation loading
+	// requirements that are overkill for this test's needs).
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO books_fts (book_id, library_id, title, filepath, subtitle, authors, filenames, narrators, series_names)
+		 VALUES (?, ?, ?, ?, '', '', '', '', '')`,
+		book.ID, library.ID, book.Title, book.Filepath)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO series_fts (series_id, library_id, name, description, book_titles, book_authors)
+		 VALUES (?, ?, ?, '', '', '')`,
+		series.ID, library.ID, series.Name)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO persons_fts (person_id, library_id, name, sort_name) VALUES (?, ?, ?, ?)`,
+		person.ID, library.ID, person.Name, person.SortName)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO genres_fts (genre_id, library_id, name) VALUES (?, ?, ?)`,
+		genre.ID, library.ID, genre.Name)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO tags_fts (tag_id, library_id, name) VALUES (?, ?, ?)`,
+		tag.ID, library.ID, tag.Name)
+	require.NoError(t, err)
+
+	return seededIDs{
+		LibraryID: library.ID,
+		BookID:    book.ID,
+		FileID:    file.ID,
+		SeriesID:  series.ID,
+		PersonID:  person.ID,
+		GenreID:   genre.ID,
+		TagID:     tag.ID,
+	}
+}
+
+func TestDeleteLibrary_RemovesRowAndCascades(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "Test Library")
+
+	err := svc.DeleteLibrary(ctx, seeded.LibraryID)
+	require.NoError(t, err)
+
+	// Library row removed.
+	libCount, err := db.NewSelect().Model((*models.Library)(nil)).Where("id = ?", seeded.LibraryID).Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, libCount, "library row should be gone")
+
+	// CASCADE removed children.
+	for name, count := range map[string]func() (int, error){
+		"books":   func() (int, error) { return db.NewSelect().Model((*models.Book)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx) },
+		"files":   func() (int, error) { return db.NewSelect().Model((*models.File)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx) },
+		"series":  func() (int, error) { return db.NewSelect().Model((*models.Series)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx) },
+		"persons": func() (int, error) { return db.NewSelect().Model((*models.Person)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx) },
+		"genres":  func() (int, error) { return db.NewSelect().Model((*models.Genre)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx) },
+		"tags":    func() (int, error) { return db.NewSelect().Model((*models.Tag)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx) },
+	} {
+		n, err := count()
+		require.NoError(t, err, name)
+		assert.Zero(t, n, "%s rows should be cascaded", name)
+	}
+}
+
+func TestDeleteLibrary_PurgesFTS(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "FTS Library")
+
+	err := svc.DeleteLibrary(ctx, seeded.LibraryID)
+	require.NoError(t, err)
+
+	for _, table := range []string{"books_fts", "series_fts", "persons_fts", "genres_fts", "tags_fts"} {
+		var count int
+		err := db.NewSelect().TableExpr(table).ColumnExpr("COUNT(*)").Where("library_id = ?", seeded.LibraryID).Scan(ctx, &count)
+		require.NoError(t, err, table)
+		assert.Zero(t, count, "%s rows for deleted library should be purged", table)
+	}
+}
+
+func TestDeleteLibrary_CancelsActiveJobs(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	// Target library.
+	lib := &models.Library{Name: "Target", CoverAspectRatio: "book", DownloadFormatPreference: models.DownloadFormatOriginal}
+	_, err := db.NewInsert().Model(lib).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	// Second library whose jobs should not be touched.
+	other := &models.Library{Name: "Other", CoverAspectRatio: "book", DownloadFormatPreference: models.DownloadFormatOriginal}
+	_, err = db.NewInsert().Model(other).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	insertJob := func(status string, libraryID *int) int {
+		j := &models.Job{
+			Type:      models.JobTypeScan,
+			Status:    status,
+			LibraryID: libraryID,
+			Data:      "{}",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		_, err := db.NewInsert().Model(j).Returning("*").Exec(ctx)
+		require.NoError(t, err)
+		return j.ID
+	}
+
+	pendingID := insertJob(models.JobStatusPending, &lib.ID)
+	runningID := insertJob(models.JobStatusInProgress, &lib.ID)
+	completedID := insertJob(models.JobStatusCompleted, &lib.ID)
+	otherLibraryJobID := insertJob(models.JobStatusPending, &other.ID)
+	globalJobID := insertJob(models.JobStatusPending, nil)
+
+	err = svc.DeleteLibrary(ctx, lib.ID)
+	require.NoError(t, err)
+
+	loadStatus := func(id int) string {
+		var j models.Job
+		err := db.NewSelect().Model(&j).Where("id = ?", id).Scan(ctx)
+		require.NoError(t, err)
+		return j.Status
+	}
+
+	assert.Equal(t, models.JobStatusFailed, loadStatus(pendingID), "pending job for deleted library should be failed")
+	assert.Equal(t, models.JobStatusFailed, loadStatus(runningID), "running job for deleted library should be failed")
+	assert.Equal(t, models.JobStatusCompleted, loadStatus(completedID), "completed job must not change")
+	assert.Equal(t, models.JobStatusPending, loadStatus(otherLibraryJobID), "other library's job must not change")
+	assert.Equal(t, models.JobStatusPending, loadStatus(globalJobID), "global job (no library_id) must not change")
+}
+
+func TestDeleteLibrary_NotFound(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	err := svc.DeleteLibrary(ctx, 99999)
+	require.Error(t, err)
+
+	var codeErr *errcodes.Error
+	require.True(t, errors.As(err, &codeErr), "error must wrap errcodes.Error, got %T: %v", err, err)
+	assert.Equal(t, "not_found", codeErr.Code)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/libraries/... -run TestDeleteLibrary -v`
+
+Expected: compilation failure — `svc.DeleteLibrary undefined`. This is the Red step.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add pkg/libraries/service_test.go
+git commit -m "[Backend] Add failing tests for DeleteLibrary service"
+```
+
+---
+
+## Task 3: Implement `Service.DeleteLibrary`
+
+**Files:**
+- Modify: `pkg/libraries/service.go` — append a new method at the end.
+
+Implements the service described in the spec's Architecture → Service section. Single transaction; the order is fixed because FTS purge needs primary IDs to still exist and job cancellation benefits from `library_id` still being populated for audit.
+
+- [ ] **Step 1: Write the implementation**
+
+Append to `pkg/libraries/service.go`:
+
+```go
+// DeleteLibrary hard-deletes a library and all of its DB-resident content.
+// Files on disk are not touched. The operation runs in a single transaction:
+//
+//  1. Cancel any pending/in-progress jobs scoped to this library.
+//  2. Purge FTS rows (books_fts, series_fts, persons_fts, genres_fts, tags_fts)
+//     for this library. FTS purge must happen before the CASCADE so rows are
+//     still resolvable.
+//  3. Delete the library row; SQLite cascades the rest.
+//
+// Returns errcodes.NotFound if the library does not exist.
+func (svc *Service) DeleteLibrary(ctx context.Context, id int) error {
+	return errors.WithStack(svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
+		// Verify the library exists so we can return NotFound rather than
+		// silently succeeding on a non-existent ID.
+		exists, err := tx.NewSelect().Model((*models.Library)(nil)).Where("id = ?", id).Exists(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if !exists {
+			return errcodes.NotFound("Library")
+		}
+
+		// 1. Cancel active jobs. jobs.library_id is ON DELETE SET NULL, so rows
+		//    survive the cascade; we still update them here so the audit trail
+		//    shows they were cancelled as part of the delete.
+		_, err = tx.NewUpdate().
+			Model((*models.Job)(nil)).
+			Set("status = ?", models.JobStatusFailed).
+			Set("updated_at = ?", time.Now()).
+			Where("library_id = ?", id).
+			Where("status IN (?)", bun.In([]string{models.JobStatusPending, models.JobStatusInProgress})).
+			Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 2. Purge FTS rows. Each FTS table carries library_id directly, so
+		//    we can delete by that filter without first collecting child IDs.
+		for _, table := range []string{"books_fts", "series_fts", "persons_fts", "genres_fts", "tags_fts"} {
+			_, err := tx.ExecContext(ctx, "DELETE FROM "+table+" WHERE library_id = ?", id)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
+		// 3. Delete the library. ON DELETE CASCADE handles children.
+		_, err = tx.NewDelete().Model((*models.Library)(nil)).Where("id = ?", id).Exec(ctx)
+		return errors.WithStack(err)
+	}))
+}
+```
+
+Add the missing imports to the top of `pkg/libraries/service.go`. The file already imports `context`, `database/sql`, `time`, `errors`, `errcodes`, `models`, and `bun`. No new imports are required.
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `go test ./pkg/libraries/... -run TestDeleteLibrary -v`
+
+Expected: all four tests pass (`TestDeleteLibrary_RemovesRowAndCascades`, `TestDeleteLibrary_PurgesFTS`, `TestDeleteLibrary_CancelsActiveJobs`, `TestDeleteLibrary_NotFound`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/libraries/service.go
+git commit -m "[Backend] Add DeleteLibrary service method"
+```
+
+---
+
+## Task 4: Write failing handler tests
+
+**Files:**
+- Create: `pkg/libraries/handlers_test.go`
+
+Covers permission, library-access, not-found, and the happy path. Permission enforcement lives in middleware (not in the handler body), so the handler test mirrors the production wiring by registering the DELETE route on an Echo instance with the real auth middleware.
+
+- [ ] **Step 1: Write the test file**
+
+Create `pkg/libraries/handlers_test.go`:
+
+```go
+package libraries
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// newDeleteTestServer wires up the libraries DELETE route against a real DB
+// and a stubbed auth middleware that injects the provided user into the
+// request context. Returns the Echo instance plus a counter that increments
+// each time onLibraryChanged fires.
+func newDeleteTestServer(t *testing.T, db *bun.DB, user *models.User) (*echo.Echo, *int) {
+	t.Helper()
+
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	e.HTTPErrorHandler = errcodes.NewHandler().Handle
+
+	// Inject user context middleware that mirrors the real auth middleware.
+	stubAuth := func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if user != nil {
+				c.Set("user", user)
+				c.Set("user_id", user.ID)
+			}
+			return next(c)
+		}
+	}
+
+	authMiddleware := auth.NewMiddleware(db, "test-secret")
+	callbacks := 0
+	g := e.Group("/libraries")
+	g.Use(stubAuth)
+	RegisterRoutesWithGroup(g, db, authMiddleware, RegisterRoutesOptions{
+		OnLibraryChanged: func() { callbacks++ },
+	})
+	return e, &callbacks
+}
+
+func seedUser(t *testing.T, ctx context.Context, db *bun.DB, roleName string, allAccess bool) *models.User {
+	t.Helper()
+
+	role := &models.Role{}
+	err := db.NewSelect().Model(role).Where("name = ?", roleName).Scan(ctx)
+	require.NoError(t, err)
+
+	u := &models.User{
+		Username:         roleName + "-user",
+		PasswordHash:     "unused",
+		RoleID:           role.ID,
+		AllLibraryAccess: allAccess,
+		Role:             role,
+	}
+	_, err = db.NewInsert().Model(u).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	// Load permissions so user.HasPermission works inside middleware.
+	err = db.NewSelect().Model(u).Relation("Role").Relation("Role.Permissions").Where("u.id = ?", u.ID).Scan(ctx)
+	require.NoError(t, err)
+
+	return u
+}
+
+func TestDeleteLibraryHandler_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	admin := seedUser(t, ctx, db, models.RoleAdmin, true)
+	e, callbacks := newDeleteTestServer(t, db, admin)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "Doomed")
+
+	req := httptest.NewRequest(http.MethodDelete, "/libraries/"+strconv.Itoa(seeded.LibraryID), nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+
+	count, err := db.NewSelect().Model((*models.Library)(nil)).Where("id = ?", seeded.LibraryID).Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count, "library should be gone")
+
+	assert.Equal(t, 1, *callbacks, "onLibraryChanged should fire once on success")
+}
+
+func TestDeleteLibraryHandler_NotFound(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	admin := seedUser(t, ctx, db, models.RoleAdmin, true)
+	e, _ := newDeleteTestServer(t, db, admin)
+
+	req := httptest.NewRequest(http.MethodDelete, "/libraries/99999", nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestDeleteLibraryHandler_RequiresWritePermission(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	viewer := seedUser(t, ctx, db, models.RoleViewer, true)
+	e, callbacks := newDeleteTestServer(t, db, viewer)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "Protected")
+
+	req := httptest.NewRequest(http.MethodDelete, "/libraries/"+strconv.Itoa(seeded.LibraryID), nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	count, err := db.NewSelect().Model((*models.Library)(nil)).Where("id = ?", seeded.LibraryID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "library must survive")
+
+	assert.Zero(t, *callbacks, "onLibraryChanged must not fire on 403")
+}
+
+func TestDeleteLibraryHandler_RequiresLibraryAccess(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	editor := seedUser(t, ctx, db, models.RoleEditor, false) // no library access
+	e, _ := newDeleteTestServer(t, db, editor)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "NotYours")
+
+	req := httptest.NewRequest(http.MethodDelete, "/libraries/"+strconv.Itoa(seeded.LibraryID), nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/libraries/... -run TestDeleteLibraryHandler -v`
+
+Expected: 404 on the happy path (no DELETE route registered yet). At least `TestDeleteLibraryHandler_HappyPath` should fail with HTTP 404.
+
+Note: if `seedUser` or helper utility references don't compile, fix those first — the goal is failing tests, not compile errors.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add pkg/libraries/handlers_test.go
+git commit -m "[Backend] Add failing tests for library delete handler"
+```
+
+---
+
+## Task 5: Implement the delete handler and register the route
+
+**Files:**
+- Modify: `pkg/libraries/handlers.go` — add `delete` method.
+- Modify: `pkg/libraries/routes.go` — register the DELETE route.
+
+- [ ] **Step 1: Add the handler method**
+
+Append to `pkg/libraries/handlers.go` (after the `update` method):
+
+```go
+func (h *handler) delete(c echo.Context) error {
+	ctx := c.Request().Context()
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.NotFound("Library")
+	}
+
+	if err := h.libraryService.DeleteLibrary(ctx, id); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if h.onLibraryChanged != nil {
+		h.onLibraryChanged()
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+```
+
+- [ ] **Step 2: Register the DELETE route**
+
+In `pkg/libraries/routes.go`, append after the existing `POST /:id` registration (line 34):
+
+```go
+	g.DELETE("/:id", h.delete,
+		authMiddleware.RequirePermission(models.ResourceLibraries, models.OperationWrite),
+		authMiddleware.RequireLibraryAccess("id"))
+```
+
+The final `RegisterRoutesWithGroup` body should look like:
+
+```go
+	g.GET("", h.list)
+	g.GET("/:id", h.retrieve, authMiddleware.RequireLibraryAccess("id"))
+	g.POST("", h.create, authMiddleware.RequirePermission(models.ResourceLibraries, models.OperationWrite))
+	g.POST("/:id", h.update, authMiddleware.RequirePermission(models.ResourceLibraries, models.OperationWrite), authMiddleware.RequireLibraryAccess("id"))
+	g.DELETE("/:id", h.delete,
+		authMiddleware.RequirePermission(models.ResourceLibraries, models.OperationWrite),
+		authMiddleware.RequireLibraryAccess("id"))
+```
+
+- [ ] **Step 3: Run handler tests**
+
+Run: `go test ./pkg/libraries/... -run TestDeleteLibraryHandler -v`
+
+Expected: all four handler tests pass.
+
+- [ ] **Step 4: Run the full Go test suite**
+
+Run: `mise test`
+
+Expected: all tests pass, including unrelated packages. If any test fails because it previously referenced `DeletedAt` / `IncludeDeleted`, fix the reference inline — the cleanup in Task 1 was supposed to cover this, but a caller may have been missed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/libraries/handlers.go pkg/libraries/routes.go
+git commit -m "[Backend] Add DELETE /libraries/:id endpoint"
+```
+
+---
+
+## Task 6: Regenerate frontend types
+
+**Files:**
+- Modify: `app/types/generated/*` (auto-generated; do not hand-edit)
+
+Running tygo picks up the removal of `DeletedAt` from the Go model and the removal of `Deleted` from the update payload, so the TypeScript `Library` and `UpdateLibraryPayload` types stay in sync.
+
+- [ ] **Step 1: Run tygo**
+
+Run: `mise tygo`
+
+Expected: either "skipping, outputs are up-to-date" (which is normal per root `CLAUDE.md` — Air may have run it already) or a brief regeneration. The `app/types/generated/` directory is gitignored, so there is nothing to commit from this step.
+
+- [ ] **Step 2: Verify types compile**
+
+Run: `pnpm lint:types`
+
+Expected: no TypeScript errors.
+
+If `pnpm lint:types` surfaces errors, they are almost certainly in handwritten files that referenced the removed `deleted_at` or `deleted` fields — fix those callsites before proceeding.
+
+---
+
+## Task 7: Add `deleteLibrary` to the API client and `useDeleteLibrary` hook
+
+**Files:**
+- Modify: `app/libraries/api.ts`
+- Modify: `app/hooks/queries/libraries.ts`
+
+- [ ] **Step 1: Add the API method**
+
+Add the following method inside the `ShishoAPI` class in `app/libraries/api.ts` (beside the other domain-specific methods). If the class has no other library methods (the current file only has API-key helpers), place it after `clearKoboSync`:
+
+```ts
+  deleteLibrary(id: number): Promise<void> {
+    return this.request("DELETE", `/libraries/${id}`);
+  }
+```
+
+Note: the codebase pattern is to route other library calls through the generic `API.request(...)` directly from the hook file. Either approach works — if you prefer consistency with the existing `useLibrary` / `useUpdateLibrary` hooks, skip this step and call `API.request("DELETE", ...)` directly from the hook instead. Whichever approach is used must match the existing convention in `libraries.ts`.
+
+Decision for this plan: **skip the API class method**, call `API.request` directly from the hook to match the existing hook style.
+
+- [ ] **Step 2: Add the `useDeleteLibrary` hook**
+
+In `app/hooks/queries/libraries.ts`, import the books query key at the top alongside the existing imports:
+
+```ts
+import { QueryKey as BooksQueryKey } from "./books";
+```
+
+(If the import already exists for another reason, reuse it.)
+
+Append the new hook at the bottom of the file:
+
+```ts
+export const useDeleteLibrary = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, ShishoAPIError, { id: number }>({
+    mutationFn: ({ id }) => {
+      return API.request("DELETE", `/libraries/${id}`);
+    },
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: [QueryKey.ListLibraries] });
+      queryClient.removeQueries({ queryKey: [QueryKey.RetrieveLibrary, String(id)] });
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+    },
+  });
+};
+```
+
+Note the deliberate use of `removeQueries` (not `invalidateQueries`) for the single-library detail — the library is gone, so any cached `useLibrary` call should drop its data rather than refetch a now-404 endpoint.
+
+- [ ] **Step 3: Verify the types compile**
+
+Run: `pnpm lint:types`
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/hooks/queries/libraries.ts
+git commit -m "[Frontend] Add useDeleteLibrary mutation hook"
+```
+
+---
+
+## Task 8: Create `DeleteLibraryDialog` component and its tests
+
+**Files:**
+- Create: `app/components/library/DeleteLibraryDialog.tsx`
+- Create: `app/components/library/DeleteLibraryDialog.test.tsx`
+
+Dedicated component — not a variant of `DeleteConfirmationDialog` (which is book/file-specific). Type-to-confirm UX matches the destructive-action convention in the spec.
+
+- [ ] **Step 1: Write the failing component tests**
+
+Create `app/components/library/DeleteLibraryDialog.test.tsx`:
+
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { DeleteLibraryDialog } from "./DeleteLibraryDialog";
+
+const mockDelete = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/queries/libraries", () => ({
+  useDeleteLibrary: () => ({
+    mutateAsync: mockDelete,
+    isPending: false,
+  }),
+}));
+
+const renderDialog = (props: Partial<React.ComponentProps<typeof DeleteLibraryDialog>> = {}) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const onOpenChange = vi.fn();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DeleteLibraryDialog
+          library={{ id: 1, name: "My Library" }}
+          onOpenChange={onOpenChange}
+          open={true}
+          {...props}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  return { onOpenChange };
+};
+
+describe("DeleteLibraryDialog", () => {
+  it("disables the Delete button until the user types the exact library name", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderDialog();
+
+    const deleteButton = screen.getByRole("button", { name: /^Delete$/ });
+    expect(deleteButton).toBeDisabled();
+
+    const input = screen.getByLabelText(/Type the library name to confirm/i);
+    await user.type(input, "my library"); // wrong case
+    expect(deleteButton).toBeDisabled();
+
+    await user.clear(input);
+    await user.type(input, "My Library");
+    expect(deleteButton).toBeEnabled();
+  });
+
+  it("calls the delete mutation with the library id on confirm", async () => {
+    mockDelete.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderDialog();
+
+    await user.type(screen.getByLabelText(/Type the library name to confirm/i), "My Library");
+    await user.click(screen.getByRole("button", { name: /^Delete$/ }));
+
+    expect(mockDelete).toHaveBeenCalledWith({ id: 1 });
+  });
+
+  it("surfaces the three caveats in the warning banner", () => {
+    renderDialog();
+
+    expect(screen.getByText(/irreversible/i)).toBeInTheDocument();
+    expect(screen.getByText(/Files on disk will not be deleted/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sidecar and metadata files will not be cleaned up/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm vitest run app/components/library/DeleteLibraryDialog.test.tsx`
+
+Expected: failure — module `./DeleteLibraryDialog` does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `app/components/library/DeleteLibraryDialog.tsx`:
+
+```tsx
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useDeleteLibrary } from "@/hooks/queries/libraries";
+
+interface DeleteLibraryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  library: { id: number; name: string };
+}
+
+export function DeleteLibraryDialog({
+  open,
+  onOpenChange,
+  library,
+}: DeleteLibraryDialogProps) {
+  const [typedName, setTypedName] = useState("");
+  const deleteMutation = useDeleteLibrary();
+  const navigate = useNavigate();
+
+  // Reset the typed value whenever the dialog reopens.
+  useEffect(() => {
+    if (open) setTypedName("");
+  }, [open]);
+
+  const canDelete = typedName === library.name && !deleteMutation.isPending;
+
+  const handleConfirm = async () => {
+    try {
+      await deleteMutation.mutateAsync({ id: library.id });
+      toast.success(`Library "${library.name}" deleted.`);
+      onOpenChange(false);
+      navigate("/settings/libraries");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Something went wrong.";
+      toast.error(msg);
+    }
+  };
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-md overflow-x-hidden">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-destructive shrink-0" />
+            Delete library
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Permanently delete this library from the database.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 min-w-0">
+          <div className="bg-destructive/10 border border-destructive/20 rounded-md p-3 text-sm text-destructive break-words space-y-2">
+            <p>This action is irreversible.</p>
+            <p>Files on disk will not be deleted.</p>
+            <p>
+              Sidecar and metadata files will not be cleaned up. You&apos;ll
+              need to remove them manually if desired.
+            </p>
+          </div>
+
+          <p className="text-sm">
+            Are you sure you want to delete{" "}
+            <span className="font-medium">&ldquo;{library.name}&rdquo;</span>?
+          </p>
+
+          <div className="space-y-2">
+            <Label htmlFor="delete-library-confirm">
+              Type the library name to confirm
+            </Label>
+            <Input
+              autoComplete="off"
+              id="delete-library-confirm"
+              onChange={(e) => setTypedName(e.target.value)}
+              placeholder={library.name}
+              value={typedName}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            disabled={deleteMutation.isPending}
+            onClick={() => onOpenChange(false)}
+            variant="outline"
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={!canDelete}
+            onClick={handleConfirm}
+            variant="destructive"
+          >
+            {deleteMutation.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Delete
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm vitest run app/components/library/DeleteLibraryDialog.test.tsx`
+
+Expected: all three tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/DeleteLibraryDialog.tsx app/components/library/DeleteLibraryDialog.test.tsx
+git commit -m "[Frontend] Add DeleteLibraryDialog component"
+```
+
+---
+
+## Task 9: Wire the Danger Zone into `LibrarySettings`
+
+**Files:**
+- Modify: `app/components/pages/LibrarySettings.tsx`
+
+- [ ] **Step 1: Add the Danger Zone section**
+
+In `app/components/pages/LibrarySettings.tsx`:
+
+Add the imports at the top of the file:
+
+```tsx
+import { DeleteLibraryDialog } from "@/components/library/DeleteLibraryDialog";
+import { useAuth } from "@/hooks/useAuth";
+```
+
+Add state for the dialog near the other `useState` declarations (around line 53):
+
+```tsx
+const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+```
+
+Pull `hasPermission` from `useAuth`. Add near the top of the component body:
+
+```tsx
+const { hasPermission } = useAuth();
+const canDeleteLibrary = hasPermission("libraries", "write");
+```
+
+At the end of the `return (...)` JSX, after the existing `<div className="max-w-2xl space-y-6 border border-border rounded-md p-6">` wrapper closes but before `<UnsavedChangesDialog ...>`, insert:
+
+```tsx
+{canDeleteLibrary && libraryQuery.data && (
+  <section className="max-w-2xl mt-8 border border-destructive/40 rounded-md p-4 md:p-6">
+    <h2 className="text-base md:text-lg font-semibold text-destructive mb-1">
+      Danger Zone
+    </h2>
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-2">
+      <div className="min-w-0">
+        <p className="font-medium">Delete this library</p>
+        <p className="text-sm text-muted-foreground">
+          Permanently removes this library and all of its books, files, and
+          metadata from the database. Files on disk are not touched.
+        </p>
+      </div>
+      <Button
+        className="shrink-0"
+        onClick={() => setDeleteDialogOpen(true)}
+        size="sm"
+        variant="destructive"
+      >
+        <Trash2 className="h-4 w-4 sm:mr-2" />
+        <span className="hidden sm:inline">Delete library</span>
+      </Button>
+    </div>
+  </section>
+)}
+
+{libraryQuery.data && (
+  <DeleteLibraryDialog
+    library={{ id: libraryQuery.data.id, name: libraryQuery.data.name }}
+    onOpenChange={setDeleteDialogOpen}
+    open={deleteDialogOpen}
+  />
+)}
+```
+
+`Trash2` is already imported in this file (it's used on per-path remove buttons). No new lucide imports needed.
+
+- [ ] **Step 2: Manually verify in the dev server**
+
+Start the dev server: `mise start`
+
+In a browser:
+1. Log in as an admin user, navigate to a library's settings page.
+2. Confirm the Danger Zone appears at the bottom with a red border.
+3. Click **Delete library**. Confirm the dialog opens and the Delete button is disabled.
+4. Type a wrong value — button stays disabled. Type the exact library name — button enables.
+5. Click **Delete**. Confirm success toast, redirect to `/settings/libraries`, deleted library is absent from the list.
+6. Open `tmp/library/` on disk and confirm all original files are still there.
+7. Log out, log in as a Viewer, navigate to a library's settings page. Confirm the Danger Zone does not appear.
+
+Report back what you observed in each step.
+
+- [ ] **Step 3: Run all JS checks**
+
+Run: `mise lint:js`
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/pages/LibrarySettings.tsx
+git commit -m "[Frontend] Add Danger Zone delete action to library settings"
+```
+
+---
+
+## Task 10: Update documentation
+
+**Files:**
+- Create: `website/docs/libraries.md`
+- Modify: `website/docs/getting-started.md:44`
+
+The spec's Docs section specifies a new dedicated `libraries.md` page at `sidebar_position: 15` (between getting-started at 10 and directory-structure at 20).
+
+- [ ] **Step 1: Create the new doc page**
+
+Create `website/docs/libraries.md`:
+
+```markdown
+---
+sidebar_position: 15
+---
+
+# Libraries
+
+Shisho organizes your collection into **libraries**, each pointing at one or more directories on disk. This page covers how to create, configure, and delete a library.
+
+## Creating a Library
+
+Go to **Admin → Libraries → Add Library**. Choose a name, pick a cover aspect ratio (book, audiobook, or a fallback mode), and add one or more directory paths. Saving the library kicks off a scan of the configured paths automatically.
+
+## Library Settings
+
+Each library has its own settings page reachable from **Admin → Libraries → Settings** on the corresponding row. Settings cover:
+
+- **Library name** and **paths** — rename or add/remove scanned directories.
+- **Cover display aspect ratio** — how book and series covers render in gallery views.
+- **Download format preference** — original / KePub / Ask-on-download for EPUB and CBZ files.
+- **Organize file structure during scans** — when enabled, Shisho moves and renames files into a standardized layout. See [Directory Structure](./directory-structure.md) for the naming rules and triggering events.
+- **Plugin order** — override the global plugin order for this library.
+
+## Deleting a Library
+
+At the bottom of the library settings page, users with `libraries:write` permission (Admin and Editor roles by default) see a **Danger Zone** section with a **Delete library** button.
+
+Click the button, type the library name to confirm, and click **Delete**. The confirmation dialog surfaces these caveats:
+
+- **The action is irreversible.** There is no undo.
+- **Files on disk are not deleted.** Book files, audiobooks, comics, and PDFs remain exactly where they are.
+- **Sidecar and metadata files are not cleaned up.** `.shisho.json` sidecars, `.cover.jpg` images, and other generated metadata remain on disk. Remove them manually if you want a truly clean slate.
+
+### What is deleted
+
+- The library row itself.
+- All books, files, series, persons (authors and narrators), genres, tags, publishers, and imprints scoped to the library.
+- All file identifiers and chapters for those files.
+- Per-library plugin configuration, hook configuration, and field settings.
+- Per-user library access grants and per-user library settings (sort spec, etc.).
+- Full-text search entries for the above so searches no longer surface stale results.
+
+### What happens to active jobs
+
+Any pending or in-progress scan, hash, or plugin job scoped to the deleted library is cancelled (marked `failed`) as part of the deletion. Global jobs and jobs targeting other libraries are untouched.
+
+See [Users and Permissions](./users-and-permissions.md) for how to grant or revoke `libraries:write`.
+```
+
+- [ ] **Step 2: Update the cross-link in getting-started.md**
+
+In `website/docs/getting-started.md`, replace line 44:
+
+Before:
+```markdown
+Access Shisho at `http://localhost:5173` and create a library pointing to `/media` (or wherever you mounted your books).
+```
+
+After:
+```markdown
+Access Shisho at `http://localhost:5173` and [create a library](./libraries.md) pointing to `/media` (or wherever you mounted your books).
+```
+
+- [ ] **Step 3: Verify the docs build**
+
+Run: `mise docs`
+
+Navigate to `http://localhost:3000/shisho/docs/libraries` (or whatever URL the dev server reports) and confirm the page renders, the sidebar shows "Libraries" between "Getting Started" and "Directory Structure", and the cross-link from Getting Started resolves.
+
+Stop the dev server when done.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/docs/libraries.md website/docs/getting-started.md
+git commit -m "[Docs] Document library deletion and add Libraries page"
+```
+
+---
+
+## Task 11: Final verification
+
+- [ ] **Step 1: Run the full project check suite**
+
+Run: `mise check:quiet`
+
+Expected: the pass/fail summary reports all checks passing. This runs Go tests, Go lint, and all JS lint/tests in parallel. Per root `CLAUDE.md`, run this once — if it fails, use `mise check` for verbose output.
+
+- [ ] **Step 2: Run the full race-detection suite**
+
+Run: `mise test:race`
+
+Expected: passes cleanly. Concurrent DeleteLibrary calls are unlikely in practice but the transactional implementation should be race-clean.
+
+- [ ] **Step 3: End-to-end smoke test in the browser**
+
+Not automated (this feature has no E2E coverage planned; the unit + handler + component tests cover the surface). Perform the manual steps listed in Task 9 Step 2 once more against the final committed code.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Covered by |
+|---|---|
+| Delete library endpoint, `libraries:write`-gated | Tasks 4, 5 |
+| CASCADE coverage (books, files, series, persons, etc.) | Task 2 (TestDeleteLibrary_RemovesRowAndCascades) |
+| FTS purge (all five tables) | Tasks 2, 3 |
+| Job cancellation | Tasks 2, 3 |
+| Monitor refresh via OnLibraryChanged | Tasks 4, 5 |
+| No files on disk deleted | Implicit (no filesystem code touched); manual verification in Task 9 |
+| Remove `deleted_at` plumbing | Task 1 |
+| Danger Zone UI gated by permission | Task 9 |
+| Type-to-confirm dialog | Task 8 |
+| Three caveats in dialog copy | Task 8 (test `surfaces the three caveats`) |
+| Invalidate affected TanStack Query caches | Task 7 |
+| Docs: new `libraries.md` page with delete section | Task 10 |
+| Docs: sidebar position 15 | Task 10 Step 1 frontmatter |
+| Docs: update getting-started cross-link | Task 10 Step 2 |
+
+**Placeholder scan:** No `TBD` / `TODO` / "add appropriate X" language. Every code-bearing step contains literal code. Every test references functions or components that are defined in an earlier step in this plan.
+
+**Type consistency check:** `DeleteLibraryDialog` is referred to by that exact name in Tasks 8, 9, and the self-review. The mutation hook is `useDeleteLibrary` in all three tasks (7, 8, 9). Service method is `DeleteLibrary` in all backend tasks (2, 3, 4, 5). The `RegisterRoutesOptions.OnLibraryChanged` callback name matches its usage in Task 4's test helper and the existing `pkg/server/server.go:152-154`.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-23-delete-library.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-23-delete-library-design.md
+++ b/docs/superpowers/specs/2026-04-23-delete-library-design.md
@@ -230,14 +230,27 @@ After dropping `DeletedAt` from the Go model, run `mise tygo` to regenerate `app
 
 ## Docs
 
-`website/docs/` update:
-- Update `website/docs/libraries.md` (or whichever page documents library management; we'll grep for the closest existing doc during implementation). Add a section "Deleting a library" describing:
-  - Where to find the action (library settings → Danger Zone).
-  - Required permission (`libraries:write`).
-  - Explicit enumeration of what is and is not deleted (DB rows yes; files on disk no; sidecars no; cover files no).
+There is currently no dedicated library-management page — library creation is mentioned only in passing in `getting-started.md:44` ("create a library pointing to `/media`"), and individual library settings are covered piecemeal (the "Organize Files" toggle lives in `directory-structure.md`). Adding delete documentation to any of those pages would be a poor fit.
+
+Create a new page: **`website/docs/libraries.md`**, titled `# Libraries`.
+
+Sidebar position: `15`. This slots between `getting-started.md` (10) and `directory-structure.md` (20), which is exactly what the increments-of-10 scheme in `website/CLAUDE.md` is designed to accommodate. No other doc currently uses 15.
+
+Initial content — keep it focused; we're not trying to document every existing library feature in this change:
+
+- **Creating a library** (~3 sentences): Admin → Libraries → Add Library, name and paths, scan triggers automatically. Cross-link from `getting-started.md:44` (update that line to link here).
+- **Library settings** (~2 sentences): Brief pointer that each library has its own settings page with cover aspect ratio, download format preference, and the Organize Files toggle. Link to `directory-structure.md` for the organize-files behavior.
+- **Deleting a library** (the substantive new section):
+  - Where to find it: library settings page → Danger Zone at the bottom.
+  - Required permission: `libraries:write` (Admin and Editor roles by default).
+  - Confirmation UX: type the library name to confirm.
+  - What is deleted: the library row and all associated DB records — books, files, series, persons, genres, tags, publishers, imprints, chapters, file identifiers, plugin configs and settings, user library access and settings. Search index entries are purged. Active scan jobs for the library are cancelled.
+  - What is **not** deleted: book files on disk, sidecar files (`.shisho.json`), cover files, or any other filesystem content. You must remove these manually if desired.
   - That the action is irreversible.
 
-No changes needed to `configuration.md`, `metadata.md`, `users-and-permissions.md` (existing permission is reused), or `supported-formats.md`.
+No changes needed to `configuration.md`, `metadata.md`, `users-and-permissions.md` (existing permission is reused — can optionally add a cross-link from the Libraries row in the permissions matrix), or `supported-formats.md`.
+
+Do **not** edit anything under `versioned_docs/` — those are frozen snapshots of prior releases, per `website/CLAUDE.md`.
 
 ## CLAUDE.md updates
 

--- a/docs/superpowers/specs/2026-04-23-delete-library-design.md
+++ b/docs/superpowers/specs/2026-04-23-delete-library-design.md
@@ -1,0 +1,256 @@
+# Delete Library — Design
+
+## Problem
+
+There is currently no way to delete a library from Shisho. The data model has an unused `Library.DeletedAt` soft-delete column and a toggle in the update handler, but no UI exposes it and nothing else in the system acts on the flag. Users who create libraries by mistake, rename folders, or decommission libraries have no recourse short of editing the SQLite database.
+
+## Goals
+
+- Allow a user with `libraries:write` to delete a library from the admin libraries area.
+- The deletion is a hard delete from the database: the library row, its books, files, series, persons, genres, tags, publishers, imprints, chapters, file identifiers, plugin configs, plugin field settings, plugin hook configs, user library access entries, and user library settings are all removed.
+- Full-text search indexes (`books_fts`, `series_fts`, `persons_fts`, `genres_fts`, `tags_fts`) are purged of entries belonging to the deleted library.
+- Active scan / hash / plugin jobs targeting the library are cancelled (marked failed) so they stop running.
+- The filesystem monitor drops its watches on the removed library paths.
+- **No files on disk are deleted.** No sidecars, no cover files, no source files.
+- The action is gated behind a confirmation dialog that clearly communicates that the deletion is irreversible, that files on disk are not deleted, and that sidecar / metadata files are not cleaned up.
+- The unused `deleted_at` soft-delete plumbing is removed as part of this change.
+
+## Non-Goals
+
+- Deleting files, sidecars, covers, or any other content on disk. If the user wants the directory gone, they can remove it themselves; a future feature can layer this on top.
+- Restoring a deleted library. This is a hard delete.
+- Bulk delete across multiple libraries.
+- Exposing delete to roles other than those that already hold `libraries:write` (Admin and Editor, per the default role definitions).
+
+## Architecture
+
+### Endpoint
+
+`DELETE /api/libraries/:id`
+
+Middleware:
+- `Authenticate` (inherited from the libraries group)
+- `RequirePermission(libraries, write)`
+- `RequireLibraryAccess("id")` — prevents Editors without library access from deleting that library
+
+Response: `204 No Content` on success. Standard error codes on 403 / 404.
+
+### Handler
+
+Registered in `pkg/libraries/routes.go`:
+
+```go
+g.DELETE("/:id", h.delete,
+    authMiddleware.RequirePermission(models.ResourceLibraries, models.OperationWrite),
+    authMiddleware.RequireLibraryAccess("id"))
+```
+
+The handler (`h.delete` in `pkg/libraries/handlers.go`) looks up the library, calls `libraryService.DeleteLibrary(ctx, id)`, and — on success — invokes `h.onLibraryChanged` so the monitor refreshes its watch set.
+
+### Service
+
+`DeleteLibrary(ctx, id)` in `pkg/libraries/service.go` runs the following inside a single `RunInTx`, in order:
+
+1. **Collect IDs for FTS cleanup.** Before the cascade removes rows, select the IDs of all books, series, persons, genres, and tags that belong to this library. Hold them in memory for step 3.
+2. **Cancel in-flight jobs.** Update `jobs` rows with this `library_id` whose status is `pending` or `running`, setting status to `failed` and an error message like "Library deleted". (Jobs with `library_id = NULL` or non-terminal for other reasons are untouched.)
+3. **Purge FTS rows.** `DELETE FROM books_fts WHERE rowid IN (...)` for each of the five FTS tables, using the IDs collected in step 1. This must happen before step 4 because the FTS tables are external content tables keyed by the primary IDs — once the primary rows are gone via CASCADE, we can't reliably correlate.
+4. **Delete the library row.** `DELETE FROM libraries WHERE id = ?`. SQLite's `ON DELETE CASCADE` propagates through the FK graph. Requires `PRAGMA foreign_keys = ON`, which is already set in production and test helpers.
+
+After the transaction commits, the handler calls `onLibraryChanged` (non-transactional — it refreshes fsnotify watches in the monitor).
+
+**Rationale for ordering:**
+- FTS purge before CASCADE: external-content FTS tables need the primary IDs to be resolvable at delete time.
+- Job cancellation before library delete: the `jobs.library_id` FK uses `ON DELETE SET NULL`, so if we deleted the library first, we could still cancel by ID, but doing it first keeps the audit trail (failed job rows retain their `library_id`).
+- Everything in one tx: if FTS purge fails, we don't want a dangling half-deleted library.
+
+### Existing CASCADE coverage
+
+Audited in `pkg/migrations/20250321211048_create_initial_tables.go`, `20260124000000_create_library_plugin_tables.go`, `20260128000000_create_plugin_field_settings.go`, `20260406100000_add_fk_cascades.go`, `20260419000000_add_user_library_settings.go`:
+
+| Table | FK to libraries | Behavior |
+|---|---|---|
+| `library_paths` | `library_id` | CASCADE |
+| `books` | `library_id` | CASCADE |
+| `files` | `library_id` | CASCADE |
+| `persons` | `library_id` | CASCADE |
+| `series` | `library_id` | CASCADE |
+| `genres` | `library_id` | CASCADE |
+| `tags` | `library_id` | CASCADE |
+| `publishers` | `library_id` | CASCADE |
+| `imprints` | `library_id` | CASCADE |
+| `plugin_configs` | `library_id` | CASCADE |
+| `plugin_hook_configs` | `library_id` | CASCADE |
+| `plugin_field_settings` | `library_id` | CASCADE |
+| `user_library_settings` | `library_id` | CASCADE |
+| `user_library_access` | `library_id` | CASCADE |
+| `jobs` | `library_id` | SET NULL |
+
+Indirectly via CASCADE from `books` / `files`: `book_series`, `authors`, `narrators`, `file_identifiers`, `chapters`, `file_fingerprints`, and any other child of `books` / `files`. These are the plan's responsibility only to the extent that we verify via tests that deletion succeeds and no orphans remain.
+
+### Remove soft-delete plumbing
+
+As part of this work, the unused `deleted_at` mechanism is removed:
+
+- **Model:** Drop the `DeletedAt *time.Time` field from `models.Library` in `pkg/models/library.go`.
+- **Service:** Remove `ListLibrariesOptions.IncludeDeleted` and the `deleted_at IS NULL` filter in `listLibrariesWithTotal` (`pkg/libraries/service.go`).
+- **Handler:** In `pkg/libraries/handlers.go` `update`, drop the branch that reads `params.Deleted` and mutates `library.DeletedAt` / appends `"deleted_at"` to `opts.Columns`. Drop the `Deleted` field from the update payload struct if it is not used elsewhere.
+- **Migration:** New Bun migration that drops the `deleted_at` column from `libraries`. SQLite supports `ALTER TABLE DROP COLUMN` since 3.35; we're on a newer version. Down migration re-adds the nullable column.
+
+Any call sites referencing `IncludeDeleted` need to be updated — grep confirms it's only set inside the service itself in current code.
+
+## Frontend
+
+### Library Settings page
+
+`app/components/pages/LibrarySettings.tsx` gains a **Danger Zone** section at the bottom, conditionally rendered on `hasPermission("libraries", "write")`:
+
+```tsx
+{canWrite && (
+  <section className="mt-10 border border-destructive/40 rounded-md p-4 md:p-6">
+    <h2 className="text-base md:text-lg font-semibold text-destructive mb-1">
+      Danger Zone
+    </h2>
+    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+      <div>
+        <p className="font-medium">Delete this library</p>
+        <p className="text-sm text-muted-foreground">
+          Permanently removes this library and all of its books, files, and
+          metadata from the database. Files on disk are not touched.
+        </p>
+      </div>
+      <Button
+        variant="destructive"
+        size="sm"
+        onClick={() => setDeleteOpen(true)}
+        className="shrink-0"
+      >
+        <Trash2 className="h-4 w-4 sm:mr-2" />
+        <span className="hidden sm:inline">Delete library</span>
+      </Button>
+    </div>
+  </section>
+)}
+```
+
+The section does not participate in the Save-on-form pattern — it is a standalone destructive action.
+
+### DeleteLibraryDialog
+
+New component: `app/components/library/DeleteLibraryDialog.tsx`.
+
+Props:
+```ts
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  library: Pick<Library, "id" | "name">;
+}
+```
+
+Structure:
+- `<Dialog>` with `DialogContent className="max-w-md"`
+- `DialogHeader`: `<AlertTriangle>` icon + "Delete library"
+- Body:
+  - Red warning banner listing the three caveats:
+    - "This action is irreversible."
+    - "Files on disk will not be deleted."
+    - "Sidecar and metadata files will not be cleaned up. You'll need to remove them manually if desired."
+  - Summary line: `Are you sure you want to delete “{library.name}”?`
+  - Confirmation input: `Type the library name to confirm.` The Delete button is disabled until `typed === library.name` exactly.
+- Footer: Cancel button; destructive Delete button with loader.
+
+On success, the component:
+- Invalidates `[QueryKey.ListLibraries]` and any library-scoped queries (covered by the mutation hook).
+- Shows a success toast: `Library "{name}" deleted.`
+- Navigates to `/settings/libraries`.
+
+I am not reusing the existing `DeleteConfirmationDialog` because its `variant` union (`book | books | file`) and its file-size-summary machinery don't apply to libraries, and bolting on a "library" variant would dilute the component's purpose.
+
+### API + query hook
+
+- `app/libraries/api.ts`: add `deleteLibrary(id: number)` calling `fetch("/api/libraries/" + id, { method: "DELETE" })`.
+- `app/hooks/queries/libraries.ts`: add `useDeleteLibrary()` returning a `useMutation` that calls `deleteLibrary`. On `onSuccess`, invalidate:
+  - `[QueryKey.ListLibraries]`
+  - `[QueryKey.RetrieveLibrary]`
+  - `[BooksQueryKey.ListBooks]`, `[BooksQueryKey.RetrieveBook]` (a deleted library removes its books from any cached list)
+
+### Generated types
+
+After dropping `DeletedAt` from the Go model, run `mise tygo` to regenerate `app/types/generated/` so the frontend type for `Library` no longer has `deleted_at`.
+
+## Testing
+
+### Backend — Service
+
+`pkg/libraries/service_test.go`:
+
+- `TestDeleteLibrary_RemovesRowAndCascades` — seed a library with books, files, series, persons, genres, tags; call `DeleteLibrary`; assert zero rows remain in each child table for that `library_id`.
+- `TestDeleteLibrary_PurgesFTS` — seed searchable entities, index them via the search service, delete the library, assert no surviving rows in any of the five FTS tables keyed to the deleted IDs.
+- `TestDeleteLibrary_CancelsActiveJobs` — seed `pending` and `running` jobs scoped to the library (plus one `completed` and one with a different `library_id`), delete, assert the first two are now `failed`, `completed` untouched, other library's job untouched.
+- `TestDeleteLibrary_NotFound` — deleting a non-existent ID returns `errcodes.NotFound`.
+- `TestDeleteLibrary_Atomicity` — inject a forced failure partway through (e.g., via a test hook on FTS purge) and assert the library row survives.
+
+### Backend — Handler
+
+`pkg/libraries/handlers_test.go`:
+
+- `TestDeleteLibraryHandler_RequiresWritePermission` — viewer role gets 403.
+- `TestDeleteLibraryHandler_RequiresLibraryAccess` — editor without access to this library gets 403.
+- `TestDeleteLibraryHandler_HappyPath` — admin deletes successfully, 204, row gone.
+- `TestDeleteLibraryHandler_NotFound` — 404 on unknown ID.
+- `TestDeleteLibraryHandler_TriggersOnLibraryChanged` — handler invokes the callback exactly once on success.
+
+### Frontend
+
+`app/components/library/DeleteLibraryDialog.test.tsx`:
+
+- Delete button is disabled until the typed input matches the library name exactly.
+- Delete button is disabled while mutation is pending; shows loader.
+- On success, mutation is called with the correct ID and toast/navigation side effects fire.
+- On error, dialog stays open, error toast shown.
+
+`app/components/pages/LibrarySettings.test.tsx` (add, if existing tests cover the page):
+
+- Danger zone is not rendered for users without `libraries:write`.
+- Danger zone is rendered for users with `libraries:write`.
+
+### Manual verification
+
+1. `mise start`, create a library with a few books.
+2. Log in as Viewer — confirm no Danger Zone visible on library settings.
+3. Log in as Admin — confirm Danger Zone visible; open dialog, observe warning banner with all three caveats.
+4. Try clicking Delete without typing the name — disabled.
+5. Type the name, click Delete, confirm:
+   - Toast appears
+   - Redirected to `/settings/libraries`, deleted library not in list
+   - `tmp/library/` still contains all the files
+   - Sidecar `.shisho.json` files still exist alongside the originals
+   - DB: `sqlite3 tmp/data.sqlite "SELECT COUNT(*) FROM books"` is zero for that library's books
+   - Search: global search for a book title from the deleted library returns nothing
+
+## Docs
+
+`website/docs/` update:
+- Update `website/docs/libraries.md` (or whichever page documents library management; we'll grep for the closest existing doc during implementation). Add a section "Deleting a library" describing:
+  - Where to find the action (library settings → Danger Zone).
+  - Required permission (`libraries:write`).
+  - Explicit enumeration of what is and is not deleted (DB rows yes; files on disk no; sidecars no; cover files no).
+  - That the action is irreversible.
+
+No changes needed to `configuration.md`, `metadata.md`, `users-and-permissions.md` (existing permission is reused), or `supported-formats.md`.
+
+## CLAUDE.md updates
+
+The root `CLAUDE.md` "CASCADE does not clean up FTS indexes" gotcha already covers the pattern we're using. No new rule is needed unless the implementation surfaces one.
+
+## Open questions
+
+None at spec time.
+
+## Risk / Rollback
+
+Low-risk from a product standpoint — gated behind explicit permission and a name-typing confirmation.
+
+Database risk: dropping the `deleted_at` column is a schema change. The down migration re-adds the nullable column but does not restore data (there is no data to restore — the column is unused in production).
+
+Rollback plan if a bug is discovered post-deploy: revert the frontend and backend changes; the removed column is not depended on by any other system, so a forward-only rollback is safe.

--- a/pkg/libraries/handlers.go
+++ b/pkg/libraries/handlers.go
@@ -208,3 +208,21 @@ func (h *handler) update(c echo.Context) error {
 
 	return errors.WithStack(c.JSON(http.StatusOK, library))
 }
+
+func (h *handler) delete(c echo.Context) error {
+	ctx := c.Request().Context()
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.NotFound("Library")
+	}
+
+	if err := h.libraryService.DeleteLibrary(ctx, id); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if h.onLibraryChanged != nil {
+		h.onLibraryChanged()
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}

--- a/pkg/libraries/handlers.go
+++ b/pkg/libraries/handlers.go
@@ -2,13 +2,10 @@ package libraries
 
 import (
 	"net/http"
-	"slices"
 	"strconv"
-	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
-	"github.com/robinjoseph08/golib/pointerutil"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/jobs"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -116,9 +113,8 @@ func (h *handler) list(c echo.Context) error {
 	}
 
 	opts := ListLibrariesOptions{
-		Limit:          &params.Limit,
-		Offset:         &params.Offset,
-		IncludeDeleted: params.Deleted,
+		Limit:  &params.Limit,
+		Offset: &params.Offset,
 	}
 
 	// Filter by user's library access if user is in context
@@ -191,14 +187,6 @@ func (h *handler) update(c echo.Context) error {
 		}
 		opts.UpdateLibraryPaths = true
 	}
-	if params.Deleted != nil && (*params.Deleted && library.DeletedAt == nil || !*params.Deleted && library.DeletedAt != nil) {
-		if *params.Deleted {
-			library.DeletedAt = pointerutil.Time(time.Now())
-		} else {
-			library.DeletedAt = nil
-		}
-		opts.Columns = append(opts.Columns, "deleted_at")
-	}
 
 	// Update the model.
 	err = h.libraryService.UpdateLibrary(ctx, library, opts)
@@ -214,8 +202,7 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Notify monitor of library changes (paths added/removed, library deleted/restored).
-	if h.onLibraryChanged != nil && (opts.UpdateLibraryPaths || slices.Contains(opts.Columns, "deleted_at")) {
+	if h.onLibraryChanged != nil && opts.UpdateLibraryPaths {
 		h.onLibraryChanged()
 	}
 

--- a/pkg/libraries/handlers_test.go
+++ b/pkg/libraries/handlers_test.go
@@ -55,7 +55,7 @@ func newDeleteTestServer(t *testing.T, db *bun.DB, user *models.User) (*echo.Ech
 	return e, &callbacks
 }
 
-func seedUser(t *testing.T, ctx context.Context, db *bun.DB, roleName string, allLibraryAccess bool) *models.User {
+func seedUser(ctx context.Context, t *testing.T, db *bun.DB, roleName string, allLibraryAccess bool) *models.User {
 	t.Helper()
 
 	role := &models.Role{}
@@ -93,10 +93,10 @@ func TestDeleteLibraryHandler_HappyPath(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()
 
-	admin := seedUser(t, ctx, db, models.RoleAdmin, true)
+	admin := seedUser(ctx, t, db, models.RoleAdmin, true)
 	e, callbacks := newDeleteTestServer(t, db, admin)
 
-	seeded := seedLibraryWithContent(t, ctx, db, "Doomed")
+	seeded := seedLibraryWithContent(ctx, t, db, "Doomed")
 
 	req := httptest.NewRequest(http.MethodDelete, "/libraries/"+strconv.Itoa(seeded.LibraryID), nil)
 	rr := httptest.NewRecorder()
@@ -117,7 +117,7 @@ func TestDeleteLibraryHandler_NotFound(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()
 
-	admin := seedUser(t, ctx, db, models.RoleAdmin, true)
+	admin := seedUser(ctx, t, db, models.RoleAdmin, true)
 	e, _ := newDeleteTestServer(t, db, admin)
 
 	req := httptest.NewRequest(http.MethodDelete, "/libraries/99999", nil)
@@ -133,10 +133,10 @@ func TestDeleteLibraryHandler_RequiresWritePermission(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()
 
-	viewer := seedUser(t, ctx, db, models.RoleViewer, true)
+	viewer := seedUser(ctx, t, db, models.RoleViewer, true)
 	e, callbacks := newDeleteTestServer(t, db, viewer)
 
-	seeded := seedLibraryWithContent(t, ctx, db, "Protected")
+	seeded := seedLibraryWithContent(ctx, t, db, "Protected")
 
 	req := httptest.NewRequest(http.MethodDelete, "/libraries/"+strconv.Itoa(seeded.LibraryID), nil)
 	rr := httptest.NewRecorder()
@@ -157,10 +157,10 @@ func TestDeleteLibraryHandler_RequiresLibraryAccess(t *testing.T) {
 	db := newTestDB(t)
 	ctx := context.Background()
 
-	editor := seedUser(t, ctx, db, models.RoleEditor, false) // no library access
+	editor := seedUser(ctx, t, db, models.RoleEditor, false) // no library access
 	e, _ := newDeleteTestServer(t, db, editor)
 
-	seeded := seedLibraryWithContent(t, ctx, db, "NotYours")
+	seeded := seedLibraryWithContent(ctx, t, db, "NotYours")
 
 	req := httptest.NewRequest(http.MethodDelete, "/libraries/"+strconv.Itoa(seeded.LibraryID), nil)
 	rr := httptest.NewRecorder()

--- a/pkg/libraries/handlers_test.go
+++ b/pkg/libraries/handlers_test.go
@@ -1,0 +1,170 @@
+package libraries
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/config"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// newDeleteTestServer wires up the libraries DELETE route against a real DB
+// and a stubbed auth middleware that injects the provided user into the
+// request context. Returns the Echo instance plus a counter that increments
+// each time onLibraryChanged fires.
+func newDeleteTestServer(t *testing.T, db *bun.DB, user *models.User) (*echo.Echo, *int) {
+	t.Helper()
+
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	e.HTTPErrorHandler = errcodes.NewHandler().Handle
+
+	// Inject user context middleware that mirrors the real auth middleware.
+	stubAuth := func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if user != nil {
+				c.Set("user", user)
+				c.Set("user_id", user.ID)
+			}
+			return next(c)
+		}
+	}
+
+	cfg := config.NewForTest()
+	authService := auth.NewService(db, cfg.JWTSecret, cfg.SessionDuration())
+	authMiddleware := auth.NewMiddleware(authService)
+
+	callbacks := 0
+	g := e.Group("/libraries")
+	g.Use(stubAuth)
+	RegisterRoutesWithGroup(g, db, authMiddleware, RegisterRoutesOptions{
+		OnLibraryChanged: func() { callbacks++ },
+	})
+	return e, &callbacks
+}
+
+func seedUser(t *testing.T, ctx context.Context, db *bun.DB, roleName string, allLibraryAccess bool) *models.User {
+	t.Helper()
+
+	role := &models.Role{}
+	err := db.NewSelect().Model(role).Where("name = ?", roleName).Scan(ctx)
+	require.NoError(t, err)
+
+	u := &models.User{
+		Username:     roleName + "-user",
+		PasswordHash: "unused",
+		RoleID:       role.ID,
+		IsActive:     true,
+		Role:         role,
+	}
+	_, err = db.NewInsert().Model(u).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	// Load permissions so user.HasPermission works inside middleware.
+	err = db.NewSelect().Model(u).Relation("Role").Relation("Role.Permissions").Where("u.id = ?", u.ID).Scan(ctx)
+	require.NoError(t, err)
+
+	if allLibraryAccess {
+		// nil LibraryID means access to all libraries.
+		access := &models.UserLibraryAccess{UserID: u.ID, LibraryID: nil}
+		_, err = db.NewInsert().Model(access).Returning("*").Exec(ctx)
+		require.NoError(t, err)
+		u.LibraryAccess = []*models.UserLibraryAccess{access}
+	}
+
+	return u
+}
+
+func TestDeleteLibraryHandler_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	admin := seedUser(t, ctx, db, models.RoleAdmin, true)
+	e, callbacks := newDeleteTestServer(t, db, admin)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "Doomed")
+
+	req := httptest.NewRequest(http.MethodDelete, "/libraries/"+strconv.Itoa(seeded.LibraryID), nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+
+	count, err := db.NewSelect().Model((*models.Library)(nil)).Where("id = ?", seeded.LibraryID).Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count, "library should be gone")
+
+	assert.Equal(t, 1, *callbacks, "onLibraryChanged should fire once on success")
+}
+
+func TestDeleteLibraryHandler_NotFound(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	admin := seedUser(t, ctx, db, models.RoleAdmin, true)
+	e, _ := newDeleteTestServer(t, db, admin)
+
+	req := httptest.NewRequest(http.MethodDelete, "/libraries/99999", nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestDeleteLibraryHandler_RequiresWritePermission(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	viewer := seedUser(t, ctx, db, models.RoleViewer, true)
+	e, callbacks := newDeleteTestServer(t, db, viewer)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "Protected")
+
+	req := httptest.NewRequest(http.MethodDelete, "/libraries/"+strconv.Itoa(seeded.LibraryID), nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	count, err := db.NewSelect().Model((*models.Library)(nil)).Where("id = ?", seeded.LibraryID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "library must survive")
+
+	assert.Zero(t, *callbacks, "onLibraryChanged must not fire on 403")
+}
+
+func TestDeleteLibraryHandler_RequiresLibraryAccess(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	editor := seedUser(t, ctx, db, models.RoleEditor, false) // no library access
+	e, _ := newDeleteTestServer(t, db, editor)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "NotYours")
+
+	req := httptest.NewRequest(http.MethodDelete, "/libraries/"+strconv.Itoa(seeded.LibraryID), nil)
+	rr := httptest.NewRecorder()
+	e.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+}

--- a/pkg/libraries/routes.go
+++ b/pkg/libraries/routes.go
@@ -32,4 +32,7 @@ func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Mid
 	g.GET("/:id", h.retrieve, authMiddleware.RequireLibraryAccess("id"))
 	g.POST("", h.create, authMiddleware.RequirePermission(models.ResourceLibraries, models.OperationWrite))
 	g.POST("/:id", h.update, authMiddleware.RequirePermission(models.ResourceLibraries, models.OperationWrite), authMiddleware.RequireLibraryAccess("id"))
+	g.DELETE("/:id", h.delete,
+		authMiddleware.RequirePermission(models.ResourceLibraries, models.OperationWrite),
+		authMiddleware.RequireLibraryAccess("id"))
 }

--- a/pkg/libraries/routes.go
+++ b/pkg/libraries/routes.go
@@ -10,8 +10,8 @@ import (
 
 // RegisterRoutesOptions configures optional behaviors for library routes.
 type RegisterRoutesOptions struct {
-	// OnLibraryChanged is called after a library is created or its paths/deletion state changes.
-	// Used by the monitor to refresh filesystem watches.
+	// OnLibraryChanged is called after a library is created, has its paths
+	// updated, or is deleted. Used by the monitor to refresh filesystem watches.
 	OnLibraryChanged func()
 }
 

--- a/pkg/libraries/service.go
+++ b/pkg/libraries/service.go
@@ -213,3 +213,54 @@ func (svc *Service) UpdateLibrary(ctx context.Context, library *models.Library, 
 
 	return nil
 }
+
+// DeleteLibrary hard-deletes a library and all of its DB-resident content.
+// Files on disk are not touched. The operation runs in a single transaction:
+//
+//  1. Cancel any pending/in-progress jobs scoped to this library.
+//  2. Purge FTS rows (books_fts, series_fts, persons_fts, genres_fts, tags_fts)
+//     for this library. FTS purge must happen before the CASCADE so rows are
+//     still resolvable.
+//  3. Delete the library row; SQLite cascades the rest.
+//
+// Returns errcodes.NotFound if the library does not exist.
+func (svc *Service) DeleteLibrary(ctx context.Context, id int) error {
+	return errors.WithStack(svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
+		// Verify the library exists so we can return NotFound rather than
+		// silently succeeding on a non-existent ID.
+		exists, err := tx.NewSelect().Model((*models.Library)(nil)).Where("id = ?", id).Exists(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if !exists {
+			return errcodes.NotFound("Library")
+		}
+
+		// 1. Cancel active jobs. jobs.library_id is ON DELETE SET NULL, so rows
+		//    survive the cascade; we still update them here so the audit trail
+		//    shows they were cancelled as part of the delete.
+		_, err = tx.NewUpdate().
+			Model((*models.Job)(nil)).
+			Set("status = ?", models.JobStatusFailed).
+			Set("updated_at = ?", time.Now()).
+			Where("library_id = ?", id).
+			Where("status IN (?)", bun.In([]string{models.JobStatusPending, models.JobStatusInProgress})).
+			Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// 2. Purge FTS rows. Each FTS table carries library_id directly, so
+		//    we can delete by that filter without first collecting child IDs.
+		for _, table := range []string{"books_fts", "series_fts", "persons_fts", "genres_fts", "tags_fts"} {
+			_, err := tx.ExecContext(ctx, "DELETE FROM "+table+" WHERE library_id = ?", id)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+
+		// 3. Delete the library. ON DELETE CASCADE handles children.
+		_, err = tx.NewDelete().Model((*models.Library)(nil)).Where("id = ?", id).Exec(ctx)
+		return errors.WithStack(err)
+	}))
+}

--- a/pkg/libraries/service.go
+++ b/pkg/libraries/service.go
@@ -244,7 +244,7 @@ func (svc *Service) DeleteLibrary(ctx context.Context, id int) error {
 			Set("status = ?", models.JobStatusFailed).
 			Set("updated_at = ?", time.Now()).
 			Where("library_id = ?", id).
-			Where("status IN (?)", bun.In([]string{models.JobStatusPending, models.JobStatusInProgress})).
+			Where("status IN (?)", bun.List([]string{models.JobStatusPending, models.JobStatusInProgress})).
 			Exec(ctx)
 		if err != nil {
 			return errors.WithStack(err)

--- a/pkg/libraries/service.go
+++ b/pkg/libraries/service.go
@@ -16,10 +16,9 @@ type RetrieveLibraryOptions struct {
 }
 
 type ListLibrariesOptions struct {
-	Limit          *int
-	Offset         *int
-	IncludeDeleted bool
-	LibraryIDs     []int // If set, only return libraries with these IDs
+	Limit      *int
+	Offset     *int
+	LibraryIDs []int // If set, only return libraries with these IDs
 
 	includeTotal bool
 }
@@ -136,9 +135,6 @@ func (svc *Service) listLibrariesWithTotal(ctx context.Context, opts ListLibrari
 	}
 	if opts.Offset != nil {
 		q = q.Offset(*opts.Offset)
-	}
-	if !opts.IncludeDeleted {
-		q = q.Where("deleted_at IS NULL")
 	}
 	if len(opts.LibraryIDs) > 0 {
 		q = q.Where("l.id IN (?)", bun.List(opts.LibraryIDs))

--- a/pkg/libraries/service_test.go
+++ b/pkg/libraries/service_test.go
@@ -281,3 +281,38 @@ func TestDeleteLibrary_NotFound(t *testing.T) {
 	require.ErrorAs(t, err, &codeErr, "error must wrap errcodes.Error, got %T: %v", err, err)
 	assert.Equal(t, "not_found", codeErr.Code)
 }
+
+func TestDeleteLibrary_Atomicity(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	seeded := seedLibraryWithContent(ctx, t, db, "Atomic")
+
+	// Cancel the context before calling DeleteLibrary so the transaction
+	// rolls back partway through. This exercises the single-transaction
+	// guarantee: if any step fails, nothing commits.
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	err := svc.DeleteLibrary(cancelledCtx, seeded.LibraryID)
+	require.Error(t, err, "cancelled context should fail the delete")
+
+	// Library row must still exist.
+	libCount, err := db.NewSelect().Model((*models.Library)(nil)).Where("id = ?", seeded.LibraryID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, libCount, "library row should survive a failed transaction")
+
+	// Books must still exist (CASCADE didn't run).
+	bookCount, err := db.NewSelect().Model((*models.Book)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, bookCount, "book row should survive a failed transaction")
+
+	// FTS entries must still exist.
+	var ftsCount int
+	err = db.NewSelect().TableExpr("books_fts").ColumnExpr("COUNT(*)").Where("library_id = ?", seeded.LibraryID).Scan(ctx, &ftsCount)
+	require.NoError(t, err)
+	assert.Equal(t, 1, ftsCount, "FTS entry should survive a failed transaction")
+}

--- a/pkg/libraries/service_test.go
+++ b/pkg/libraries/service_test.go
@@ -83,9 +83,11 @@ func seedLibraryWithContent(t *testing.T, ctx context.Context, db *bun.DB, name 
 	require.NoError(t, err)
 
 	series := &models.Series{
-		LibraryID:  library.ID,
-		Name:       "Seeded Series",
-		NameSource: models.DataSourceFilepath,
+		LibraryID:      library.ID,
+		Name:           "Seeded Series",
+		NameSource:     models.DataSourceFilepath,
+		SortName:       "Seeded Series",
+		SortNameSource: models.DataSourceFilepath,
 	}
 	_, err = db.NewInsert().Model(series).Returning("*").Exec(ctx)
 	require.NoError(t, err)

--- a/pkg/libraries/service_test.go
+++ b/pkg/libraries/service_test.go
@@ -3,7 +3,6 @@ package libraries
 import (
 	"context"
 	"database/sql"
-	"errors"
 	"testing"
 	"time"
 
@@ -49,7 +48,7 @@ type seededIDs struct {
 	TagID     int
 }
 
-func seedLibraryWithContent(t *testing.T, ctx context.Context, db *bun.DB, name string) seededIDs {
+func seedLibraryWithContent(ctx context.Context, t *testing.T, db *bun.DB, name string) seededIDs {
 	t.Helper()
 
 	library := &models.Library{
@@ -157,7 +156,7 @@ func TestDeleteLibrary_RemovesRowAndCascades(t *testing.T) {
 	ctx := context.Background()
 	svc := NewService(db)
 
-	seeded := seedLibraryWithContent(t, ctx, db, "Test Library")
+	seeded := seedLibraryWithContent(ctx, t, db, "Test Library")
 
 	err := svc.DeleteLibrary(ctx, seeded.LibraryID)
 	require.NoError(t, err)
@@ -201,7 +200,7 @@ func TestDeleteLibrary_PurgesFTS(t *testing.T) {
 	ctx := context.Background()
 	svc := NewService(db)
 
-	seeded := seedLibraryWithContent(t, ctx, db, "FTS Library")
+	seeded := seedLibraryWithContent(ctx, t, db, "FTS Library")
 
 	err := svc.DeleteLibrary(ctx, seeded.LibraryID)
 	require.NoError(t, err)
@@ -279,6 +278,6 @@ func TestDeleteLibrary_NotFound(t *testing.T) {
 	require.Error(t, err)
 
 	var codeErr *errcodes.Error
-	require.True(t, errors.As(err, &codeErr), "error must wrap errcodes.Error, got %T: %v", err, err)
+	require.ErrorAs(t, err, &codeErr, "error must wrap errcodes.Error, got %T: %v", err, err)
 	assert.Equal(t, "not_found", codeErr.Code)
 }

--- a/pkg/libraries/service_test.go
+++ b/pkg/libraries/service_test.go
@@ -61,25 +61,31 @@ func seedLibraryWithContent(t *testing.T, ctx context.Context, db *bun.DB, name 
 	require.NoError(t, err)
 
 	book := &models.Book{
-		LibraryID: library.ID,
-		Title:     "Seeded Book",
-		Filepath:  "/tmp/seeded",
+		LibraryID:       library.ID,
+		Title:           "Seeded Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Seeded Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        "/tmp/seeded",
 	}
 	_, err = db.NewInsert().Model(book).Returning("*").Exec(ctx)
 	require.NoError(t, err)
 
 	file := &models.File{
-		LibraryID: library.ID,
-		BookID:    book.ID,
-		Filepath:  "/tmp/seeded/book.epub",
-		FileType:  "epub",
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		Filepath:      "/tmp/seeded/book.epub",
+		FileType:      "epub",
+		FilesizeBytes: 1,
 	}
 	_, err = db.NewInsert().Model(file).Returning("*").Exec(ctx)
 	require.NoError(t, err)
 
 	series := &models.Series{
-		LibraryID: library.ID,
-		Name:      "Seeded Series",
+		LibraryID:  library.ID,
+		Name:       "Seeded Series",
+		NameSource: models.DataSourceFilepath,
 	}
 	_, err = db.NewInsert().Model(series).Returning("*").Exec(ctx)
 	require.NoError(t, err)

--- a/pkg/libraries/service_test.go
+++ b/pkg/libraries/service_test.go
@@ -1,0 +1,276 @@
+package libraries
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func newTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { db.Close() })
+
+	return db
+}
+
+// seedLibraryWithContent creates a library with one book, one file, one series,
+// one person, one genre, one tag, and corresponding FTS entries. Returns the
+// library ID and the seeded entity IDs for assertions.
+type seededIDs struct {
+	LibraryID int
+	BookID    int
+	FileID    int
+	SeriesID  int
+	PersonID  int
+	GenreID   int
+	TagID     int
+}
+
+func seedLibraryWithContent(t *testing.T, ctx context.Context, db *bun.DB, name string) seededIDs {
+	t.Helper()
+
+	library := &models.Library{
+		Name:                     name,
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID: library.ID,
+		Title:     "Seeded Book",
+		Filepath:  "/tmp/seeded",
+	}
+	_, err = db.NewInsert().Model(book).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID: library.ID,
+		BookID:    book.ID,
+		Filepath:  "/tmp/seeded/book.epub",
+		FileType:  "epub",
+	}
+	_, err = db.NewInsert().Model(file).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	series := &models.Series{
+		LibraryID: library.ID,
+		Name:      "Seeded Series",
+	}
+	_, err = db.NewInsert().Model(series).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	person := &models.Person{
+		LibraryID: library.ID,
+		Name:      "Seeded Person",
+		SortName:  "Person, Seeded",
+	}
+	_, err = db.NewInsert().Model(person).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	genre := &models.Genre{
+		LibraryID: library.ID,
+		Name:      "Seeded Genre",
+	}
+	_, err = db.NewInsert().Model(genre).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	tag := &models.Tag{
+		LibraryID: library.ID,
+		Name:      "Seeded Tag",
+	}
+	_, err = db.NewInsert().Model(tag).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	// Seed minimal FTS rows directly (Index* methods have relation loading
+	// requirements that are overkill for this test's needs).
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO books_fts (book_id, library_id, title, filepath, subtitle, authors, filenames, narrators, series_names)
+		 VALUES (?, ?, ?, ?, '', '', '', '', '')`,
+		book.ID, library.ID, book.Title, book.Filepath)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO series_fts (series_id, library_id, name, description, book_titles, book_authors)
+		 VALUES (?, ?, ?, '', '', '')`,
+		series.ID, library.ID, series.Name)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO persons_fts (person_id, library_id, name, sort_name) VALUES (?, ?, ?, ?)`,
+		person.ID, library.ID, person.Name, person.SortName)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO genres_fts (genre_id, library_id, name) VALUES (?, ?, ?)`,
+		genre.ID, library.ID, genre.Name)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO tags_fts (tag_id, library_id, name) VALUES (?, ?, ?)`,
+		tag.ID, library.ID, tag.Name)
+	require.NoError(t, err)
+
+	return seededIDs{
+		LibraryID: library.ID,
+		BookID:    book.ID,
+		FileID:    file.ID,
+		SeriesID:  series.ID,
+		PersonID:  person.ID,
+		GenreID:   genre.ID,
+		TagID:     tag.ID,
+	}
+}
+
+func TestDeleteLibrary_RemovesRowAndCascades(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "Test Library")
+
+	err := svc.DeleteLibrary(ctx, seeded.LibraryID)
+	require.NoError(t, err)
+
+	// Library row removed.
+	libCount, err := db.NewSelect().Model((*models.Library)(nil)).Where("id = ?", seeded.LibraryID).Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, libCount, "library row should be gone")
+
+	// CASCADE removed children.
+	for name, count := range map[string]func() (int, error){
+		"books": func() (int, error) {
+			return db.NewSelect().Model((*models.Book)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx)
+		},
+		"files": func() (int, error) {
+			return db.NewSelect().Model((*models.File)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx)
+		},
+		"series": func() (int, error) {
+			return db.NewSelect().Model((*models.Series)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx)
+		},
+		"persons": func() (int, error) {
+			return db.NewSelect().Model((*models.Person)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx)
+		},
+		"genres": func() (int, error) {
+			return db.NewSelect().Model((*models.Genre)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx)
+		},
+		"tags": func() (int, error) {
+			return db.NewSelect().Model((*models.Tag)(nil)).Where("library_id = ?", seeded.LibraryID).Count(ctx)
+		},
+	} {
+		n, err := count()
+		require.NoError(t, err, name)
+		assert.Zero(t, n, "%s rows should be cascaded", name)
+	}
+}
+
+func TestDeleteLibrary_PurgesFTS(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	seeded := seedLibraryWithContent(t, ctx, db, "FTS Library")
+
+	err := svc.DeleteLibrary(ctx, seeded.LibraryID)
+	require.NoError(t, err)
+
+	for _, table := range []string{"books_fts", "series_fts", "persons_fts", "genres_fts", "tags_fts"} {
+		var count int
+		err := db.NewSelect().TableExpr(table).ColumnExpr("COUNT(*)").Where("library_id = ?", seeded.LibraryID).Scan(ctx, &count)
+		require.NoError(t, err, table)
+		assert.Zero(t, count, "%s rows for deleted library should be purged", table)
+	}
+}
+
+func TestDeleteLibrary_CancelsActiveJobs(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	// Target library.
+	lib := &models.Library{Name: "Target", CoverAspectRatio: "book", DownloadFormatPreference: models.DownloadFormatOriginal}
+	_, err := db.NewInsert().Model(lib).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	// Second library whose jobs should not be touched.
+	other := &models.Library{Name: "Other", CoverAspectRatio: "book", DownloadFormatPreference: models.DownloadFormatOriginal}
+	_, err = db.NewInsert().Model(other).Returning("*").Exec(ctx)
+	require.NoError(t, err)
+
+	insertJob := func(status string, libraryID *int) int {
+		j := &models.Job{
+			Type:      models.JobTypeScan,
+			Status:    status,
+			LibraryID: libraryID,
+			Data:      "{}",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		_, err := db.NewInsert().Model(j).Returning("*").Exec(ctx)
+		require.NoError(t, err)
+		return j.ID
+	}
+
+	pendingID := insertJob(models.JobStatusPending, &lib.ID)
+	runningID := insertJob(models.JobStatusInProgress, &lib.ID)
+	completedID := insertJob(models.JobStatusCompleted, &lib.ID)
+	otherLibraryJobID := insertJob(models.JobStatusPending, &other.ID)
+	globalJobID := insertJob(models.JobStatusPending, nil)
+
+	err = svc.DeleteLibrary(ctx, lib.ID)
+	require.NoError(t, err)
+
+	loadStatus := func(id int) string {
+		var j models.Job
+		err := db.NewSelect().Model(&j).Where("id = ?", id).Scan(ctx)
+		require.NoError(t, err)
+		return j.Status
+	}
+
+	assert.Equal(t, models.JobStatusFailed, loadStatus(pendingID), "pending job for deleted library should be failed")
+	assert.Equal(t, models.JobStatusFailed, loadStatus(runningID), "running job for deleted library should be failed")
+	assert.Equal(t, models.JobStatusCompleted, loadStatus(completedID), "completed job must not change")
+	assert.Equal(t, models.JobStatusPending, loadStatus(otherLibraryJobID), "other library's job must not change")
+	assert.Equal(t, models.JobStatusPending, loadStatus(globalJobID), "global job (no library_id) must not change")
+}
+
+func TestDeleteLibrary_NotFound(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	err := svc.DeleteLibrary(ctx, 99999)
+	require.Error(t, err)
+
+	var codeErr *errcodes.Error
+	require.True(t, errors.As(err, &codeErr), "error must wrap errcodes.Error, got %T: %v", err, err)
+	assert.Equal(t, "not_found", codeErr.Code)
+}

--- a/pkg/libraries/validators.go
+++ b/pkg/libraries/validators.go
@@ -9,9 +9,8 @@ type CreateLibraryPayload struct {
 }
 
 type ListLibrariesQuery struct {
-	Limit   int  `query:"limit" json:"limit,omitempty" default:"10" validate:"min=1,max=100"`
-	Offset  int  `query:"offset" json:"offset,omitempty" validate:"min=0"`
-	Deleted bool `query:"deleted" json:"deleted,omitempty"`
+	Limit  int `query:"limit" json:"limit,omitempty" default:"10" validate:"min=1,max=100"`
+	Offset int `query:"offset" json:"offset,omitempty" validate:"min=0"`
 }
 
 type UpdateLibraryPayload struct {
@@ -20,5 +19,4 @@ type UpdateLibraryPayload struct {
 	CoverAspectRatio         *string  `json:"cover_aspect_ratio,omitempty" validate:"omitempty,oneof=book audiobook book_fallback_audiobook audiobook_fallback_book"`
 	DownloadFormatPreference *string  `json:"download_format_preference,omitempty" validate:"omitempty,oneof=original kepub ask"`
 	LibraryPaths             []string `json:"library_paths,omitempty" validate:"omitempty,min=1,max=50,dive"`
-	Deleted                  *bool    `json:"deleted,omitempty" validate:"omitempty"`
 }

--- a/pkg/migrations/20260423000000_drop_libraries_deleted_at.go
+++ b/pkg/migrations/20260423000000_drop_libraries_deleted_at.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE libraries DROP COLUMN deleted_at`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE libraries ADD COLUMN deleted_at TIMESTAMPTZ`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/library.go
+++ b/pkg/models/library.go
@@ -24,5 +24,4 @@ type Library struct {
 	CoverAspectRatio         string         `bun:",nullzero" json:"cover_aspect_ratio"`
 	DownloadFormatPreference string         `bun:",nullzero,default:'original'" json:"download_format_preference"`
 	LibraryPaths             []*LibraryPath `bun:"rel:has-many" json:"library_paths,omitempty" tstype:"LibraryPath[]"`
-	DeletedAt                *time.Time     `json:"deleted_at,omitempty"`
 }

--- a/website/docs/directory-structure.md
+++ b/website/docs/directory-structure.md
@@ -27,7 +27,7 @@ Shisho works best when each book has its own directory. All editions of a book (
 
 ## Organize Files
 
-Shisho includes an optional "Organize Files" feature in library settings that can automatically organize your books into a consistent directory structure. When enabled, Shisho will move and rename files based on metadata — during scans, when you identify a book and apply a plugin search result (the target file is renamed to match the identified title), and when you manually edit a book's title (each main file whose stored name still matches the old title is renamed too; custom filenames that differ from the book title are preserved).
+Shisho includes an optional "Organize Files" feature in [library settings](./libraries.md) that can automatically organize your books into a consistent directory structure. When enabled, Shisho will move and rename files based on metadata — during scans, when you identify a book and apply a plugin search result (the target file is renamed to match the identified title), and when you manually edit a book's title (each main file whose stored name still matches the old title is renamed too; custom filenames that differ from the book title are preserved).
 
 If you prefer to manage your own file organization, you can leave this disabled and Shisho will work with whatever structure you have. With Organize Files disabled, these actions still update the book's title and the corresponding files' stored names in the database, but no files are moved or renamed on disk.
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -41,7 +41,7 @@ Start the container:
 docker compose up -d
 ```
 
-Access Shisho at `http://localhost:5173` and create a library pointing to `/media` (or wherever you mounted your books).
+Access Shisho at `http://localhost:5173` and [create a library](./libraries.md) pointing to `/media` (or wherever you mounted your books).
 
 ## File Permissions (PUID/PGID)
 

--- a/website/docs/libraries.md
+++ b/website/docs/libraries.md
@@ -30,7 +30,7 @@ Click the button, type the library name to confirm, and click **Delete**. The co
 - **Files on disk are not deleted.** Book files, audiobooks, comics, and PDFs remain exactly where they are.
 - **Sidecar and metadata files are not cleaned up.** `.shisho.json` sidecars, `.cover.jpg` images, and other generated metadata remain on disk. Remove them manually if you want a truly clean slate.
 
-### What is deleted
+### What Is Deleted
 
 - The library row itself.
 - All books, files, series, persons (authors and narrators), genres, tags, publishers, and imprints scoped to the library.
@@ -39,7 +39,7 @@ Click the button, type the library name to confirm, and click **Delete**. The co
 - Per-user library access grants and per-user library settings (sort spec, etc.).
 - Full-text search entries for the above so searches no longer surface stale results.
 
-### What happens to active jobs
+### What Happens to Active Jobs
 
 Any pending or in-progress scan, hash, or plugin job scoped to the deleted library is cancelled (marked `failed`) as part of the deletion. Global jobs and jobs targeting other libraries are untouched.
 

--- a/website/docs/libraries.md
+++ b/website/docs/libraries.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 15
+---
+
+# Libraries
+
+Shisho organizes your collection into **libraries**, each pointing at one or more directories on disk. This page covers how to create, configure, and delete a library.
+
+## Creating a Library
+
+Go to **Admin → Libraries → Add Library**. Choose a name, pick a cover aspect ratio (book, audiobook, or a fallback mode), and add one or more directory paths. Saving the library kicks off a scan of the configured paths automatically.
+
+## Library Settings
+
+Each library has its own settings page reachable from **Admin → Libraries → Settings** on the corresponding row. Settings cover:
+
+- **Library name** and **paths** — rename or add/remove scanned directories.
+- **Cover display aspect ratio** — how book and series covers render in gallery views.
+- **Download format preference** — original / KePub / Ask-on-download for EPUB and CBZ files.
+- **Organize file structure during scans** — when enabled, Shisho moves and renames files into a standardized layout. See [Directory Structure](./directory-structure.md) for the naming rules and triggering events.
+- **Plugin order** — override the global plugin order for this library.
+
+## Deleting a Library
+
+At the bottom of the library settings page, users with `libraries:write` permission (Admin and Editor roles by default) see a **Danger Zone** section with a **Delete library** button.
+
+Click the button, type the library name to confirm, and click **Delete**. The confirmation dialog surfaces these caveats:
+
+- **The action is irreversible.** There is no undo.
+- **Files on disk are not deleted.** Book files, audiobooks, comics, and PDFs remain exactly where they are.
+- **Sidecar and metadata files are not cleaned up.** `.shisho.json` sidecars, `.cover.jpg` images, and other generated metadata remain on disk. Remove them manually if you want a truly clean slate.
+
+### What is deleted
+
+- The library row itself.
+- All books, files, series, persons (authors and narrators), genres, tags, publishers, and imprints scoped to the library.
+- All file identifiers and chapters for those files.
+- Per-library plugin configuration, hook configuration, and field settings.
+- Per-user library access grants and per-user library settings (sort spec, etc.).
+- Full-text search entries for the above so searches no longer surface stale results.
+
+### What happens to active jobs
+
+Any pending or in-progress scan, hash, or plugin job scoped to the deleted library is cancelled (marked `failed`) as part of the deletion. Global jobs and jobs targeting other libraries are untouched.
+
+See [Users and Permissions](./users-and-permissions.md) for how to grant or revoke `libraries:write`.


### PR DESCRIPTION
## Summary
- Adds a `DELETE /api/libraries/:id` endpoint gated by `libraries:write` and library-access middleware. Cancels in-flight jobs, purges FTS entries for books/series/persons/genres/tags, and deletes the library row (CASCADE handles child tables) — all in one transaction. Files on disk are untouched.
- Adds a Danger Zone section to the library settings page with a type-to-confirm `DeleteLibraryDialog` that calls out the three caveats (irreversible, files on disk untouched, sidecars untouched).
- Removes the unused `deleted_at` soft-delete plumbing (model field, service filter, update-handler branch, validator fields, and a migration that drops the column).
- Adds a new `website/docs/libraries.md` page documenting library creation, settings, and deletion; updates `getting-started.md` to link to it.

## Test plan
- `mise check:quiet` passes (lint, Go tests, JS lint, JS tests)
- `go test -race ./pkg/libraries/...` passes
- 5 Go service tests cover cascades, FTS purge, job cancellation, not-found, and transactional atomicity
- 4 Go handler tests cover happy path, not-found, `libraries:write` enforcement, and library-access enforcement
- 3 frontend component tests cover type-to-confirm gating, mutation call, and caveat rendering
- Manually verify in the dev server: admin sees the Danger Zone and can delete a library; viewer does not see it; files on disk remain after deletion