### PR TITLE
[Frontend] Compare cover pages by number in identify review

### DIFF
--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -624,12 +624,18 @@ export function IdentifyReviewForm({
   const currentCoverDims = useImageDimensions(currentCoverUrl);
   const newCoverDims = useImageDimensions(newCoverPreviewUrl);
 
-  // Prefer keeping the current cover when it's at least as high-resolution
-  // as the plugin cover (by pixel count) — avoids unnecessary writes/churn.
-  const preferCurrentCover =
-    !!currentCoverDims &&
-    !!newCoverDims &&
-    currentCoverDims.w * currentCoverDims.h >= newCoverDims.w * newCoverDims.h;
+  // For page-based files with a plugin-supplied cover_page, compare by page
+  // number instead of pixel resolution — the cover is a page of the file
+  // itself, so resolution is a function of the source file, not the choice.
+  // Same page → unchanged (prefer current); different page → prefer new.
+  const currentCoverPage = file?.cover_page ?? null;
+  const isPageBasedCoverChoice = isFilePageBased && newCoverPage != null;
+  const preferCurrentCover = isPageBasedCoverChoice
+    ? currentCoverPage !== null && currentCoverPage === newCoverPage
+    : !!currentCoverDims &&
+      !!newCoverDims &&
+      currentCoverDims.w * currentCoverDims.h >=
+        newCoverDims.w * newCoverDims.h;
   const [coverUserTouched, setCoverUserTouched] = useState(false);
   useEffect(() => {
     if (preferCurrentCover && !coverUserTouched) {
@@ -840,15 +846,21 @@ export function IdentifyReviewForm({
           <div className="flex gap-4 text-xs text-muted-foreground">
             {currentCoverUrl && (
               <span className="w-[calc(6rem+4px)] text-center">
-                {currentCoverDims
-                  ? `${currentCoverDims.w} × ${currentCoverDims.h}`
-                  : "\u00A0"}
+                {isPageBasedCoverChoice
+                  ? currentCoverPage !== null
+                    ? `Page ${currentCoverPage + 1}`
+                    : "\u00A0"
+                  : currentCoverDims
+                    ? `${currentCoverDims.w} × ${currentCoverDims.h}`
+                    : "\u00A0"}
               </span>
             )}
             <span className="w-[calc(6rem+4px)] text-center">
-              {newCoverDims
-                ? `${newCoverDims.w} × ${newCoverDims.h}`
-                : "\u00A0"}
+              {isPageBasedCoverChoice
+                ? `Page ${newCoverPage + 1}`
+                : newCoverDims
+                  ? `${newCoverDims.w} × ${newCoverDims.h}`
+                  : "\u00A0"}
             </span>
           </div>
         </div>

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -618,30 +618,43 @@ export function IdentifyReviewForm({
     ? `/api/books/files/${file.id}/cover?v=${new Date(file.updated_at).getTime()}`
     : undefined;
   const hasCoverChoice = !!newCoverPreviewUrl;
-  const [coverSelection, setCoverSelection] = useState<"current" | "new">(
-    hasCoverChoice && !isDisabled("cover") ? "new" : "current",
-  );
-  const currentCoverDims = useImageDimensions(currentCoverUrl);
-  const newCoverDims = useImageDimensions(newCoverPreviewUrl);
-
+  const currentCoverPage = file?.cover_page ?? null;
   // For page-based files with a plugin-supplied cover_page, compare by page
   // number instead of pixel resolution — the cover is a page of the file
   // itself, so resolution is a function of the source file, not the choice.
-  // Same page → unchanged (prefer current); different page → prefer new.
-  const currentCoverPage = file?.cover_page ?? null;
   const isPageBasedCoverChoice = isFilePageBased && newCoverPage != null;
+  // Dimensions only matter for the resolution-based comparison on non-page
+  // formats. Skip the image preload entirely for page-based choices.
+  const currentCoverDims = useImageDimensions(
+    isPageBasedCoverChoice ? undefined : currentCoverUrl,
+  );
+  const newCoverDims = useImageDimensions(
+    isPageBasedCoverChoice ? undefined : newCoverPreviewUrl,
+  );
+  // Same page → unchanged (prefer current); different page → prefer new.
   const preferCurrentCover = isPageBasedCoverChoice
     ? currentCoverPage !== null && currentCoverPage === newCoverPage
     : !!currentCoverDims &&
       !!newCoverDims &&
       currentCoverDims.w * currentCoverDims.h >=
         newCoverDims.w * newCoverDims.h;
+  // The selection we'd land on if the user didn't touch anything. Used to
+  // seed useState and to detect drift in `hasChanges` — factoring this out
+  // keeps the two in lockstep so a future refactor of the auto-select
+  // effect can't leave them subtly out of sync.
+  const defaultCoverSelection: "current" | "new" =
+    hasCoverChoice && !isDisabled("cover") && !preferCurrentCover
+      ? "new"
+      : "current";
+  const [coverSelection, setCoverSelection] = useState<"current" | "new">(
+    defaultCoverSelection,
+  );
   const [coverUserTouched, setCoverUserTouched] = useState(false);
   useEffect(() => {
-    if (preferCurrentCover && !coverUserTouched) {
-      setCoverSelection("current");
+    if (!coverUserTouched) {
+      setCoverSelection(defaultCoverSelection);
     }
-  }, [preferCurrentCover, coverUserTouched]);
+  }, [defaultCoverSelection, coverUserTouched]);
 
   // ---- Unsaved changes tracking ----
   const hasChanges = useMemo(() => {
@@ -662,10 +675,7 @@ export function IdentifyReviewForm({
       language !== defaults.language.value ||
       abridged !== defaults.abridged.value ||
       !equal(identifiers, defaults.identifiers.value) ||
-      coverSelection !==
-        (hasCoverChoice && !disabledFields.has("cover") && !preferCurrentCover
-          ? "new"
-          : "current")
+      coverSelection !== defaultCoverSelection
     );
   }, [
     title,
@@ -686,9 +696,7 @@ export function IdentifyReviewForm({
     identifiers,
     coverSelection,
     defaults,
-    hasCoverChoice,
-    disabledFields,
-    preferCurrentCover,
+    defaultCoverSelection,
   ]);
 
   useEffect(() => {

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -632,16 +632,19 @@ export function IdentifyReviewForm({
     isPageBasedCoverChoice ? undefined : newCoverPreviewUrl,
   );
   // Same page → unchanged (prefer current); different page → prefer new.
+  // Requires `currentCoverUrl` so we don't default to a "Current" thumbnail
+  // that isn't rendered (the current button is guarded by `currentCoverUrl`).
   const preferCurrentCover = isPageBasedCoverChoice
-    ? currentCoverPage !== null && currentCoverPage === newCoverPage
+    ? !!currentCoverUrl &&
+      currentCoverPage !== null &&
+      currentCoverPage === newCoverPage
     : !!currentCoverDims &&
       !!newCoverDims &&
       currentCoverDims.w * currentCoverDims.h >=
         newCoverDims.w * newCoverDims.h;
-  // The selection we'd land on if the user didn't touch anything. Used to
-  // seed useState and to detect drift in `hasChanges` — factoring this out
-  // keeps the two in lockstep so a future refactor of the auto-select
-  // effect can't leave them subtly out of sync.
+  // The selection we'd land on if the user didn't touch anything. Used by
+  // useState init, the auto-select effect, and `hasChanges` — keeping it in
+  // one place avoids the three sites drifting.
   const defaultCoverSelection: "current" | "new" =
     hasCoverChoice && !isDisabled("cover") && !preferCurrentCover
       ? "new"


### PR DESCRIPTION
## Summary
- For page-based formats (CBZ, PDF) with a plugin-supplied `cover_page`, the identify review form compares page numbers instead of pixel resolution — same page stays "Unchanged" and keeps the current selection, a different page is "Changed" and prefers the new cover
- Thumbnails under the cover choices now show `Page N` (1-indexed) for page-based selections; non-page-based formats keep the existing `W × H` dimensions
- No scan/backend changes: the scan path already compares `CoverPage` by page number and `upgradeEnricherCover` already skips page-based formats

## Test plan
- Identify a CBZ or PDF using a plugin that returns a `cover_page` matching the file's current `cover_page`; confirm the Cover row shows the "Unchanged" badge, the current thumbnail is selected by default, and both thumbnails show `Page N`
- Identify a CBZ or PDF using a plugin that returns a different `cover_page`; confirm the badge shows "Changed", the new thumbnail is selected by default, and both thumbnails show their respective page numbers
- Identify a non-page-based file (EPUB, M4B) where the plugin supplies a `cover_url`; confirm the thumbnails still show pixel dimensions (`W × H`) and the higher-resolution option is preferred