### PR TITLE
[Backend] Remove unused search query scaffolding types

### DIFF
--- a/pkg/search/validators.go
+++ b/pkg/search/validators.go
@@ -39,28 +39,3 @@ type PersonSearchResult struct {
 	SortName  string `json:"sort_name"`
 	LibraryID int    `json:"library_id"`
 }
-
-// BooksQuery represents the query parameters for book search.
-type BooksQuery struct {
-	Query     string   `query:"search" json:"search,omitempty" validate:"omitempty,max=100"`
-	LibraryID *int     `query:"library_id" json:"library_id,omitempty" validate:"omitempty,min=1" tstype:"number"`
-	FileTypes []string `query:"file_types" json:"file_types,omitempty"` // Filter by file types (e.g., ["epub", "m4b"])
-	Limit     int      `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
-	Offset    int      `query:"offset" json:"offset,omitempty" validate:"min=0"`
-}
-
-// SeriesQuery represents the query parameters for series search.
-type SeriesQuery struct {
-	Query     string `query:"search" json:"search,omitempty" validate:"omitempty,max=100"`
-	LibraryID *int   `query:"library_id" json:"library_id,omitempty" validate:"omitempty,min=1" tstype:"number"`
-	Limit     int    `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
-	Offset    int    `query:"offset" json:"offset,omitempty" validate:"min=0"`
-}
-
-// PeopleQuery represents the query parameters for people search.
-type PeopleQuery struct {
-	Query     string `query:"search" json:"search,omitempty" validate:"omitempty,max=100"`
-	LibraryID *int   `query:"library_id" json:"library_id,omitempty" validate:"omitempty,min=1" tstype:"number"`
-	Limit     int    `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
-	Offset    int    `query:"offset" json:"offset,omitempty" validate:"min=0"`
-}


### PR DESCRIPTION
## Summary
- `BooksQuery`, `SeriesQuery`, and `PeopleQuery` were defined in `pkg/search/validators.go` with no handlers or routes. Their optional `LibraryID *int` was a latent footgun — future endpoints built off them without proper access checks could leak cross-library data, since only the `globalSearch` handler enforces `HasLibraryAccess`.
- The live `/search` endpoint remains correctly secured (required `library_id` + `HasLibraryAccess` + per-query `WHERE library_id = ?`). Deleting the dead scaffolding removes the risk without changing any runtime behavior.

## Test plan
- `mise check:quiet` passes (Go lint, Go tests, JS lint, JS tests).
- No frontend/backend references to the removed types (`BooksQuery`, `SeriesQuery`, `PeopleQuery` from `pkg/search`) — grep confirmed the only hits were the definitions themselves and unrelated compound names like `ListBooksQuery` / `BooksQueryKey`.
- Manual sanity check: `GET /search?q=foo&library_id=<accessible>` still returns results; `library_id=<inaccessible>` still returns empty; omitting `library_id` still 400s via validator.