### PR TITLE
[Fix] Encode non-ASCII filenames in Content-Disposition per RFC 5987

### DIFF
--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/genres"
 	"github.com/shishobooks/shisho/pkg/htmlutil"
+	"github.com/shishobooks/shisho/pkg/httputil"
 	"github.com/shishobooks/shisho/pkg/imprints"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/lists"
@@ -1767,8 +1768,7 @@ func (h *handler) downloadFile(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Set content disposition for download with the formatted filename
-	c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+downloadFilename+"\"")
+	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
 
 	return c.File(cachedPath)
 }
@@ -1802,9 +1802,8 @@ func (h *handler) downloadOriginalFile(c echo.Context) error {
 		return errcodes.NotFound("File not found on disk")
 	}
 
-	// Set content disposition for download with the original filename
 	filename := filepath.Base(file.Filepath)
-	c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	httputil.SetAttachmentFilename(c.Response(), filename)
 
 	return c.File(file.Filepath)
 }
@@ -1874,8 +1873,7 @@ func (h *handler) downloadKepubFile(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Set content disposition for download with the formatted filename
-	c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+downloadFilename+"\"")
+	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
 
 	return c.File(cachedPath)
 }

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
+	"github.com/shishobooks/shisho/pkg/httputil"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/people"
@@ -808,13 +809,13 @@ func (h *handler) DownloadFile(c echo.Context) error {
 				"error":     genErr.Message,
 			})
 			filename := filepath.Base(file.Filepath)
-			c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+			httputil.SetAttachmentFilename(c.Response(), filename)
 			return c.File(file.Filepath)
 		}
 		return errors.WithStack(err)
 	}
 
-	c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+downloadFilename+"\"")
+	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
 	return c.File(cachedPath)
 }
 
@@ -882,7 +883,7 @@ func (h *handler) DownloadFileKepub(c echo.Context) error {
 				"file_type": file.FileType,
 			})
 			filename := filepath.Base(file.Filepath)
-			c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+			httputil.SetAttachmentFilename(c.Response(), filename)
 			return c.File(file.Filepath)
 		}
 		var genErr *filegen.GenerationError
@@ -893,13 +894,13 @@ func (h *handler) DownloadFileKepub(c echo.Context) error {
 				"error":     genErr.Message,
 			})
 			filename := filepath.Base(file.Filepath)
-			c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+			httputil.SetAttachmentFilename(c.Response(), filename)
 			return c.File(file.Filepath)
 		}
 		return errors.WithStack(err)
 	}
 
-	c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+downloadFilename+"\"")
+	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
 	return c.File(cachedPath)
 }
 

