### PR TITLE
[Fix] Trust upstream proxy X-Forwarded-Proto in Caddy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,17 @@
 # Shisho Production Configuration
 # Serves frontend on / and proxies /api/* to the Go backend
 
+{
+    servers {
+        # Trust X-Forwarded-* headers from upstream reverse proxies on private
+        # networks (e.g. Nginx Proxy Manager in a Docker network). Without this,
+        # Caddy overwrites X-Forwarded-Proto with its own scheme (http) and the
+        # Go backend emits http:// hrefs in OPDS feeds — which causes KOReader
+        # to follow an http->https redirect and drop its Authorization header.
+        trusted_proxies static private_ranges
+    }
+}
+
 :5173 {
     # Logging
     log {

--- a/website/docs/opds.md
+++ b/website/docs/opds.md
@@ -40,6 +40,12 @@ This serves the same catalog but EPUB and CBZ downloads are converted to KePub f
 
 OPDS uses HTTP Basic Authentication with your Shisho username and password — the same credentials you use to log in to the web UI. Most OPDS apps prompt for these when you add a new catalog.
 
+### Behind a reverse proxy
+
+If you're running Shisho behind an HTTPS-terminating reverse proxy (Nginx Proxy Manager, Traefik, etc.), the upstream proxy must forward `X-Forwarded-Proto: https` so Shisho generates `https://` hrefs in feed entries. OPDS clients like KOReader drop the `Authorization` header when following an `http://` → `https://` redirect, which surfaces as 401s on sub-feeds.
+
+The bundled Caddy config trusts `X-Forwarded-*` headers from any RFC1918 private-range address, which covers the usual Docker/LAN topology. If your upstream proxy is on a public IP or in a non-RFC1918 range (some VPN networks, CGNAT, etc.), you'll need to override the Caddyfile and add the upstream's address to Caddy's [`trusted_proxies`](https://caddyserver.com/docs/caddyfile/options#trusted-proxies).
+
 ## Catalog Structure
 
 The feed is organized as:


### PR DESCRIPTION
## Summary
- When an upstream reverse proxy (e.g. Nginx Proxy Manager) terminates TLS and forwards to Caddy over HTTP, Caddy was overwriting the upstream's `X-Forwarded-Proto: https` with its own scheme (`http`) because the upstream wasn't in Caddy's trusted-proxy list.
- The Go backend's `getBaseURL()` then emitted `http://` hrefs in OPDS feed entries. KOReader loaded the root catalog over HTTPS fine, but clicked subsection links point to `http://`, triggering an http→https redirect at the edge. KOReader drops its `Authorization` header when following redirects, so the redirected request hit the backend unauthenticated and returned 401.
- Adding `servers { trusted_proxies static private_ranges }` tells Caddy to trust `X-Forwarded-*` from private-network upstreams, so the original `https` proto is preserved and OPDS hrefs come out as `https://`.

## Test plan
- Behind an HTTPS-terminating reverse proxy on a private network (e.g. Nginx Proxy Manager in Docker), configure a KOReader OPDS catalog pointing at the public HTTPS URL.
- Open the catalog → libraries list loads (was already working).
- Tap a library → sub-feed loads without a 401 (previously 401'd).
- `curl -u user:pass https://<public-host>/opds/v1/epub+cbz/libraries/1` — the `<link href=...>` values in the returned Atom XML should be `https://…`, not `http://…`.
- Local dev (no reverse proxy) still works: `mise start`, hit OPDS endpoints directly on `:5173`.