### PR TITLE
[Fix] Skip placeholder data when accumulating directory picker entries

### DIFF
--- a/app/components/library/DirectoryPickerDialog.test.tsx
+++ b/app/components/library/DirectoryPickerDialog.test.tsx
@@ -1,0 +1,200 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BrowseQuery, BrowseResponse, Entry } from "@/types";
+
+import DirectoryPickerDialog from "./DirectoryPickerDialog";
+
+// --- Mock state plumbing ---
+//
+// We model React Query's behavior by tracking a "current key" (path+offset).
+// When the component requests a different key than `currentKey`, the mock
+// returns the previous key's data as placeholder with `isPlaceholderData=true`
+// and `isFetching=true` — matching how `placeholderData: keepPreviousData`
+// behaves in production. The test advances `currentKey` to simulate the
+// fetch completing.
+
+type BrowseState = {
+  data: BrowseResponse | undefined;
+  dataUpdatedAt: number;
+  isPlaceholderData: boolean;
+  isFetching: boolean;
+  isLoading: boolean;
+  isError: boolean;
+  error: { message: string } | null;
+};
+
+let currentKey = "";
+let lastSettledData: BrowseResponse | undefined;
+let lastDataUpdatedAt = 0;
+let keyResponses: Record<string, BrowseResponse> = {};
+
+const keyOf = (q: BrowseQuery) => `${q.path}::${q.offset ?? 0}`;
+
+vi.mock("@/hooks/queries/filesystem", () => ({
+  useFilesystemBrowse: (q: BrowseQuery): BrowseState => {
+    const requestedKey = keyOf(q);
+    if (requestedKey === currentKey) {
+      return {
+        data: lastSettledData,
+        dataUpdatedAt: lastDataUpdatedAt,
+        isPlaceholderData: false,
+        isFetching: false,
+        isLoading: lastSettledData === undefined,
+        isError: false,
+        error: null,
+      };
+    }
+    return {
+      data: lastSettledData,
+      dataUpdatedAt: 0,
+      isPlaceholderData: lastSettledData !== undefined,
+      isFetching: true,
+      isLoading: lastSettledData === undefined,
+      isError: false,
+      error: null,
+    };
+  },
+  QueryKey: { FilesystemBrowse: "FilesystemBrowse" },
+}));
+
+const settle = (key: string) => {
+  currentKey = key;
+  lastSettledData = keyResponses[key];
+  lastDataUpdatedAt = Date.now();
+};
+
+const makeEntries = (start: number, count: number): Entry[] =>
+  Array.from({ length: count }, (_, i) => ({
+    name: `entry-${start + i}`,
+    path: `/root/entry-${start + i}`,
+    is_dir: true,
+  }));
+
+const wrap = (ui: React.ReactNode) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {ui}
+  </QueryClientProvider>
+);
+
+const renderDialog = () =>
+  render(
+    wrap(
+      <DirectoryPickerDialog
+        initialPath="/root"
+        onOpenChange={() => {}}
+        onSelect={() => {}}
+        open
+      />,
+    ),
+  );
+
+describe("DirectoryPickerDialog", () => {
+  beforeEach(() => {
+    currentKey = "";
+    lastSettledData = undefined;
+    lastDataUpdatedAt = 0;
+    keyResponses = {};
+  });
+
+  it("does not duplicate entries when Load More transitions through placeholder data", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    keyResponses["/root::0"] = {
+      current_path: "/root",
+      entries: makeEntries(1, 50),
+      total: 100,
+      has_more: true,
+    };
+    keyResponses["/root::50"] = {
+      current_path: "/root",
+      entries: makeEntries(51, 50),
+      total: 100,
+      has_more: false,
+    };
+    settle("/root::0");
+
+    const { rerender } = renderDialog();
+
+    expect(screen.getByText("entry-1")).toBeInTheDocument();
+    expect(screen.getByText("entry-50")).toBeInTheDocument();
+
+    // Click Load More — component will request offset:50, which the mock
+    // treats as a key mismatch (returns placeholder = entries 1-50).
+    await user.click(screen.getByRole("button", { name: /load more/i }));
+
+    // Simulate the offset:50 fetch settling.
+    settle("/root::50");
+    rerender(
+      wrap(
+        <DirectoryPickerDialog
+          initialPath="/root"
+          onOpenChange={() => {}}
+          onSelect={() => {}}
+          open
+        />,
+      ),
+    );
+
+    expect(screen.getAllByText("entry-1")).toHaveLength(1);
+    expect(screen.getAllByText("entry-50")).toHaveLength(1);
+    expect(screen.getByText("entry-51")).toBeInTheDocument();
+    expect(screen.getByText("entry-100")).toBeInTheDocument();
+  });
+
+  it("does not retain previous directory's entries after navigating into a subdirectory", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    keyResponses["/root::0"] = {
+      current_path: "/root",
+      entries: makeEntries(1, 50),
+      total: 50,
+      has_more: false,
+    };
+    keyResponses["/root/entry-1::0"] = {
+      current_path: "/root/entry-1",
+      entries: [
+        { name: "child-a", path: "/root/entry-1/child-a", is_dir: true },
+      ],
+      total: 1,
+      has_more: false,
+    };
+    settle("/root::0");
+
+    const { rerender } = renderDialog();
+
+    expect(screen.getByText("entry-1")).toBeInTheDocument();
+
+    // Click into the subdirectory. The component navigates to
+    // /root/entry-1, the mock returns the placeholder (old entries) with
+    // isFetching=true while the real fetch is "in flight".
+    await user.click(screen.getByText("entry-1"));
+
+    // Mid-flight: previous directory's entries must NOT be visible. The
+    // accumulator must skip placeholder data, and the spinner condition
+    // must trigger when entries are empty + a fetch is in progress.
+    expect(screen.queryByText("entry-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("entry-50")).not.toBeInTheDocument();
+
+    // Settle the new directory's fetch.
+    settle("/root/entry-1::0");
+    rerender(
+      wrap(
+        <DirectoryPickerDialog
+          initialPath="/root"
+          onOpenChange={() => {}}
+          onSelect={() => {}}
+          open
+        />,
+      ),
+    );
+
+    expect(screen.getByText("child-a")).toBeInTheDocument();
+    expect(screen.queryByText("entry-50")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/library/DirectoryPickerDialog.test.tsx
+++ b/app/components/library/DirectoryPickerDialog.test.tsx
@@ -29,7 +29,6 @@ type BrowseState = {
 
 let currentKey = "";
 let lastSettledData: BrowseResponse | undefined;
-let lastDataUpdatedAt = 0;
 let dataUpdatedAtTick = 0;
 let keyResponses: Record<string, BrowseResponse> = {};
 
@@ -38,13 +37,17 @@ let keyResponses: Record<string, BrowseResponse> = {};
 const keyOf = (q: BrowseQuery) =>
   `${q.path}::${q.offset ?? 0}::${q.search ?? ""}::${q.show_hidden ? 1 : 0}`;
 
+// Mirrors React Query's `placeholderData: keepPreviousData` semantics
+// synchronously on the same render where the key changed — exactly how
+// production behaves. Tests can therefore assert mid-flight state right after
+// the user action that changed the key, without awaiting flushes.
 vi.mock("@/hooks/queries/filesystem", () => ({
   useFilesystemBrowse: (q: BrowseQuery): BrowseState => {
     const requestedKey = keyOf(q);
     if (requestedKey === currentKey) {
       return {
         data: lastSettledData,
-        dataUpdatedAt: lastDataUpdatedAt,
+        dataUpdatedAt: dataUpdatedAtTick,
         isPlaceholderData: false,
         isFetching: false,
         isLoading: lastSettledData === undefined,
@@ -68,9 +71,9 @@ vi.mock("@/hooks/queries/filesystem", () => ({
 const settle = (key: string) => {
   currentKey = key;
   lastSettledData = keyResponses[key];
-  // Use a monotonic counter so re-settles always change `dataUpdatedAt` and
+  // Monotonic counter so re-settles always change `dataUpdatedAt` and
   // re-trigger the accumulator effect, regardless of fake-timer state.
-  lastDataUpdatedAt = ++dataUpdatedAtTick;
+  dataUpdatedAtTick++;
 };
 
 const makeEntries = (start: number, count: number): Entry[] =>
@@ -104,7 +107,6 @@ describe("DirectoryPickerDialog", () => {
   beforeEach(() => {
     currentKey = "";
     lastSettledData = undefined;
-    lastDataUpdatedAt = 0;
     dataUpdatedAtTick = 0;
     keyResponses = {};
   });
@@ -184,9 +186,11 @@ describe("DirectoryPickerDialog", () => {
 
     // Mid-flight: previous directory's entries must NOT be visible. The
     // accumulator must skip placeholder data, and the spinner condition
-    // must trigger when entries are empty + a fetch is in progress.
-    expect(screen.queryByText("entry-1")).not.toBeInTheDocument();
+    // must trigger when entries are empty + a fetch is in progress. (The
+    // breadcrumb now correctly shows "entry-1" as a path segment, so we
+    // assert against `entry-50`, which only ever appears in the listing.)
     expect(screen.queryByText("entry-50")).not.toBeInTheDocument();
+    expect(screen.queryByText("entry-2")).not.toBeInTheDocument();
 
     // Settle the new directory's fetch.
     settle("/root/entry-1::0::::0");
@@ -203,6 +207,7 @@ describe("DirectoryPickerDialog", () => {
 
     expect(screen.getByText("child-a")).toBeInTheDocument();
     expect(screen.queryByText("entry-50")).not.toBeInTheDocument();
+    expect(screen.queryByText("entry-2")).not.toBeInTheDocument();
   });
 
   it("does not retain previous results during a debounced search transition", async () => {

--- a/app/components/library/DirectoryPickerDialog.test.tsx
+++ b/app/components/library/DirectoryPickerDialog.test.tsx
@@ -30,9 +30,13 @@ type BrowseState = {
 let currentKey = "";
 let lastSettledData: BrowseResponse | undefined;
 let lastDataUpdatedAt = 0;
+let dataUpdatedAtTick = 0;
 let keyResponses: Record<string, BrowseResponse> = {};
 
-const keyOf = (q: BrowseQuery) => `${q.path}::${q.offset ?? 0}`;
+// Key on every BrowseQuery field the component varies (path, offset, search,
+// show_hidden) so the mock models placeholder transitions for all of them.
+const keyOf = (q: BrowseQuery) =>
+  `${q.path}::${q.offset ?? 0}::${q.search ?? ""}::${q.show_hidden ? 1 : 0}`;
 
 vi.mock("@/hooks/queries/filesystem", () => ({
   useFilesystemBrowse: (q: BrowseQuery): BrowseState => {
@@ -64,7 +68,9 @@ vi.mock("@/hooks/queries/filesystem", () => ({
 const settle = (key: string) => {
   currentKey = key;
   lastSettledData = keyResponses[key];
-  lastDataUpdatedAt = Date.now();
+  // Use a monotonic counter so re-settles always change `dataUpdatedAt` and
+  // re-trigger the accumulator effect, regardless of fake-timer state.
+  lastDataUpdatedAt = ++dataUpdatedAtTick;
 };
 
 const makeEntries = (start: number, count: number): Entry[] =>
@@ -99,25 +105,26 @@ describe("DirectoryPickerDialog", () => {
     currentKey = "";
     lastSettledData = undefined;
     lastDataUpdatedAt = 0;
+    dataUpdatedAtTick = 0;
     keyResponses = {};
   });
 
   it("does not duplicate entries when Load More transitions through placeholder data", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
-    keyResponses["/root::0"] = {
+    keyResponses["/root::0::::0"] = {
       current_path: "/root",
       entries: makeEntries(1, 50),
       total: 100,
       has_more: true,
     };
-    keyResponses["/root::50"] = {
+    keyResponses["/root::50::::0"] = {
       current_path: "/root",
       entries: makeEntries(51, 50),
       total: 100,
       has_more: false,
     };
-    settle("/root::0");
+    settle("/root::0::::0");
 
     const { rerender } = renderDialog();
 
@@ -129,7 +136,7 @@ describe("DirectoryPickerDialog", () => {
     await user.click(screen.getByRole("button", { name: /load more/i }));
 
     // Simulate the offset:50 fetch settling.
-    settle("/root::50");
+    settle("/root::50::::0");
     rerender(
       wrap(
         <DirectoryPickerDialog
@@ -150,13 +157,13 @@ describe("DirectoryPickerDialog", () => {
   it("does not retain previous directory's entries after navigating into a subdirectory", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
-    keyResponses["/root::0"] = {
+    keyResponses["/root::0::::0"] = {
       current_path: "/root",
       entries: makeEntries(1, 50),
       total: 50,
       has_more: false,
     };
-    keyResponses["/root/entry-1::0"] = {
+    keyResponses["/root/entry-1::0::::0"] = {
       current_path: "/root/entry-1",
       entries: [
         { name: "child-a", path: "/root/entry-1/child-a", is_dir: true },
@@ -164,7 +171,7 @@ describe("DirectoryPickerDialog", () => {
       total: 1,
       has_more: false,
     };
-    settle("/root::0");
+    settle("/root::0::::0");
 
     const { rerender } = renderDialog();
 
@@ -182,7 +189,7 @@ describe("DirectoryPickerDialog", () => {
     expect(screen.queryByText("entry-50")).not.toBeInTheDocument();
 
     // Settle the new directory's fetch.
-    settle("/root/entry-1::0");
+    settle("/root/entry-1::0::::0");
     rerender(
       wrap(
         <DirectoryPickerDialog
@@ -196,5 +203,51 @@ describe("DirectoryPickerDialog", () => {
 
     expect(screen.getByText("child-a")).toBeInTheDocument();
     expect(screen.queryByText("entry-50")).not.toBeInTheDocument();
+  });
+
+  it("does not retain previous results during a debounced search transition", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    keyResponses["/root::0::::0"] = {
+      current_path: "/root",
+      entries: makeEntries(1, 50),
+      total: 50,
+      has_more: false,
+    };
+    keyResponses["/root::0::book::0"] = {
+      current_path: "/root",
+      entries: [{ name: "book-1", path: "/root/book-1", is_dir: true }],
+      total: 1,
+      has_more: false,
+    };
+    settle("/root::0::::0");
+
+    const { rerender } = renderDialog();
+
+    expect(screen.getByText("entry-1")).toBeInTheDocument();
+
+    // Type a search term and let the 300ms debounce fire.
+    await user.type(screen.getByPlaceholderText(/search/i), "book");
+    await vi.advanceTimersByTimeAsync(400);
+
+    // Mid-flight: previous (unfiltered) entries must NOT be visible.
+    expect(screen.queryByText("entry-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("entry-50")).not.toBeInTheDocument();
+
+    // Settle the search query.
+    settle("/root::0::book::0");
+    rerender(
+      wrap(
+        <DirectoryPickerDialog
+          initialPath="/root"
+          onOpenChange={() => {}}
+          onSelect={() => {}}
+          open
+        />,
+      ),
+    );
+
+    expect(screen.getByText("book-1")).toBeInTheDocument();
+    expect(screen.queryByText("entry-1")).not.toBeInTheDocument();
   });
 });

--- a/app/components/library/DirectoryPickerDialog.test.tsx
+++ b/app/components/library/DirectoryPickerDialog.test.tsx
@@ -189,6 +189,12 @@ describe("DirectoryPickerDialog", () => {
     // must trigger when entries are empty + a fetch is in progress. (The
     // breadcrumb now correctly shows "entry-1" as a path segment, so we
     // assert against `entry-50`, which only ever appears in the listing.)
+    //
+    // Note: this asserts post-flush state. `userEvent.click` flushes both
+    // the click handler's render AND any follow-up effect renders, so this
+    // test does not by itself prove the single-render-batch invariant —
+    // only that final state is correct. The single-render guarantee is
+    // documented by the inline reset in the action handlers.
     expect(screen.queryByText("entry-50")).not.toBeInTheDocument();
     expect(screen.queryByText("entry-2")).not.toBeInTheDocument();
 

--- a/app/components/library/DirectoryPickerDialog.tsx
+++ b/app/components/library/DirectoryPickerDialog.tsx
@@ -96,7 +96,13 @@ const DirectoryPickerDialog = ({
 
   // Accumulate entries for "load more" functionality.
   // Use dataUpdatedAt to detect when new data actually arrives.
+  // Skip placeholder data: the global QueryClient enables
+  // `placeholderData: keepPreviousData`, so when the query key changes (load
+  // more or directory navigation) `data` briefly holds the previous query's
+  // entries. Appending those would duplicate the prior page or pollute the
+  // accumulator with entries from a different directory.
   useEffect(() => {
+    if (browseQuery.isPlaceholderData) return;
     if (browseQuery.data?.entries) {
       if (offset === 0) {
         setAccumulatedEntries(browseQuery.data.entries);
@@ -252,18 +258,24 @@ const DirectoryPickerDialog = ({
 
         {/* Directory listing */}
         <div className="h-[400px] border rounded-md overflow-y-auto">
-          {browseQuery.isLoading && offset === 0 ? (
-            <div className="flex items-center justify-center h-full py-12">
-              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-            </div>
-          ) : browseQuery.isError ? (
+          {browseQuery.isError ? (
             <div className="flex items-center justify-center h-full py-12 text-destructive">
               {browseQuery.error?.message || "Failed to load directory"}
             </div>
           ) : accumulatedEntries.length === 0 ? (
-            <div className="flex items-center justify-center h-full py-12 text-muted-foreground">
-              No entries found
-            </div>
+            // While accumulatedEntries is empty during a fetch (initial load
+            // or directory navigation), show a spinner instead of "No entries
+            // found". `isLoading` is false when placeholder data is active,
+            // so use `isFetching` to cover the placeholder transition too.
+            browseQuery.isFetching ? (
+              <div className="flex items-center justify-center h-full py-12">
+                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-full py-12 text-muted-foreground">
+                No entries found
+              </div>
+            )
           ) : (
             <div className="p-2">
               {/* Directories */}

--- a/app/components/library/DirectoryPickerDialog.tsx
+++ b/app/components/library/DirectoryPickerDialog.tsx
@@ -114,14 +114,16 @@ const DirectoryPickerDialog = ({
   }, [browseQuery.dataUpdatedAt]);
 
   // Repopulate from cache if entries were cleared but cached data exists.
-  // This handles the case when opening the dialog with a previously-browsed path.
+  // This handles the case when opening the dialog with a previously-browsed
+  // path. Skip placeholder data for the same reason as the accumulator above.
   useEffect(() => {
     if (
       accumulatedEntries.length === 0 &&
       browseQuery.data?.entries &&
       browseQuery.data.entries.length > 0 &&
       offset === 0 &&
-      !browseQuery.isFetching
+      !browseQuery.isFetching &&
+      !browseQuery.isPlaceholderData
     ) {
       setAccumulatedEntries(browseQuery.data.entries);
     }
@@ -129,6 +131,7 @@ const DirectoryPickerDialog = ({
     accumulatedEntries.length,
     browseQuery.data?.entries,
     browseQuery.isFetching,
+    browseQuery.isPlaceholderData,
     offset,
   ]);
 
@@ -189,8 +192,11 @@ const DirectoryPickerDialog = ({
     setOffset((prev) => prev + 50);
   }, []);
 
-  const hasMore = browseQuery.data?.has_more ?? false;
-  const total = browseQuery.data?.total ?? 0;
+  // Only trust pagination metadata from a settled fetch, not from the
+  // previous query's placeholder data.
+  const settled = browseQuery.isPlaceholderData ? undefined : browseQuery.data;
+  const hasMore = settled?.has_more ?? false;
+  const total = settled?.total ?? 0;
   const remaining = total - accumulatedEntries.length;
 
   const directories = accumulatedEntries.filter((e) => e.is_dir);
@@ -263,10 +269,11 @@ const DirectoryPickerDialog = ({
               {browseQuery.error?.message || "Failed to load directory"}
             </div>
           ) : accumulatedEntries.length === 0 ? (
-            // While accumulatedEntries is empty during a fetch (initial load
-            // or directory navigation), show a spinner instead of "No entries
-            // found". `isLoading` is false when placeholder data is active,
-            // so use `isFetching` to cover the placeholder transition too.
+            // While accumulatedEntries is empty during any fetch (initial
+            // load, navigation, search, or hidden-toggle), show a spinner
+            // instead of "No entries found". `isLoading` is false when
+            // placeholder data is active, so use `isFetching` to cover the
+            // placeholder transition too.
             browseQuery.isFetching ? (
               <div className="flex items-center justify-center h-full py-12">
                 <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />

--- a/app/components/library/DirectoryPickerDialog.tsx
+++ b/app/components/library/DirectoryPickerDialog.tsx
@@ -179,11 +179,14 @@ const DirectoryPickerDialog = ({
     }
   }, []);
 
-  const handleShowHiddenChange = useCallback((checked: boolean) => {
-    setShowHidden(checked);
-    setOffset(0);
-    setAccumulatedEntries([]);
-  }, []);
+  const handleShowHiddenChange = useCallback(
+    (checked: boolean | "indeterminate") => {
+      setShowHidden(checked === true);
+      setOffset(0);
+      setAccumulatedEntries([]);
+    },
+    [],
+  );
 
   const handleToggleSelect = useCallback((path: string) => {
     setSelectedPaths((prev) => {
@@ -273,9 +276,7 @@ const DirectoryPickerDialog = ({
           <label className="flex items-center gap-2 text-sm whitespace-nowrap cursor-pointer">
             <Checkbox
               checked={showHidden}
-              onCheckedChange={(checked) =>
-                handleShowHiddenChange(checked as boolean)
-              }
+              onCheckedChange={handleShowHiddenChange}
             />
             Show hidden files
           </label>

--- a/app/components/library/DirectoryPickerDialog.tsx
+++ b/app/components/library/DirectoryPickerDialog.tsx
@@ -135,8 +135,13 @@ const DirectoryPickerDialog = ({
     offset,
   ]);
 
+  // Only trust the response (entries, current_path, has_more, total) when
+  // it's the settled result for the current query key — placeholder data is
+  // the previous query's response and would render stale state.
+  const settled = browseQuery.isPlaceholderData ? undefined : browseQuery.data;
+
   const pathSegments = useMemo(() => {
-    const path = browseQuery.data?.current_path || currentPath;
+    const path = settled?.current_path || currentPath;
     if (path === "/") return [{ name: "/", path: "/" }];
 
     const segments = path.split("/").filter(Boolean);
@@ -149,7 +154,7 @@ const DirectoryPickerDialog = ({
     }
 
     return result;
-  }, [browseQuery.data?.current_path, currentPath]);
+  }, [settled?.current_path, currentPath]);
 
   const handleNavigate = useCallback((path: string) => {
     setCurrentPath(path);
@@ -178,10 +183,10 @@ const DirectoryPickerDialog = ({
   }, []);
 
   const handleSelectCurrentDirectory = useCallback(() => {
-    const path = browseQuery.data?.current_path || currentPath;
+    const path = settled?.current_path || currentPath;
     onSelect([path]);
     onOpenChange(false);
-  }, [browseQuery.data?.current_path, currentPath, onSelect, onOpenChange]);
+  }, [settled?.current_path, currentPath, onSelect, onOpenChange]);
 
   const handleConfirmSelection = useCallback(() => {
     onSelect(Array.from(selectedPaths));
@@ -192,9 +197,6 @@ const DirectoryPickerDialog = ({
     setOffset((prev) => prev + 50);
   }, []);
 
-  // Only trust pagination metadata from a settled fetch, not from the
-  // previous query's placeholder data.
-  const settled = browseQuery.isPlaceholderData ? undefined : browseQuery.data;
   const hasMore = settled?.has_more ?? false;
   const total = settled?.total ?? 0;
   const remaining = total - accumulatedEntries.length;

--- a/app/components/library/DirectoryPickerDialog.tsx
+++ b/app/components/library/DirectoryPickerDialog.tsx
@@ -55,19 +55,18 @@ const DirectoryPickerDialog = ({
     return () => clearTimeout(timer);
   }, [currentPath]);
 
-  // Debounce search input.
+  // Debounce search input. Reset pagination + accumulator in the same
+  // setState batch as the debounced commit so the listing flips to a
+  // spinner in a single render (no flash of pre-search results paired
+  // with the new query state).
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedSearch(search);
+      setOffset(0);
+      setAccumulatedEntries([]);
     }, DEBOUNCE_MS);
     return () => clearTimeout(timer);
   }, [search]);
-
-  // Reset when path changes or search/hidden toggles.
-  useEffect(() => {
-    setOffset(0);
-    setAccumulatedEntries([]);
-  }, [currentPath, debouncedSearch, showHidden]);
 
   // Reset when dialog opens.
   useEffect(() => {
@@ -156,10 +155,18 @@ const DirectoryPickerDialog = ({
     return result;
   }, [settled?.current_path, currentPath]);
 
+  // Each handler that changes the query key (path, debounced search, or
+  // hidden toggle) must reset offset+accumulatedEntries in the same setState
+  // batch so React commits a single render with both the new query state
+  // and an empty accumulator. Splitting the reset into a follow-up effect
+  // would commit one render with the new path but the previous directory's
+  // entries still showing.
   const handleNavigate = useCallback((path: string) => {
     setCurrentPath(path);
     setSearch("");
     setDebouncedSearch("");
+    setOffset(0);
+    setAccumulatedEntries([]);
   }, []);
 
   const handleEntryClick = useCallback((entry: Entry) => {
@@ -167,7 +174,15 @@ const DirectoryPickerDialog = ({
       setCurrentPath(entry.path);
       setSearch("");
       setDebouncedSearch("");
+      setOffset(0);
+      setAccumulatedEntries([]);
     }
+  }, []);
+
+  const handleShowHiddenChange = useCallback((checked: boolean) => {
+    setShowHidden(checked);
+    setOffset(0);
+    setAccumulatedEntries([]);
   }, []);
 
   const handleToggleSelect = useCallback((path: string) => {
@@ -258,7 +273,9 @@ const DirectoryPickerDialog = ({
           <label className="flex items-center gap-2 text-sm whitespace-nowrap cursor-pointer">
             <Checkbox
               checked={showHidden}
-              onCheckedChange={(checked) => setShowHidden(checked as boolean)}
+              onCheckedChange={(checked) =>
+                handleShowHiddenChange(checked as boolean)
+              }
             />
             Show hidden files
           </label>


### PR DESCRIPTION
## Summary
- Clicking **Load more** in the library directory picker duplicated the previously-loaded entries, and navigating into a subdirectory left the parent's entries on screen until the new fetch settled.
- Root cause: the global `QueryClient` enables `placeholderData: keepPreviousData`, so on a query-key change `useFilesystemBrowse` briefly returns the previous query's data with `dataUpdatedAt=0`. The accumulator effect fired on that transition and either appended the prior page (Load more) or polluted the accumulator with the previous directory's entries (navigation).
- Skip the accumulator when `isPlaceholderData` is true, and use `isFetching` for the empty-state spinner since `isLoading` is false while a placeholder is active.

## Test plan
- New `DirectoryPickerDialog.test.tsx` covers both regressions: a Load-more sequence (asserts no entry duplication after the offset:50 fetch settles) and a navigation sequence (asserts the parent's entries vanish during the in-flight fetch and the new directory renders cleanly when it settles).
- Manually: open the library settings → "Add path" → pick a directory with >50 entries, click **Load more**, confirm new entries are appended (not duplicated). Then navigate into a subdirectory and confirm the parent's listing clears immediately and a spinner shows until the new directory loads.
- `mise check:quiet` passes locally.