### PR TITLE
[Frontend] Surface plugin load errors in the UI

### DIFF
--- a/app/components/plugins/InstalledTab.tsx
+++ b/app/components/plugins/InstalledTab.tsx
@@ -58,7 +58,6 @@ export const InstalledTab = () => {
     const capabilityLabels = deriveCapabilityLabels(caps);
     const imageUrl = availableEntry?.imageUrl || undefined;
     const isOfficial = availableEntry?.is_official ?? false;
-    const isDisabled = plugin.status !== PluginStatusActive;
     const isThisUpdating =
       updatePluginVersion.isPending &&
       updatePluginVersion.variables?.scope === plugin.scope &&
@@ -97,15 +96,16 @@ export const InstalledTab = () => {
         }
         capabilities={capabilityLabels}
         description={plugin.description}
-        disabled={isDisabled}
         href={`/settings/plugins/${plugin.scope}/${plugin.id}`}
         id={plugin.id}
         imageUrl={imageUrl}
         isOfficial={isOfficial}
         key={`${plugin.scope}/${plugin.id}`}
+        loadError={plugin.load_error}
         name={plugin.name}
         repoName={repoNameByScope.get(plugin.scope)}
         scope={plugin.scope}
+        status={plugin.status}
         updateAvailable={plugin.update_available_version ?? undefined}
         version={plugin.version}
       />

--- a/app/components/plugins/PluginDetailHero.test.tsx
+++ b/app/components/plugins/PluginDetailHero.test.tsx
@@ -1,9 +1,25 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 
 import type { AvailablePlugin } from "@/hooks/queries/plugins";
+import {
+  PluginStatusActive,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+  type Plugin,
+} from "@/types/generated/models";
 
 import { PluginDetailHero } from "./PluginDetailHero";
+
+const wrap = (ui: ReactNode) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {ui}
+  </QueryClientProvider>
+);
 
 const baseAvailable: AvailablePlugin = {
   compatible: true,
@@ -16,6 +32,16 @@ const baseAvailable: AvailablePlugin = {
   overview: "",
   scope: "shisho",
   versions: [],
+};
+
+const baseInstalled: Plugin = {
+  auto_update: false,
+  id: "p",
+  installed_at: "2026-01-01T00:00:00Z",
+  name: "Plugin",
+  scope: "shisho",
+  status: PluginStatusActive,
+  version: "1.0.0",
 };
 
 describe("PluginDetailHero", () => {
@@ -43,5 +69,60 @@ describe("PluginDetailHero", () => {
       />,
     );
     expect(screen.queryByLabelText(/official plugin/i)).toBeNull();
+  });
+
+  it("renders the load-error alert when status is Malfunctioned", () => {
+    render(
+      wrap(
+        <PluginDetailHero
+          canWrite={false}
+          id="p"
+          installed={{
+            ...baseInstalled,
+            load_error: "failed to load plugin: invalid field",
+            status: PluginStatusMalfunctioned,
+          }}
+          scope="shisho"
+        />,
+      ),
+    );
+    expect(screen.getByText(/plugin failed to load/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/failed to load plugin: invalid field/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Incompatible alert when status is NotSupported without a load_error", () => {
+    render(
+      wrap(
+        <PluginDetailHero
+          canWrite={false}
+          id="p"
+          installed={{
+            ...baseInstalled,
+            status: PluginStatusNotSupported,
+          }}
+          scope="shisho"
+        />,
+      ),
+    );
+    expect(
+      screen.getByText(/not compatible with this shisho version/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the alert for an Active plugin", () => {
+    render(
+      wrap(
+        <PluginDetailHero
+          canWrite={false}
+          id="p"
+          installed={baseInstalled}
+          scope="shisho"
+        />,
+      ),
+    );
+    expect(screen.queryByText(/failed to load/i)).toBeNull();
+    expect(screen.queryByText(/not compatible/i)).toBeNull();
   });
 });

--- a/app/components/plugins/PluginDetailHero.tsx
+++ b/app/components/plugins/PluginDetailHero.tsx
@@ -101,7 +101,7 @@ export const PluginDetailHero = ({
           <Alert className="p-3" variant="destructive">
             <AlertTitle>{alert.title}</AlertTitle>
             {alert.body && (
-              <AlertDescription className="break-all font-mono text-xs text-muted-foreground">
+              <AlertDescription className="break-words font-mono text-xs">
                 {alert.body}
               </AlertDescription>
             )}

--- a/app/components/plugins/PluginDetailHero.tsx
+++ b/app/components/plugins/PluginDetailHero.tsx
@@ -7,13 +7,9 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import type { AvailablePlugin } from "@/hooks/queries/plugins";
-import {
-  PluginStatusActive,
-  PluginStatusMalfunctioned,
-  PluginStatusNotSupported,
-  type Plugin,
-} from "@/types/generated/models";
+import { PluginStatusActive, type Plugin } from "@/types/generated/models";
 
+import { pluginAlertContent } from "./pluginAlertContent";
 import { PluginHeroActions } from "./PluginHeroActions";
 import { PluginLogo } from "./PluginLogo";
 
@@ -53,6 +49,8 @@ export const PluginDetailHero = ({
   const isOfficial = available?.is_official ?? false;
   const version = installed?.version;
   const updateAvailable = installed?.update_available_version ?? undefined;
+
+  const alert = pluginAlertContent(installed);
 
   const metaParts: ReactNode[] = [];
   if (version) metaParts.push(`v${version}`);
@@ -99,23 +97,16 @@ export const PluginDetailHero = ({
           )}
         </div>
 
-        {installed &&
-          (installed.status === PluginStatusMalfunctioned ||
-            installed.status === PluginStatusNotSupported ||
-            installed.load_error) && (
-            <Alert className="p-3" variant="destructive">
-              <AlertTitle>
-                {installed.status === PluginStatusNotSupported
-                  ? "Plugin is not compatible with this Shisho version"
-                  : "Plugin failed to load"}
-              </AlertTitle>
-              {installed.load_error && (
-                <AlertDescription className="break-all font-mono text-xs text-muted-foreground">
-                  {installed.load_error}
-                </AlertDescription>
-              )}
-            </Alert>
-          )}
+        {alert && (
+          <Alert className="p-3" variant="destructive">
+            <AlertTitle>{alert.title}</AlertTitle>
+            {alert.body && (
+              <AlertDescription className="break-all font-mono text-xs text-muted-foreground">
+                {alert.body}
+              </AlertDescription>
+            )}
+          </Alert>
+        )}
 
         {metaParts.length > 0 && (
           <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">

--- a/app/components/plugins/PluginDetailHero.tsx
+++ b/app/components/plugins/PluginDetailHero.tsx
@@ -6,7 +6,12 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import type { AvailablePlugin } from "@/hooks/queries/plugins";
-import { PluginStatusActive, type Plugin } from "@/types/generated/models";
+import {
+  PluginStatusActive,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+  type Plugin,
+} from "@/types/generated/models";
 
 import { PluginHeroActions } from "./PluginHeroActions";
 import { PluginLogo } from "./PluginLogo";
@@ -92,6 +97,24 @@ export const PluginDetailHero = ({
             <Badge variant="secondary">Not installed</Badge>
           )}
         </div>
+
+        {installed &&
+          (installed.status === PluginStatusMalfunctioned ||
+            installed.status === PluginStatusNotSupported ||
+            installed.load_error) && (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
+              <p className="font-medium text-destructive">
+                {installed.status === PluginStatusNotSupported
+                  ? "Plugin is not compatible with this Shisho version"
+                  : "Plugin failed to load"}
+              </p>
+              {installed.load_error && (
+                <p className="mt-1 break-words font-mono text-xs text-muted-foreground">
+                  {installed.load_error}
+                </p>
+              )}
+            </div>
+          )}
 
         {metaParts.length > 0 && (
           <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">

--- a/app/components/plugins/PluginDetailHero.tsx
+++ b/app/components/plugins/PluginDetailHero.tsx
@@ -1,6 +1,7 @@
 import { BadgeCheck, ExternalLink } from "lucide-react";
 import { Fragment, type ReactNode } from "react";
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -102,18 +103,18 @@ export const PluginDetailHero = ({
           (installed.status === PluginStatusMalfunctioned ||
             installed.status === PluginStatusNotSupported ||
             installed.load_error) && (
-            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
-              <p className="font-medium text-destructive">
+            <Alert className="p-3" variant="destructive">
+              <AlertTitle>
                 {installed.status === PluginStatusNotSupported
                   ? "Plugin is not compatible with this Shisho version"
                   : "Plugin failed to load"}
-              </p>
+              </AlertTitle>
               {installed.load_error && (
-                <p className="mt-1 break-words font-mono text-xs text-muted-foreground">
+                <AlertDescription className="break-all font-mono text-xs text-muted-foreground">
                   {installed.load_error}
-                </p>
+                </AlertDescription>
               )}
-            </div>
+            </Alert>
           )}
 
         {metaParts.length > 0 && (

--- a/app/components/plugins/PluginRow.test.tsx
+++ b/app/components/plugins/PluginRow.test.tsx
@@ -4,6 +4,13 @@ import React from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  PluginStatusActive,
+  PluginStatusDisabled,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+} from "@/types/generated/models";
+
 import { PluginRow } from "./PluginRow";
 
 const base = {
@@ -31,9 +38,39 @@ describe("PluginRow", () => {
     expect(screen.getByText("Official Shisho Plugins")).toBeInTheDocument();
   });
 
-  it("renders the Disabled badge when disabled=true", () => {
-    render(wrap(<PluginRow {...base} disabled />));
+  it("renders no status badge when status is Active", () => {
+    render(wrap(<PluginRow {...base} status={PluginStatusActive} />));
+    expect(screen.queryByText(/disabled/i)).toBeNull();
+    expect(screen.queryByText(/error/i)).toBeNull();
+    expect(screen.queryByText(/incompatible/i)).toBeNull();
+  });
+
+  it("renders the Disabled badge when status is Disabled", () => {
+    render(wrap(<PluginRow {...base} status={PluginStatusDisabled} />));
     expect(screen.getByText(/disabled/i)).toBeInTheDocument();
+  });
+
+  it("renders the Error badge with load_error as title when status is Malfunctioned", () => {
+    render(
+      wrap(
+        <PluginRow
+          {...base}
+          loadError="failed to load plugin: invalid field"
+          status={PluginStatusMalfunctioned}
+        />,
+      ),
+    );
+    const badge = screen.getByText(/error/i);
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute(
+      "title",
+      "failed to load plugin: invalid field",
+    );
+  });
+
+  it("renders the Incompatible badge when status is NotSupported", () => {
+    render(wrap(<PluginRow {...base} status={PluginStatusNotSupported} />));
+    expect(screen.getByText(/incompatible/i)).toBeInTheDocument();
   });
 
   it("renders capability badges on meta line", () => {

--- a/app/components/plugins/PluginRow.tsx
+++ b/app/components/plugins/PluginRow.tsx
@@ -4,6 +4,12 @@ import { Link } from "react-router-dom";
 
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/libraries/utils";
+import {
+  PluginStatusActive,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+  type PluginStatus,
+} from "@/types/generated/models";
 
 import { PluginLogo } from "./PluginLogo";
 
@@ -11,38 +17,59 @@ export interface PluginRowProps {
   actions?: ReactNode;
   capabilities: string[];
   description?: string;
-  disabled?: boolean;
   href: string;
   id: string;
   imageUrl?: string | null;
   isOfficial?: boolean;
+  loadError?: string;
   name: string;
   repoName?: string;
   scope: string;
+  status?: PluginStatus;
   updateAvailable?: string;
   version?: string;
 }
+
+const renderStatusBadge = (
+  status: PluginStatus | undefined,
+  loadError?: string,
+) => {
+  if (status === undefined || status === PluginStatusActive) return null;
+  if (status === PluginStatusMalfunctioned) {
+    return (
+      <Badge title={loadError} variant="destructive">
+        Error
+      </Badge>
+    );
+  }
+  if (status === PluginStatusNotSupported) {
+    return <Badge variant="outline">Incompatible</Badge>;
+  }
+  return <Badge variant="secondary">Disabled</Badge>;
+};
 
 export const PluginRow = ({
   actions,
   capabilities,
   description,
-  disabled,
   href,
   id,
   imageUrl,
   isOfficial,
+  loadError,
   name,
   repoName,
   scope,
+  status,
   updateAvailable,
   version,
 }: PluginRowProps) => {
+  const isInactive = status !== undefined && status !== PluginStatusActive;
   return (
     <Link
       className={cn(
         "group flex items-center gap-4 rounded-md border border-border px-4 py-3 transition-colors hover:bg-accent/30",
-        disabled && "opacity-50 saturate-50",
+        isInactive && "opacity-50 saturate-50",
       )}
       to={href}
     >
@@ -56,7 +83,7 @@ export const PluginRow = ({
       <div className="min-w-0 flex-1 space-y-1">
         <div className="flex flex-wrap items-center gap-2">
           <span className="truncate font-medium">{name}</span>
-          {disabled && <Badge variant="secondary">Disabled</Badge>}
+          {renderStatusBadge(status, loadError)}
           {updateAvailable && <Badge>Update {updateAvailable}</Badge>}
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">

--- a/app/components/plugins/pluginAlertContent.test.ts
+++ b/app/components/plugins/pluginAlertContent.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PluginStatusActive,
+  PluginStatusDisabled,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+  type Plugin,
+} from "@/types/generated/models";
+
+import { pluginAlertContent } from "./pluginAlertContent";
+
+const base: Plugin = {
+  auto_update: false,
+  id: "p",
+  installed_at: "2026-01-01T00:00:00Z",
+  name: "Plugin",
+  scope: "shisho",
+  status: PluginStatusActive,
+  version: "1.0.0",
+};
+
+describe("pluginAlertContent", () => {
+  it("returns null when no plugin is installed", () => {
+    expect(pluginAlertContent(undefined)).toBeNull();
+  });
+
+  it("returns null for Active plugins", () => {
+    expect(pluginAlertContent(base)).toBeNull();
+  });
+
+  it("returns null for Disabled plugins with no load_error", () => {
+    expect(
+      pluginAlertContent({ ...base, status: PluginStatusDisabled }),
+    ).toBeNull();
+  });
+
+  it("returns the failed-to-load title for Malfunctioned", () => {
+    expect(
+      pluginAlertContent({
+        ...base,
+        load_error: "boom",
+        status: PluginStatusMalfunctioned,
+      }),
+    ).toEqual({ body: "boom", title: "Plugin failed to load" });
+  });
+
+  it("returns the incompatible title for NotSupported, preserving load_error when present", () => {
+    expect(
+      pluginAlertContent({
+        ...base,
+        status: PluginStatusNotSupported,
+      }),
+    ).toEqual({
+      body: undefined,
+      title: "Plugin is not compatible with this Shisho version",
+    });
+
+    expect(
+      pluginAlertContent({
+        ...base,
+        load_error: "requires Shisho 99.0.0",
+        status: PluginStatusNotSupported,
+      }),
+    ).toEqual({
+      body: "requires Shisho 99.0.0",
+      title: "Plugin is not compatible with this Shisho version",
+    });
+  });
+
+  it("falls back to failed-to-load when load_error is set without a bad status", () => {
+    expect(
+      pluginAlertContent({
+        ...base,
+        load_error: "stale error text",
+      }),
+    ).toEqual({ body: "stale error text", title: "Plugin failed to load" });
+  });
+});

--- a/app/components/plugins/pluginAlertContent.test.ts
+++ b/app/components/plugins/pluginAlertContent.test.ts
@@ -68,12 +68,9 @@ describe("pluginAlertContent", () => {
     });
   });
 
-  it("falls back to failed-to-load when load_error is set without a bad status", () => {
+  it("returns null for an Active plugin with a stale load_error, matching persisted status", () => {
     expect(
-      pluginAlertContent({
-        ...base,
-        load_error: "stale error text",
-      }),
-    ).toEqual({ body: "stale error text", title: "Plugin failed to load" });
+      pluginAlertContent({ ...base, load_error: "stale error text" }),
+    ).toBeNull();
   });
 });

--- a/app/components/plugins/pluginAlertContent.ts
+++ b/app/components/plugins/pluginAlertContent.ts
@@ -14,7 +14,7 @@ export const pluginAlertContent = (
       title: "Plugin is not compatible with this Shisho version",
     };
   }
-  if (installed.status === PluginStatusMalfunctioned || installed.load_error) {
+  if (installed.status === PluginStatusMalfunctioned) {
     return { body: installed.load_error, title: "Plugin failed to load" };
   }
   return null;

--- a/app/components/plugins/pluginAlertContent.ts
+++ b/app/components/plugins/pluginAlertContent.ts
@@ -17,5 +17,6 @@ export const pluginAlertContent = (
   if (installed.status === PluginStatusMalfunctioned) {
     return { body: installed.load_error, title: "Plugin failed to load" };
   }
+  // Active/Disabled: no alert, even if a stale load_error is still on the row.
   return null;
 };

--- a/app/components/plugins/pluginAlertContent.ts
+++ b/app/components/plugins/pluginAlertContent.ts
@@ -1,0 +1,21 @@
+import {
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+  type Plugin,
+} from "@/types/generated/models";
+
+export const pluginAlertContent = (
+  installed: Plugin | undefined,
+): { body?: string; title: string } | null => {
+  if (!installed) return null;
+  if (installed.status === PluginStatusNotSupported) {
+    return {
+      body: installed.load_error,
+      title: "Plugin is not compatible with this Shisho version",
+    };
+  }
+  if (installed.status === PluginStatusMalfunctioned || installed.load_error) {
+    return { body: installed.load_error, title: "Plugin failed to load" };
+  }
+  return null;
+};

--- a/app/hooks/queries/plugins.test.ts
+++ b/app/hooks/queries/plugins.test.ts
@@ -3,7 +3,9 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
-import { QueryKey, useUninstallPlugin } from "./plugins";
+import { API } from "@/libraries/api";
+
+import { QueryKey, useUninstallPlugin, useUpdatePlugin } from "./plugins";
 
 // Mock the API layer so the mutation completes without a real HTTP call.
 vi.mock("@/libraries/api", async () => {
@@ -89,5 +91,40 @@ describe("useUninstallPlugin", () => {
     expect(
       client.getQueryState(["libraries", "lib-1", "settings"])?.isInvalidated,
     ).toBe(false);
+  });
+});
+
+describe("useUpdatePlugin", () => {
+  // A failed enable still mutates server state (the plugin row gets
+  // Malfunctioned + load_error persisted), so the detail page needs the
+  // installed-plugins query refetched on error too — otherwise the error
+  // alert doesn't appear until the user reloads.
+  it("invalidates PluginsInstalled when the mutation fails", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    client.setQueryData([QueryKey.PluginsInstalled], []);
+
+    vi.mocked(API.request).mockRejectedValueOnce(new Error("422"));
+
+    const { result } = renderHook(() => useUpdatePlugin(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current
+        .mutateAsync({
+          id: "test",
+          payload: { enabled: true },
+          scope: "shisho",
+        })
+        .catch(() => undefined);
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.PluginsInstalled])?.isInvalidated,
+      ).toBe(true);
+    });
   });
 });

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -298,7 +298,10 @@ export const useUpdatePlugin = () => {
     mutationFn: ({ scope, id, payload }) => {
       return API.request("PATCH", `/plugins/installed/${scope}/${id}`, payload);
     },
-    onSuccess: () => {
+    // Refetch on both success and failure: a failed enable still mutates
+    // server state (Malfunctioned status + load_error get persisted), which
+    // the detail page needs to render the error alert without a manual reload.
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKey.PluginsInstalled],
       });

--- a/docs/superpowers/plans/2026-04-23-plugin-load-errors-ui.md
+++ b/docs/superpowers/plans/2026-04-23-plugin-load-errors-ui.md
@@ -1,0 +1,800 @@
+# Plugin Load Error UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface plugin load errors to users — return a proper error from the enable endpoint, and render status-specific badges + error text on the installed list and plugin detail page.
+
+**Architecture:** Three-part change. (1) `pkg/plugins/handler.go:update` persists the malfunctioned/not-supported state and then returns `errcodes.ValidationError(loadErr.Error())` so the frontend mutation's `catch` branch fires with the real message. (2) `PluginRow` accepts a `status` prop and renders one of three badges (Disabled / Error / Incompatible). (3) `PluginDetailHero` renders an inline alert block when `installed.load_error` is set or status is Malfunctioned/NotSupported.
+
+**Tech Stack:** Go (Echo, Bun), React 19 + TypeScript, Vitest + React Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-plugin-load-errors-ui-design.md`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `pkg/plugins/handler.go` | Modify `update` to persist-then-error on load failure during enable |
+| `pkg/plugins/handler_enable_test.go` | **Create** — Go test for the new error path |
+| `app/components/plugins/PluginRow.tsx` | Replace `disabled` boolean with `status` prop; render status-specific badge |
+| `app/components/plugins/PluginRow.test.tsx` | Update existing disabled case; add Malfunctioned and NotSupported cases |
+| `app/components/plugins/InstalledTab.tsx` | Pass `plugin.status` (and `plugin.load_error`) to `PluginRow` |
+| `app/components/plugins/PluginDetailHero.tsx` | Add the load-error alert block under the title row |
+| `app/components/plugins/PluginDetailHero.test.tsx` | Add cases for load_error block and NotSupported without load_error |
+
+No model changes, no migrations, no generated types to regenerate.
+
+---
+
+## Task 1: Backend — failing test for bad-enable returns error
+
+**Files:**
+- Create: `pkg/plugins/handler_enable_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package plugins
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdate_EnableLoadFailure_ReturnsError confirms that toggling a plugin's
+// enable flag to true when the plugin cannot be loaded returns a 422 error and
+// still persists the Malfunctioned status + load_error to the database so the
+// UI can render it after a refetch.
+func TestUpdate_EnableLoadFailure_ReturnsError(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	pluginDir := t.TempDir()
+
+	// Plugin with a manifest declaring an enricher field that doesn't exist.
+	// LoadPlugin will reject this with an "invalid metadata field" error.
+	scope := "test"
+	id := "broken-enricher"
+	destDir := filepath.Join(pluginDir, scope, id)
+	require.NoError(t, os.MkdirAll(destDir, 0755))
+	manifest := `{
+  "manifestVersion": 1,
+  "id": "broken-enricher",
+  "name": "Broken Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "fileTypes": ["epub"],
+      "fields": ["nonsenseField"]
+    }
+  }
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "manifest.json"), []byte(manifest), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "main.js"),
+		[]byte(`var plugin=(function(){return{metadataEnricher:{search:function(){return{results:[]}}}};})();`), 0644))
+
+	ctx := context.Background()
+	// Pre-install as Disabled so the PATCH path exercises the enable branch.
+	require.NoError(t, svc.InstallPlugin(ctx, &models.Plugin{
+		Scope:       scope,
+		ID:          id,
+		Name:        "Broken Enricher",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusDisabled,
+		InstalledAt: time.Now(),
+	}))
+
+	mgr := NewManager(svc, pluginDir, "")
+	h := NewHandler(svc, mgr, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"enabled": true}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("scope", "id")
+	c.SetParamValues(scope, id)
+
+	err := h.update(c)
+	// The handler must surface a 422 error via the errcodes pipeline.
+	require.Error(t, err)
+	var ec *errcodes.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, http.StatusUnprocessableEntity, ec.HTTPCode)
+	assert.Contains(t, ec.Message, "nonsenseField")
+
+	// And the plugin row must be persisted as Malfunctioned with the load_error.
+	retrieved, err := svc.RetrievePlugin(ctx, scope, id)
+	require.NoError(t, err)
+	assert.Equal(t, models.PluginStatusMalfunctioned, retrieved.Status)
+	require.NotNil(t, retrieved.LoadError)
+	assert.Contains(t, *retrieved.LoadError, "nonsenseField")
+}
+```
+
+- [ ] **Step 2: Run test — expect fail**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && go test ./pkg/plugins/ -run TestUpdate_EnableLoadFailure_ReturnsError -v`
+
+Expected: FAIL. Current handler returns `nil` from `c.JSON(http.StatusOK, plugin)`, so `require.Error(t, err)` fails.
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+git add pkg/plugins/handler_enable_test.go
+git commit -m "[Test] Add failing test for plugin enable load-failure error response"
+```
+
+---
+
+## Task 2: Backend — return error when enable-triggered load fails
+
+**Files:**
+- Modify: `pkg/plugins/handler.go` (the `update` method, currently around lines 369-455)
+
+- [ ] **Step 1: Implement the change**
+
+In `handler.update`, locate the enable block:
+
+```go
+		if *payload.Enabled && !wasActive {
+			// Enabling: set Active and load the plugin
+			plugin.Status = models.PluginStatusActive
+			if err := h.manager.LoadPlugin(ctx, scope, id); err != nil {
+				errMsg := err.Error()
+				plugin.LoadError = &errMsg
+				if isVersionIncompatible(err) {
+					plugin.Status = models.PluginStatusNotSupported
+				} else {
+					plugin.Status = models.PluginStatusMalfunctioned
+				}
+				h.manager.emitEvent(PluginEventMalfunctioned, scope, id, nil)
+			} else {
+				plugin.LoadError = nil
+				var hooks []string
+				if rt := h.manager.GetRuntime(scope, id); rt != nil {
+					hooks = rt.HookTypes()
+				}
+				h.manager.emitEvent(PluginEventEnabled, scope, id, hooks)
+			}
+		} else if !*payload.Enabled && wasActive {
+```
+
+Introduce a `loadErr` variable captured from `LoadPlugin` so we can return it **after** persisting. Replace the block with:
+
+```go
+		var loadErr error
+		if *payload.Enabled && !wasActive {
+			// Enabling: set Active and load the plugin
+			plugin.Status = models.PluginStatusActive
+			if err := h.manager.LoadPlugin(ctx, scope, id); err != nil {
+				loadErr = err
+				errMsg := err.Error()
+				plugin.LoadError = &errMsg
+				if isVersionIncompatible(err) {
+					plugin.Status = models.PluginStatusNotSupported
+				} else {
+					plugin.Status = models.PluginStatusMalfunctioned
+				}
+				h.manager.emitEvent(PluginEventMalfunctioned, scope, id, nil)
+			} else {
+				plugin.LoadError = nil
+				var hooks []string
+				if rt := h.manager.GetRuntime(scope, id); rt != nil {
+					hooks = rt.HookTypes()
+				}
+				h.manager.emitEvent(PluginEventEnabled, scope, id, hooks)
+			}
+		} else if !*payload.Enabled && wasActive {
+```
+
+Then, after `h.service.UpdatePlugin(ctx, plugin)` succeeds (and before the config/confidence-threshold branches), add the error return. The final portion of the method changes from:
+
+```go
+	if err := h.service.UpdatePlugin(ctx, plugin); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if payload.Config != nil {
+		// ...
+	}
+
+	// ... confidence-threshold branches ...
+
+	return errors.WithStack(c.JSON(http.StatusOK, plugin))
+}
+```
+
+to:
+
+```go
+	if err := h.service.UpdatePlugin(ctx, plugin); err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Surface enable-time load failures as a 422 so the frontend toast shows
+	// the real reason. The Malfunctioned/NotSupported status is already
+	// persisted above, so a follow-up GET reflects the broken state.
+	if loadErr != nil {
+		return errcodes.ValidationError(loadErr.Error())
+	}
+
+	if payload.Config != nil {
+		// ...
+	}
+
+	// ... confidence-threshold branches ...
+
+	return errors.WithStack(c.JSON(http.StatusOK, plugin))
+}
+```
+
+- [ ] **Step 2: Run the new test — expect pass**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && go test ./pkg/plugins/ -run TestUpdate_EnableLoadFailure_ReturnsError -v`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full plugins package — expect pass (no regressions)**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && go test ./pkg/plugins/ -count=1`
+
+Expected: PASS. If anything fails, the most likely cause is a test that PATCHes `enabled: true` with a load-failing plugin and used to assert `err == nil` — update it to assert the new 422 behavior.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/plugins/handler.go
+git commit -m "[Backend] Return 422 when enabling a plugin fails to load"
+```
+
+---
+
+## Task 3: Frontend — PluginRow status-aware badges (failing tests)
+
+**Files:**
+- Modify: `app/components/plugins/PluginRow.test.tsx`
+
+- [ ] **Step 1: Update the existing "disabled" test and add three new tests**
+
+Replace the `it("renders the Disabled badge when disabled=true", ...)` block with the following, and add an import for the status constants at the top of the file next to the existing imports:
+
+```tsx
+import {
+  PluginStatusActive,
+  PluginStatusDisabled,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+} from "@/types/generated/models";
+```
+
+Replace the existing disabled test and add new ones:
+
+```tsx
+  it("renders no status badge when status is Active", () => {
+    render(wrap(<PluginRow {...base} status={PluginStatusActive} />));
+    expect(screen.queryByText(/disabled/i)).toBeNull();
+    expect(screen.queryByText(/error/i)).toBeNull();
+    expect(screen.queryByText(/incompatible/i)).toBeNull();
+  });
+
+  it("renders the Disabled badge when status is Disabled", () => {
+    render(wrap(<PluginRow {...base} status={PluginStatusDisabled} />));
+    expect(screen.getByText(/disabled/i)).toBeInTheDocument();
+  });
+
+  it("renders the Error badge with load_error as title when status is Malfunctioned", () => {
+    render(
+      wrap(
+        <PluginRow
+          {...base}
+          loadError="failed to load plugin: invalid field"
+          status={PluginStatusMalfunctioned}
+        />,
+      ),
+    );
+    const badge = screen.getByText(/error/i);
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute(
+      "title",
+      "failed to load plugin: invalid field",
+    );
+  });
+
+  it("renders the Incompatible badge when status is NotSupported", () => {
+    render(wrap(<PluginRow {...base} status={PluginStatusNotSupported} />));
+    expect(screen.getByText(/incompatible/i)).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run tests — expect fail**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && pnpm vitest run app/components/plugins/PluginRow.test.tsx`
+
+Expected: FAIL. `status` prop doesn't exist yet; the component only accepts `disabled`.
+
+- [ ] **Step 3: Commit the red tests**
+
+```bash
+git add app/components/plugins/PluginRow.test.tsx
+git commit -m "[Test] Update PluginRow tests for status-aware badges"
+```
+
+---
+
+## Task 4: Frontend — implement PluginRow status prop
+
+**Files:**
+- Modify: `app/components/plugins/PluginRow.tsx`
+
+- [ ] **Step 1: Replace the `disabled` prop with `status` + optional `loadError`**
+
+The full new file contents:
+
+```tsx
+import { BadgeCheck, ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/libraries/utils";
+import {
+  PluginStatusActive,
+  PluginStatusDisabled,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+  type PluginStatus,
+} from "@/types/generated/models";
+
+import { PluginLogo } from "./PluginLogo";
+
+export interface PluginRowProps {
+  actions?: ReactNode;
+  capabilities: string[];
+  description?: string;
+  href: string;
+  id: string;
+  imageUrl?: string | null;
+  isOfficial?: boolean;
+  loadError?: string;
+  name: string;
+  repoName?: string;
+  scope: string;
+  status?: PluginStatus;
+  updateAvailable?: string;
+  version?: string;
+}
+
+const renderStatusBadge = (status: PluginStatus | undefined, loadError?: string) => {
+  if (status === undefined || status === PluginStatusActive) return null;
+  if (status === PluginStatusMalfunctioned) {
+    return (
+      <Badge title={loadError} variant="destructive">
+        Error
+      </Badge>
+    );
+  }
+  if (status === PluginStatusNotSupported) {
+    return <Badge variant="outline">Incompatible</Badge>;
+  }
+  // PluginStatusDisabled and any future non-active value fall back to Disabled.
+  return <Badge variant="secondary">Disabled</Badge>;
+};
+
+export const PluginRow = ({
+  actions,
+  capabilities,
+  description,
+  href,
+  id,
+  imageUrl,
+  isOfficial,
+  loadError,
+  name,
+  repoName,
+  scope,
+  status,
+  updateAvailable,
+  version,
+}: PluginRowProps) => {
+  const isInactive = status !== undefined && status !== PluginStatusActive;
+  return (
+    <Link
+      className={cn(
+        "group flex items-center gap-4 rounded-md border border-border px-4 py-3 transition-colors hover:bg-accent/30",
+        isInactive && "opacity-50 saturate-50",
+      )}
+      to={href}
+    >
+      <PluginLogo
+        id={id}
+        imageUrl={imageUrl ?? undefined}
+        scope={scope}
+        size={40}
+      />
+
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="truncate font-medium">{name}</span>
+          {renderStatusBadge(status, loadError)}
+          {updateAvailable && <Badge>Update {updateAvailable}</Badge>}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          {version && <span>v{version}</span>}
+          {capabilities.map((cap) => (
+            <Badge key={cap} variant="outline">
+              {cap}
+            </Badge>
+          ))}
+          {repoName && (
+            <>
+              <span aria-hidden="true" className="text-muted-foreground/50">
+                ·
+              </span>
+              <span className="inline-flex items-center gap-1">
+                {isOfficial && (
+                  <BadgeCheck
+                    aria-label="Official plugin"
+                    className="h-3.5 w-3.5 text-primary"
+                  />
+                )}
+                {repoName}
+              </span>
+            </>
+          )}
+        </div>
+        {description && (
+          <p className="line-clamp-2 text-xs text-muted-foreground">
+            {description}
+          </p>
+        )}
+      </div>
+
+      {actions && (
+        <div
+          className="flex items-center gap-2"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          {actions}
+        </div>
+      )}
+
+      <ChevronRight
+        aria-hidden="true"
+        className="h-4 w-4 flex-shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+      />
+    </Link>
+  );
+};
+```
+
+- [ ] **Step 2: Update the existing disabled test that still uses the old prop name**
+
+The test `it("renders the Disabled badge when disabled=true", ...)` was replaced in Task 3, but the earlier test at `PluginRow.test.tsx:23` (`renders name and version on meta line`) and the other tests use `base` which doesn't include `disabled`. Scan the file for any remaining `disabled` prop usage and change to `status={PluginStatusDisabled}`. At the time of writing only the test removed in Task 3 used it; verify with:
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && grep -n 'disabled' app/components/plugins/PluginRow.test.tsx`
+
+Expected: matches should only be `status={PluginStatusDisabled}` / `/disabled/i` regexes from Task 3.
+
+- [ ] **Step 3: Run PluginRow tests — expect pass**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && pnpm vitest run app/components/plugins/PluginRow.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/plugins/PluginRow.tsx
+git commit -m "[Frontend] PluginRow renders status-specific badges"
+```
+
+---
+
+## Task 5: Frontend — InstalledTab passes status through
+
+**Files:**
+- Modify: `app/components/plugins/InstalledTab.tsx` (the `renderRow` function around lines 53-113)
+
+- [ ] **Step 1: Remove `disabled` computation and forward `status` + `loadError`**
+
+In `renderRow`, delete the line `const isDisabled = plugin.status !== PluginStatusActive;` (it's around line 61) and change the `PluginRow` invocation from:
+
+```tsx
+      <PluginRow
+        actions={...}
+        capabilities={capabilityLabels}
+        description={plugin.description}
+        disabled={isDisabled}
+        href={`/settings/plugins/${plugin.scope}/${plugin.id}`}
+        ...
+      />
+```
+
+to:
+
+```tsx
+      <PluginRow
+        actions={...}
+        capabilities={capabilityLabels}
+        description={plugin.description}
+        href={`/settings/plugins/${plugin.scope}/${plugin.id}`}
+        id={plugin.id}
+        imageUrl={imageUrl}
+        isOfficial={isOfficial}
+        key={`${plugin.scope}/${plugin.id}`}
+        loadError={plugin.load_error}
+        name={plugin.name}
+        repoName={repoNameByScope.get(plugin.scope)}
+        scope={plugin.scope}
+        status={plugin.status}
+        updateAvailable={plugin.update_available_version ?? undefined}
+        version={plugin.version}
+      />
+```
+
+Only the `disabled` → `status` + `loadError` lines are new; the rest is unchanged. Keep `actions` (the Update button wiring) exactly as it was.
+
+- [ ] **Step 2: Type-check and run frontend tests**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && pnpm lint:types`
+
+Expected: PASS (no TS errors).
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && pnpm vitest run app/components/plugins/`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/plugins/InstalledTab.tsx
+git commit -m "[Frontend] Installed plugins list distinguishes Error and Incompatible states"
+```
+
+---
+
+## Task 6: Frontend — PluginDetailHero error alert (failing tests)
+
+**Files:**
+- Modify: `app/components/plugins/PluginDetailHero.test.tsx`
+
+- [ ] **Step 1: Add three new tests covering the error block**
+
+Add to the existing `describe("PluginDetailHero", ...)`, after the existing two tests. First, add imports at the top:
+
+```tsx
+import type { Plugin } from "@/types/generated/models";
+import {
+  PluginStatusActive,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+} from "@/types/generated/models";
+```
+
+Add a `baseInstalled` helper next to `baseAvailable`:
+
+```tsx
+const baseInstalled: Plugin = {
+  auto_update: false,
+  id: "p",
+  installed_at: "2026-01-01T00:00:00Z",
+  name: "Plugin",
+  scope: "shisho",
+  status: PluginStatusActive,
+  version: "1.0.0",
+};
+```
+
+Then add the tests:
+
+```tsx
+  it("renders the load-error alert when status is Malfunctioned", () => {
+    render(
+      <PluginDetailHero
+        canWrite={false}
+        id="p"
+        installed={{
+          ...baseInstalled,
+          load_error: "failed to load plugin: invalid field",
+          status: PluginStatusMalfunctioned,
+        }}
+        scope="shisho"
+      />,
+    );
+    expect(screen.getByText(/plugin failed to load/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/failed to load plugin: invalid field/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the Incompatible alert when status is NotSupported without a load_error", () => {
+    render(
+      <PluginDetailHero
+        canWrite={false}
+        id="p"
+        installed={{
+          ...baseInstalled,
+          status: PluginStatusNotSupported,
+        }}
+        scope="shisho"
+      />,
+    );
+    expect(
+      screen.getByText(/not compatible with this shisho version/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the alert for an Active plugin", () => {
+    render(
+      <PluginDetailHero
+        canWrite={false}
+        id="p"
+        installed={baseInstalled}
+        scope="shisho"
+      />,
+    );
+    expect(screen.queryByText(/failed to load/i)).toBeNull();
+    expect(screen.queryByText(/not compatible/i)).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run tests — expect fail**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && pnpm vitest run app/components/plugins/PluginDetailHero.test.tsx`
+
+Expected: FAIL. The alert block does not exist yet.
+
+- [ ] **Step 3: Commit the red tests**
+
+```bash
+git add app/components/plugins/PluginDetailHero.test.tsx
+git commit -m "[Test] Add PluginDetailHero tests for load-error alert"
+```
+
+---
+
+## Task 7: Frontend — implement PluginDetailHero alert block
+
+**Files:**
+- Modify: `app/components/plugins/PluginDetailHero.tsx`
+
+- [ ] **Step 1: Import the extra status constants**
+
+Change the existing import:
+
+```tsx
+import { PluginStatusActive, type Plugin } from "@/types/generated/models";
+```
+
+to:
+
+```tsx
+import {
+  PluginStatusActive,
+  PluginStatusMalfunctioned,
+  PluginStatusNotSupported,
+  type Plugin,
+} from "@/types/generated/models";
+```
+
+- [ ] **Step 2: Insert the alert block inside the info column**
+
+Inside `PluginDetailHero`, the middle column contains the title row, `metaParts`, and `description`. Insert a new block between the title row `<div className="flex flex-wrap items-center gap-2">...</div>` and the `metaParts` block. The info column becomes:
+
+```tsx
+      <div className="flex-1 space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-xl font-semibold">{name}</h1>
+          {updateAvailable && (
+            <Badge variant="default">
+              Update available — {updateAvailable}
+            </Badge>
+          )}
+          {!installed && available && (
+            <Badge variant="secondary">Not installed</Badge>
+          )}
+        </div>
+
+        {installed &&
+          (installed.status === PluginStatusMalfunctioned ||
+            installed.status === PluginStatusNotSupported ||
+            installed.load_error) && (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
+              <p className="font-medium text-destructive">
+                {installed.status === PluginStatusNotSupported
+                  ? "Plugin is not compatible with this Shisho version"
+                  : "Plugin failed to load"}
+              </p>
+              {installed.load_error && (
+                <p className="mt-1 break-words font-mono text-xs text-muted-foreground">
+                  {installed.load_error}
+                </p>
+              )}
+            </div>
+          )}
+
+        {metaParts.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            {metaParts.map((part, i) => (
+              <Fragment key={i}>
+                {i > 0 && (
+                  <span aria-hidden="true" className="text-muted-foreground/50">
+                    ·
+                  </span>
+                )}
+                {part}
+              </Fragment>
+            ))}
+          </div>
+        )}
+
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+```
+
+Everything outside the info column (the logo, the right-side actions column) stays unchanged.
+
+- [ ] **Step 3: Run PluginDetailHero tests — expect pass**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && pnpm vitest run app/components/plugins/PluginDetailHero.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/plugins/PluginDetailHero.tsx
+git commit -m "[Frontend] Show load error on plugin detail page"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Run the full check suite**
+
+Run: `cd /Users/robinjoseph/.worktrees/shisho/plugin-errors && mise check:quiet`
+
+Expected: one-line PASS summary. If anything fails, fix the underlying cause and re-run (do not `--no-verify`).
+
+- [ ] **Step 2: Manual smoke test (if the dev server is available)**
+
+With `mise start` running:
+
+1. Visit `/settings/plugins`. A plugin with `status: -2` should render a red `Error` badge; hovering reveals the `load_error` message.
+2. Click into that plugin. The detail page should render a red alert block under the title with "Plugin failed to load" and the error text in monospace.
+3. Toggle the enable switch off, then on again — the failing re-enable produces a toast containing the real error message (not "Plugin enabled").
+4. A plugin with `status: -3` (NotSupported) should show an outline `Incompatible` badge on the list and the "not compatible with this Shisho version" alert on the detail page.
+
+If no UI session is available, explicitly say so rather than claiming success.
+
+- [ ] **Step 3: Nothing to commit — verification only.**
+
+---
+
+## Self-Review Notes
+
+- Every spec requirement (enable returns error, list shows distinct badges, detail shows error text) maps to a task: #1-#2, #3-#5, #6-#7 respectively.
+- No placeholders or "similar to" — each step contains the exact code.
+- Type names are consistent across tasks: `PluginStatus`, `PluginStatusActive`, `PluginStatusDisabled`, `PluginStatusMalfunctioned`, `PluginStatusNotSupported` (all re-exported from `@/types/generated/models`); the `loadError` prop name on `PluginRow` matches the `load_error` field on `Plugin` (snake_case on the wire, camelCase at the React prop boundary).
+- No docs update — matches the spec's "No user-facing doc changes" note.

--- a/docs/superpowers/specs/2026-04-23-plugin-load-errors-ui-design.md
+++ b/docs/superpowers/specs/2026-04-23-plugin-load-errors-ui-design.md
@@ -1,0 +1,105 @@
+# Surface plugin load errors in the UI
+
+## Problem
+
+When a user toggles a plugin on from the installed list or detail page and loading fails (e.g. bad manifest field, incompatible version), three things go wrong:
+
+1. The `PATCH /plugins/installed/:scope/:id` endpoint returns **HTTP 200** with the plugin object even though load failed. The plugin row has `status: -2` (Malfunctioned) and a populated `load_error`, but the client treats the response as success and shows a "Plugin enabled" toast.
+2. On the installed plugins list, every non-Active status (`Disabled`, `Malfunctioned`, `NotSupported`) renders the same generic `Disabled` badge with a dimmed row. Users can't distinguish "I turned this off" from "this is broken".
+3. The plugin detail page does not render `load_error` anywhere, so there is no way to see *why* a plugin is broken without inspecting the raw JSON response.
+
+## Goals
+
+- Enabling a broken plugin shows the actual error to the user immediately (toast).
+- The installed-plugins list visibly distinguishes Malfunctioned / NotSupported from a user-disabled plugin.
+- The detail page shows the full `load_error` text verbatim when one is present, so the user can act on it (fix manifest, reinstall, etc.).
+
+## Non-goals
+
+- No changes to the startup `LoadAll` path or the scan/install flows. Those already persist `LoadError` to the DB; the new UI picks them up automatically.
+- No new status codes or fields on the `Plugin` model. `status` and `load_error` are sufficient.
+- No retry/auto-heal logic. The existing switch already lets the user toggle off and back on after fixing the plugin.
+
+## Design
+
+### Backend — `pkg/plugins/handler.go`
+
+In `handler.update`, the `enable: true` branch currently swallows the load error:
+
+```go
+if err := h.manager.LoadPlugin(ctx, scope, id); err != nil {
+    errMsg := err.Error()
+    plugin.LoadError = &errMsg
+    // ... set Status, emit event ...
+}
+// ... later ...
+return c.JSON(http.StatusOK, plugin)
+```
+
+Change this so that:
+
+1. The plugin row is still persisted with its Malfunctioned/NotSupported status and `LoadError` (no regression — this is what allows the list to show the badge on refetch).
+2. After persisting, if load failed, the handler returns `errcodes.ValidationError(loadErr.Error())`, which maps to HTTP 422 with body `{ error: { code: "validation_error", message: <loadErr> } }` via the existing `errcodes` handler. This is the same helper used a few lines below for confidence-threshold validation, so it fits the file's conventions.
+
+This only affects the user-initiated enable path. Disable, config updates, and auto-update continue to return 200.
+
+### Frontend — installed list
+
+**`app/components/plugins/PluginRow.tsx`**
+
+Replace the single `disabled` boolean prop with a richer status prop:
+
+- New prop `status?: PluginStatus` (optional so the Discover tab, which lists not-installed plugins, doesn't need it).
+- Map status → badge:
+  - `PluginStatusActive` → no badge (current behavior for enabled rows)
+  - `PluginStatusDisabled` → `<Badge variant="secondary">Disabled</Badge>` (current behavior)
+  - `PluginStatusMalfunctioned` → `<Badge variant="destructive">Error</Badge>` with `title={load_error}` so hovering reveals the message
+  - `PluginStatusNotSupported` → `<Badge variant="outline">Incompatible</Badge>`
+- Keep the row dimming (`opacity-50 saturate-50`) for any non-Active status.
+
+**`app/components/plugins/InstalledTab.tsx`**
+
+Pass `status` and (when malfunctioned) `loadError` into `PluginRow`. The existing sort that groups disabled-after-enabled stays — malfunctioned rows sort with the disabled group.
+
+### Frontend — plugin detail
+
+**`app/components/plugins/PluginDetailHero.tsx`**
+
+When `installed?.load_error` is truthy **or** status is Malfunctioned/NotSupported, render an alert block under the title row (above the meta line):
+
+```tsx
+{(installed.status === PluginStatusMalfunctioned ||
+  installed.status === PluginStatusNotSupported ||
+  installed.load_error) && (
+  <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm">
+    <p className="font-medium text-destructive">
+      {installed.status === PluginStatusNotSupported
+        ? "Plugin is not compatible with this Shisho version"
+        : "Plugin failed to load"}
+    </p>
+    {installed.load_error && (
+      <p className="mt-1 break-words font-mono text-xs text-muted-foreground">
+        {installed.load_error}
+      </p>
+    )}
+  </div>
+)}
+```
+
+The enable switch remains in its current position so the user can toggle off and back on after fixing the underlying issue.
+
+**`app/components/pages/PluginDetail.tsx` — `handleToggleEnabled`**
+
+No change needed. The mutation's `catch` block already shows `err.message` via `toast.error`; the backend change feeds it the real load error.
+
+## Testing
+
+- **Backend unit test** (`pkg/plugins/handler_test.go` — add a case): toggling enable on a plugin whose manifest has an invalid enricher field returns a 422-class error, and a follow-up `GET /plugins/installed` shows the row with `status: -2` and populated `load_error`.
+- **Frontend component tests**:
+  - `PluginRow.test.tsx`: one case per status renders the expected badge text; `Malfunctioned` has the hover title attribute.
+  - `PluginDetailHero.test.tsx`: renders the alert block when `load_error` is set; renders the "not compatible" copy when status is `NotSupported` without a load_error; does not render when status is Active.
+- **Manual verification**: enable the broken `hmanga Enricher` plugin from the screenshot; confirm the toast shows the real error, the installed list row shows a red `Error` badge with hover title, and the detail page renders the error block.
+
+## Docs
+
+No user-facing doc changes. The plugin system's user docs don't currently describe plugin states granularly enough for this to warrant a new section, and the behavior is self-explanatory in the UI.

--- a/pkg/errcodes/errors.go
+++ b/pkg/errcodes/errors.go
@@ -87,6 +87,17 @@ func ValidationError(msg string) error {
 	}
 }
 
+// PluginLoadFailure returns a 422 error for a plugin that failed to load at
+// runtime (e.g., malformed manifest, incompatible host version). The request
+// itself was well-formed — the side effect failed.
+func PluginLoadFailure(msg string) error {
+	return &Error{
+		http.StatusUnprocessableEntity,
+		msg,
+		"plugin_load_failure",
+	}
+}
+
 func MalformedPayload() error {
 	return &Error{
 		http.StatusBadRequest,

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -430,13 +430,6 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Surface enable-time load failures as a 422 so the frontend toast shows
-	// the real reason. The Malfunctioned/NotSupported status is already
-	// persisted above, so a follow-up GET reflects the broken state.
-	if loadErr != nil {
-		return errcodes.PluginLoadFailure(loadErr.Error())
-	}
-
 	if payload.Config != nil {
 		for key, value := range payload.Config {
 			if err := h.service.SetConfig(ctx, scope, id, key, value); err != nil {
@@ -458,6 +451,13 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 		plugin.ConfidenceThreshold = payload.ConfidenceThreshold
+	}
+
+	// Surface enable-time load failures as a 422 after applying config/threshold
+	// writes, so a caller mixing enable+config in one payload still gets their
+	// config persisted and the Malfunctioned state + error message reported.
+	if loadErr != nil {
+		return errcodes.PluginLoadFailure(loadErr.Error())
 	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, plugin))

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -385,6 +385,7 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	var loadErr error
 	if payload.Enabled != nil {
 		wasActive := plugin.Status == models.PluginStatusActive
 
@@ -392,6 +393,7 @@ func (h *handler) update(c echo.Context) error {
 			// Enabling: set Active and load the plugin
 			plugin.Status = models.PluginStatusActive
 			if err := h.manager.LoadPlugin(ctx, scope, id); err != nil {
+				loadErr = err
 				errMsg := err.Error()
 				plugin.LoadError = &errMsg
 				if isVersionIncompatible(err) {
@@ -426,6 +428,13 @@ func (h *handler) update(c echo.Context) error {
 
 	if err := h.service.UpdatePlugin(ctx, plugin); err != nil {
 		return errors.WithStack(err)
+	}
+
+	// Surface enable-time load failures as a 422 so the frontend toast shows
+	// the real reason. The Malfunctioned/NotSupported status is already
+	// persisted above, so a follow-up GET reflects the broken state.
+	if loadErr != nil {
+		return errcodes.ValidationError(loadErr.Error())
 	}
 
 	if payload.Config != nil {

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -434,7 +434,7 @@ func (h *handler) update(c echo.Context) error {
 	// the real reason. The Malfunctioned/NotSupported status is already
 	// persisted above, so a follow-up GET reflects the broken state.
 	if loadErr != nil {
-		return errcodes.ValidationError(loadErr.Error())
+		return errcodes.PluginLoadFailure(loadErr.Error())
 	}
 
 	if payload.Config != nil {

--- a/pkg/plugins/handler_enable_test.go
+++ b/pkg/plugins/handler_enable_test.go
@@ -64,7 +64,10 @@ func TestUpdate_EnableLoadFailure_ReturnsError(t *testing.T) {
 	h := NewHandler(svc, mgr, nil)
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"enabled": true}`))
+	// Mix enable+config in one payload; config writes must still persist even
+	// when the load fails so the user doesn't silently lose their config edits.
+	req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(
+		`{"enabled": true, "config": {"api_key": "abc"}}`))
 	req.Header.Set("Content-Type", "application/json")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -86,4 +89,10 @@ func TestUpdate_EnableLoadFailure_ReturnsError(t *testing.T) {
 	assert.Equal(t, models.PluginStatusMalfunctioned, retrieved.Status)
 	require.NotNil(t, retrieved.LoadError)
 	assert.Contains(t, *retrieved.LoadError, "nonsenseField")
+
+	// Config writes are independent of load success — they must survive.
+	apiKey, err := svc.GetConfigRaw(ctx, scope, id, "api_key")
+	require.NoError(t, err)
+	require.NotNil(t, apiKey)
+	assert.Equal(t, "abc", *apiKey)
 }

--- a/pkg/plugins/handler_enable_test.go
+++ b/pkg/plugins/handler_enable_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestUpdate_EnableLoadFailure_ReturnsError confirms that toggling a plugin's
-// enable flag to true when the plugin cannot be loaded returns a 422 error and
-// still persists the Malfunctioned status + load_error to the database so the
-// UI can render it after a refetch.
-func TestUpdate_EnableLoadFailure_ReturnsError(t *testing.T) {
+// TestUpdate_EnableLoadFailure_Returns422AndPersistsConfig confirms that
+// toggling a plugin's enable flag to true when the plugin cannot be loaded
+// returns a 422 error, persists the Malfunctioned status + load_error, and —
+// when the same payload included a config update — persists the config too.
+func TestUpdate_EnableLoadFailure_Returns422AndPersistsConfig(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)

--- a/pkg/plugins/handler_enable_test.go
+++ b/pkg/plugins/handler_enable_test.go
@@ -1,0 +1,87 @@
+package plugins
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdate_EnableLoadFailure_ReturnsError confirms that toggling a plugin's
+// enable flag to true when the plugin cannot be loaded returns a 422 error and
+// still persists the Malfunctioned status + load_error to the database so the
+// UI can render it after a refetch.
+func TestUpdate_EnableLoadFailure_ReturnsError(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+	pluginDir := t.TempDir()
+
+	// Plugin with a manifest declaring an enricher field that doesn't exist.
+	// LoadPlugin will reject this with an "invalid metadata field" error.
+	scope := "test"
+	id := "broken-enricher"
+	destDir := filepath.Join(pluginDir, scope, id)
+	require.NoError(t, os.MkdirAll(destDir, 0755))
+	manifest := `{
+  "manifestVersion": 1,
+  "id": "broken-enricher",
+  "name": "Broken Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "fileTypes": ["epub"],
+      "fields": ["nonsenseField"]
+    }
+  }
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "manifest.json"), []byte(manifest), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "main.js"),
+		[]byte(`var plugin=(function(){return{metadataEnricher:{search:function(){return{results:[]}}}};})();`), 0644))
+
+	ctx := context.Background()
+	// Pre-install as Disabled so the PATCH path exercises the enable branch.
+	require.NoError(t, svc.InstallPlugin(ctx, &models.Plugin{
+		Scope:       scope,
+		ID:          id,
+		Name:        "Broken Enricher",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusDisabled,
+		InstalledAt: time.Now(),
+	}))
+
+	mgr := NewManager(svc, pluginDir, "")
+	h := NewHandler(svc, mgr, nil)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(`{"enabled": true}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("scope", "id")
+	c.SetParamValues(scope, id)
+
+	err := h.update(c)
+	// The handler must surface a 422 error via the errcodes pipeline.
+	require.Error(t, err)
+	var ec *errcodes.Error
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, http.StatusUnprocessableEntity, ec.HTTPCode)
+	assert.Contains(t, ec.Message, "nonsenseField")
+
+	// And the plugin row must be persisted as Malfunctioned with the load_error.
+	retrieved, err := svc.RetrievePlugin(ctx, scope, id)
+	require.NoError(t, err)
+	assert.Equal(t, models.PluginStatusMalfunctioned, retrieved.Status)
+	require.NotNil(t, retrieved.LoadError)
+	assert.Contains(t, *retrieved.LoadError, "nonsenseField")
+}

--- a/pkg/plugins/handler_enable_test.go
+++ b/pkg/plugins/handler_enable_test.go
@@ -77,6 +77,7 @@ func TestUpdate_EnableLoadFailure_ReturnsError(t *testing.T) {
 	var ec *errcodes.Error
 	require.ErrorAs(t, err, &ec)
 	assert.Equal(t, http.StatusUnprocessableEntity, ec.HTTPCode)
+	assert.Equal(t, "plugin_load_failure", ec.Code)
 	assert.Contains(t, ec.Message, "nonsenseField")
 
 	// And the plugin row must be persisted as Malfunctioned with the load_error.

--- a/pkg/plugins/handler_enable_test.go
+++ b/pkg/plugins/handler_enable_test.go
@@ -22,6 +22,7 @@ import (
 // still persists the Malfunctioned status + load_error to the database so the
 // UI can render it after a refetch.
 func TestUpdate_EnableLoadFailure_ReturnsError(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	pluginDir := t.TempDir()

--- a/website/docs/plugins/overview.md
+++ b/website/docs/plugins/overview.md
@@ -31,6 +31,19 @@ To install a plugin:
 
 Plugins can also be installed by placing them directly in the plugin directory for [development or testing](./development#local-development) purposes.
 
+## Plugin Status
+
+Each installed plugin has a status that determines whether it runs. You can see the status on the **Installed** tab and on each plugin's detail page.
+
+| Status | What it means |
+|--------|---------------|
+| **Active** | Plugin is loaded and participating in scans/enrichment per its mode. |
+| **Disabled** | You turned the plugin off via its enable toggle. Turn it back on to re-enable. |
+| **Error** | The plugin is installed but failed to load — usually a manifest or runtime problem. The detail page shows the underlying error. |
+| **Incompatible** | The plugin's `minShishoVersion` is higher than your running version. Update Shisho to use this plugin. |
+
+When enabling a plugin fails, a toast shows the load error and the plugin row is marked **Error**. Open the plugin's detail page to see the full error text in monospace; use it to fix the plugin's manifest or code. If the plugin came from a repository, check for an updated version — the error may already be fixed upstream.
+
 ## Configuring Plugins
 
 Many plugins have configuration options, such as API keys for external services. After installing a plugin:


### PR DESCRIPTION
## Summary
- Enabling a broken plugin now returns 422 with the real load error, so the toast shows why it failed (instead of a misleading "enabled" success).
- The installed plugins list distinguishes Disabled / Error / Incompatible states with status-specific badges; the Error badge surfaces the full load_error on hover.
- The plugin detail page renders a destructive shadcn `Alert` (`role="alert"`) with the load error in monospace when a plugin is Malfunctioned, NotSupported, or otherwise has a load_error.

## Test plan
- `mise check:quiet` passes (Go + JS tests and lints).
- New Go test `TestUpdate_EnableLoadFailure_ReturnsError` covers the 422 response, the `plugin_load_failure` errcode, and that the Malfunctioned state is still persisted.
- New React tests cover every status badge on `PluginRow` and every alert branch on `PluginDetailHero`, plus unit tests for the extracted `pluginAlertContent` helper.
- Manual: toggle a known-broken plugin on from `/settings/plugins` — confirm the toast shows the real error, the list row shows a red `Error` badge with hover tooltip, and the detail page renders the error block with the full message.