### PR TITLE
[Backend] Cache successful Basic Auth results to speed up OPDS

### DIFF
--- a/pkg/auth/basic_auth_cache.go
+++ b/pkg/auth/basic_auth_cache.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"sync"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// defaultBasicAuthCacheTTL bounds how long a successful Basic Auth result is
+// reused before re-running bcrypt + the user lookup. OPDS clients re-send
+// credentials on every request, so without this cache each click pays the
+// full bcrypt cost. The trade-off: a deactivated user or rotated password
+// remains usable for OPDS for up to this window.
+const defaultBasicAuthCacheTTL = 60 * time.Second
+
+type basicAuthCacheEntry struct {
+	user      *models.User
+	expiresAt time.Time
+}
+
+type basicAuthCache struct {
+	mu      sync.Mutex
+	entries map[string]basicAuthCacheEntry
+	ttl     time.Duration
+}
+
+func newBasicAuthCache(ttl time.Duration) *basicAuthCache {
+	return &basicAuthCache{
+		entries: make(map[string]basicAuthCacheEntry),
+		ttl:     ttl,
+	}
+}
+
+func (c *basicAuthCache) get(key string) (*models.User, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, key)
+		return nil, false
+	}
+	return entry.user, true
+}
+
+func (c *basicAuthCache) put(key string, user *models.User) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = basicAuthCacheEntry{
+		user:      user,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+// basicAuthCacheKey derives a cache key from the credentials without holding
+// the plaintext password in memory. The username is kept verbatim and
+// concatenated through ":" — already the Basic Auth separator, so it cannot
+// appear in the username — guaranteeing distinct (user, password) pairs map
+// to distinct keys.
+func basicAuthCacheKey(username, password string) string {
+	sum := sha256.Sum256([]byte(password))
+	return username + ":" + base64.RawStdEncoding.EncodeToString(sum[:])
+}

--- a/pkg/auth/basic_auth_cache.go
+++ b/pkg/auth/basic_auth_cache.go
@@ -12,8 +12,8 @@ import (
 // defaultBasicAuthCacheTTL bounds how long a successful Basic Auth result is
 // reused before re-running bcrypt + the user lookup. OPDS clients re-send
 // credentials on every request, so without this cache each click pays the
-// full bcrypt cost. The trade-off: a deactivated user or rotated password
-// remains usable for OPDS for up to this window.
+// full bcrypt cost. Trade-off: a deactivated user, rotated password, or
+// changed role/library-access stays in effect on OPDS for up to this window.
 const defaultBasicAuthCacheTTL = 60 * time.Second
 
 type basicAuthCacheEntry struct {
@@ -21,6 +21,16 @@ type basicAuthCacheEntry struct {
 	expiresAt time.Time
 }
 
+// basicAuthCache caches successful Basic Auth results keyed by
+// (username, sha256(password)). Eviction is lazy — entries are dropped on
+// the next get() for that key. Memory growth is bounded by the number of
+// distinct (user, password) pairs that successfully authenticate, so stale
+// entries from password rotation linger at most until process restart but
+// cannot grow unboundedly under attacker control (failed auths are not
+// cached).
+//
+// The cached *models.User is shared across concurrent callers — treat it
+// as read-only.
 type basicAuthCache struct {
 	mu      sync.Mutex
 	entries map[string]basicAuthCacheEntry
@@ -49,6 +59,9 @@ func (c *basicAuthCache) get(key string) (*models.User, bool) {
 }
 
 func (c *basicAuthCache) put(key string, user *models.User) {
+	if user == nil {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.entries[key] = basicAuthCacheEntry{
@@ -57,11 +70,11 @@ func (c *basicAuthCache) put(key string, user *models.User) {
 	}
 }
 
-// basicAuthCacheKey derives a cache key from the credentials without holding
-// the plaintext password in memory. The username is kept verbatim and
-// concatenated through ":" — already the Basic Auth separator, so it cannot
-// appear in the username — guaranteeing distinct (user, password) pairs map
-// to distinct keys.
+// basicAuthCacheKey derives a cache key without retaining the plaintext
+// password in memory. Distinct (username, password) pairs map to distinct
+// keys: the username arrives here from strings.SplitN(decoded, ":", 2) in
+// BasicAuth, so by construction it cannot contain a ":" — making
+// `username + ":" + sha256(password)` an unambiguous concatenation.
 func basicAuthCacheKey(username, password string) string {
 	sum := sha256.Sum256([]byte(password))
 	return username + ":" + base64.RawStdEncoding.EncodeToString(sum[:])

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -23,13 +23,15 @@ const (
 
 // Middleware provides authentication middleware.
 type Middleware struct {
-	authService *Service
+	authService    *Service
+	basicAuthCache *basicAuthCache
 }
 
 // NewMiddleware creates a new auth middleware.
 func NewMiddleware(authService *Service) *Middleware {
 	return &Middleware{
-		authService: authService,
+		authService:    authService,
+		basicAuthCache: newBasicAuthCache(defaultBasicAuthCacheTTL),
 	}
 }
 
@@ -168,9 +170,20 @@ func (m *Middleware) BasicAuth(next echo.HandlerFunc) echo.HandlerFunc {
 		username := parts[0]
 		password := parts[1]
 
-		user, err := m.authService.Authenticate(ctx, username, password)
-		if err != nil {
-			return respondBasicAuthRequired(c)
+		cacheKey := basicAuthCacheKey(username, password)
+		user, ok := m.basicAuthCache.get(cacheKey)
+		if !ok {
+			authed, authErr := m.authService.Authenticate(ctx, username, password)
+			if authErr != nil {
+				return respondBasicAuthRequired(c)
+			}
+			user = authed
+			// Skip caching while a password reset is required so that
+			// completing the reset takes effect on the very next OPDS hit
+			// without waiting for the TTL.
+			if !user.MustChangePassword {
+				m.basicAuthCache.put(cacheKey, user)
+			}
 		}
 		if user.MustChangePassword {
 			return respondBasicAuthRequired(c)

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -169,6 +169,163 @@ func TestMiddlewareAuthenticate_BlocksCrossUserPasswordReset(t *testing.T) {
 	assert.Equal(t, "password_reset_required", codeErr.Code)
 }
 
+func TestMiddlewareBasicAuth_CachesSuccessfulAuth(t *testing.T) {
+	t.Parallel()
+
+	db := setupMiddlewareDB(t)
+	authService := NewService(db, "test-secret", 30*24*time.Hour)
+	middleware := NewMiddleware(authService)
+	ctx := context.Background()
+
+	role := new(models.Role)
+	require.NoError(t, db.NewSelect().Model(role).Where("name = ?", models.RoleViewer).Scan(ctx))
+
+	hashed, err := HashPassword("password1")
+	require.NoError(t, err)
+	user := &models.User{
+		Username:     "cacheuser",
+		PasswordHash: hashed,
+		RoleID:       role.ID,
+		IsActive:     true,
+	}
+	_, err = db.NewInsert().Model(user).Exec(ctx)
+	require.NoError(t, err)
+
+	access := &models.UserLibraryAccess{UserID: user.ID, LibraryID: nil}
+	_, err = db.NewInsert().Model(access).Exec(ctx)
+	require.NoError(t, err)
+
+	doRequest := func() (called bool, status int) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/opds/catalog", nil)
+		req.SetBasicAuth("cacheuser", "password1")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := middleware.BasicAuth(func(_ echo.Context) error {
+			called = true
+			return nil
+		})(c)
+		require.NoError(t, err)
+		return called, rec.Code
+	}
+
+	called, _ := doRequest()
+	require.True(t, called, "first request should authenticate")
+
+	// Break the password hash in the DB. If the cache is working, the next
+	// request still succeeds because it never touches the DB or bcrypt.
+	_, err = db.NewUpdate().
+		Model((*models.User)(nil)).
+		Set("password_hash = ?", "$2a$12$broken.hash.that.cannot.match.any.password.at.all.aaaaaaaaaaa").
+		Where("id = ?", user.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	called, _ = doRequest()
+	assert.True(t, called, "second request should hit the cache and succeed despite invalidated DB hash")
+}
+
+func TestMiddlewareBasicAuth_CacheRespectsTTL(t *testing.T) {
+	t.Parallel()
+
+	db := setupMiddlewareDB(t)
+	authService := NewService(db, "test-secret", 30*24*time.Hour)
+	middleware := NewMiddleware(authService)
+	middleware.basicAuthCache = newBasicAuthCache(20 * time.Millisecond)
+	ctx := context.Background()
+
+	role := new(models.Role)
+	require.NoError(t, db.NewSelect().Model(role).Where("name = ?", models.RoleViewer).Scan(ctx))
+
+	hashed, err := HashPassword("password1")
+	require.NoError(t, err)
+	user := &models.User{
+		Username:     "ttluser",
+		PasswordHash: hashed,
+		RoleID:       role.ID,
+		IsActive:     true,
+	}
+	_, err = db.NewInsert().Model(user).Exec(ctx)
+	require.NoError(t, err)
+
+	access := &models.UserLibraryAccess{UserID: user.ID, LibraryID: nil}
+	_, err = db.NewInsert().Model(access).Exec(ctx)
+	require.NoError(t, err)
+
+	doRequest := func() (called bool, status int) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/opds/catalog", nil)
+		req.SetBasicAuth("ttluser", "password1")
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		err := middleware.BasicAuth(func(_ echo.Context) error {
+			called = true
+			return nil
+		})(c)
+		require.NoError(t, err)
+		return called, rec.Code
+	}
+
+	called, _ := doRequest()
+	require.True(t, called)
+
+	// Break the hash and wait for the cache entry to expire.
+	_, err = db.NewUpdate().
+		Model((*models.User)(nil)).
+		Set("password_hash = ?", "$2a$12$broken.hash.that.cannot.match.any.password.at.all.aaaaaaaaaaa").
+		Where("id = ?", user.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	time.Sleep(40 * time.Millisecond)
+
+	called, status := doRequest()
+	assert.False(t, called, "after TTL expiry the cache must miss and the broken hash should reject the request")
+	assert.Equal(t, http.StatusUnauthorized, status)
+}
+
+func TestMiddlewareBasicAuth_DoesNotCacheFailedAuth(t *testing.T) {
+	t.Parallel()
+
+	db := setupMiddlewareDB(t)
+	authService := NewService(db, "test-secret", 30*24*time.Hour)
+	middleware := NewMiddleware(authService)
+	ctx := context.Background()
+
+	role := new(models.Role)
+	require.NoError(t, db.NewSelect().Model(role).Where("name = ?", models.RoleViewer).Scan(ctx))
+
+	hashed, err := HashPassword("rightpassword")
+	require.NoError(t, err)
+	user := &models.User{
+		Username:     "neguser",
+		PasswordHash: hashed,
+		RoleID:       role.ID,
+		IsActive:     true,
+	}
+	_, err = db.NewInsert().Model(user).Exec(ctx)
+	require.NoError(t, err)
+
+	access := &models.UserLibraryAccess{UserID: user.ID, LibraryID: nil}
+	_, err = db.NewInsert().Model(access).Exec(ctx)
+	require.NoError(t, err)
+
+	doRequest := func(password string) int {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/opds/catalog", nil)
+		req.SetBasicAuth("neguser", password)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		require.NoError(t, middleware.BasicAuth(func(_ echo.Context) error { return nil })(c))
+		return rec.Code
+	}
+
+	assert.Equal(t, http.StatusUnauthorized, doRequest("wrong"))
+	assert.Equal(t, http.StatusOK, doRequest("rightpassword"))
+}
+
 func TestMiddlewareBasicAuth_RejectsWhenMustChangePassword(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -195,23 +195,23 @@ func TestMiddlewareBasicAuth_CachesSuccessfulAuth(t *testing.T) {
 	_, err = db.NewInsert().Model(access).Exec(ctx)
 	require.NoError(t, err)
 
-	doRequest := func() (called bool, status int) {
+	doRequest := func() bool {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/opds/catalog", nil)
 		req.SetBasicAuth("cacheuser", "password1")
 		rec := httptest.NewRecorder()
 		c := e.NewContext(req, rec)
 
+		called := false
 		err := middleware.BasicAuth(func(_ echo.Context) error {
 			called = true
 			return nil
 		})(c)
 		require.NoError(t, err)
-		return called, rec.Code
+		return called
 	}
 
-	called, _ := doRequest()
-	require.True(t, called, "first request should authenticate")
+	require.True(t, doRequest(), "first request should authenticate")
 
 	// Break the password hash in the DB. If the cache is working, the next
 	// request still succeeds because it never touches the DB or bcrypt.
@@ -222,8 +222,7 @@ func TestMiddlewareBasicAuth_CachesSuccessfulAuth(t *testing.T) {
 		Exec(ctx)
 	require.NoError(t, err)
 
-	called, _ = doRequest()
-	assert.True(t, called, "second request should hit the cache and succeed despite invalidated DB hash")
+	assert.True(t, doRequest(), "second request should hit the cache and succeed despite invalidated DB hash")
 }
 
 func TestMiddlewareBasicAuth_CacheRespectsTTL(t *testing.T) {
@@ -232,7 +231,7 @@ func TestMiddlewareBasicAuth_CacheRespectsTTL(t *testing.T) {
 	db := setupMiddlewareDB(t)
 	authService := NewService(db, "test-secret", 30*24*time.Hour)
 	middleware := NewMiddleware(authService)
-	middleware.basicAuthCache = newBasicAuthCache(20 * time.Millisecond)
+	middleware.basicAuthCache = newBasicAuthCache(100 * time.Millisecond)
 	ctx := context.Background()
 
 	role := new(models.Role)
@@ -279,7 +278,7 @@ func TestMiddlewareBasicAuth_CacheRespectsTTL(t *testing.T) {
 		Exec(ctx)
 	require.NoError(t, err)
 
-	time.Sleep(40 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	called, status := doRequest()
 	assert.False(t, called, "after TTL expiry the cache must miss and the broken hash should reject the request")
@@ -322,8 +321,25 @@ func TestMiddlewareBasicAuth_DoesNotCacheFailedAuth(t *testing.T) {
 		return rec.Code
 	}
 
+	require.Equal(t, http.StatusUnauthorized, doRequest("wrong"))
+
+	// The failed attempt above must not have inserted anything into the cache.
+	middleware.basicAuthCache.mu.Lock()
+	entries := len(middleware.basicAuthCache.entries)
+	middleware.basicAuthCache.mu.Unlock()
+	assert.Equal(t, 0, entries, "failed auth must not populate the cache")
+
+	// And the wrong password must keep getting rejected even after the DB hash
+	// is broken — i.e. the prior failure didn't poison the cache to "succeed"
+	// against a now-invalidated DB.
+	_, err = db.NewUpdate().
+		Model((*models.User)(nil)).
+		Set("password_hash = ?", "$2a$12$broken.hash.that.cannot.match.any.password.at.all.aaaaaaaaaaa").
+		Where("id = ?", user.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
 	assert.Equal(t, http.StatusUnauthorized, doRequest("wrong"))
-	assert.Equal(t, http.StatusOK, doRequest("rightpassword"))
 }
 
 func TestMiddlewareBasicAuth_RejectsWhenMustChangePassword(t *testing.T) {


### PR DESCRIPTION
## Summary
- OPDS clients re-send Basic Auth credentials on every request, so each catalog click was paying the full bcrypt cost (~200–300ms at cost 12) and dominating request latency.
- Cache verified users for 60s in `pkg/auth/middleware.go`, keyed by `username + ":" + sha256(password)` so plaintext never sits in memory; subsequent hits skip bcrypt and the user/role/library-access query entirely.
- Failed auth and `must_change_password` users are not cached, so password resets and lockouts take effect on the very next OPDS request rather than waiting for the TTL.

## Test plan
- `TZ=America/Chicago CI=true go test -race ./pkg/auth/` — covers cache hit (hash broken in DB mid-flight, second request still succeeds), TTL expiry (broken hash takes effect after sleep), failed auth not cached, and the existing `MustChangePassword` rejection path.
- Manually hit any OPDS endpoint (e.g. `/opds/v1/epub/catalog`) twice with the same Basic Auth credentials and confirm the second request is dramatically faster than the first.
- Confirm a deactivated/reset user is rejected on the next OPDS request after the password change (within ~60s of cache TTL).