### PR TITLE
[Fix] Serve covers and persist metadata for root-level library files

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -102,13 +102,12 @@ file.CoverImageFilename = &newCoverPath
 
 **Why this matters:** Handlers resolve the full path at runtime by joining `book.Filepath` with `CoverImageFilename`. If `CoverImageFilename` contains a full path, this results in an invalid doubled path like `/path/to/path/to/cover.jpg`.
 
-**Use the shared resolution helpers in `pkg/fileutils/operations.go`** rather than hand-rolling `os.Stat` / `!info.IsDir()` / `filepath.Dir` dances:
+**Always resolve cover paths via the file, not the book**, because `book.Filepath` can be a synthetic organized-folder path that never exists on disk (root-level books in libraries with `OrganizeFileStructure` disabled — see `scanFileCreateNew`). The cover lives alongside the file for both root-level and directory-backed books.
 
-- **`ResolveCoverPath(bookFilepath, coverFilename) string`** — read-side callers (serving, fingerprinting, file-generation) that already have a resolved `book.Filepath` from the DB. Example: `fileutils.ResolveCoverPath(file.Book.Filepath, *file.CoverImageFilename)` in the `fileCover` handler.
-- **`ResolveCoverDir(bookFilepath) string`** — same read-side contract but returns just the directory (e.g. for `uploadFileCover`, which enumerates existing cover files). Stat-failure fallback returns the path unchanged — **safe only for read-side callers** whose `bookFilepath` is known to exist.
-- **`ResolveCoverDirForWrite(bookFilepath, fileFilepath) string`** — write-side callers in the scanner where `bookFilepath` may be a synthetic organized-folder path that does not yet exist on disk (`scanFileCreateNew` computes `bookPath` for root-level new files before the organized directory is created). Falls back to `filepath.Dir(fileFilepath)` — the library directory where the file actually lives — when the book path doesn't resolve to a real directory.
+- **Read-side (serving, fingerprinting, file generation):** use `filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)`. Pure-string, no stat, no synthetic-path trap. Examples: `fileCover`/`bookCover` in `pkg/books/handlers.go`, `pkg/series/handlers.go`, `pkg/ereader/handlers.go`, `pkg/kobo/handlers.go`, `pkg/filegen/*`, `pkg/downloadcache/fingerprint.go`, and `deleteFileFromDisk`.
+- **Write-side (scanner, pre-organize):** use `fileutils.ResolveCoverDirForWrite(bookFilepath, fileFilepath)` when `bookFilepath` may be a synthetic organized-folder path that hasn't been created on disk yet. Falls back to `filepath.Dir(fileFilepath)` when the book path doesn't resolve to a real directory.
 