--- a/pkg/httputil/contentdisposition.go
+++ b/pkg/httputil/contentdisposition.go
@@ -13,7 +13,8 @@ import (
 // For ASCII-only filenames, only the legacy quoted form is emitted. When the
 // filename contains anything outside printable ASCII, both a sanitized ASCII
 // fallback (filename=) and a percent-encoded UTF-8 form (filename*=) are
-// emitted; clients that understand filename* take precedence per RFC 6266 §4.3.
+// emitted; per RFC 6266 §4.3 modern clients prefer filename* while legacy
+// clients ignore the unknown parameter and use the ASCII fallback.
 //
 // This matters for OPDS clients like KOReader's "Use server filenames" mode,
 // which parses the header to name the downloaded file on the device.
@@ -60,6 +61,8 @@ func escapeQuoted(s string) string {
 
 // needsExtendedForm reports whether the filename contains any byte that
 // can't be represented losslessly in a printable-ASCII quoted-string.
+// Iterates runes, so invalid UTF-8 bytes (decoded as U+FFFD) also trigger
+// the extended form, matching the byte-level encoding done by percentEncode.
 func needsExtendedForm(s string) bool {
 	for _, r := range s {
 		if r < 0x20 || r > 0x7E {

--- a/pkg/httputil/contentdisposition.go
+++ b/pkg/httputil/contentdisposition.go
@@ -27,8 +27,9 @@ func SetAttachmentFilename(w http.ResponseWriter, filename string) {
 	w.Header().Set("Content-Disposition", header)
 }
 
-// asciiFallback strips bytes outside printable ASCII and tidies the result so
-// it is safe to drop into a quoted-string. Returns "download" if nothing
+// asciiFallback strips runes outside printable ASCII and tidies the result so
+// it is safe to drop into a quoted-string. Invalid UTF-8 decodes to U+FFFD
+// which is also out of range and gets stripped. Returns "download" if nothing
 // usable remains, and prepends "download" to results that would start with a
 // dot (e.g. "тест.epub" -> ".epub" -> "download.epub").
 func asciiFallback(s string) string {

--- a/pkg/httputil/contentdisposition.go
+++ b/pkg/httputil/contentdisposition.go
@@ -1,0 +1,101 @@
+// Package httputil provides small HTTP helpers shared across handlers.
+package httputil
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// SetAttachmentFilename writes a Content-Disposition: attachment header that
+// works across the spectrum of HTTP clients per RFC 6266 / RFC 5987.
+//
+// For ASCII-only filenames, only the legacy quoted form is emitted. When the
+// filename contains anything outside printable ASCII, both a sanitized ASCII
+// fallback (filename=) and a percent-encoded UTF-8 form (filename*=) are
+// emitted; clients that understand filename* take precedence per RFC 6266 §4.3.
+//
+// This matters for OPDS clients like KOReader's "Use server filenames" mode,
+// which parses the header to name the downloaded file on the device.
+func SetAttachmentFilename(w http.ResponseWriter, filename string) {
+	fallback := asciiFallback(filename)
+	header := `attachment; filename="` + escapeQuoted(fallback) + `"`
+	if needsExtendedForm(filename) {
+		header += "; filename*=UTF-8''" + percentEncode(filename)
+	}
+	w.Header().Set("Content-Disposition", header)
+}
+
+// asciiFallback strips bytes outside printable ASCII and tidies the result so
+// it is safe to drop into a quoted-string. Returns "download" if nothing
+// usable remains, and prepends "download" to results that would start with a
+// dot (e.g. "тест.epub" -> ".epub" -> "download.epub").
+func asciiFallback(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= 0x20 && r <= 0x7E {
+			b.WriteRune(r)
+		}
+	}
+	cleaned := strings.TrimSpace(b.String())
+	for strings.Contains(cleaned, "  ") {
+		cleaned = strings.ReplaceAll(cleaned, "  ", " ")
+	}
+	if cleaned == "" {
+		return "download"
+	}
+	if strings.HasPrefix(cleaned, ".") {
+		return "download" + cleaned
+	}
+	return cleaned
+}
+
+// escapeQuoted escapes backslashes and double quotes for use inside an
+// HTTP quoted-string (RFC 7230 §3.2.6).
+func escapeQuoted(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}
+
+// needsExtendedForm reports whether the filename contains any byte that
+// can't be represented losslessly in a printable-ASCII quoted-string.
+func needsExtendedForm(s string) bool {
+	for _, r := range s {
+		if r < 0x20 || r > 0x7E {
+			return true
+		}
+	}
+	return false
+}
+
+// percentEncode encodes a UTF-8 string per RFC 5987 attr-char rules: keep
+// alphanumerics and !#$&+-.^_`|~, percent-encode every other byte uppercase.
+func percentEncode(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isAttrChar(c) {
+			b.WriteByte(c)
+		} else {
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}
+
+func isAttrChar(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z':
+		return true
+	case c >= 'a' && c <= 'z':
+		return true
+	case c >= '0' && c <= '9':
+		return true
+	}
+	switch c {
+	case '!', '#', '$', '&', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	}
+	return false
+}

--- a/pkg/httputil/contentdisposition_test.go
+++ b/pkg/httputil/contentdisposition_test.go
@@ -1,0 +1,80 @@
+package httputil
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetAttachmentFilename(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filename string
+		expected string
+	}{
+		{
+			name:     "plain ASCII filename",
+			filename: "book.epub",
+			expected: `attachment; filename="book.epub"`,
+		},
+		{
+			name:     "ASCII with spaces",
+			filename: "[Author] Title.epub",
+			expected: `attachment; filename="[Author] Title.epub"`,
+		},
+		{
+			name:     "ASCII with backslash gets escaped",
+			filename: `weird\name.epub`,
+			expected: `attachment; filename="weird\\name.epub"`,
+		},
+		{
+			name:     "ASCII with double quote gets escaped",
+			filename: `say "hi".epub`,
+			expected: `attachment; filename="say \"hi\".epub"`,
+		},
+		{
+			name:     "Unicode filename emits both forms",
+			filename: "[著者] タイトル.epub",
+			expected: `attachment; filename="[] .epub"; filename*=UTF-8''%5B%E8%91%97%E8%80%85%5D%20%E3%82%BF%E3%82%A4%E3%83%88%E3%83%AB.epub`,
+		},
+		{
+			name:     "accented Latin emits both forms",
+			filename: "Café.epub",
+			expected: `attachment; filename="Caf.epub"; filename*=UTF-8''Caf%C3%A9.epub`,
+		},
+		{
+			name:     "unicode collapses internal whitespace in fallback",
+			filename: "A 漢 B.epub",
+			expected: `attachment; filename="A B.epub"; filename*=UTF-8''A%20%E6%BC%A2%20B.epub`,
+		},
+		{
+			name:     "ASCII control bytes are stripped from fallback",
+			filename: "book\x01.epub",
+			expected: `attachment; filename="book.epub"; filename*=UTF-8''book%01.epub`,
+		},
+		{
+			name:     "empty filename falls back to download",
+			filename: "",
+			expected: `attachment; filename="download"`,
+		},
+		{
+			name:     "all-unicode filename uses download fallback",
+			filename: "тест.epub",
+			expected: `attachment; filename="download.epub"; filename*=UTF-8''%D1%82%D0%B5%D1%81%D1%82.epub`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			SetAttachmentFilename(rec, tt.filename)
+
+			assert.Equal(t, tt.expected, rec.Header().Get("Content-Disposition"))
+		})
+	}
+}

--- a/pkg/httputil/contentdisposition_test.go
+++ b/pkg/httputil/contentdisposition_test.go
@@ -56,6 +56,16 @@ func TestSetAttachmentFilename(t *testing.T) {
 			expected: `attachment; filename="book.epub"; filename*=UTF-8''book%01.epub`,
 		},
 		{
+			name:     "DEL byte triggers extended form and is percent-encoded",
+			filename: "book\x7f.epub",
+			expected: `attachment; filename="book.epub"; filename*=UTF-8''book%7F.epub`,
+		},
+		{
+			name:     "CR/LF cannot inject extra headers",
+			filename: "a\r\nX-Evil: yes\r\nb.epub",
+			expected: `attachment; filename="aX-Evil: yesb.epub"; filename*=UTF-8''a%0D%0AX-Evil%3A%20yes%0D%0Ab.epub`,
+		},
+		{
 			name:     "empty filename falls back to download",
 			filename: "",
 			expected: `attachment; filename="download"`,

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/events"
+	"github.com/shishobooks/shisho/pkg/httputil"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
 )
@@ -198,7 +199,7 @@ func (h *handler) download(c echo.Context) error {
 	}
 
 	filename := fmt.Sprintf("shisho-download-%d-books.zip", data.FileCount)
-	c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	httputil.SetAttachmentFilename(c.Response(), filename)
 
 	return c.File(zipPath)
 }

--- a/pkg/kobo/handlers.go
+++ b/pkg/kobo/handlers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
+	"github.com/shishobooks/shisho/pkg/httputil"
 	"github.com/shishobooks/shisho/pkg/models"
 	"golang.org/x/image/draw"
 )
@@ -678,7 +679,7 @@ func getBaseURL(c echo.Context) string {
 // serveFileWithHeaders serves a file with proper Content-Type and Content-Disposition headers.
 func serveFileWithHeaders(c echo.Context, filepath, filename string) error {
 	c.Response().Header().Set("Content-Type", "application/octet-stream")
-	c.Response().Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	httputil.SetAttachmentFilename(c.Response(), filename)
 	return c.File(filepath)
 }
 

--- a/pkg/opds/handlers.go
+++ b/pkg/opds/handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
+	"github.com/shishobooks/shisho/pkg/httputil"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/settings"
 	"github.com/shishobooks/shisho/pkg/sortspec"
@@ -730,14 +731,13 @@ func (h *handler) download(c echo.Context) error {
 			})
 			// Fall back to original file
 			filename := filepath.Base(file.Filepath)
-			c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+			httputil.SetAttachmentFilename(c.Response(), filename)
 			return c.File(file.Filepath)
 		}
 		return errors.WithStack(err)
 	}
 
