### PR TITLE
[Fix] Reset cover error flag so failed thumbnails can recover

### DIFF
--- a/app/components/library/FileCoverThumbnail.test.tsx
+++ b/app/components/library/FileCoverThumbnail.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { File } from "@/types";
+
+import FileCoverThumbnail from "./FileCoverThumbnail";
+
+function makeFile(overrides: Partial<File> = {}): File {
+  return {
+    id: 1,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    library_id: 1,
+    book_id: 1,
+    filepath: "/library/book.epub",
+    file_type: "epub",
+    file_role: "main",
+    filesize_bytes: 1000,
+    cover_image_filename: "cover.jpg",
+    ...overrides,
+  };
+}
+
+describe("FileCoverThumbnail", () => {
+  it("renders cover image when file has a cover", () => {
+    const { container } = render(<FileCoverThumbnail file={makeFile()} />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("/api/books/files/1/cover");
+  });
+
+  it("hides the img and shows placeholder after load error", () => {
+    const { container } = render(<FileCoverThumbnail file={makeFile()} />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+
+    fireEvent.error(img!);
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("re-mounts the img when cacheKey bumps after an error", () => {
+    const file = makeFile();
+    const { container, rerender } = render(
+      <FileCoverThumbnail cacheKey={111} file={file} />,
+    );
+    const firstImg = container.querySelector("img");
+    expect(firstImg).not.toBeNull();
+    expect(firstImg?.getAttribute("src")).toBe(
+      "/api/books/files/1/cover?v=111",
+    );
+
+    fireEvent.error(firstImg!);
+    expect(container.querySelector("img")).toBeNull();
+
+    rerender(<FileCoverThumbnail cacheKey={222} file={file} />);
+    const secondImg = container.querySelector("img");
+    expect(secondImg).not.toBeNull();
+    expect(secondImg?.getAttribute("src")).toBe(
+      "/api/books/files/1/cover?v=222",
+    );
+  });
+
+  it("re-mounts the img when cover_image_filename changes after an error", () => {
+    const { container, rerender } = render(
+      <FileCoverThumbnail
+        file={makeFile({ cover_image_filename: "old.jpg" })}
+      />,
+    );
+    const firstImg = container.querySelector("img");
+    expect(firstImg).not.toBeNull();
+
+    fireEvent.error(firstImg!);
+    expect(container.querySelector("img")).toBeNull();
+
+    rerender(
+      <FileCoverThumbnail
+        file={makeFile({ cover_image_filename: "new.jpg" })}
+      />,
+    );
+    expect(container.querySelector("img")).not.toBeNull();
+  });
+});

--- a/app/components/library/FileCoverThumbnail.tsx
+++ b/app/components/library/FileCoverThumbnail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import CoverPlaceholder from "@/components/library/CoverPlaceholder";
 import { cn } from "@/libraries/utils";
@@ -28,6 +28,14 @@ function FileCoverThumbnail({
 }: FileCoverThumbnailProps) {
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
+
+  // Reset the error flag when the URL would change — either the cover
+  // filename was replaced or the cacheKey bumped from a data refetch. Without
+  // this, a transient load failure latches the placeholder forever because
+  // the <img> stays unmounted and the `key` bump can't remount it.
+  useEffect(() => {
+    setImageError(false);
+  }, [cacheKey, file.cover_image_filename]);
 
   const isAudiobook = file.file_type === "m4b";
   const aspectClass = isAudiobook ? "aspect-square" : "aspect-[2/3]";

--- a/app/components/library/FileCoverThumbnail.tsx
+++ b/app/components/library/FileCoverThumbnail.tsx
@@ -29,12 +29,15 @@ function FileCoverThumbnail({
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
 
-  // Reset the error flag when the URL would change — either the cover
-  // filename was replaced or the cacheKey bumped from a data refetch. Without
-  // this, a transient load failure latches the placeholder forever because
-  // the <img> stays unmounted and the `key` bump can't remount it.
+  // Reset both flags when the URL would change — either the cover filename
+  // was replaced or the cacheKey bumped from a data refetch. Without resetting
+  // imageError, a transient load failure latches the placeholder forever
+  // because the <img> is conditionally unrendered and the `key` bump can't
+  // remount it. Without resetting imageLoaded, the remounted <img> renders at
+  // full opacity during the fresh fetch, skipping the fade-in.
   useEffect(() => {
     setImageError(false);
+    setImageLoaded(false);
   }, [cacheKey, file.cover_image_filename]);
 
   const isAudiobook = file.file_type === "m4b";

--- a/app/components/library/GlobalSearch.tsx
+++ b/app/components/library/GlobalSearch.tsx
@@ -65,11 +65,13 @@ const SearchResultCover = ({
   const [coverLoaded, setCoverLoaded] = useState(() => isCoverLoaded(coverUrl));
   const [coverError, setCoverError] = useState(false);
 
-  // Reset the error flag when the URL changes so a previously-failed cover
-  // can re-mount after the underlying image becomes available (e.g., after
-  // a rescan). Without this, the placeholder is latched until full reload.
+  // Reset error and re-seed loaded state when the URL changes so a
+  // previously-failed cover can re-mount after the underlying image becomes
+  // available (e.g., after a rescan), and so the loaded flag reflects the
+  // current URL's cache status rather than whatever was set for a prior URL.
   useEffect(() => {
     setCoverError(false);
+    setCoverLoaded(isCoverLoaded(coverUrl));
   }, [coverUrl]);
 
   const handleCoverLoad = () => {

--- a/app/components/library/GlobalSearch.tsx
+++ b/app/components/library/GlobalSearch.tsx
@@ -65,6 +65,13 @@ const SearchResultCover = ({
   const [coverLoaded, setCoverLoaded] = useState(() => isCoverLoaded(coverUrl));
   const [coverError, setCoverError] = useState(false);
 
+  // Reset the error flag when the URL changes so a previously-failed cover
+  // can re-mount after the underlying image becomes available (e.g., after
+  // a rescan). Without this, the placeholder is latched until full reload.
+  useEffect(() => {
+    setCoverError(false);
+  }, [coverUrl]);
+
   const handleCoverLoad = () => {
     markCoverLoaded(coverUrl);
     setCoverLoaded(true);


### PR DESCRIPTION
## Summary
- `FileCoverThumbnail` and `SearchResultCover` latched `imageError=true` on first `onError` and never reset it, so a transient cover-load failure (e.g., during a rescan) permanently stuck the placeholder even after the cover became available and the parent bumped `cacheKey`.
- Added a `useEffect` that resets the error flag when `cacheKey` or `file.cover_image_filename` changes, mirroring the existing pattern in `CoverGalleryTabs` and `BookDetail`.
- Added unit tests for `FileCoverThumbnail` covering the happy path, error unmount, and remount on `cacheKey`/`cover_image_filename` change.

Closes the "M7" finding from PR #132 review.

## Test plan
- Run `mise test:unit` — new `FileCoverThumbnail.test.tsx` covers the regression.
- Manual: load a book whose file cover 404s, trigger a rescan that regenerates the cover, and confirm the thumbnail refreshes without a full page reload.
- Manual: same flow via the global search dropdown's `SearchResultCover`.