### PR TITLE
[Fix] Sort CBZ pages naturally across all numeric runs in kepub

### DIFF
--- a/pkg/kepub/cbz.go
+++ b/pkg/kepub/cbz.go
@@ -726,27 +726,43 @@ func generateUUID() string {
 		now&0xFFFFFFFFFFFF)
 }
 
-// naturalLess compares strings naturally (so "page2" < "page10").
+// naturalLess compares strings naturally by alternating non-digit and digit
+// runs: digit runs compare numerically (so "page2" < "page10"), non-digit runs
+// compare byte-wise. This correctly orders filenames with multiple numbers,
+// e.g. "Foo 365 - c001 - p000.jpg" < "Foo 365 - c001 - p001.jpg".
 func naturalLess(a, b string) bool {
-	// Simple natural sort: extract numbers and compare
-	return extractNumber(a) < extractNumber(b)
-}
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		aDigit := a[i] >= '0' && a[i] <= '9'
+		bDigit := b[j] >= '0' && b[j] <= '9'
 
-// extractNumber extracts the first number found in a string.
-func extractNumber(s string) int {
-	var numStr string
-	for _, c := range s {
-		if c >= '0' && c <= '9' {
-			numStr += string(c)
-		} else if numStr != "" {
-			break
+		if aDigit && bDigit {
+			aStart := i
+			for i < len(a) && a[i] >= '0' && a[i] <= '9' {
+				i++
+			}
+			bStart := j
+			for j < len(b) && b[j] >= '0' && b[j] <= '9' {
+				j++
+			}
+			aNum := strings.TrimLeft(a[aStart:i], "0")
+			bNum := strings.TrimLeft(b[bStart:j], "0")
+			if len(aNum) != len(bNum) {
+				return len(aNum) < len(bNum)
+			}
+			if aNum != bNum {
+				return aNum < bNum
+			}
+			continue
 		}
+
+		if a[i] != b[j] {
+			return a[i] < b[j]
+		}
+		i++
+		j++
 	}
-	if numStr == "" {
-		return 0
-	}
-	n, _ := strconv.Atoi(numStr)
-	return n
+	return len(a)-i < len(b)-j
 }
 
 // Kobo Libra Color screen dimensions (from KCC profiles).

--- a/pkg/kepub/cbz_test.go
+++ b/pkg/kepub/cbz_test.go
@@ -556,33 +556,18 @@ func TestNaturalLess(t *testing.T) {
 		{"page10", "page2", false},
 		{"1", "2", true},
 		{"page001", "page002", true},
+		// Filenames with a leading number (from the title) followed by the page number.
+		// Must compare ALL numeric runs, not just the first.
+		{"365 Days - c001 - p000.jpg", "365 Days - c001 - p001.jpg", true},
+		{"365 Days - c001 - p001.jpg", "365 Days - c001 - p000.jpg", false},
+		{"365 Days - c001 - p197.jpg", "365 Days - c002 - p000.jpg", true},
+		{"365 Days - c002 - p000.jpg", "365 Days - c001 - p197.jpg", false},
+		{"365 Days - c001 - p002-p003.jpg", "365 Days - c001 - p004.jpg", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
 			result := naturalLess(tt.a, tt.b)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestExtractNumber(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		input    string
-		expected int
-	}{
-		{"page1", 1},
-		{"page10", 10},
-		{"123", 123},
-		{"page001.jpg", 1},
-		{"nonum", 0},
-		{"", 0},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			result := extractNumber(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
## Summary
- `naturalLess` in `pkg/kepub/cbz.go` only compared the first digit run in each filename. Filenames that started with a number (e.g. `365 Days to the Wedding - c001 (v01) - p000.jpg`) all collided on that leading `365`, so the comparator treated every page as equal and Go's unstable `sort.Slice` left them in ZIP central-directory order — some CBZs happened to list the last page first, which then opened as page 1 in the generated kepub.
- Replaced the extract-first-number approach with a proper natural sort that walks both strings and compares digit runs numerically and non-digit runs byte-wise, so every numeric segment participates in the ordering.
- Dropped the now-unused `extractNumber` helper and its test.

## Test plan
- `go test ./pkg/kepub/` passes, including new `TestNaturalLess` cases covering multi-numeric-run filenames.
- Regenerated a kepub from a CBZ with leading-number filenames; `OEBPS/images/page0001.jpg` is now the real cover page instead of the last page.
- `mise check:quiet` passes.