-	// Set content disposition for download with the formatted filename
-	c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+downloadFilename+"\"")
+	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
 
 	return c.File(cachedPath)
 }
@@ -801,7 +801,7 @@ func (h *handler) downloadKepub(c echo.Context) error {
 			})
 			// Fall back to original file for unsupported types (M4B)
 			filename := filepath.Base(file.Filepath)
-			c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+			httputil.SetAttachmentFilename(c.Response(), filename)
 			return c.File(file.Filepath)
 		}
 		// For other errors, also fall back to original
@@ -813,14 +813,13 @@ func (h *handler) downloadKepub(c echo.Context) error {
 				"error":     genErr.Message,
 			})
 			filename := filepath.Base(file.Filepath)
-			c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+			httputil.SetAttachmentFilename(c.Response(), filename)
 			return c.File(file.Filepath)
 		}
 		return errors.WithStack(err)
 	}
 
-	// Set content disposition for download with the formatted filename
-	c.Response().Header().Set("Content-Disposition", "attachment; filename=\""+downloadFilename+"\"")
+	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
 
 	return c.File(cachedPath)
 }


### PR DESCRIPTION
## Summary
- Add `httputil.SetAttachmentFilename` that emits Content-Disposition with both an ASCII fallback (`filename=`) and an RFC 5987 percent-encoded UTF-8 form (`filename*=UTF-8''`) per RFC 6266 §4.3.
- Route all 13 download endpoints through it (OPDS, books, ereader, jobs, kobo) so non-ASCII titles survive transit.
- Fixes the class of bug where KOReader's "Use server filenames" mode landed books on disk with mangled or percent-literal names (see [koreader/koreader#14679](https://github.com/koreader/koreader/issues/14679)). Affects any library with Japanese, accented, or other non-ASCII titles.

## Test plan
- `mise check:quiet` passes.
- New unit tests in `pkg/httputil/contentdisposition_test.go` cover ASCII, accented Latin, CJK, control bytes, escaping, and the empty / dot-prefix `download` fallback.
- Manually: hit `/opds/download/<file_id>` for a book with a non-ASCII title and confirm the response carries both `filename="..."` and `filename*=UTF-8''<percent>` parts; download via KOReader with "Use server filenames" enabled and verify the on-device filename matches the server-side title.