-For callers that only hold a `file.Filepath` (e.g. `deleteFileFromDisk`, `recoverMissingCover`), prefer the pure-string `filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)` — it's always correct (the cover lives alongside the file for both root-level and directory-backed books) and immune to stat races when the main file has already been removed.
+**Book sidecars** for root-level books are similarly anchored next to the file — `sidecar.WriteBookSidecarFromModel(book)` falls back via `book.Files[0].Filepath` when `book.Filepath` doesn't resolve to an existing directory. Reads use `sidecar.ReadBookSidecarFromModel(book, fileHint)` and pass the current file as a hint so resolution works before the book's Files relation is loaded.
 
 ### Data Source Priority System
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1408,6 +1408,8 @@ func containsColumn(cols []string, target string) bool {
 
 // removeColumn returns a new slice with the first occurrence of target
 // removed. Allocates a fresh backing array — does not alias cols.
+// Assumes target appears at most once (guaranteed by the single-append
+// contract at each column-queuing site in the handler).
 func removeColumn(cols []string, target string) []string {
 	out := make([]string, 0, len(cols))
 	removed := false

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -923,56 +923,10 @@ func (h *handler) updateFile(c echo.Context) error {
 			narratorNames = append(narratorNames, narratorName)
 		}
 
-		// For M4B files with OrganizeFileStructure enabled, rename the file to include narrator
+		// For M4B files with OrganizeFileStructure enabled, reorganize so the
+		// new narrator appears in the filename/path.
 		if file.FileType == models.FileTypeM4B && library.OrganizeFileStructure && len(narratorNames) > 0 {
-			// Get author names from the book
-			authorNames := make([]string, 0, len(book.Authors))
-			for _, a := range book.Authors {
-				if a.Person != nil {
-					authorNames = append(authorNames, a.Person.Name)
-				}
-			}
-
-			// Use file.Name for title if available, otherwise book.Title
-			title := book.Title
-			if file.Name != nil && *file.Name != "" {
-				title = *file.Name
-			}
-
-			// Generate organized name options
-			organizeOpts := fileutils.OrganizedNameOptions{
-				AuthorNames:   authorNames,
-				NarratorNames: narratorNames,
-				Title:         title,
-				FileType:      file.FileType,
-			}
-
-			// Rename the file
-			// Use RenameOrganizedFileForSupplement to avoid renaming the book sidecar.
-			// File-level changes (narrator, name) should not affect the book's sidecar -
-			// only book-level changes (title, author) should rename the book sidecar.
-			newPath, err := fileutils.RenameOrganizedFileOnly(file.Filepath, organizeOpts)
-			if err != nil {
-				log.Error("failed to rename file with narrator", logger.Data{
-					"file_id": file.ID,
-					"path":    file.Filepath,
-					"error":   err.Error(),
-				})
-			} else if newPath != file.Filepath {
-				log.Info("renamed file with narrator", logger.Data{
-					"file_id":  file.ID,
-					"old_path": file.Filepath,
-					"new_path": newPath,
-				})
-				// Update cover path if it exists (covers are renamed by rename function)
-				if file.CoverImageFilename != nil {
-					newCoverPath := fileutils.ComputeNewCoverFilename(*file.CoverImageFilename, newPath)
-					file.CoverImageFilename = &newCoverPath
-					opts.Columns = append(opts.Columns, "cover_image_filename")
-				}
-				file.Filepath = newPath
-				opts.Columns = append(opts.Columns, "filepath")
-			}
+			file = h.reorganizeFileAfterMetadataChange(ctx, library, book, file, narratorNames, &opts)
 		}
 	}
 
@@ -998,15 +952,6 @@ func (h *handler) updateFile(c echo.Context) error {
 
 	// Reorganize file if name changed and library has OrganizeFileStructure enabled
 	if nameChanged && library.OrganizeFileStructure {
-		// Get author names from the book
-		authorNames := make([]string, 0, len(book.Authors))
-		for _, a := range book.Authors {
-			if a.Person != nil {
-				authorNames = append(authorNames, a.Person.Name)
-			}
-		}
-
-		// Get narrator names if M4B
 		narratorNames := make([]string, 0)
 		if file.FileType == models.FileTypeM4B {
 			for _, n := range file.Narrators {
@@ -1015,47 +960,7 @@ func (h *handler) updateFile(c echo.Context) error {
 				}
 			}
 		}
-
-		// Use file.Name for title if available, otherwise book.Title
-		title := book.Title
-		if file.Name != nil && *file.Name != "" {
-			title = *file.Name
-		}
-
-		// Generate organized name options
-		organizeOpts := fileutils.OrganizedNameOptions{
-			AuthorNames:   authorNames,
-			NarratorNames: narratorNames,
-			Title:         title,
-			FileType:      file.FileType,
-		}
-
-		// Rename the file
-		// Use RenameOrganizedFileForSupplement to avoid renaming the book sidecar.
-		// File-level changes (name) should not affect the book's sidecar -
-		// only book-level changes (title, author) should rename the book sidecar.
-		newPath, err := fileutils.RenameOrganizedFileOnly(file.Filepath, organizeOpts)
-		if err != nil {
-			log.Error("failed to rename file after name change", logger.Data{
-				"file_id": file.ID,
-				"path":    file.Filepath,
-				"error":   err.Error(),
-			})
-		} else if newPath != file.Filepath {
-			log.Info("renamed file after name change", logger.Data{
-				"file_id":  file.ID,
-				"old_path": file.Filepath,
-				"new_path": newPath,
-			})
-			// Update cover path if it exists (covers are renamed by rename function)
-			if file.CoverImageFilename != nil {
-				newCoverPath := fileutils.ComputeNewCoverFilename(*file.CoverImageFilename, newPath)
-				file.CoverImageFilename = &newCoverPath
-				opts.Columns = append(opts.Columns, "cover_image_filename")
-			}
-			file.Filepath = newPath
-			opts.Columns = append(opts.Columns, "filepath")
-		}
+		file = h.reorganizeFileAfterMetadataChange(ctx, library, book, file, narratorNames, &opts)
 	}
 
 	// Update URL
@@ -1292,6 +1197,106 @@ func (h *handler) updateFile(c echo.Context) error {
 	return errors.WithStack(c.JSON(http.StatusOK, file))
 }
 
+// reorganizeFileAfterMetadataChange reorganizes a file on disk after a
+// file-level metadata change (name or narrator) when the library has
+// OrganizeFileStructure enabled.
+//
+// For files that already live inside their organized folder this does a
+// same-folder rename (equivalent to the old RenameOrganizedFileOnly path).
+// For root-level files — which can happen when a library was previously
+// organize=false or when organize hasn't finished running after a toggle —
+// it delegates to OrganizeBookFiles so the file is moved into its
+// organized folder and book.Filepath is kept in sync. Previously a
+// rename-in-place at the library root left book.Filepath pointing at a
+// synthetic path that diverged from the actual file location.
+//
+// Returns the (possibly reloaded) file model so the caller can pick up any
+// path/cover updates persisted by the book-organize path.
+func (h *handler) reorganizeFileAfterMetadataChange(
+	ctx context.Context,
+	library *models.Library,
+	book *models.Book,
+	file *models.File,
+	narratorNames []string,
+	opts *UpdateFileOptions,
+) *models.File {
+	log := logger.FromContext(ctx)
+
+	isRootLevel := false
+	fileDir := filepath.Dir(file.Filepath)
+	for _, lp := range library.LibraryPaths {
+		if fileDir == lp.Filepath {
+			isRootLevel = true
+			break
+		}
+	}
+
+	if isRootLevel {
+		// Delegate to book-level organize so the file is moved into its
+		// organized folder and book.Filepath is updated in lockstep. The
+		// narrators already persisted above (and the new file name if
+		// relevant) are picked up by organizeBookFiles via a fresh DB read.
+		if err := h.bookService.OrganizeBookFiles(ctx, book); err != nil {
+			log.Error("failed to organize book files after file metadata change", logger.Data{
+				"file_id": file.ID,
+				"book_id": book.ID,
+				"error":   err.Error(),
+			})
+			return file
+		}
+		// Reload the file so the caller sees the updated filepath and cover.
+		if updated, err := h.bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &file.ID}); err == nil {
+			return updated
+		}
+		return file
+	}
+
+	// Same-folder rename. Book.Filepath already points at the book's
+	// directory for directory-backed books, so there's nothing to sync.
+	authorNames := make([]string, 0, len(book.Authors))
+	for _, a := range book.Authors {
+		if a.Person != nil {
+			authorNames = append(authorNames, a.Person.Name)
+		}
+	}
+	title := book.Title
+	if file.Name != nil && *file.Name != "" {
+		title = *file.Name
+	}
+	organizeOpts := fileutils.OrganizedNameOptions{
+		AuthorNames:   authorNames,
+		NarratorNames: narratorNames,
+		Title:         title,
+		FileType:      file.FileType,
+	}
+	// RenameOrganizedFileOnly leaves the book sidecar untouched — file-level
+	// changes must not rename the book sidecar.
+	newPath, err := fileutils.RenameOrganizedFileOnly(file.Filepath, organizeOpts)
+	if err != nil {
+		log.Error("failed to rename file after metadata change", logger.Data{
+			"file_id": file.ID,
+			"path":    file.Filepath,
+			"error":   err.Error(),
+		})
+		return file
+	}
+	if newPath != file.Filepath {
+		log.Info("renamed file after metadata change", logger.Data{
+			"file_id":  file.ID,
+			"old_path": file.Filepath,
+			"new_path": newPath,
+		})
+		if file.CoverImageFilename != nil {
+			newCoverPath := fileutils.ComputeNewCoverFilename(*file.CoverImageFilename, newPath)
+			file.CoverImageFilename = &newCoverPath
+			opts.Columns = append(opts.Columns, "cover_image_filename")
+		}
+		file.Filepath = newPath
+		opts.Columns = append(opts.Columns, "filepath")
+	}
+	return file
+}
+
 func (h *handler) fileCover(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.Atoi(c.Param("id"))
@@ -1320,7 +1325,12 @@ func (h *handler) fileCover(c echo.Context) error {
 	} else {
 		coverFilename = filepath.Base(file.Filepath) + ".cover" + file.CoverExtension()
 	}
-	coverPath := fileutils.ResolveCoverPath(file.Book.Filepath, coverFilename)
+	// Resolve the cover via the file's parent dir rather than book.Filepath.
+	// book.Filepath may be a synthetic organized-folder path that never exists
+	// on disk (root-level files in libraries with OrganizeFileStructure
+	// disabled), in which case ResolveCoverPath would stat-fail and fall back
+	// to that junk path. The cover always lives alongside the file.
+	coverPath := filepath.Join(filepath.Dir(file.Filepath), coverFilename)
 
 	c.Response().Header().Set("Cache-Control", "private, no-cache")
 	return errors.WithStack(c.File(coverPath))
@@ -1525,7 +1535,10 @@ func (h *handler) bookCover(c echo.Context) error {
 		return errcodes.NotFound("Cover")
 	}
 
-	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
+	// Resolve the cover via the file's parent dir rather than book.Filepath —
+	// see fileCover for the rationale (synthetic organized-folder paths for
+	// root-level files break book.Filepath-based resolution).
+	coverPath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
 	c.Response().Header().Set("Cache-Control", "private, no-cache")
 	return errors.WithStack(c.File(coverPath))
 }

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1343,7 +1343,7 @@ func (h *handler) reorganizeFileAfterMetadataChange(
 		// — narrators are their own table rows, already persisted before
 		// this call, and narrator_source reflects the user's manual intent
 		// regardless of whether the filename update succeeded.
-		revertRenameDrivenColumns(ctx, h.bookService, file, opts, log)
+		h.revertRenameDrivenColumns(ctx, file, opts, log)
 		return file
 	}
 	if newPath != file.Filepath {
@@ -1364,13 +1364,12 @@ func (h *handler) reorganizeFileAfterMetadataChange(
 }
 
 // revertRenameDrivenColumns undoes in-memory file.Name / file.NameSource
-// changes queued for the outer UpdateFile when a rename failed, so the DB
-// doesn't end up carrying new metadata while the file sits at its old path
-// on disk. Reads the pre-update values from the DB snapshot. Silently
+// changes queued for the outer UpdateFile when a same-folder rename failed,
+// so the DB doesn't end up carrying new metadata while the file sits at its
+// old path on disk. Reads the pre-update values from the DB. Silently
 // returns if there's nothing to revert.
-func revertRenameDrivenColumns(
+func (h *handler) revertRenameDrivenColumns(
 	ctx context.Context,
-	bookService bookServiceIface,
 	file *models.File,
 	opts *UpdateFileOptions,
 	log logger.Logger,
@@ -1380,7 +1379,7 @@ func revertRenameDrivenColumns(
 	if !hasName && !hasNameSource {
 		return
 	}
-	snapshot, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &file.ID})
+	snapshot, err := h.bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &file.ID})
 	if err != nil {
 		log.Error("failed to snapshot file for rename-failure revert", logger.Data{
 			"file_id": file.ID,
@@ -1407,20 +1406,19 @@ func containsColumn(cols []string, target string) bool {
 	return false
 }
 
+// removeColumn returns a new slice with the first occurrence of target
+// removed. Allocates a fresh backing array — does not alias cols.
 func removeColumn(cols []string, target string) []string {
-	out := cols[:0]
+	out := make([]string, 0, len(cols))
+	removed := false
 	for _, c := range cols {
-		if c != target {
-			out = append(out, c)
+		if !removed && c == target {
+			removed = true
+			continue
 		}
+		out = append(out, c)
 	}
 	return out
-}
-
-// bookServiceIface is the minimal slice of *Service that revertRenameDrivenColumns
-// needs. Allows easier testing without a full service wiring.
-type bookServiceIface interface {
-	RetrieveFile(ctx context.Context, opts RetrieveFileOptions) (*models.File, error)
 }
 
 func (h *handler) fileCover(c echo.Context) error {

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1337,6 +1337,13 @@ func (h *handler) reorganizeFileAfterMetadataChange(
 			"path":    file.Filepath,
 			"error":   err.Error(),
 		})
+		// Revert the pending name/name_source DB writes so the outer
+		// UpdateFile doesn't persist the new name while the file stays at
+		// its old path on disk. Narrator-driven renames don't need reverting
+		// — narrators are their own table rows, already persisted before
+		// this call, and narrator_source reflects the user's manual intent
+		// regardless of whether the filename update succeeded.
+		revertRenameDrivenColumns(ctx, h.bookService, file, opts, log)
 		return file
 	}
 	if newPath != file.Filepath {
@@ -1354,6 +1361,66 @@ func (h *handler) reorganizeFileAfterMetadataChange(
 		opts.Columns = append(opts.Columns, "filepath")
 	}
 	return file
+}
+
+// revertRenameDrivenColumns undoes in-memory file.Name / file.NameSource
+// changes queued for the outer UpdateFile when a rename failed, so the DB
+// doesn't end up carrying new metadata while the file sits at its old path
+// on disk. Reads the pre-update values from the DB snapshot. Silently
+// returns if there's nothing to revert.
+func revertRenameDrivenColumns(
+	ctx context.Context,
+	bookService bookServiceIface,
+	file *models.File,
+	opts *UpdateFileOptions,
+	log logger.Logger,
+) {
+	hasName := containsColumn(opts.Columns, "name")
+	hasNameSource := containsColumn(opts.Columns, "name_source")
+	if !hasName && !hasNameSource {
+		return
+	}
+	snapshot, err := bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &file.ID})
+	if err != nil {
+		log.Error("failed to snapshot file for rename-failure revert", logger.Data{
+			"file_id": file.ID,
+			"error":   err.Error(),
+		})
+		return
+	}
+	if hasName {
+		file.Name = snapshot.Name
+		opts.Columns = removeColumn(opts.Columns, "name")
+	}
+	if hasNameSource {
+		file.NameSource = snapshot.NameSource
+		opts.Columns = removeColumn(opts.Columns, "name_source")
+	}
+}
+
+func containsColumn(cols []string, target string) bool {
+	for _, c := range cols {
+		if c == target {
+			return true
+		}
+	}
+	return false
+}
+
+func removeColumn(cols []string, target string) []string {
+	out := cols[:0]
+	for _, c := range cols {
+		if c != target {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// bookServiceIface is the minimal slice of *Service that revertRenameDrivenColumns
+// needs. Allows easier testing without a full service wiring.
+type bookServiceIface interface {
+	RetrieveFile(ctx context.Context, opts RetrieveFileOptions) (*models.File, error)
 }
 
 func (h *handler) fileCover(c echo.Context) error {

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -800,12 +800,7 @@ func (h *handler) updateFile(c echo.Context) error {
 
 		// When downgrading from main to supplement, clear all main-file-only metadata
 		if oldRole == models.FileRoleMain && newRole == models.FileRoleSupplement {
-			// Delete cover image file if it exists. CoverImageFilename stores
-			// just the filename — use a pure-string join against
-			// filepath.Dir(file.Filepath) rather than stat'ing book.Filepath.
-			// book.Filepath may be a synthetic organized-folder path that
-			// never exists on disk for root-level files, and ResolveCoverPath
-			// would fall back to that junk path. The cover always lives
+			// Delete cover image file if it exists. The cover always lives
 			// alongside the file for both root-level and directory-backed
 			// books, so filepath.Dir(file.Filepath) is always correct.
 			if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
@@ -890,6 +885,21 @@ func (h *handler) updateFile(c echo.Context) error {
 		oldNarratorPersonIDs = append(oldNarratorPersonIDs, narrator.PersonID)
 	}
 
+	// narratorNames tracks the authoritative narrator list for this file —
+	// either the freshly-written names from this request, or (when narrators
+	// weren't touched) the in-memory relation from the initial file load.
+	// Any downstream branch that reorganizes the file must use this variable
+	// so that a name-triggered reorg following a narrator update doesn't
+	// fall back to stale file.Narrators.
+	var narratorNames []string
+	if file.FileType == models.FileTypeM4B && params.Narrators == nil {
+		for _, n := range file.Narrators {
+			if n.Person != nil {
+				narratorNames = append(narratorNames, n.Person.Name)
+			}
+		}
+	}
+
 	// Update narrators
 	if params.Narrators != nil {
 		narratorsChanged = true
@@ -902,7 +912,7 @@ func (h *handler) updateFile(c echo.Context) error {
 		}
 
 		// Create new narrator associations
-		narratorNames := make([]string, 0, len(params.Narrators))
+		narratorNames = make([]string, 0, len(params.Narrators))
 		for i, narratorName := range params.Narrators {
 			if narratorName == "" {
 				continue
@@ -952,14 +962,9 @@ func (h *handler) updateFile(c echo.Context) error {
 
 	// Reorganize file if name changed and library has OrganizeFileStructure enabled
 	if nameChanged && library.OrganizeFileStructure {
-		narratorNames := make([]string, 0)
-		if file.FileType == models.FileTypeM4B {
-			for _, n := range file.Narrators {
-				if n.Person != nil {
-					narratorNames = append(narratorNames, n.Person.Name)
-				}
-			}
-		}
+		// narratorNames is already authoritative — either set from the new
+		// narrator request above or populated from the pre-update in-memory
+		// relation (which is still current if narrators weren't touched).
 		file = h.reorganizeFileAfterMetadataChange(ctx, library, book, file, narratorNames, &opts)
 	}
 
@@ -1235,8 +1240,23 @@ func (h *handler) reorganizeFileAfterMetadataChange(
 		// OrganizeBookFiles reads files fresh from the DB, so flush any
 		// pending in-memory updates (name, cover_image_filename, etc.) on
 		// this file first. Otherwise a just-changed file.Name would not be
-		// reflected in the organized path.
+		// reflected in the organized path. If the subsequent organize fails
+		// we roll back those DB writes so DB and disk stay consistent.
+		var preFlushFile *models.File
+		var flushedColumns []string
 		if len(opts.Columns) > 0 {
+			// Snapshot the pre-flush DB state so we can revert if organize
+			// fails and DB+disk would otherwise diverge.
+			snapshot, err := h.bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &file.ID})
+			if err != nil {
+				log.Error("failed to snapshot file before organize", logger.Data{
+					"file_id": file.ID,
+					"error":   err.Error(),
+				})
+				return file
+			}
+			preFlushFile = snapshot
+
 			if err := h.bookService.UpdateFile(ctx, file, *opts); err != nil {
 				log.Error("failed to flush file updates before organize", logger.Data{
 					"file_id": file.ID,
@@ -1245,24 +1265,49 @@ func (h *handler) reorganizeFileAfterMetadataChange(
 				return file
 			}
 			// Already persisted — prevent the outer UpdateFile call from
-			// writing the same columns again.
+			// writing the same columns again. Keep a copy for revert.
+			flushedColumns = append([]string{}, opts.Columns...)
 			opts.Columns = opts.Columns[:0]
 		}
 		// Delegate to book-level organize so the file is moved into its
 		// organized folder and book.Filepath is updated in lockstep.
-		if err := h.bookService.OrganizeBookFiles(ctx, book); err != nil {
+		organizeErr := h.bookService.OrganizeBookFiles(ctx, book)
+		if organizeErr != nil {
 			log.Error("failed to organize book files after file metadata change", logger.Data{
 				"file_id": file.ID,
 				"book_id": book.ID,
-				"error":   err.Error(),
+				"error":   organizeErr.Error(),
+			})
+		}
+
+		// Reload the file so we can detect whether organize actually moved
+		// it. OrganizeBookFiles logs and continues when an individual file's
+		// organize fails (e.g. the source was deleted out from under us), so
+		// a nil error doesn't guarantee the move happened.
+		updated, reloadErr := h.bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &file.ID})
+		if reloadErr != nil {
+			log.Error("failed to reload file after organize", logger.Data{
+				"file_id": file.ID,
+				"error":   reloadErr.Error(),
 			})
 			return file
 		}
-		// Reload the file so the caller sees the updated filepath and cover.
-		if updated, err := h.bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &file.ID}); err == nil {
-			return updated
+
+		// If the file didn't actually move (organize failed explicitly OR
+		// silently), revert the pre-organize flush so the DB doesn't show
+		// new metadata while disk still has the file at its old path.
+		if updated.Filepath == file.Filepath {
+			if preFlushFile != nil && len(flushedColumns) > 0 {
+				if rbErr := h.bookService.UpdateFile(ctx, preFlushFile, UpdateFileOptions{Columns: flushedColumns}); rbErr != nil {
+					log.Error("failed to revert file update after organize failure", logger.Data{
+						"file_id": file.ID,
+						"error":   rbErr.Error(),
+					})
+				}
+			}
+			return file
 		}
-		return file
+		return updated
 	}
 
 	// Same-folder rename. Book.Filepath already points at the book's
@@ -1339,11 +1384,9 @@ func (h *handler) fileCover(c echo.Context) error {
 	} else {
 		coverFilename = filepath.Base(file.Filepath) + ".cover" + file.CoverExtension()
 	}
-	// Resolve the cover via the file's parent dir rather than book.Filepath.
-	// book.Filepath may be a synthetic organized-folder path that never exists
-	// on disk (root-level files in libraries with OrganizeFileStructure
-	// disabled), in which case ResolveCoverPath would stat-fail and fall back
-	// to that junk path. The cover always lives alongside the file.
+	// Resolve the cover via the file's parent dir — book.Filepath may be a
+	// synthetic organized-folder path that never exists on disk for
+	// root-level files. The cover always lives alongside the file.
 	coverPath := filepath.Join(filepath.Dir(file.Filepath), coverFilename)
 
 	c.Response().Header().Set("Cache-Control", "private, no-cache")

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1232,10 +1232,24 @@ func (h *handler) reorganizeFileAfterMetadataChange(
 	}
 
 	if isRootLevel {
+		// OrganizeBookFiles reads files fresh from the DB, so flush any
+		// pending in-memory updates (name, cover_image_filename, etc.) on
+		// this file first. Otherwise a just-changed file.Name would not be
+		// reflected in the organized path.
+		if len(opts.Columns) > 0 {
+			if err := h.bookService.UpdateFile(ctx, file, *opts); err != nil {
+				log.Error("failed to flush file updates before organize", logger.Data{
+					"file_id": file.ID,
+					"error":   err.Error(),
+				})
+				return file
+			}
+			// Already persisted — prevent the outer UpdateFile call from
+			// writing the same columns again.
+			opts.Columns = opts.Columns[:0]
+		}
 		// Delegate to book-level organize so the file is moved into its
-		// organized folder and book.Filepath is updated in lockstep. The
-		// narrators already persisted above (and the new file name if
-		// relevant) are picked up by organizeBookFiles via a fresh DB read.
+		// organized folder and book.Filepath is updated in lockstep.
 		if err := h.bookService.OrganizeBookFiles(ctx, book); err != nil {
 			log.Error("failed to organize book files after file metadata change", logger.Data{
 				"file_id": file.ID,
@@ -1384,15 +1398,10 @@ func (h *handler) uploadFileCover(c echo.Context) error {
 		return errcodes.ValidationError("Cover upload is not supported for this file type.")
 	}
 
-	// Get the parent book for the cover directory
-	book, err := h.bookService.RetrieveBook(ctx, RetrieveBookOptions{
-		ID: &file.BookID,
-	})
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	coverDir := fileutils.ResolveCoverDir(book.Filepath)
+	// The cover always lives next to the file — using book.Filepath here
+	// would fail for root-level books where book.Filepath is a synthetic
+	// path that doesn't exist on disk.
+	coverDir := filepath.Dir(file.Filepath)
 
 	// Generate the cover filename: {filename}.cover.{ext}
 	filename := filepath.Base(file.Filepath)

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1201,14 +1201,14 @@ func (h *handler) updateFile(c echo.Context) error {
 // file-level metadata change (name or narrator) when the library has
 // OrganizeFileStructure enabled.
 //
-// For files that already live inside their organized folder this does a
-// same-folder rename (equivalent to the old RenameOrganizedFileOnly path).
-// For root-level files — which can happen when a library was previously
-// organize=false or when organize hasn't finished running after a toggle —
-// it delegates to OrganizeBookFiles so the file is moved into its
-// organized folder and book.Filepath is kept in sync. Previously a
-// rename-in-place at the library root left book.Filepath pointing at a
-// synthetic path that diverged from the actual file location.
+// For files that already live inside their organized folder this does an
+// in-folder rename via RenameOrganizedFileOnly. For root-level files —
+// which can happen when a library was previously organize=false or when
+// organize hasn't finished running after a toggle — it delegates to
+// OrganizeBookFiles so the file is moved into its organized folder and
+// book.Filepath is kept in sync. Rename-in-place at the library root
+// would otherwise leave book.Filepath pointing at a synthetic path that
+// diverges from the actual file location.
 //
 // Returns the (possibly reloaded) file model so the caller can pick up any
 // path/cover updates persisted by the book-organize path.

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -1178,6 +1178,82 @@ func TestUpdateFile_Narrators_RootLevelM4B_OrganizesFileAndSyncsBookPath(t *test
 		"book.Filepath should track the organized folder")
 }
 
+// Regression: when both narrators and name are updated on a directory-backed
+// M4B in the same request, the name-triggered reorganize must use the NEW
+// narrator names (just persisted this request), not the stale in-memory
+// file.Narrators relation. Previously the name branch built narratorNames
+// from the in-memory file.Narrators which wasn't refreshed after the
+// narrator-update DB writes, producing a filename with stale narrators.
+func TestUpdateFile_NarratorsAndName_DirectoryBacked_UsesNewNarratorsInFilename(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	libraryDir := t.TempDir()
+	bookDir := filepath.Join(libraryDir, "Old Author", "Old Title")
+	require.NoError(t, os.MkdirAll(bookDir, 0755))
+	m4bPath := filepath.Join(bookDir, "original.m4b")
+	require.NoError(t, os.WriteFile(m4bPath, []byte("m4b"), 0644))
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "audiobook",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.LibraryPath{LibraryID: library.ID, Filepath: libraryDir}).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Old Title",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Old Title",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	author := &models.Person{Name: "Old Author", LibraryID: library.ID, SortName: "Old Author"}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.Author{BookID: book.ID, PersonID: author.ID, SortOrder: 1}).Exec(ctx)
+	require.NoError(t, err)
+
+	// Pre-existing stale narrator so file.Narrators is non-empty on load.
+	stalePerson := &models.Person{Name: "Stale Narrator", LibraryID: library.ID, SortName: "Stale Narrator"}
+	_, err = db.NewInsert().Model(stalePerson).Exec(ctx)
+	require.NoError(t, err)
+	file := setupTestFile(t, db, book, models.FileTypeM4B, m4bPath)
+	_, err = db.NewInsert().Model(&models.Narrator{FileID: file.ID, PersonID: stalePerson.ID, SortOrder: 1}).Exec(ctx)
+	require.NoError(t, err)
+
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+	e := setupTestServer(t, db)
+	// Update BOTH narrators (swap Stale for Fresh) AND name in one request.
+	body := `{"narrators": ["Fresh Narrator"], "name": "Fresh Title"}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	var updatedFile models.File
+	err = db.NewSelect().Model(&updatedFile).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+
+	// The organized filename must reflect the NEW narrator, not the stale one.
+	assert.Contains(t, filepath.Base(updatedFile.Filepath), "Fresh Narrator",
+		"organized filename should include the new narrator; got %s", updatedFile.Filepath)
+	assert.NotContains(t, filepath.Base(updatedFile.Filepath), "Stale Narrator",
+		"organized filename should NOT include the replaced stale narrator; got %s", updatedFile.Filepath)
+}
+
 // Regression: when file.Name is updated on a root-level file in a library
 // with OrganizeFileStructure enabled, the new name must be reflected in the
 // organized filename. Previously the root-level branch of organizeBookFiles
@@ -1246,6 +1322,86 @@ func TestUpdateFile_Name_RootLevelFile_OrganizesWithNewName(t *testing.T) {
 		"organized filename should include the new file.Name; got %s", updatedFile.Filepath)
 	_, err = os.Stat(updatedFile.Filepath)
 	require.NoError(t, err, "file should exist at new organized location %s", updatedFile.Filepath)
+}
+
+// Regression: when OrganizeBookFiles fails partway through a file metadata
+// change on a root-level file, the helper must revert the DB write it just
+// made so the DB and on-disk state stay consistent. Without the revert the
+// user would see the new metadata in the UI while the file sits unchanged
+// on disk.
+func TestUpdateFile_Name_RootLevelFile_OrganizeFailure_RevertsDBState(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	libraryDir := t.TempDir()
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.LibraryPath{LibraryID: library.ID, Filepath: libraryDir}).Exec(ctx)
+	require.NoError(t, err)
+
+	epubPath := filepath.Join(libraryDir, "original.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub"), 0644))
+
+	syntheticBookPath := filepath.Join(libraryDir, "Author Name", "Book Title")
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Book Title",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book Title",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        syntheticBookPath,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	author := &models.Person{Name: "Author Name", LibraryID: library.ID, SortName: "Author Name"}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.Author{BookID: book.ID, PersonID: author.ID, SortOrder: 1}).Exec(ctx)
+	require.NoError(t, err)
+
+	originalName := "Original Name"
+	originalNameSource := models.DataSourceManual
+	file := setupTestFile(t, db, book, models.FileTypeEPUB, epubPath)
+	file.Name = &originalName
+	file.NameSource = &originalNameSource
+	_, err = db.NewUpdate().Model(file).Column("name", "name_source").WherePK().Exec(ctx)
+	require.NoError(t, err)
+
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+	// Force OrganizeBookFiles to fail by removing the file on disk between
+	// the DB insert and the update request. OrganizeRootLevelFile will try
+	// to move the missing file and fail.
+	require.NoError(t, os.Remove(epubPath))
+
+	e := setupTestServer(t, db)
+	body := `{"name": "Attempted New Name"}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	// The handler doesn't surface organize errors as HTTP failures (they
+	// are logged), so we still get 200 — but the DB must be reverted.
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	var reloaded models.File
+	err = db.NewSelect().Model(&reloaded).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.Name)
+	assert.Equal(t, originalName, *reloaded.Name,
+		"file.Name must be reverted to the pre-update value when organize fails")
+	require.NotNil(t, reloaded.NameSource)
+	assert.Equal(t, originalNameSource, *reloaded.NameSource,
+		"file.NameSource must be reverted to the pre-update value when organize fails")
 }
 
 // Regression: uploading a cover to a root-level file previously resolved

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1174,6 +1176,154 @@ func TestUpdateFile_Narrators_RootLevelM4B_OrganizesFileAndSyncsBookPath(t *test
 	require.NoError(t, err)
 	assert.Equal(t, filepath.Dir(updatedFile.Filepath), updatedBook.Filepath,
 		"book.Filepath should track the organized folder")
+}
+
+// Regression: when file.Name is updated on a root-level file in a library
+// with OrganizeFileStructure enabled, the new name must be reflected in the
+// organized filename. Previously the root-level branch of organizeBookFiles
+// always used book.Title (ignoring file.Name), and the handler persisted
+// file.Name after reorganize, so the new name was lost.
+func TestUpdateFile_Name_RootLevelFile_OrganizesWithNewName(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	libraryDir := t.TempDir()
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	libraryPath := &models.LibraryPath{LibraryID: library.ID, Filepath: libraryDir}
+	_, err = db.NewInsert().Model(libraryPath).Exec(ctx)
+	require.NoError(t, err)
+
+	epubPath := filepath.Join(libraryDir, "original.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub content"), 0644))
+
+	syntheticBookPath := filepath.Join(libraryDir, "Author Name", "Book Title")
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Book Title",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book Title",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        syntheticBookPath,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	author := &models.Person{Name: "Author Name", LibraryID: library.ID, SortName: "Author Name"}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+	authorAssoc := &models.Author{BookID: book.ID, PersonID: author.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(authorAssoc).Exec(ctx)
+	require.NoError(t, err)
+
+	file := setupTestFile(t, db, book, models.FileTypeEPUB, epubPath)
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+	e := setupTestServer(t, db)
+	body := `{"name": "Custom Name"}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	var updatedFile models.File
+	err = db.NewSelect().Model(&updatedFile).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+
+	// The organized filename should reflect the new file.Name, not the original
+	// filename or book.Title.
+	assert.Contains(t, filepath.Base(updatedFile.Filepath), "Custom Name",
+		"organized filename should include the new file.Name; got %s", updatedFile.Filepath)
+	_, err = os.Stat(updatedFile.Filepath)
+	require.NoError(t, err, "file should exist at new organized location %s", updatedFile.Filepath)
+}
+
+// Regression: uploading a cover to a root-level file previously resolved
+// the cover directory via book.Filepath (synthetic, non-existent), so the
+// write failed with "no such file or directory". The cover must be written
+// next to the file.
+func TestUploadFileCover_RootLevelFile_SyntheticBookPath_WritesNextToFile(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	libraryDir := t.TempDir()
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	epubPath := filepath.Join(libraryDir, "root-book.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub content"), 0644))
+
+	syntheticBookPath := filepath.Join(libraryDir, "Author Name", "Book Title")
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Root Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Root Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        syntheticBookPath,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := setupTestFile(t, db, book, models.FileTypeEPUB, epubPath)
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+	// Build multipart upload body with a tiny valid PNG.
+	pngData := []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+		0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41,
+		0x54, 0x08, 0x99, 0x63, 0xF8, 0x0F, 0x00, 0x00,
+		0x01, 0x01, 0x00, 0x01, 0x1B, 0xB6, 0xEE, 0x56,
+		0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44,
+		0xAE, 0x42, 0x60, 0x82,
+	}
+
+	var body strings.Builder
+	writer := multipart.NewWriter(&body)
+	partHeader := make(textproto.MIMEHeader)
+	partHeader.Set("Content-Disposition", `form-data; name="cover"; filename="cover.png"`)
+	partHeader.Set("Content-Type", "image/png")
+	part, err := writer.CreatePart(partHeader)
+	require.NoError(t, err)
+	_, err = part.Write(pngData)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	e := setupTestServer(t, db)
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID)+"/cover", strings.NewReader(body.String()))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	// Cover should have been written alongside the file, not under the synthetic book dir.
+	expectedCover := filepath.Join(libraryDir, "root-book.epub.cover.png")
+	_, err = os.Stat(expectedCover)
+	require.NoError(t, err, "cover should exist at %s", expectedCover)
+
+	// Synthetic book dir must not have been created.
+	_, err = os.Stat(syntheticBookPath)
+	assert.True(t, os.IsNotExist(err), "synthetic book dir must not be created for cover upload")
 }
 
 func TestUpdateBook_Title_UpdatesMainFileName_WhenMatchesOldTitle(t *testing.T) {

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -1404,6 +1404,84 @@ func TestUpdateFile_Name_RootLevelFile_OrganizeFailure_RevertsDBState(t *testing
 		"file.NameSource must be reverted to the pre-update value when organize fails")
 }
 
+// Regression: when RenameOrganizedFileOnly fails on a directory-backed file
+// (e.g. the source file was removed out from under us), the helper must
+// revert the pending name/name_source columns so the outer UpdateFile
+// doesn't persist a new name while the file sits at its old path on disk.
+// Mirrors the same-class invariant that M5 enforces for the root-level
+// branch.
+func TestUpdateFile_Name_DirectoryBacked_RenameFailure_RevertsDBState(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	libraryDir := t.TempDir()
+	bookDir := filepath.Join(libraryDir, "Author", "Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0755))
+	epubPath := filepath.Join(bookDir, "book.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub"), 0644))
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.LibraryPath{LibraryID: library.ID, Filepath: libraryDir}).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	author := &models.Person{Name: "Author", LibraryID: library.ID, SortName: "Author"}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.Author{BookID: book.ID, PersonID: author.ID, SortOrder: 1}).Exec(ctx)
+	require.NoError(t, err)
+
+	originalName := "Original Name"
+	originalNameSource := models.DataSourceManual
+	file := setupTestFile(t, db, book, models.FileTypeEPUB, epubPath)
+	file.Name = &originalName
+	file.NameSource = &originalNameSource
+	_, err = db.NewUpdate().Model(file).Column("name", "name_source").WherePK().Exec(ctx)
+	require.NoError(t, err)
+
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+	// Force RenameOrganizedFileOnly to fail by removing the source file.
+	require.NoError(t, os.Remove(epubPath))
+
+	e := setupTestServer(t, db)
+	body := `{"name": "Attempted New Name"}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	var reloaded models.File
+	err = db.NewSelect().Model(&reloaded).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.Name)
+	assert.Equal(t, originalName, *reloaded.Name,
+		"file.Name must be reverted when rename fails in the directory-backed branch")
+	require.NotNil(t, reloaded.NameSource)
+	assert.Equal(t, originalNameSource, *reloaded.NameSource,
+		"file.NameSource must be reverted when rename fails in the directory-backed branch")
+}
+
 // Regression: uploading a cover to a root-level file previously resolved
 // the cover directory via book.Filepath (synthetic, non-existent), so the
 // write failed with "no such file or directory". The cover must be written

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -1005,6 +1005,177 @@ func TestUpdateFile_DowngradeMainToSupplement_DeletesCoverFile(t *testing.T) {
 	})
 }
 
+// Regression: when a user drops a file at the library root with
+// OrganizeFileStructure disabled, scanFileCreateNew writes a synthetic
+// organized-folder path into book.Filepath that never exists on disk. The
+// actual cover lives alongside the file at filepath.Dir(file.Filepath),
+// not under the synthetic book path. The bookCover and fileCover handlers
+// must resolve the cover via the file's parent dir, not book.Filepath.
+func TestServeCover_RootLevelFile_SyntheticBookPath_ServesCoverFromFileDir(t *testing.T) {
+	t.Parallel()
+
+	runServe := func(t *testing.T, fetchURL func(bookID, fileID int) string) {
+		t.Helper()
+		db := setupTestDB(t)
+		ctx := context.Background()
+
+		library := &models.Library{
+			Name:                     "Test Library",
+			CoverAspectRatio:         "book",
+			DownloadFormatPreference: models.DownloadFormatOriginal,
+		}
+		_, err := db.NewInsert().Model(library).Exec(ctx)
+		require.NoError(t, err)
+
+		libraryDir := t.TempDir()
+		epubPath := filepath.Join(libraryDir, "root-book.epub")
+		require.NoError(t, os.WriteFile(epubPath, []byte("epub content"), 0644))
+
+		// Synthetic organized-folder path — same shape scanFileCreateNew
+		// produces for root-level files regardless of OrganizeFileStructure.
+		syntheticBookPath := filepath.Join(libraryDir, "Author Name", "Book Title")
+		book := &models.Book{
+			LibraryID:       library.ID,
+			Title:           "Root Book",
+			TitleSource:     models.DataSourceFilepath,
+			SortTitle:       "Root Book",
+			SortTitleSource: models.DataSourceFilepath,
+			AuthorSource:    models.DataSourceFilepath,
+			Filepath:        syntheticBookPath,
+		}
+		_, err = db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+
+		file := setupTestFile(t, db, book, models.FileTypeEPUB, epubPath)
+
+		coverFilename := filepath.Base(epubPath) + ".cover.jpg"
+		coverFullPath := filepath.Join(libraryDir, coverFilename)
+		coverData := []byte("cover-bytes")
+		require.NoError(t, os.WriteFile(coverFullPath, coverData, 0644))
+
+		mimeType := "image/jpeg"
+		coverSource := models.DataSourceExistingCover
+		file.CoverImageFilename = &coverFilename
+		file.CoverMimeType = &mimeType
+		file.CoverSource = &coverSource
+		_, err = db.NewUpdate().
+			Model(file).
+			Column("cover_image_filename", "cover_mime_type", "cover_source").
+			WherePK().
+			Exec(ctx)
+		require.NoError(t, err)
+
+		user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+		e := setupTestServer(t, db)
+		req := httptest.NewRequest(http.MethodGet, fetchURL(book.ID, file.ID), nil)
+		rr := executeRequestWithUser(t, e, req, user)
+
+		require.Equal(t, http.StatusOK, rr.Code,
+			"expected 200 serving cover for root-level file with synthetic book path, got %d: %s",
+			rr.Code, rr.Body.String())
+		assert.Equal(t, coverData, rr.Body.Bytes(),
+			"expected cover body to match the file planted next to the root-level file")
+	}
+
+	t.Run("bookCover", func(t *testing.T) {
+		t.Parallel()
+		runServe(t, func(bookID, _ int) string {
+			return "/books/" + strconv.Itoa(bookID) + "/cover"
+		})
+	})
+
+	t.Run("fileCover", func(t *testing.T) {
+		t.Parallel()
+		runServe(t, func(_, fileID int) string {
+			return "/books/files/" + strconv.Itoa(fileID) + "/cover"
+		})
+	})
+}
+
+// Regression: when narrators are updated on a root-level M4B file in a
+// library with OrganizeFileStructure enabled, the handler must move the
+// file into its organized folder AND keep book.Filepath in sync. The
+// previous behavior called RenameOrganizedFileOnly, which renamed the file
+// in place at the library root and left book.Filepath pointing at the
+// synthetic organized path — a desync that broke book-level sidecar
+// resolution and future reorganize attempts.
+func TestUpdateFile_Narrators_RootLevelM4B_OrganizesFileAndSyncsBookPath(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	libraryDir := t.TempDir()
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "audiobook",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	libraryPath := &models.LibraryPath{LibraryID: library.ID, Filepath: libraryDir}
+	_, err = db.NewInsert().Model(libraryPath).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create a real M4B file at the library root.
+	m4bPath := filepath.Join(libraryDir, "book.m4b")
+	require.NoError(t, os.WriteFile(m4bPath, []byte("m4b content"), 0644))
+
+	// Book with synthetic organized-folder path (what scanFileCreateNew
+	// writes) — doesn't exist on disk.
+	syntheticBookPath := filepath.Join(libraryDir, "Author Name", "Book Title")
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Book Title",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book Title",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        syntheticBookPath,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	// Author association so organize can compute the folder name.
+	author := &models.Person{Name: "Author Name", LibraryID: library.ID, SortName: "Author Name"}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+	authorAssoc := &models.Author{BookID: book.ID, PersonID: author.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(authorAssoc).Exec(ctx)
+	require.NoError(t, err)
+
+	file := setupTestFile(t, db, book, models.FileTypeM4B, m4bPath)
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+	e := setupTestServer(t, db)
+	body := `{"narrators": ["Narrator Name"]}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	// File must have been moved out of the library root and into an
+	// organized folder under the library path.
+	var updatedFile models.File
+	err = db.NewSelect().Model(&updatedFile).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.NotEqual(t, libraryDir, filepath.Dir(updatedFile.Filepath),
+		"file should no longer be at the library root after organize; path=%s", updatedFile.Filepath)
+	_, err = os.Stat(updatedFile.Filepath)
+	require.NoError(t, err, "renamed file should exist at %s", updatedFile.Filepath)
+
+	// book.Filepath must match the file's containing directory — no more
+	// synthetic-path desync.
+	var updatedBook models.Book
+	err = db.NewSelect().Model(&updatedBook).Where("id = ?", book.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Dir(updatedFile.Filepath), updatedBook.Filepath,
+		"book.Filepath should track the organized folder")
+}
+
 func TestUpdateBook_Title_UpdatesMainFileName_WhenMatchesOldTitle(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/books/merge.go
+++ b/pkg/books/merge.go
@@ -37,14 +37,35 @@ type MoveFilesResult struct {
 
 // fileMove tracks a file move operation for rollback purposes.
 type fileMove struct {
-	fileID    int
-	oldPath   string
-	newPath   string
-	oldDir    string // Source directory for cleanup
-	oldBookID int
-	newBookID int
-	fileMoved bool // True if the physical file was moved
-	dbUpdated bool // True if the database was updated
+	fileID         int
+	oldPath        string
+	newPath        string
+	oldDir         string // Source directory for cleanup
+	oldBookID      int
+	newBookID      int
+	fileMoved      bool   // True if the physical file was moved
+	dbUpdated      bool   // True if the database was updated
+	createdDirRoot string // Topmost ancestor dir we created via MkdirAll, or "" if none
+}
+
+// firstNonExistentAncestor walks up from dir and returns the topmost path in
+// the chain that does not exist on disk. Returns "" if dir already exists
+// (no MkdirAll would create anything).
+func firstNonExistentAncestor(dir string) string {
+	if _, err := os.Stat(dir); err == nil {
+		return ""
+	}
+	cur := dir
+	for {
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return cur
+		}
+		if _, err := os.Stat(parent); err == nil {
+			return cur
+		}
+		cur = parent
+	}
 }
 
 // MoveFilesToBook moves files from their current books to a target book.
@@ -170,15 +191,23 @@ func (svc *Service) MoveFilesToBook(ctx context.Context, opts MoveFilesOptions) 
 					// may be a synthetic organized-folder path that hasn't been
 					// created on disk yet (e.g. the target book was root-level and
 					// organize hasn't run). moveFile below uses os.Rename and will
-					// fail if the parent dir is missing.
+					// fail if the parent dir is missing. Track the topmost dir we
+					// create so rollback can clean it up if the move fails.
+					createdRoot := firstNonExistentAncestor(filepath.Dir(newPath))
 					if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
 						failures := svc.rollbackFileMoves(ctx, moves)
 						baseErr := errors.Wrapf(err, "failed to create destination dir for file %d", file.ID)
 						return wrapErrorWithRollbackFailures(baseErr, failures)
 					}
+					move.createdDirRoot = createdRoot
 					// Move file along with associated files (covers, sidecars)
 					_, err := fileutils.MoveFileWithAssociatedFiles(file.Filepath, newPath)
 					if err != nil {
+						// Clean up the dir chain we just created — the move
+						// failed, so the tree is empty.
+						if move.createdDirRoot != "" {
+							_ = os.RemoveAll(move.createdDirRoot)
+						}
 						// Rollback any previous moves
 						failures := svc.rollbackFileMoves(ctx, moves)
 						baseErr := errors.Wrapf(err, "failed to move file %d to %s", file.ID, newPath)
@@ -232,6 +261,10 @@ func (svc *Service) MoveFilesToBook(ctx context.Context, opts MoveFilesOptions) 
 							newPath: move.newPath,
 							err:     rbErr,
 						})
+					} else if move.createdDirRoot != "" {
+						// File is back at its original location; the dir chain
+						// we created is now empty.
+						_ = os.RemoveAll(move.createdDirRoot)
 					}
 				}
 				// Rollback any previous moves
@@ -715,6 +748,12 @@ func (svc *Service) rollbackFileMoves(ctx context.Context, moves []fileMove) []r
 					newPath: move.newPath,
 					err:     err,
 				})
+				continue
+			}
+			if move.createdDirRoot != "" {
+				// File is back at its original location; the dir chain we
+				// created is now empty.
+				_ = os.RemoveAll(move.createdDirRoot)
 			}
 		}
 	}

--- a/pkg/books/merge.go
+++ b/pkg/books/merge.go
@@ -166,6 +166,16 @@ func (svc *Service) MoveFilesToBook(ctx context.Context, opts MoveFilesOptions) 
 				newPath = fileutils.GenerateUniqueFilepathIfExists(newPath)
 
 				if newPath != file.Filepath {
+					// Ensure the destination directory exists. targetBook.Filepath
+					// may be a synthetic organized-folder path that hasn't been
+					// created on disk yet (e.g. the target book was root-level and
+					// organize hasn't run). moveFile below uses os.Rename and will
+					// fail if the parent dir is missing.
+					if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
+						failures := svc.rollbackFileMoves(ctx, moves)
+						baseErr := errors.Wrapf(err, "failed to create destination dir for file %d", file.ID)
+						return wrapErrorWithRollbackFailures(baseErr, failures)
+					}
 					// Move file along with associated files (covers, sidecars)
 					_, err := fileutils.MoveFileWithAssociatedFiles(file.Filepath, newPath)
 					if err != nil {

--- a/pkg/books/merge_integration_test.go
+++ b/pkg/books/merge_integration_test.go
@@ -116,6 +116,103 @@ func TestMoveFilesToBook_WithOrganizeFileStructure(t *testing.T) {
 	assert.Equal(t, targetBook.ID, movedFile.BookID)
 }
 
+// Regression: when the target book has a synthetic organized-folder path
+// that doesn't exist on disk (root-level book that hasn't been organized
+// yet), MoveFilesToBook must create the destination directory before moving.
+// Previously it would fail with "no such file or directory" because
+// moveFile calls os.Rename on a non-existent target directory.
+func TestMoveFilesToBook_TargetBookHasSyntheticPath_CreatesDirAndMoves(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	tmpDir := t.TempDir()
+	sourceDir := filepath.Join(tmpDir, "source")
+	require.NoError(t, os.MkdirAll(sourceDir, 0755))
+
+	sourceFile := filepath.Join(sourceDir, "test.epub")
+	require.NoError(t, os.WriteFile(sourceFile, []byte("test content"), 0644))
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	libraryPath := &models.LibraryPath{LibraryID: library.ID, Filepath: tmpDir}
+	_, err = db.NewInsert().Model(libraryPath).Exec(ctx)
+	require.NoError(t, err)
+
+	now := time.Now()
+	sourceBook := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Source Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Source Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        sourceDir,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = db.NewInsert().Model(sourceBook).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        sourceBook.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      sourceFile,
+		FilesizeBytes: 12,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Target book with synthetic (non-existent) path — matches what
+	// scanFileCreateNew writes for root-level books before organize runs.
+	syntheticTargetDir := filepath.Join(tmpDir, "Author Name", "Target Book")
+	targetBook := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Target Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Target Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        syntheticTargetDir,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = db.NewInsert().Model(targetBook).Exec(ctx)
+	require.NoError(t, err)
+
+	// Sanity check: the synthetic target dir does not exist yet.
+	_, err = os.Stat(syntheticTargetDir)
+	require.True(t, os.IsNotExist(err))
+
+	result, err := svc.MoveFilesToBook(ctx, MoveFilesOptions{
+		FileIDs:      []int{file.ID},
+		TargetBookID: &targetBook.ID,
+		LibraryID:    library.ID,
+	})
+	require.NoError(t, err, "MoveFilesToBook should create missing target dir and succeed")
+	assert.Equal(t, 1, result.FilesMoved)
+
+	newFilePath := filepath.Join(syntheticTargetDir, "test.epub")
+	_, err = os.Stat(newFilePath)
+	require.NoError(t, err, "file should exist at new location")
+
+	moved, err := svc.RetrieveFile(ctx, RetrieveFileOptions{ID: &file.ID})
+	require.NoError(t, err)
+	assert.Equal(t, newFilePath, moved.Filepath)
+}
+
 func TestMoveFilesToBook_WithoutOrganizeFileStructure_NoPhysicalMove(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/pkg/books/merge_integration_test.go
+++ b/pkg/books/merge_integration_test.go
@@ -213,6 +213,98 @@ func TestMoveFilesToBook_TargetBookHasSyntheticPath_CreatesDirAndMoves(t *testin
 	assert.Equal(t, newFilePath, moved.Filepath)
 }
 
+// Regression: when the target book has a synthetic path and the move fails
+// after MkdirAll created the destination directory chain, the rollback path
+// must remove the newly-created dirs so they don't accumulate as empty
+// orphans under the library root.
+func TestMoveFilesToBook_MoveFailure_CleansUpCreatedDestDirs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	tmpDir := t.TempDir()
+	sourceDir := filepath.Join(tmpDir, "source")
+	require.NoError(t, os.MkdirAll(sourceDir, 0755))
+
+	sourceFile := filepath.Join(sourceDir, "test.epub")
+	require.NoError(t, os.WriteFile(sourceFile, []byte("content"), 0644))
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.LibraryPath{LibraryID: library.ID, Filepath: tmpDir}).Exec(ctx)
+	require.NoError(t, err)
+
+	now := time.Now()
+	sourceBook := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Source",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Source",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        sourceDir,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = db.NewInsert().Model(sourceBook).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        sourceBook.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      sourceFile,
+		FilesizeBytes: 7,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	syntheticTargetDir := filepath.Join(tmpDir, "NewAuthor", "NewTitle")
+	targetBook := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "NewTitle",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "NewTitle",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        syntheticTargetDir,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	_, err = db.NewInsert().Model(targetBook).Exec(ctx)
+	require.NoError(t, err)
+
+	// Remove the source file on disk so os.Rename fails when MoveFilesToBook
+	// tries to move it, forcing the rollback path.
+	require.NoError(t, os.Remove(sourceFile))
+
+	_, err = svc.MoveFilesToBook(ctx, MoveFilesOptions{
+		FileIDs:      []int{file.ID},
+		TargetBookID: &targetBook.ID,
+		LibraryID:    library.ID,
+	})
+	require.Error(t, err, "move should fail because source file is missing")
+
+	// The created dir chain must be removed on failure so we don't leave
+	// empty orphan directories in the library root.
+	_, statErr := os.Stat(syntheticTargetDir)
+	assert.True(t, os.IsNotExist(statErr),
+		"expected synthetic target dir to be cleaned up on move failure: %v", statErr)
+	_, statErr = os.Stat(filepath.Dir(syntheticTargetDir))
+	assert.True(t, os.IsNotExist(statErr),
+		"expected top-most created parent dir to also be cleaned up")
+}
+
 func TestMoveFilesToBook_WithoutOrganizeFileStructure_NoPhysicalMove(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1678,13 +1678,10 @@ func deleteFileFromDisk(file *models.File) error {
 		return errors.Wrap(err, "failed to delete main file")
 	}
 
-	// Delete cover image if exists (best effort). Use a pure-string join
-	// rather than fileutils.ResolveCoverPath here: that helper stats the
-	// first argument, and file.Filepath may have been removed manually
-	// by the user before this function runs (or just now, above). For
-	// both root-level and directory-backed books, the cover lives
-	// alongside the file, so filepath.Dir(file.Filepath) is always the
-	// cover dir regardless of whether the main file exists on disk.
+	// Delete cover image if exists (best effort). The cover lives alongside
+	// the file for both root-level and directory-backed books, so
+	// filepath.Dir(file.Filepath) is always the cover dir regardless of
+	// whether the main file exists on disk.
 	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
 		coverPath := filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)
 		_ = os.Remove(coverPath)

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -934,6 +934,16 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 			// Set file type for proper volume formatting
 			organizeOpts.FileType = file.FileType
 
+			// Prefer file.Name for the per-file title (consistent with the
+			// isDirectoryBased and else branches below). Without this, a
+			// user-edited file name on a root-level file would be dropped
+			// when organize moves the file into its folder.
+			if file.Name != nil && *file.Name != "" {
+				organizeOpts.Title = *file.Name
+			} else {
+				organizeOpts.Title = book.Title
+			}
+
 			// Populate narrator names from file's narrators for M4B files
 			organizeOpts.NarratorNames = nil
 			for _, n := range file.Narrators {

--- a/pkg/books/service_test.go
+++ b/pkg/books/service_test.go
@@ -390,10 +390,10 @@ func TestDeleteBookAndFiles_DeletesBookFilesAndDiskFiles(t *testing.T) {
 // regression test for a bug where deleteFileFromDisk resolved the cover
 // path by stat'ing file.Filepath. If the main file had already been
 // removed from disk (e.g. the user manually deleted it before triggering
-// the app's delete), the stat would fail, ResolveCoverDir would fall
-// back to treating file.Filepath as a directory, and the resulting
-// cover path would be a junk location — silently leaving the cover file
-// orphaned on disk.
+// the app's delete), the stat would fail and the resulting cover path
+// would be a junk location — silently leaving the cover file orphaned.
+// The current implementation uses a pure-string join against
+// filepath.Dir(file.Filepath) which is stat-race-free.
 func TestDeleteBookAndFiles_RemovesCoverWhenMainFileAlreadyMissing(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/downloadcache/fingerprint.go
+++ b/pkg/downloadcache/fingerprint.go
@@ -5,10 +5,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"sort"
 	"time"
 
-	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
@@ -293,10 +293,11 @@ func ComputeFingerprint(book *models.Book, file *models.File) (*Fingerprint, err
 	}
 
 	// Add cover information if present. CoverImageFilename stores only the
-	// filename; resolve it against the book's cover directory so Path is
-	// usable and Stat sees the real file for modtime.
+	// filename; resolve it via the file's parent dir (where the cover always
+	// lives for both directory-backed and root-level books) so Stat sees the
+	// real file for modtime.
 	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
-		coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
+		coverPath := filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)
 		mimeType := ""
 		if file.CoverMimeType != nil {
 			mimeType = *file.CoverMimeType

--- a/pkg/downloadcache/fingerprint_test.go
+++ b/pkg/downloadcache/fingerprint_test.go
@@ -136,9 +136,10 @@ func TestComputeFingerprint(t *testing.T) {
 		assert.Empty(t, fp.Narrators)
 	})
 
-	t.Run("cover information is resolved against book directory", func(t *testing.T) {
+	t.Run("cover information is resolved against file directory", func(t *testing.T) {
 		// CoverImageFilename stores just the filename; the full path is
-		// resolved at runtime against book.Filepath.
+		// resolved at runtime against the file's parent dir (where the cover
+		// always lives for both directory-backed and root-level books).
 		tmpDir := t.TempDir()
 		coverFilename := "book.epub.cover.jpg"
 		coverAbsPath := filepath.Join(tmpDir, coverFilename)
@@ -151,6 +152,7 @@ func TestComputeFingerprint(t *testing.T) {
 
 		book := &models.Book{Title: "Book with Cover", Filepath: tmpDir}
 		file := &models.File{
+			Filepath:           filepath.Join(tmpDir, "book.epub"),
 			CoverImageFilename: strPtr(coverFilename),
 			CoverMimeType:      strPtr("image/jpeg"),
 		}
@@ -167,6 +169,7 @@ func TestComputeFingerprint(t *testing.T) {
 	t.Run("cover with non-existent filename uses zero time", func(t *testing.T) {
 		book := &models.Book{Title: "Book", Filepath: "/nonexistent"}
 		file := &models.File{
+			Filepath:           "/nonexistent/book.epub",
 			CoverImageFilename: strPtr("missing.jpg"),
 			CoverMimeType:      strPtr("image/jpeg"),
 		}
@@ -175,8 +178,8 @@ func TestComputeFingerprint(t *testing.T) {
 		require.NoError(t, err)
 
 		require.NotNil(t, fp.Cover)
-		// Path is still resolved via ResolveCoverPath even when stat fails —
-		// locks in the join contract.
+		// Path is resolved via filepath.Dir(file.Filepath) even when stat
+		// fails — locks in the join contract.
 		assert.Equal(t, filepath.Join("/nonexistent", "missing.jpg"), fp.Cover.Path)
 		assert.True(t, fp.Cover.ModTime.IsZero())
 	})

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -17,7 +17,6 @@ import (
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
-	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/people"
@@ -736,7 +735,9 @@ func (h *handler) Cover(c echo.Context) error {
 		return errcodes.NotFound("Cover")
 	}
 
-	coverPath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
+	// Resolve via the file's parent dir — book.Filepath may be a synthetic
+	// organized-folder path that doesn't exist on disk for root-level files.
+	coverPath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
 	c.Response().Header().Set("Cache-Control", "private, no-cache")
 	return errors.WithStack(c.File(coverPath))
 }

--- a/pkg/filegen/epub.go
+++ b/pkg/filegen/epub.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
@@ -81,13 +80,13 @@ func (g *EPUBGenerator) Generate(ctx context.Context, srcPath, destPath string, 
 	var newCoverData []byte
 	var newCoverMimeType string
 	if file.CoverImageFilename != nil && *file.CoverImageFilename != "" {
-		coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
-		if coverPath != "" {
-			newCoverData, err = os.ReadFile(coverPath)
-			if err == nil {
-				if file.CoverMimeType != nil {
-					newCoverMimeType = *file.CoverMimeType
-				}
+		// Resolve via the file's parent dir — book.Filepath may be a synthetic
+		// organized-folder path that doesn't exist on disk for root-level files.
+		coverPath := filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)
+		newCoverData, err = os.ReadFile(coverPath)
+		if err == nil {
+			if file.CoverMimeType != nil {
+				newCoverMimeType = *file.CoverMimeType
 			}
 		}
 	}

--- a/pkg/filegen/epub_test.go
+++ b/pkg/filegen/epub_test.go
@@ -232,6 +232,7 @@ func TestEPUBGenerator_Generate(t *testing.T) {
 		// CoverImageFilename is just the filename, not the full path
 		file := &models.File{
 			FileType:           models.FileTypeEPUB,
+			Filepath:           srcPath,
 			CoverImageFilename: &coverFilename,
 			CoverMimeType:      &mimeType,
 		}
@@ -278,6 +279,7 @@ func TestEPUBGenerator_Generate(t *testing.T) {
 		mimeType := "image/jpeg"
 		file := &models.File{
 			FileType:           models.FileTypeEPUB,
+			Filepath:           srcPath,
 			CoverImageFilename: &coverFilename,
 			CoverMimeType:      &mimeType,
 		}

--- a/pkg/filegen/m4b.go
+++ b/pkg/filegen/m4b.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/mp4"
@@ -39,7 +38,7 @@ func (g *M4BGenerator) Generate(ctx context.Context, srcPath, destPath string, b
 	newMeta := g.buildMetadata(book, file, srcMeta)
 
 	// Handle cover replacement
-	if err := g.loadCover(book, file, newMeta); err != nil {
+	if err := g.loadCover(file, newMeta); err != nil {
 		return NewGenerationError(models.FileTypeM4B, err, "failed to load cover image")
 	}
 
@@ -243,14 +242,13 @@ func (g *M4BGenerator) buildMetadata(book *models.Book, file *models.File, src *
 }
 
 // loadCover reads the cover image from the file system and sets it on the metadata.
-func (g *M4BGenerator) loadCover(book *models.Book, file *models.File, meta *mp4.Metadata) error {
-	if file.CoverImageFilename == nil {
+func (g *M4BGenerator) loadCover(file *models.File, meta *mp4.Metadata) error {
+	if file.CoverImageFilename == nil || *file.CoverImageFilename == "" {
 		return nil
 	}
-	coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
-	if coverPath == "" {
-		return nil
-	}
+	// Resolve via the file's parent dir — book.Filepath may be a synthetic
+	// organized-folder path that doesn't exist on disk for root-level files.
+	coverPath := filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)
 
 	data, err := os.ReadFile(coverPath)
 	if err != nil {

--- a/pkg/filegen/m4b_test.go
+++ b/pkg/filegen/m4b_test.go
@@ -339,6 +339,7 @@ func TestM4BGenerator_Generate(t *testing.T) {
 		}
 		file := &models.File{
 			FileType:           models.FileTypeM4B,
+			Filepath:           srcPath,
 			CoverImageFilename: &coverFilename,
 			CoverMimeType:      &mimeType,
 		}

--- a/pkg/fileutils/operations.go
+++ b/pkg/fileutils/operations.go
@@ -417,31 +417,18 @@ func getBaseNameWithoutExt(path string) string {
 	return strings.TrimSuffix(base, ext)
 }
 
-// ResolveCoverDir resolves the directory that contains a book's cover images.
-// Accepts either the book's filepath or any file inside the book directory
-// (e.g. file.Filepath). For directory-backed books (the common case), the
-// book filepath is the cover dir itself. For root-level books (where
-// book.Filepath is the file, not a directory) or when given a file path,
-// the cover dir is the file's parent. If the path cannot be stat'd, returns
-// it unchanged — safe for read-side callers that are resolving a path the
-// DB already tells us exists, but NOT safe for write-side callers whose
-// bookFilepath may be a synthetic path that hasn't been created yet. Those
-// callers must use ResolveCoverDirForWrite.
-func ResolveCoverDir(bookFilepath string) string {
-	if info, err := os.Stat(bookFilepath); err == nil && !info.IsDir() {
-		return filepath.Dir(bookFilepath)
-	}
-	return bookFilepath
-}
-
 // ResolveCoverDirForWrite resolves the directory where a cover image should
-// be written. Unlike ResolveCoverDir (the read-side helper), this handles
-// the case where bookFilepath may be a synthetic organized-folder path that
-// does not yet exist on disk — common when scanning root-level files in
-// libraries with OrganizeFileStructure enabled, where the organized
-// directory is created later in the batch. In that case the cover must
-// land alongside the file at filepath.Dir(fileFilepath), which is where
-// extractAndSaveCover wrote the file-embedded cover.
+// be written. Handles the case where bookFilepath may be a synthetic
+// organized-folder path that does not yet exist on disk — common when
+// scanning root-level files in libraries with OrganizeFileStructure enabled,
+// where the organized directory is created later in the batch. In that case
+// the cover must land alongside the file at filepath.Dir(fileFilepath), which
+// is where extractAndSaveCover wrote the file-embedded cover.
+//
+// Read-side callers that already have a resolved file.Filepath from the DB
+// should NOT use this helper — prefer the pure-string
+// filepath.Join(filepath.Dir(file.Filepath), coverFilename) which is always
+// correct for both directory-backed and root-level books.
 //
 // If bookFilepath resolves to a real directory, it's used. Otherwise (stat
 // fails, or bookFilepath is a file), falls back to filepath.Dir(fileFilepath).
@@ -456,17 +443,6 @@ func ResolveCoverDirForWrite(bookFilepath, fileFilepath string) string {
 		return bookFilepath
 	}
 	return filepath.Dir(fileFilepath)
-}
-
-// ResolveCoverPath resolves the full path to a file's cover image on disk.
-// CoverImageFilename in the database stores only the filename, so the full
-// path must be constructed at runtime by joining it with the book's cover
-// directory. Returns an empty string if coverFilename is empty.
-func ResolveCoverPath(bookFilepath, coverFilename string) string {
-	if coverFilename == "" {
-		return ""
-	}
-	return filepath.Join(ResolveCoverDir(bookFilepath), coverFilename)
 }
 
 // ComputeNewCoverFilename computes the new cover filename after a file has been renamed.

--- a/pkg/fileutils/operations_test.go
+++ b/pkg/fileutils/operations_test.go
@@ -886,32 +886,6 @@ func TestMoveFileWithAssociatedFiles(t *testing.T) {
 	}
 }
 
-func TestResolveCoverDir(t *testing.T) {
-	t.Parallel()
-
-	t.Run("directory-backed book returns book dir unchanged", func(t *testing.T) {
-		t.Parallel()
-		bookDir := t.TempDir()
-		assert.Equal(t, bookDir, ResolveCoverDir(bookDir))
-	})
-
-	t.Run("root-level book returns parent of file", func(t *testing.T) {
-		t.Parallel()
-		libraryDir := t.TempDir()
-		bookFilepath := filepath.Join(libraryDir, "book.epub")
-		if err := os.WriteFile(bookFilepath, []byte("epub"), 0644); err != nil {
-			t.Fatalf("failed to write test file: %v", err)
-		}
-		assert.Equal(t, libraryDir, ResolveCoverDir(bookFilepath))
-	})
-
-	t.Run("nonexistent path is treated as a directory path", func(t *testing.T) {
-		t.Parallel()
-		bookDir := filepath.Join(t.TempDir(), "missing")
-		assert.Equal(t, bookDir, ResolveCoverDir(bookDir))
-	})
-}
-
 func TestResolveCoverDirForWrite(t *testing.T) {
 	t.Parallel()
 
@@ -947,43 +921,5 @@ func TestResolveCoverDirForWrite(t *testing.T) {
 		// new file in a library with OrganizeFileStructure enabled.
 		syntheticBookPath := filepath.Join(libraryDir, "Author", "Title")
 		assert.Equal(t, libraryDir, ResolveCoverDirForWrite(syntheticBookPath, filePath))
-	})
-}
-
-func TestResolveCoverPath(t *testing.T) {
-	t.Parallel()
-
-	t.Run("empty cover filename returns empty", func(t *testing.T) {
-		t.Parallel()
-		got := ResolveCoverPath(t.TempDir(), "")
-		assert.Empty(t, got)
-	})
-
-	t.Run("directory-backed book joins cover filename to book dir", func(t *testing.T) {
-		t.Parallel()
-		bookDir := t.TempDir()
-		got := ResolveCoverPath(bookDir, "book.epub.cover.jpg")
-		assert.Equal(t, filepath.Join(bookDir, "book.epub.cover.jpg"), got)
-	})
-
-	t.Run("root-level book joins cover filename to parent of file", func(t *testing.T) {
-		t.Parallel()
-		libraryDir := t.TempDir()
-		bookFilepath := filepath.Join(libraryDir, "book.epub")
-		if err := os.WriteFile(bookFilepath, []byte("epub"), 0644); err != nil {
-			t.Fatalf("failed to write test file: %v", err)
-		}
-		got := ResolveCoverPath(bookFilepath, "book.epub.cover.jpg")
-		assert.Equal(t, filepath.Join(libraryDir, "book.epub.cover.jpg"), got)
-	})
-
-	t.Run("nonexistent bookFilepath is treated as a directory path", func(t *testing.T) {
-		t.Parallel()
-		// If we can't stat the book path (e.g., because it was moved or deleted),
-		// fall back to treating it as a directory — matches the existing
-		// behavior in filegen.resolveCoverPath and the fileCover handler.
-		bookDir := filepath.Join(t.TempDir(), "missing")
-		got := ResolveCoverPath(bookDir, "book.epub.cover.jpg")
-		assert.Equal(t, filepath.Join(bookDir, "book.epub.cover.jpg"), got)
 	})
 }

--- a/pkg/kobo/handlers.go
+++ b/pkg/kobo/handlers.go
@@ -10,6 +10,7 @@ import (
 	_ "image/png" // Register PNG decoder
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -21,7 +22,6 @@ import (
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
-	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/models"
 	"golang.org/x/image/draw"
 )
@@ -239,13 +239,9 @@ func (h *handler) handleCover(c echo.Context) error {
 		return errcodes.NotFound("Cover")
 	}
 
-	// Get the book to determine the cover path base dir
-	book, err := h.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &file.BookID})
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	coverPath := fileutils.ResolveCoverPath(book.Filepath, *file.CoverImageFilename)
+	// Resolve via the file's parent dir — book.Filepath may be a synthetic
+	// organized-folder path that doesn't exist on disk for root-level files.
+	coverPath := filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)
 
 	// Stat source cover for Last-Modified + conditional GET short-circuit.
 	// This runs before the resize so revalidated requests skip the expensive

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -2,6 +2,7 @@ package series
 
 import (
 	"net/http"
+	"path/filepath"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
@@ -9,7 +10,6 @@ import (
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/errcodes"
-	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/search"
@@ -270,7 +270,9 @@ func (h *handler) seriesCover(c echo.Context) error {
 		return errcodes.NotFound("Series cover")
 	}
 
-	coverImagePath := fileutils.ResolveCoverPath(book.Filepath, *coverFile.CoverImageFilename)
+	// Resolve via the file's parent dir — book.Filepath may be a synthetic
+	// organized-folder path that doesn't exist on disk for root-level files.
+	coverImagePath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
 
 	// Set appropriate headers
 	c.Response().Header().Set("Cache-Control", "private, no-cache")

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -115,24 +115,25 @@ func ReadBookSidecar(bookPath string) (*BookSidecar, error) {
 // ReadBookSidecarFromModel reads the book sidecar for a Book, using the same
 // anchor-resolution logic as WriteBookSidecarFromModel. For root-level books
 // with a synthetic book.Filepath, the sidecar is read from next to a file in
-// the book instead of from the non-existent synthetic directory. The optional
-// fileHint is used as a fallback anchor when book.Files is not populated —
-// pass the current file being scanned so resolution works even before the
-// book has been reloaded with its files relation.
+// the book instead of from the non-existent synthetic directory.
+//
+// fileHint (may be nil) is consulted when the resolved anchor doesn't exist
+// on disk — typically because book.Files was not loaded and book.Filepath is
+// the synthetic pre-organize path. Pass the current file being scanned so
+// resolution works before the book is reloaded with its files relation.
 func ReadBookSidecarFromModel(book *models.Book, fileHint *models.File) (*BookSidecar, error) {
 	anchor := resolveBookSidecarAnchor(book)
-	// If the anchor still resolves to a non-existent directory (no files on
-	// the book model yet), fall back to the hint's filepath.
-	if anchor != "" {
-		if info, err := os.Stat(anchor); err != nil || (!info.IsDir() && filepath.Ext(anchor) == "") {
-			if fileHint != nil && fileHint.Filepath != "" {
-				anchor = fileHint.Filepath
-			}
+	if anchor == "" || !pathExists(anchor) {
+		if fileHint != nil && fileHint.Filepath != "" {
+			anchor = fileHint.Filepath
 		}
-	} else if fileHint != nil && fileHint.Filepath != "" {
-		anchor = fileHint.Filepath
 	}
 	return ReadBookSidecar(anchor)
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 // ReadFileSidecar reads and parses a file sidecar.

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -112,6 +112,29 @@ func ReadBookSidecar(bookPath string) (*BookSidecar, error) {
 	return &s, nil
 }
 
+// ReadBookSidecarFromModel reads the book sidecar for a Book, using the same
+// anchor-resolution logic as WriteBookSidecarFromModel. For root-level books
+// with a synthetic book.Filepath, the sidecar is read from next to a file in
+// the book instead of from the non-existent synthetic directory. The optional
+// fileHint is used as a fallback anchor when book.Files is not populated —
+// pass the current file being scanned so resolution works even before the
+// book has been reloaded with its files relation.
+func ReadBookSidecarFromModel(book *models.Book, fileHint *models.File) (*BookSidecar, error) {
+	anchor := resolveBookSidecarAnchor(book)
+	// If the anchor still resolves to a non-existent directory (no files on
+	// the book model yet), fall back to the hint's filepath.
+	if anchor != "" {
+		if info, err := os.Stat(anchor); err != nil || (!info.IsDir() && filepath.Ext(anchor) == "") {
+			if fileHint != nil && fileHint.Filepath != "" {
+				anchor = fileHint.Filepath
+			}
+		}
+	} else if fileHint != nil && fileHint.Filepath != "" {
+		anchor = fileHint.Filepath
+	}
+	return ReadBookSidecar(anchor)
+}
+
 // ReadFileSidecar reads and parses a file sidecar.
 // Returns nil, nil if the sidecar doesn't exist or filePath is empty.
 func ReadFileSidecar(filePath string) (*FileSidecar, error) {
@@ -280,9 +303,45 @@ func FileSidecarFromModel(file *models.File) *FileSidecar {
 }
 
 // WriteBookSidecarFromModel writes a book sidecar from a Book model.
+//
+// For root-level books in libraries with OrganizeFileStructure disabled,
+// the scanner writes a synthetic organized-folder path into book.Filepath
+// that never exists on disk. Writing a sidecar to that path would fail, so
+// if book.Filepath doesn't resolve to an existing directory we fall back to
+// anchoring the sidecar next to a file in the book (preferring a main file).
+// The cover always lives next to the file in that case, so co-locating the
+// book sidecar matches how the rest of the system resolves paths.
 func WriteBookSidecarFromModel(book *models.Book) error {
 	s := BookSidecarFromModel(book)
-	return WriteBookSidecar(book.Filepath, s)
+	return WriteBookSidecar(resolveBookSidecarAnchor(book), s)
+}
+
+// resolveBookSidecarAnchor returns the path to pass to BookSidecarPath for
+// writing. Prefers book.Filepath when it resolves to an existing directory;
+// otherwise falls back to a file in the book. Returns an empty string only
+// when both book.Filepath and any file path are empty — WriteBookSidecar
+// guards empty input.
+func resolveBookSidecarAnchor(book *models.Book) string {
+	if book == nil {
+		return ""
+	}
+	if book.Filepath != "" {
+		if info, err := os.Stat(book.Filepath); err == nil && info.IsDir() {
+			return book.Filepath
+		}
+	}
+	// Fall back to a file's path. Prefer a main file for stable naming.
+	for _, f := range book.Files {
+		if f != nil && f.FileRole == models.FileRoleMain && f.Filepath != "" {
+			return f.Filepath
+		}
+	}
+	for _, f := range book.Files {
+		if f != nil && f.Filepath != "" {
+			return f.Filepath
+		}
+	}
+	return book.Filepath
 }
 
 // WriteFileSidecarFromModel writes a file sidecar from a File model.

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -494,6 +494,50 @@ func TestWriteBookSidecarFromModel(t *testing.T) {
 	assert.Equal(t, "Jane Smith", readBack.Authors[0].Name)
 }
 
+// Regression: scanFileCreateNew writes a synthetic organized-folder path
+// into book.Filepath for root-level files regardless of OrganizeFileStructure.
+// When OrganizeFileStructure=false, that synthetic directory never exists on
+// disk, so WriteBookSidecarFromModel's write fails and the book sidecar is
+// never persisted. The fix falls back to anchoring the sidecar next to a file
+// in the book.
+func TestWriteBookSidecarFromModel_SyntheticBookPath_AnchorsToFile(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Real file at the library root, matching the root-level scenario.
+	filePath := filepath.Join(tmpDir, "root-book.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("epub content"), 0644))
+
+	// book.Filepath is a synthetic organized folder path that does NOT exist.
+	syntheticBookPath := filepath.Join(tmpDir, "Author Name", "Book Title")
+
+	book := &models.Book{
+		Filepath: syntheticBookPath,
+		Title:    "Root Book",
+		Authors: []*models.Author{
+			{Person: &models.Person{Name: "Author Name", SortName: "Name, Author"}, SortOrder: 0},
+		},
+		Files: []*models.File{
+			{Filepath: filePath, FileRole: models.FileRoleMain},
+		},
+	}
+
+	err := WriteBookSidecarFromModel(book)
+	require.NoError(t, err, "write should succeed by anchoring to file path")
+
+	// Read back from the file-anchored location.
+	readBack, err := ReadBookSidecar(filePath)
+	require.NoError(t, err)
+	require.NotNil(t, readBack)
+	assert.Equal(t, "Root Book", readBack.Title)
+	assert.Len(t, readBack.Authors, 1)
+	assert.Equal(t, "Author Name", readBack.Authors[0].Name)
+
+	// Synthetic directory must not have been created as a side effect.
+	_, err = os.Stat(syntheticBookPath)
+	assert.True(t, os.IsNotExist(err), "synthetic book dir should not be created by sidecar write")
+}
+
 func TestWriteFileSidecar_SetsVersion(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -782,7 +782,7 @@ func (w *Worker) scanFileCore(
 
 	// Read sidecar files if they exist (higher priority than file metadata)
 	// Sidecars can override file metadata but not manual user edits
-	bookSidecarData, err := sidecar.ReadBookSidecar(book.Filepath)
+	bookSidecarData, err := sidecar.ReadBookSidecarFromModel(book, file)
 	if err != nil {
 		logWarn("failed to read book sidecar", logger.Data{"error": err.Error()})
 	}
@@ -2143,37 +2143,26 @@ func (w *Worker) scanFileCore(
 	if err != nil {
 		logWarn("failed to reload book for sidecar", logger.Data{"error": err.Error()})
 	} else {
-		// Check if the book directory exists. For root-level files with OrganizeFileStructure
-		// enabled, we need to create the directory before writing the sidecar.
-		// If the directory doesn't exist and org is disabled, we skip writing the book sidecar
-		// since the files haven't been organized yet.
-		bookDirExists := false
-		if info, statErr := os.Stat(reloadedBook.Filepath); statErr == nil && info.IsDir() {
-			bookDirExists = true
-		}
-
-		if !bookDirExists {
-			// Check if the library has OrganizeFileStructure enabled
+		// For root-level files with OrganizeFileStructure enabled, pre-create
+		// the synthetic organized folder so the soon-to-run organize step can
+		// move the file into it and the book sidecar lands at the final path.
+		// When OrganizeFileStructure is disabled, WriteBookSidecarFromModel's
+		// fallback anchors the sidecar next to the file, so no MkdirAll here.
+		if info, statErr := os.Stat(reloadedBook.Filepath); statErr != nil || !info.IsDir() {
 			lib, libErr := w.libraryService.RetrieveLibrary(ctx, libraries.RetrieveLibraryOptions{
 				ID: &reloadedBook.LibraryID,
 			})
 			if libErr != nil {
 				logWarn("failed to retrieve library for sidecar", logger.Data{"error": libErr.Error()})
 			} else if lib.OrganizeFileStructure {
-				// Create the directory for root-level files that will be organized
 				if mkdirErr := os.MkdirAll(reloadedBook.Filepath, 0755); mkdirErr != nil {
 					logWarn("failed to create book directory for sidecar", logger.Data{"error": mkdirErr.Error()})
-				} else {
-					bookDirExists = true
 				}
 			}
-			// If org is disabled, skip writing book sidecar (files are at root level)
 		}
 
-		if bookDirExists {
-			if err := sidecar.WriteBookSidecarFromModel(reloadedBook); err != nil {
-				logWarn("failed to write book sidecar", logger.Data{"error": err.Error()})
-			}
+		if err := sidecar.WriteBookSidecarFromModel(reloadedBook); err != nil {
+			logWarn("failed to write book sidecar", logger.Data{"error": err.Error()})
 		}
 		book = reloadedBook
 	}

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2148,6 +2148,9 @@ func (w *Worker) scanFileCore(
 		// move the file into it and the book sidecar lands at the final path.
 		// When OrganizeFileStructure is disabled, WriteBookSidecarFromModel's
 		// fallback anchors the sidecar next to the file, so no MkdirAll here.
+		// If MkdirAll fails (permissions, etc.) we still attempt the write —
+		// the fallback will anchor next to the file so metadata isn't silently
+		// lost, just ends up at the pre-organize path.
 		if info, statErr := os.Stat(reloadedBook.Filepath); statErr != nil || !info.IsDir() {
 			lib, libErr := w.libraryService.RetrieveLibrary(ctx, libraries.RetrieveLibraryOptions{
 				ID: &reloadedBook.LibraryID,


### PR DESCRIPTION
## Summary
- Fix several issues stemming from the scanner writing a synthetic organized-folder path into `book.Filepath` for root-level files regardless of `OrganizeFileStructure`. When organize is off, that synthetic directory never exists, breaking downstream code that treats `book.Filepath` as a real path.
- Cover-serving handlers and file-generation / fingerprinting callers now resolve covers via `filepath.Dir(file.Filepath)`; book sidecars for root-level books anchor next to the file; `MoveFilesToBook` creates missing destination dirs; and file-level updates that would orphan a root-level file at the library root now delegate to `OrganizeBookFiles` to keep `book.Filepath` in sync.

## Test plan
- In a library with `OrganizeFileStructure` disabled, drop a CBZ/EPUB/M4B file directly in the library root, scan, and confirm the cover loads in the UI (book and file cover endpoints), in OPDS, in the eReader browser, and in Kobo thumbnails.
- Confirm a book sidecar (`{filename}.metadata.json`) gets written next to the root-level file on scan and on book metadata edits.
- With `OrganizeFileStructure` disabled, rescan a root-level book and confirm sidecar-sourced book metadata is still picked up.
- With `OrganizeFileStructure` enabled, merge a file into a book whose `Filepath` is still a synthetic path (e.g. an un-organized root-level target) and confirm the move succeeds and the destination directory is created.
- With `OrganizeFileStructure` enabled, add narrators to a root-level M4B and confirm the file is moved into its organized folder and `book.Filepath` tracks the new folder.
- Run `mise check:quiet` — passes.