### PR TITLE
[Fix] Discard stale sidecars on rescan so replaced files re-extract metadata

### DIFF
--- a/app/hooks/queries/resync.ts
+++ b/app/hooks/queries/resync.ts
@@ -4,6 +4,7 @@ import { API } from "@/libraries/api";
 import { Book, File } from "@/types";
 
 import { QueryKey } from "./books";
+import { QueryKey as ChaptersQueryKey } from "./chapters";
 
 export type RescanMode = "scan" | "refresh" | "reset";
 
@@ -37,7 +38,7 @@ export const useResyncFile = () => {
         payload,
       );
     },
-    onSuccess: (result) => {
+    onSuccess: (result, { fileId }) => {
       // If not deleted, invalidate queries to refresh data
       if (!("file_deleted" in result && result.file_deleted)) {
         const file = result as File;
@@ -46,6 +47,9 @@ export const useResyncFile = () => {
         });
       }
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListBooks] });
+      queryClient.invalidateQueries({
+        queryKey: [ChaptersQueryKey.FileChapters, fileId],
+      });
     },
   });
 };
@@ -72,6 +76,9 @@ export const useResyncBook = () => {
         queryKey: [QueryKey.RetrieveBook, String(bookId)],
       });
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListBooks] });
+      queryClient.invalidateQueries({
+        queryKey: [ChaptersQueryKey.FileChapters],
+      });
     },
   });
 };

