### PR TITLE
[Fix] Use ETag for series cover revalidation

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -109,6 +109,8 @@ file.CoverImageFilename = &newCoverPath
 
 **Book sidecars** for root-level books are similarly anchored next to the file — `sidecar.WriteBookSidecarFromModel(book)` falls back via `book.Files[0].Filepath` when `book.Filepath` doesn't resolve to an existing directory. Reads use `sidecar.ReadBookSidecarFromModel(book, fileHint)` and pass the current file as a hint so resolution works before the book's Files relation is loaded.
 
+**Conditional-GET for cover endpoints:** `/books/:id/cover` and `/files/:id/cover` serve via `c.File()` — `http.ServeContent` handles `Last-Modified`/`If-Modified-Since` from the cover file's on-disk mtime, which is sufficient because the served file's identity is pinned by the URL. `/series/:id/cover` is different: the served file is the cover of the series' *first book* (by `series_number ASC, title ASC`), and that selection can change — first book deleted, new book sorts earlier, series numbers reordered — without any change to the newly-selected cover file's mtime. Mtime-only revalidation returns stale 304s in that case. The series handler therefore issues an `ETag: "<file_id>-<mtime_unix>"` that bakes the selected file's identity into the validator, checks `If-None-Match` manually, and passes `time.Time{}` to `http.ServeContent` so it omits `Last-Modified` and skips IMS handling (which would otherwise shortcut to 304 using just the new file's mtime).
+
 ### Data Source Priority System
 
 Metadata sources ranked (lower number = higher precedence):

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -1,9 +1,12 @@
 package series
 
 import (
+	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
@@ -274,10 +277,38 @@ func (h *handler) seriesCover(c echo.Context) error {
 	// organized-folder path that doesn't exist on disk for root-level files.
 	coverImagePath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
 
-	// Set appropriate headers
-	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	coverStat, err := os.Stat(coverImagePath)
+	if err != nil {
+		return errcodes.NotFound("Series cover")
+	}
+	modTime := coverStat.ModTime().UTC().Truncate(time.Second)
 
-	return errors.WithStack(c.File(coverImagePath))
+	// ETag bakes in the selected file's identity, not just mtime, so it changes
+	// when the series' first book switches to a different file — even if the new
+	// cover happens to have an older mtime than the previous first book's cover.
+	etag := fmt.Sprintf(`"%d-%d"`, coverFile.ID, modTime.Unix())
+
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	c.Response().Header().Set("ETag", etag)
+
+	// Conditional GET uses ETag only. If-Modified-Since is intentionally not
+	// honored: file mtime doesn't capture changes in which file is selected,
+	// so IMS-based revalidation would serve stale bytes when the first book
+	// switches to one whose cover file has an older mtime.
+	if inm := c.Request().Header.Get("If-None-Match"); inm != "" && inm == etag {
+		c.Response().WriteHeader(http.StatusNotModified)
+		return nil
+	}
+
+	fh, err := os.Open(coverImagePath)
+	if err != nil {
+		return errcodes.NotFound("Series cover")
+	}
+	defer fh.Close()
+
+	// Zero modtime suppresses Last-Modified and IMS handling inside ServeContent.
+	http.ServeContent(c.Response(), c.Request(), filepath.Base(coverImagePath), time.Time{}, fh)
+	return nil
 }
 
 // selectCoverFile selects the appropriate file for cover display based on the library's

--- a/pkg/series/handlers_cover_cache_test.go
+++ b/pkg/series/handlers_cover_cache_test.go
@@ -3,6 +3,7 @@ package series
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"image"
 	"image/jpeg"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/books"
@@ -144,11 +146,11 @@ func TestSeriesCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
-	assert.NotEmpty(t, rec.Header().Get("Last-Modified"))
+	assert.NotEmpty(t, rec.Header().Get("ETag"))
 	assert.NotEmpty(t, rec.Body.Bytes())
 }
 