--- a/pkg/chapters/service.go
+++ b/pkg/chapters/service.go
@@ -12,15 +12,20 @@ import (
 
 // ShouldUpdateChapters determines if chapters should be updated based on priority rules.
 // Returns true if the new chapters should replace existing ones.
+//
+// When forceRefresh is true, sidecar-sourced chapters are skipped so that the
+// embedded file metadata wins — matching the convention used by
+// shouldApplySidecarScalar / shouldApplySidecarRelationship in pkg/worker.
+// All non-sidecar sources still apply unconditionally under forceRefresh.
 func ShouldUpdateChapters(newChapters []mediafile.ParsedChapter, newSource string, existingSource *string, forceRefresh bool) bool {
 	// Never update with empty chapters
 	if len(newChapters) == 0 {
 		return false
 	}
 
-	// Force refresh bypasses priority checks
 	if forceRefresh {
-		return true
+		// Skip sidecar so embedded file metadata wins; everything else applies.
+		return newSource != models.DataSourceSidecar
 	}
 
 	// Treat nil/empty existing source as filepath priority (lowest priority)

--- a/pkg/chapters/service_test.go
+++ b/pkg/chapters/service_test.go
@@ -1,0 +1,112 @@
+package chapters
+
+import (
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/mediafile"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldUpdateChapters(t *testing.T) {
+	t.Parallel()
+
+	href := "ch1.xhtml"
+	chapters := []mediafile.ParsedChapter{{Title: "Chapter 1", Href: &href}}
+
+	manualSource := models.DataSourceManual
+	sidecarSource := models.DataSourceSidecar
+	pluginSource := models.DataSourcePluginPrefix + "test"
+	m4bSource := models.DataSourceM4BMetadata
+	filepathSource := models.DataSourceFilepath
+
+	tests := []struct {
+		name           string
+		chapters       []mediafile.ParsedChapter
+		newSource      string
+		existingSource *string
+		forceRefresh   bool
+		want           bool
+	}{
+		{
+			name:           "empty chapters never apply",
+			chapters:       nil,
+			newSource:      m4bSource,
+			existingSource: nil,
+			forceRefresh:   true,
+			want:           false,
+		},
+		{
+			name:           "force refresh + file source overrides manual",
+			chapters:       chapters,
+			newSource:      m4bSource,
+			existingSource: &manualSource,
+			forceRefresh:   true,
+			want:           true,
+		},
+		{
+			name:           "force refresh + sidecar source is skipped (matches scalar/relationship convention)",
+			chapters:       chapters,
+			newSource:      sidecarSource,
+			existingSource: &m4bSource,
+			forceRefresh:   true,
+			want:           false,
+		},
+		{
+			name:           "force refresh + plugin source applies",
+			chapters:       chapters,
+			newSource:      pluginSource,
+			existingSource: &manualSource,
+			forceRefresh:   true,
+			want:           true,
+		},
+		{
+			name:           "no force refresh: higher priority sidecar overrides file metadata",
+			chapters:       chapters,
+			newSource:      sidecarSource,
+			existingSource: &m4bSource,
+			forceRefresh:   false,
+			want:           true,
+		},
+		{
+			name:           "no force refresh: lower priority file metadata cannot override manual",
+			chapters:       chapters,
+			newSource:      m4bSource,
+			existingSource: &manualSource,
+			forceRefresh:   false,
+			want:           false,
+		},
+		{
+			name:           "no force refresh: equal priority sources can replace (≤)",
+			chapters:       chapters,
+			newSource:      m4bSource,
+			existingSource: &m4bSource,
+			forceRefresh:   false,
+			want:           true,
+		},
+		{
+			name:           "no force refresh: nil existing source treated as filepath (lowest)",
+			chapters:       chapters,
+			newSource:      m4bSource,
+			existingSource: nil,
+			forceRefresh:   false,
+			want:           true,
+		},
+		{
+			name:           "no force refresh: filepath source cannot replace filepath (equal allowed)",
+			chapters:       chapters,
+			newSource:      filepathSource,
+			existingSource: &filepathSource,
+			forceRefresh:   false,
+			want:           true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ShouldUpdateChapters(tt.chapters, tt.newSource, tt.existingSource, tt.forceRefresh)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -513,11 +513,7 @@ func (w *Worker) scanFileByID(ctx context.Context, opts ScanOptions, cache *Scan
 	// it when:
 	//   - Reset mode handles its own wipe via resetBookFileState below.
 	//   - Refresh mode ("re-scan as if this were the first time") — wipe so
-	//     re-derivation from file/plugins actually takes effect. Note that
-	//     scalar/relationship sidecar applies are short-circuited by
-	//     forceRefresh in scan_helpers.go, but chapters.ShouldUpdateChapters
-	//     does NOT short-circuit on forceRefresh, so this deletion is the
-	//     load-bearing fix for chapters in Refresh mode specifically.
+	//     re-derivation from file/plugins actually takes effect.
 	//   - Scan mode when the file on disk has changed since we last recorded
 	//     its size/mtime — the cached sidecar is stale extraction data and
 	//     would mask the new file's metadata.
@@ -2667,7 +2663,7 @@ func removeFileSidecar(filePath string, logWarn func(msg string, data logger.Dat
 // removeBookSidecar deletes the book sidecar for a book. Mirrors the
 // anchor-resolution logic in resolveBookSidecarAnchor: prefers book.Filepath
 // when it resolves to an existing directory, otherwise falls back to file
-// paths (covers root-level books whose synthetic organized book.Filepath
+// anchors (covers root-level books whose synthetic organized book.Filepath
 // never exists on disk). ENOENT is silent; other errors are logged via
 // logWarn.
 func removeBookSidecar(book *models.Book, logWarn func(msg string, data logger.Data)) {
@@ -2693,8 +2689,9 @@ func removeBookSidecar(book *models.Book, logWarn func(msg string, data logger.D
 		}
 	}
 	// book.Filepath isn't a real directory — fall back to file anchors used
-	// by root-level books with synthetic organized paths.
-	tryRemove(book.Filepath)
+	// by root-level books with synthetic organized paths. Skip the redundant
+	// retry on book.Filepath itself; we already established it doesn't anchor
+	// a real sidecar location.
 	for _, f := range book.Files {
 		if f != nil {
 			tryRemove(f.Filepath)
@@ -3966,9 +3963,7 @@ func (w *Worker) resetBookState(ctx context.Context, book *models.Book) error {
 // per-file.
 func (w *Worker) resetBookFileState(ctx context.Context, book *models.Book, file *models.File, skipBookWipe bool) error {
 	log := logger.FromContext(ctx)
-	logWarn := func(msg string, data logger.Data) {
-		log.Warn(msg, data)
-	}
+	logWarn := func(msg string, data logger.Data) { log.Warn(msg, data) }
 	if !skipBookWipe {
 		if err := w.resetBookState(ctx, book); err != nil {
 			return errors.Wrap(err, "failed to reset book state")

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -506,6 +506,31 @@ func (w *Worker) scanFileByID(ctx context.Context, opts ScanOptions, cache *Scan
 		logWarn("failed to recover missing cover", logger.Data{"file_id": file.ID, "error": err.Error()})
 	}
 
+	// Decide whether the cached file sidecar should be discarded before
+	// scanFileCore reads it. The sidecar overrides file metadata (sidecar has
+	// higher priority), so a stale sidecar from a previous scan will revert
+	// freshly-extracted values (chapters, narrators, identifiers, etc.). Drop
+	// it when:
+	//   - Reset mode handles its own wipe via resetBookFileState below.
+	//   - Refresh mode ("re-scan as if this were the first time") — wipe so
+	//     re-derivation from file/plugins actually takes effect.
+	//   - Scan mode when the file on disk has changed since we last recorded
+	//     its size/mtime — the cached sidecar is stale extraction data and
+	//     would mask the new file's metadata.
+	if !opts.Reset && file.FileRole != models.FileRoleSupplement {
+		// Only treat the file as "swapped" on positive evidence of change. A
+		// nil FileModifiedAt means we don't know — could be a pre-migration
+		// row whose sidecar we shouldn't discard.
+		fileSwapped := file.FileModifiedAt != nil &&
+			(fileStat.Size() != file.FilesizeBytes ||
+				!fileStat.ModTime().Truncate(time.Second).Equal(file.FileModifiedAt.Truncate(time.Second)))
+		if opts.ForceRefresh || fileSwapped {
+			if sidecarPath := sidecar.FileSidecarPath(file.Filepath); sidecarPath != "" {
+				_ = os.Remove(sidecarPath)
+			}
+		}
+	}
+
 	// File exists on disk - parse metadata
 	// For supplements (PDF, txt, etc.), derive minimal metadata from filename since they don't have embedded metadata
 	var metadata *mediafile.ParsedMetadata
@@ -3876,6 +3901,22 @@ func (w *Worker) resetBookFileState(ctx context.Context, book *models.Book, file
 		if err := w.resetBookState(ctx, book); err != nil {
 			return errors.Wrap(err, "failed to reset book state")
 		}
+		// Remove the book sidecar so previously-written values (subtitle,
+		// description, authors, etc.) don't get re-applied as higher-priority
+		// "sidecar" data on the next scan. The sidecar is rewritten at the end
+		// of the scan with the freshly-derived state.
+		if anchor := book.Filepath; anchor != "" {
+			if sidecarPath := sidecar.BookSidecarPath(anchor); sidecarPath != "" {
+				_ = os.Remove(sidecarPath)
+			}
+		}
+		// Also try the file-anchored location used for root-level books whose
+		// book.Filepath is a synthetic organized path that never exists on disk.
+		if file != nil && file.Filepath != "" {
+			if sidecarPath := sidecar.BookSidecarPath(file.Filepath); sidecarPath != "" {
+				_ = os.Remove(sidecarPath)
+			}
+		}
 	}
 
 	// --- File-level columns ---
@@ -3936,6 +3977,16 @@ func (w *Worker) resetBookFileState(ctx context.Context, book *models.Book, file
 	}
 	if err := w.chapterService.DeleteChaptersForFile(ctx, file.ID); err != nil {
 		return errors.Wrap(err, "failed to delete file chapters")
+	}
+
+	// Remove the file sidecar so previously-written values (chapters,
+	// narrators, identifiers, etc.) don't get re-applied as higher-priority
+	// "sidecar" data on the next scan. The sidecar is rewritten at the end of
+	// the scan with the freshly-derived state.
+	if file.Filepath != "" {
+		if sidecarPath := sidecar.FileSidecarPath(file.Filepath); sidecarPath != "" {
+			_ = os.Remove(sidecarPath)
+		}
 	}
 
 	return nil

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -513,7 +513,11 @@ func (w *Worker) scanFileByID(ctx context.Context, opts ScanOptions, cache *Scan
 	// it when:
 	//   - Reset mode handles its own wipe via resetBookFileState below.
 	//   - Refresh mode ("re-scan as if this were the first time") — wipe so
-	//     re-derivation from file/plugins actually takes effect.
+	//     re-derivation from file/plugins actually takes effect. Note that
+	//     scalar/relationship sidecar applies are short-circuited by
+	//     forceRefresh in scan_helpers.go, but chapters.ShouldUpdateChapters
+	//     does NOT short-circuit on forceRefresh, so this deletion is the
+	//     load-bearing fix for chapters in Refresh mode specifically.
 	//   - Scan mode when the file on disk has changed since we last recorded
 	//     its size/mtime — the cached sidecar is stale extraction data and
 	//     would mask the new file's metadata.
@@ -525,9 +529,7 @@ func (w *Worker) scanFileByID(ctx context.Context, opts ScanOptions, cache *Scan
 			(fileStat.Size() != file.FilesizeBytes ||
 				!fileStat.ModTime().Truncate(time.Second).Equal(file.FileModifiedAt.Truncate(time.Second)))
 		if opts.ForceRefresh || fileSwapped {
-			if sidecarPath := sidecar.FileSidecarPath(file.Filepath); sidecarPath != "" {
-				_ = os.Remove(sidecarPath)
-			}
+			removeFileSidecar(file.Filepath, logWarn)
 		}
 	}
 
@@ -710,6 +712,17 @@ func (w *Worker) scanBook(ctx context.Context, opts ScanOptions, cache *ScanCach
 		if err := w.resetBookState(ctx, book); err != nil {
 			return nil, errors.Wrap(err, "failed to reset book state")
 		}
+	}
+
+	// Drop the book sidecar so previously-cached book-level fields (subtitle,
+	// description, authors, etc.) don't get re-applied as higher-priority
+	// "sidecar" data on the next scan. Done once at the book level rather
+	// than per-file because the book sidecar is shared across files. Fires in
+	// Reset (matches the wipe semantics) and Refresh ("as if first time")
+	// modes — Scan mode preserves the sidecar since other files in the book
+	// may not have changed.
+	if opts.Reset || opts.ForceRefresh {
+		removeBookSidecar(book, logWarn)
 	}
 
 	// Initialize file results
@@ -2634,6 +2647,51 @@ func deriveInitialTitle(path string, isRootLevelFile bool, metadata *mediafile.P
 	return title
 }
 
+// removeFileSidecar deletes the file sidecar at filePath. ENOENT is silent;
+// other errors are logged via logWarn. Used when the cached sidecar is known
+// to be stale (file replaced, Reset/Refresh requested) so that fresh scan
+// results aren't re-overridden by old sidecar data.
+func removeFileSidecar(filePath string, logWarn func(msg string, data logger.Data)) {
+	if filePath == "" {
+		return
+	}
+	sidecarPath := sidecar.FileSidecarPath(filePath)
+	if sidecarPath == "" {
+		return
+	}
+	if err := os.Remove(sidecarPath); err != nil && !os.IsNotExist(err) {
+		logWarn("failed to remove stale file sidecar", logger.Data{"path": sidecarPath, "error": err.Error()})
+	}
+}
+
+// removeBookSidecar deletes the book sidecar for a book. Tries both the
+// directory-anchored path and the file-anchored fallback used for root-level
+// books with a synthetic organized book.Filepath that never exists on disk.
+// ENOENT is silent; other errors are logged via logWarn.
+func removeBookSidecar(book *models.Book, logWarn func(msg string, data logger.Data)) {
+	tryRemove := func(anchor string) {
+		if anchor == "" {
+			return
+		}
+		sidecarPath := sidecar.BookSidecarPath(anchor)
+		if sidecarPath == "" {
+			return
+		}
+		if err := os.Remove(sidecarPath); err != nil && !os.IsNotExist(err) {
+			logWarn("failed to remove stale book sidecar", logger.Data{"path": sidecarPath, "error": err.Error()})
+		}
+	}
+	if book == nil {
+		return
+	}
+	tryRemove(book.Filepath)
+	for _, f := range book.Files {
+		if f != nil {
+			tryRemove(f.Filepath)
+		}
+	}
+}
+
 // applyFilepathFallbacks populates empty metadata fields from the filepath.
 // This fills in title, authors, narrators, and series using the same logic
 // that scanFileCreateNew uses when creating a book for the first time.
@@ -3897,26 +3955,15 @@ func (w *Worker) resetBookState(ctx context.Context, book *models.Book) error {
 // scanBook which handles the book-level wipe once for all files rather than
 // per-file.
 func (w *Worker) resetBookFileState(ctx context.Context, book *models.Book, file *models.File, skipBookWipe bool) error {
+	log := logger.FromContext(ctx)
+	logWarn := func(msg string, data logger.Data) {
+		log.Warn(msg, data)
+	}
 	if !skipBookWipe {
 		if err := w.resetBookState(ctx, book); err != nil {
 			return errors.Wrap(err, "failed to reset book state")
 		}
-		// Remove the book sidecar so previously-written values (subtitle,
-		// description, authors, etc.) don't get re-applied as higher-priority
-		// "sidecar" data on the next scan. The sidecar is rewritten at the end
-		// of the scan with the freshly-derived state.
-		if anchor := book.Filepath; anchor != "" {
-			if sidecarPath := sidecar.BookSidecarPath(anchor); sidecarPath != "" {
-				_ = os.Remove(sidecarPath)
-			}
-		}
-		// Also try the file-anchored location used for root-level books whose
-		// book.Filepath is a synthetic organized path that never exists on disk.
-		if file != nil && file.Filepath != "" {
-			if sidecarPath := sidecar.BookSidecarPath(file.Filepath); sidecarPath != "" {
-				_ = os.Remove(sidecarPath)
-			}
-		}
+		removeBookSidecar(book, logWarn)
 	}
 
 	// --- File-level columns ---
@@ -3983,11 +4030,7 @@ func (w *Worker) resetBookFileState(ctx context.Context, book *models.Book, file
 	// narrators, identifiers, etc.) don't get re-applied as higher-priority
 	// "sidecar" data on the next scan. The sidecar is rewritten at the end of
 	// the scan with the freshly-derived state.
-	if file.Filepath != "" {
-		if sidecarPath := sidecar.FileSidecarPath(file.Filepath); sidecarPath != "" {
-			_ = os.Remove(sidecarPath)
-		}
-	}
+	removeFileSidecar(file.Filepath, logWarn)
 
 	return nil
 }

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2664,10 +2664,12 @@ func removeFileSidecar(filePath string, logWarn func(msg string, data logger.Dat
 	}
 }
 
-// removeBookSidecar deletes the book sidecar for a book. Tries both the
-// directory-anchored path and the file-anchored fallback used for root-level
-// books with a synthetic organized book.Filepath that never exists on disk.
-// ENOENT is silent; other errors are logged via logWarn.
+// removeBookSidecar deletes the book sidecar for a book. Mirrors the
+// anchor-resolution logic in resolveBookSidecarAnchor: prefers book.Filepath
+// when it resolves to an existing directory, otherwise falls back to file
+// paths (covers root-level books whose synthetic organized book.Filepath
+// never exists on disk). ENOENT is silent; other errors are logged via
+// logWarn.
 func removeBookSidecar(book *models.Book, logWarn func(msg string, data logger.Data)) {
 	tryRemove := func(anchor string) {
 		if anchor == "" {
@@ -2684,6 +2686,14 @@ func removeBookSidecar(book *models.Book, logWarn func(msg string, data logger.D
 	if book == nil {
 		return
 	}
+	if book.Filepath != "" {
+		if info, err := os.Stat(book.Filepath); err == nil && info.IsDir() {
+			tryRemove(book.Filepath)
+			return
+		}
+	}
+	// book.Filepath isn't a real directory — fall back to file anchors used
+	// by root-level books with synthetic organized paths.
 	tryRemove(book.Filepath)
 	for _, f := range book.Files {
 		if f != nil {

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -5318,12 +5318,11 @@ func TestScanBook_ResetMode_DiscardsStaleBookSidecar(t *testing.T) {
 	// Manually plant a stale subtitle in the book sidecar. If the sidecar
 	// isn't dropped before scanFileCore runs, this stale value will be
 	// re-applied on top of the freshly-derived (empty) subtitle.
-	bookSidecarPath := sidecar.BookSidecarPath(bookDir)
-	require.NotEmpty(t, bookSidecarPath)
 	staleSubtitle := "Stale Subtitle From Old Sidecar"
 	require.NoError(t, sidecar.WriteBookSidecar(bookDir, &sidecar.BookSidecar{
 		Subtitle: &staleSubtitle,
 	}))
+	require.FileExists(t, sidecar.BookSidecarPath(bookDir), "planted book sidecar should be on disk before reset runs")
 
 	_, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
 		BookID:       bookID,

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/sidecar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -5048,10 +5049,9 @@ func TestScanFileByID_ScanMode_ReplacedFile_UsesNewChapters(t *testing.T) {
 	require.Len(t, files, 1)
 	fileID := files[0].ID
 
+	originalStat, err := os.Stat(m4bPath)
+	require.NoError(t, err)
 	require.NoError(t, os.Remove(m4bPath))
-	// Sleep briefly so the new file's mtime is at least a second later than
-	// the original (we compare with second precision to match SQLite storage).
-	time.Sleep(1100 * time.Millisecond)
 	testgen.GenerateM4B(t, bookDir, "book.m4b", testgen.M4BOptions{
 		Title:    "Scan Book",
 		Artist:   "Test Author",
@@ -5062,8 +5062,13 @@ func TestScanFileByID_ScanMode_ReplacedFile_UsesNewChapters(t *testing.T) {
 			{Title: "New C", Start: 20},
 		},
 	})
+	// Force the new file's mtime to be at least a second later than the
+	// original so the size/mtime change-detection in scanFileByID fires
+	// regardless of how fast the test ran.
+	newMtime := originalStat.ModTime().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(m4bPath, newMtime, newMtime))
 
-	_, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+	_, err = tc.worker.scanInternal(tc.ctx, ScanOptions{
 		FileID:       fileID,
 		ForceRefresh: false,
 		SkipPlugins:  false,
@@ -5285,6 +5290,52 @@ func TestScanBook_ResetMode_WipesBookOnce(t *testing.T) {
 
 	// Authors should be repopulated from EPUB
 	assert.NotEmpty(t, book.Authors, "authors should be repopulated after reset")
+}
+
+// Book-level Reset routes through scanBook, which calls scanFileByID with
+// BookResetDone=true — so the book-sidecar deletion in resetBookFileState's
+// !skipBookWipe branch never runs in this path. Verify scanBook itself drops
+// a stale book sidecar so its old fields don't get re-applied.
+func TestScanBook_ResetMode_DiscardsStaleBookSidecar(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author Name] Sidecar Reset Book")
+	testgen.GenerateEPUB(t, bookDir, "file1.epub", testgen.EPUBOptions{
+		Title:   "Sidecar Reset Book",
+		Authors: []string{"Author Name"},
+	})
+
+	require.NoError(t, tc.runScan())
+
+	allBooks := tc.listBooks()
+	require.Len(t, allBooks, 1)
+	bookID := allBooks[0].ID
+
+	// Manually plant a stale subtitle in the book sidecar. If the sidecar
+	// isn't dropped before scanFileCore runs, this stale value will be
+	// re-applied on top of the freshly-derived (empty) subtitle.
+	bookSidecarPath := sidecar.BookSidecarPath(bookDir)
+	require.NotEmpty(t, bookSidecarPath)
+	staleSubtitle := "Stale Subtitle From Old Sidecar"
+	require.NoError(t, sidecar.WriteBookSidecar(bookDir, &sidecar.BookSidecar{
+		Subtitle: &staleSubtitle,
+	}))
+
+	_, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		BookID:       bookID,
+		ForceRefresh: true,
+		SkipPlugins:  true,
+		Reset:        true,
+	}, nil)
+	require.NoError(t, err)
+
+	book, err := tc.bookService.RetrieveBook(tc.ctx, books.RetrieveBookOptions{ID: &bookID})
+	require.NoError(t, err)
+	assert.Nil(t, book.Subtitle, "stale subtitle from book sidecar must not survive book-level reset")
 }
 
 func TestScanFileCore_Title_PluginSource_NotVolumeNormalized(t *testing.T) {

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -4925,6 +4925,218 @@ func TestScanFileByID_ResetMode_ClearsNonFileMetadata(t *testing.T) {
 	assert.FileExists(t, newCoverPath, "new cover file should exist on disk after reset")
 }
 
+func TestScanFileByID_ResetMode_ReExtractsChapters(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Test Author] Chaptered Book")
+	testgen.GenerateM4B(t, bookDir, "chaptered.m4b", testgen.M4BOptions{
+		Title:    "Chaptered Book",
+		Artist:   "Test Author",
+		Duration: 30,
+		Chapters: []testgen.M4BChapter{
+			{Title: "Intro", Start: 0},
+			{Title: "Middle", Start: 10},
+			{Title: "End", Start: 20},
+		},
+	})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	fileID := files[0].ID
+
+	initialChapters := tc.listChapters(fileID)
+	require.Len(t, initialChapters, 3, "chapters should be extracted on initial scan")
+
+	result, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		FileID:       fileID,
+		ForceRefresh: true,
+		SkipPlugins:  true,
+		Reset:        true,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	chaptersAfterReset := tc.listChapters(fileID)
+	assert.Len(t, chaptersAfterReset, 3, "chapters should be re-extracted from file after reset")
+}
+
+// Refresh mode wipes the file sidecar so re-derivation from file/plugins
+// actually takes effect — otherwise the cached sidecar would override the new
+// file's chapters even with forceRefresh=true.
+func TestScanFileByID_RefreshMode_ReplacedFile_UsesNewChapters(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Test Author] Refresh Book")
+	m4bPath := testgen.GenerateM4B(t, bookDir, "book.m4b", testgen.M4BOptions{
+		Title:    "Refresh Book",
+		Artist:   "Test Author",
+		Duration: 30,
+		Chapters: []testgen.M4BChapter{
+			{Title: "Old A", Start: 0},
+			{Title: "Old B", Start: 15},
+		},
+	})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	fileID := files[0].ID
+
+	require.NoError(t, os.Remove(m4bPath))
+	testgen.GenerateM4B(t, bookDir, "book.m4b", testgen.M4BOptions{
+		Title:    "Refresh Book",
+		Artist:   "Test Author",
+		Duration: 30,
+		Chapters: []testgen.M4BChapter{
+			{Title: "New A", Start: 0},
+			{Title: "New B", Start: 10},
+			{Title: "New C", Start: 20},
+		},
+	})
+
+	_, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		FileID:       fileID,
+		ForceRefresh: true,
+		SkipPlugins:  false,
+		Reset:        false,
+	}, nil)
+	require.NoError(t, err)
+
+	chaptersAfterRefresh := tc.listChapters(fileID)
+	require.Len(t, chaptersAfterRefresh, 3)
+	assert.Equal(t, "New A", chaptersAfterRefresh[0].Title)
+}
+
+// Scan mode wipes the file sidecar when the file on disk has changed since
+// the last scan (size/mtime differ). Without this, the stale sidecar would
+// mask the replaced file's metadata.
+func TestScanFileByID_ScanMode_ReplacedFile_UsesNewChapters(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Test Author] Scan Book")
+	m4bPath := testgen.GenerateM4B(t, bookDir, "book.m4b", testgen.M4BOptions{
+		Title:    "Scan Book",
+		Artist:   "Test Author",
+		Duration: 30,
+		Chapters: []testgen.M4BChapter{
+			{Title: "Old A", Start: 0},
+			{Title: "Old B", Start: 15},
+		},
+	})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	fileID := files[0].ID
+
+	require.NoError(t, os.Remove(m4bPath))
+	// Sleep briefly so the new file's mtime is at least a second later than
+	// the original (we compare with second precision to match SQLite storage).
+	time.Sleep(1100 * time.Millisecond)
+	testgen.GenerateM4B(t, bookDir, "book.m4b", testgen.M4BOptions{
+		Title:    "Scan Book",
+		Artist:   "Test Author",
+		Duration: 30,
+		Chapters: []testgen.M4BChapter{
+			{Title: "New A", Start: 0},
+			{Title: "New B", Start: 10},
+			{Title: "New C", Start: 20},
+		},
+	})
+
+	_, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		FileID:       fileID,
+		ForceRefresh: false,
+		SkipPlugins:  false,
+		Reset:        false,
+	}, nil)
+	require.NoError(t, err)
+
+	chaptersAfterScan := tc.listChapters(fileID)
+	require.Len(t, chaptersAfterScan, 3)
+	assert.Equal(t, "New A", chaptersAfterScan[0].Title)
+}
+
+// Reproduces a real-world reset bug: user replaces a file on disk with one that
+// has different chapters, then rescans with reset-to-file-metadata. The new
+// file's chapters should win — but the stale sidecar (written during the
+// initial scan) holds the old chapter list and overrides them because sidecar
+// has higher priority than file metadata.
+func TestScanFileByID_ResetMode_ReplacedFile_UsesNewChapters(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Test Author] Replaced Book")
+	m4bPath := testgen.GenerateM4B(t, bookDir, "book.m4b", testgen.M4BOptions{
+		Title:    "Replaced Book",
+		Artist:   "Test Author",
+		Duration: 30,
+		Chapters: []testgen.M4BChapter{
+			{Title: "Bad 1", Start: 0},
+			{Title: "Bad 2", Start: 15},
+		},
+	})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	fileID := files[0].ID
+
+	initialChapters := tc.listChapters(fileID)
+	require.Len(t, initialChapters, 2)
+	require.Equal(t, "Bad 1", initialChapters[0].Title)
+
+	require.NoError(t, os.Remove(m4bPath))
+	testgen.GenerateM4B(t, bookDir, "book.m4b", testgen.M4BOptions{
+		Title:    "Replaced Book",
+		Artist:   "Test Author",
+		Duration: 30,
+		Chapters: []testgen.M4BChapter{
+			{Title: "Good 1", Start: 0},
+			{Title: "Good 2", Start: 10},
+			{Title: "Good 3", Start: 20},
+		},
+	})
+
+	_, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		FileID:       fileID,
+		ForceRefresh: true,
+		SkipPlugins:  true,
+		Reset:        true,
+	}, nil)
+	require.NoError(t, err)
+
+	chaptersAfterReset := tc.listChapters(fileID)
+	require.Len(t, chaptersAfterReset, 3, "should pick up the 3 new chapters from the replaced file")
+	assert.Equal(t, "Good 1", chaptersAfterReset[0].Title)
+	assert.Equal(t, "Good 2", chaptersAfterReset[1].Title)
+	assert.Equal(t, "Good 3", chaptersAfterReset[2].Title)
+}
+
 func TestScanFileByID_ResetMode_FilepathFallbackTitle(t *testing.T) {
 	t.Parallel()
 	tc := newTestContext(t)

--- a/website/docs/sidecar-files.md
+++ b/website/docs/sidecar-files.md
@@ -144,9 +144,9 @@ This means:
 
 The **Rescan** dialog on a book or file offers three modes that interact with sidecars differently:
 
-- **Scan for new metadata** — Reads file metadata and runs plugins. Sidecar values are applied as usual according to the priority system. Won't overwrite manual edits.
-- **Refresh all metadata** — Re-reads file metadata and runs plugins, bypassing the priority system. Sidecar values are skipped. Overwrites all fields including manual edits.
-- **Reset to file metadata** — Re-reads only the metadata embedded in the source file(s), skipping both plugins and sidecars. Use this when plugin enrichment has matched incorrectly and you want to start fresh with just what's in the file.
+- **Scan for new metadata** — Reads file metadata and runs plugins. Sidecar values are applied as usual according to the priority system. Won't overwrite manual edits. If the underlying file has been replaced on disk (its size or modification time differs from what was last scanned), the cached file sidecar is dropped first so the new file's metadata takes effect instead of being masked by the old sidecar.
+- **Refresh all metadata** — Re-reads file metadata and runs plugins, bypassing the priority system. Cached sidecars are dropped before the scan runs so re-derivation actually takes effect; manual edits stored in the database are still subject to being overwritten by the fresh scan since this mode bypasses priority. The sidecar is rewritten from the new state at the end of the scan.
+- **Reset to file metadata** — Re-reads only the metadata embedded in the source file(s), skipping plugins. Cached sidecars are dropped along with the rest of the prior metadata state. Use this when plugin enrichment has matched incorrectly and you want to start fresh with just what's in the file.
 
 ## When Sidecars Are Read
 


### PR DESCRIPTION
## Summary
- File sidecars override file metadata in source priority, so replacing a file on disk and rescanning silently kept the old extracted values (chapters, narrators, identifiers, etc.). Reset, Refresh, and Scan modes were all affected — only Reset is conceptually a "wipe everything" mode, but all three should pick up new file content after a swap.
- `resetBookFileState` now deletes both file and book sidecars. `scanFileByID` deletes the file sidecar in Refresh mode (always — matches "as if first time" and lets plugin re-enrichment actually take effect) and in Scan mode when `size`/`mtime` differ from the DB record (positive evidence of file replacement). End-of-scan rewrites regenerate sidecars from current DB state, so manual edits stored with manual source priority survive through the DB regardless.
- `useResyncFile` / `useResyncBook` now invalidate the `FileChapters` query so the chapters tab actually refetches after a rescan instead of showing the pre-rescan cache.

## Test plan
- Unit: `TestScanFileByID_ResetMode_ReplacedFile_UsesNewChapters`, `TestScanFileByID_RefreshMode_ReplacedFile_UsesNewChapters`, `TestScanFileByID_ScanMode_ReplacedFile_UsesNewChapters` — all three new tests fail without the fix and pass with it.
- Existing: `TestScanFileByID_ResetMode_ClearsNonFileMetadata`, `TestScanFileByID_ResetMode_FilepathFallbackTitle`, `TestScanFileByID_ResetMode_ReExtractsChapters` still pass.
- Manual: scan a file with chapters, replace the file on disk with one that has different chapters, click Rescan → "Reset to file metadata" / "Refresh all metadata" / "Scan for new metadata" → chapters tab should show the new chapters.