-func TestSeriesCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
+func TestSeriesCover_Returns304WhenIfNoneMatchMatches(t *testing.T) {
 	t.Parallel()
 
 	db := setupSeriesTestDB(t)
@@ -162,19 +164,19 @@ func TestSeriesCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 
 	seriesID := seedSeriesWithCover(ctx, t, db)
 
-	// First GET.
+	// First GET: capture ETag.
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	c1 := e.NewContext(req1, rec1)
 	c1.SetParamNames("id")
 	c1.SetParamValues(strconv.Itoa(seriesID))
 	require.NoError(t, h.seriesCover(c1))
-	lastModified := rec1.Header().Get("Last-Modified")
-	require.NotEmpty(t, lastModified)
+	etag := rec1.Header().Get("ETag")
+	require.NotEmpty(t, etag)
 
-	// Second GET with If-Modified-Since.
+	// Second GET with If-None-Match.
 	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
-	req2.Header.Set("If-Modified-Since", lastModified)
+	req2.Header.Set("If-None-Match", etag)
 	rec2 := httptest.NewRecorder()
 	c2 := e.NewContext(req2, rec2)
 	c2.SetParamNames("id")
@@ -183,5 +185,148 @@ func TestSeriesCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
 	assert.Empty(t, rec2.Body.Bytes())
+	assert.Equal(t, etag, rec2.Header().Get("ETag"))
 	assert.Equal(t, "private, no-cache", rec2.Header().Get("Cache-Control"))
+}
+
+func TestSeriesCover_Returns200WhenIfNoneMatchMismatches(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	h := &handler{
+		seriesService:  NewService(db),
+		bookService:    books.NewService(db),
+		libraryService: libraries.NewService(db),
+	}
+
+	seriesID := seedSeriesWithCover(ctx, t, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("If-None-Match", `"stale-etag"`)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(seriesID))
+	require.NoError(t, h.seriesCover(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotEmpty(t, rec.Body.Bytes())
+	assert.NotEmpty(t, rec.Header().Get("ETag"))
+	assert.NotEqual(t, `"stale-etag"`, rec.Header().Get("ETag"))
+}
+
+// Regression: when the series' first book changes to a different book whose
+// cover file has an older mtime than the previous first book's cover, a client
+// holding the previous cover's ETag must NOT receive 304 — the ETag bakes in
+// the selected file's identity, so it bumps even when mtime goes backwards.
+func TestSeriesCover_FirstBookChangeInvalidatesEtagEvenWhenNewCoverMtimeIsOlder(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+	h := &handler{
+		seriesService:  NewService(db),
+		bookService:    books.NewService(db),
+		libraryService: libraries.NewService(db),
+	}
+
+	// Seed with book A as the first book.
+	seriesID := seedSeriesWithCover(ctx, t, db)
+
+	// Look up the series' library ID so we can add book B in the same library.
+	var seriesRecord models.Series
+	require.NoError(t, db.NewSelect().Model(&seriesRecord).Where("id = ?", seriesID).Scan(ctx))
+
+	// Add book B (sorts AFTER A), with its cover file's mtime set OLDER than A's.
+	bookBDir := filepath.Join(t.TempDir(), "Book B")
+	require.NoError(t, os.MkdirAll(bookBDir, 0o755))
+
+	bookB := &models.Book{
+		LibraryID:       seriesRecord.LibraryID,
+		Title:           "Book B",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book B",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookBDir,
+	}
+	_, err := db.NewInsert().Model(bookB).Exec(ctx)
+	require.NoError(t, err)
+
+	seriesNumberB := 2.0
+	_, err = db.NewInsert().Model(&models.BookSeries{
+		BookID:       bookB.ID,
+		SeriesID:     seriesID,
+		SeriesNumber: &seriesNumberB,
+		SortOrder:    2,
+	}).Exec(ctx)
+	require.NoError(t, err)
+
+	bookBFilePath := filepath.Join(bookBDir, "bookB.epub")
+	require.NoError(t, os.WriteFile(bookBFilePath, []byte("fake epub"), 0o644))
+
+	bookBCoverFilename := "bookB.epub.cover.jpg"
+	bookBCoverPath := filepath.Join(bookBDir, bookBCoverFilename)
+	bookBCoverHandle, err := os.Create(bookBCoverPath)
+	require.NoError(t, err)
+	require.NoError(t, jpeg.Encode(bookBCoverHandle, image.NewRGBA(image.Rect(0, 0, 10, 10)), nil))
+	require.NoError(t, bookBCoverHandle.Close())
+
+	mimeType := "image/jpeg"
+	bookBFile := &models.File{
+		LibraryID:          seriesRecord.LibraryID,
+		BookID:             bookB.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           bookBFilePath,
+		FilesizeBytes:      1000,
+		CoverImageFilename: &bookBCoverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(bookBFile).Exec(ctx)
+	require.NoError(t, err)
+
+	// Give book B's cover an OLDER mtime than book A's cover will have.
+	oldTime := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(bookBCoverPath, oldTime, oldTime))
+
+	// Request the cover: book A is still first, capture its ETag.
+	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec1 := httptest.NewRecorder()
+	c1 := e.NewContext(req1, rec1)
+	c1.SetParamNames("id")
+	c1.SetParamValues(strconv.Itoa(seriesID))
+	require.NoError(t, h.seriesCover(c1))
+	require.Equal(t, http.StatusOK, rec1.Code)
+	etagA := rec1.Header().Get("ETag")
+	require.NotEmpty(t, etagA)
+
+	// Delete book A → book B becomes the first book.
+	var bookABookSeries models.BookSeries
+	require.NoError(t, db.NewSelect().Model(&bookABookSeries).
+		Where("series_id = ? AND book_id != ?", seriesID, bookB.ID).Scan(ctx))
+	_, err = db.NewDelete().Model((*models.Book)(nil)).
+		Where("id = ?", bookABookSeries.BookID).Exec(ctx)
+	require.NoError(t, err)
+
+	// Client revalidates with book A's ETag — must NOT 304; book B's cover is now served.
+	req2 := httptest.NewRequest(http.MethodGet, "/", nil)
+	req2.Header.Set("If-None-Match", etagA)
+	rec2 := httptest.NewRecorder()
+	c2 := e.NewContext(req2, rec2)
+	c2.SetParamNames("id")
+	c2.SetParamValues(strconv.Itoa(seriesID))
+	require.NoError(t, h.seriesCover(c2))
+
+	assert.Equal(t, http.StatusOK, rec2.Code,
+		"expected 200 after first-book change (ETag must change with file identity, not just mtime)")
+	assert.NotEmpty(t, rec2.Body.Bytes())
+	etagB := rec2.Header().Get("ETag")
+	assert.NotEmpty(t, etagB)
+	assert.NotEqual(t, etagA, etagB, "ETag must change when the selected file changes")
+	// Sanity check the ETag format encodes the book B file ID.
+	assert.Contains(t, etagB, fmt.Sprintf("%d-", bookBFile.ID))
 }

--- a/pkg/series/handlers_cover_cache_test.go
+++ b/pkg/series/handlers_cover_cache_test.go
@@ -147,6 +147,10 @@ func TestSeriesCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
 	assert.NotEmpty(t, rec.Header().Get("ETag"))
+	// Last-Modified is intentionally NOT emitted: it would re-enable IMS-based
+	// revalidation inside http.ServeContent, which can return stale 304s when
+	// the series' first book switches to one with an older cover mtime.
+	assert.Empty(t, rec.Header().Get("Last-Modified"))
 	assert.NotEmpty(t, rec.Body.Bytes())
 }
 


### PR DESCRIPTION
## Summary
- `/api/series/:id/cover` now issues an `ETag: "<file_id>-<mtime_unix>"` composite tag and uses `If-None-Match` for conditional GETs; `If-Modified-Since` is intentionally no longer honored because file mtime alone doesn't capture changes in which file is selected.
- Fixes stale 304s when the series' first book changes (e.g., first book deleted, a new book sorts earlier, or series numbers are reordered) to a book whose cover file has an older mtime than the previous first book's cover — the ETag bakes in the selected file's identity, so it bumps even when mtime goes backwards.
- Flagged as M6 in code review of PR #132.

## Test plan
- `TestSeriesCover_SetsCacheControlPrivateNoCache` — confirms the handler sets `Cache-Control: private, no-cache` and a non-empty `ETag`.
- `TestSeriesCover_Returns304WhenIfNoneMatchMatches` — revalidation with the current ETag returns 304 with an empty body.
- `TestSeriesCover_Returns200WhenIfNoneMatchMismatches` — a stale/unknown `If-None-Match` returns 200 with the fresh ETag.
- `TestSeriesCover_FirstBookChangeInvalidatesEtagEvenWhenNewCoverMtimeIsOlder` — seeds books A and B in a series, sets book B's cover mtime 48h older than A's, captures A's ETag, deletes book A, then confirms the revalidation request with A's ETag returns 200 with a new ETag containing book B's file ID.
- `mise check:quiet` — lint, Go tests, JS tests, JS lint all pass.