### PR TITLE
[Feature] Per-user gallery cover size

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -980,6 +980,40 @@ The 300ms delay ensures cleanup runs after Radix's buggy unmount effects complet
 
 **Related:** DropdownMenu components that trigger dialogs should also have `onCloseAutoFocus={(e) => e.preventDefault()}` on `DropdownMenuContent` to prevent focus management conflicts.
 
+### asChild trigger components must forwardRef
+
+**Problem:** When a Radix `XxxTrigger asChild` wraps a custom React function component (instead of a direct `<Button>` or DOM element), the component must be a `forwardRef` that spreads incoming props onto the underlying button. Otherwise:
+
+- For **floating** primitives (`Popover`, `DropdownMenu`, `HoverCard`, `Tooltip` with positioning, `ContextMenu`): the popper has no DOM ref to anchor to, so Floating UI falls back to the document origin `(0, 0)` and the content renders **off-screen** (often above the viewport). The trigger's onClick still fires — the component appears to do nothing.
+- For **non-floating** primitives (`Sheet`, `Drawer`, `Dialog`): the panel still renders correctly because it's positioned relative to the viewport, not the trigger. But focus management on close can't restore focus to the trigger, and screen reader / keyboard semantics suffer.
+
+This bug is **invisible in jsdom unit tests** — Radix's positioning math doesn't run there. Caught only in a real browser.
+
+**Required pattern for any custom component used as an asChild trigger:**
+
+```tsx
+import { forwardRef } from "react";
+
+export const MyButton = forwardRef<
+  HTMLButtonElement,
+  { isDirty: boolean } & React.ComponentPropsWithoutRef<typeof Button>
+>(({ isDirty, ...props }, ref) => (
+  <Button ref={ref} {...props}>
+    {/* ... */}
+  </Button>
+));
+MyButton.displayName = "MyButton";
+```
+
+Three things matter:
+1. `forwardRef` — receives the ref from Radix's Slot
+2. `ref={ref}` on the underlying `<Button>` — passes the ref to a DOM element (Button itself is forwardRef'd)
+3. `{...props}` — Radix's Slot adds `onClick`, `aria-expanded`, `aria-controls`, `data-state` etc. via `React.cloneElement`; these must reach the button
+
+Direct `<Button>` (the shadcn/ui primitive) is already forwardRef'd, so the common case `<PopoverTrigger asChild><Button>...</Button></PopoverTrigger>` works without ceremony. The footgun is when you wrap that Button in a custom presentational component (`SizeButton`, `SortButton`, `FilterButton`).
+
+**Existing forwardRef'd trigger components:** `SizeButton`, `SortButton`, `FilterButton`. Follow the same shape if you add another.
+
 ## Key Files
 
 | Purpose | Location |

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -30,6 +30,10 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  COVER_WIDTH_CLASS,
+  DEFAULT_GALLERY_SIZE,
+} from "@/constants/gallerySize";
 import { useDeleteBook, useResyncBook } from "@/hooks/queries/books";
 import { type RescanMode } from "@/hooks/queries/resync";
 import { useIsTruncated } from "@/hooks/useIsTruncated";
@@ -40,6 +44,7 @@ import {
   FileTypeCBZ,
   type Book,
   type File,
+  type GallerySize,
 } from "@/types";
 import { isCoverLoaded, markCoverLoaded } from "@/utils/coverCache";
 
@@ -54,6 +59,7 @@ interface BookItemProps {
   onSelect?: () => void;
   onShiftSelect?: () => void;
   cacheKey?: number;
+  gallerySize?: GallerySize;
 }
 
 // Selects the file that would be used for the cover based on cover_aspect_ratio setting
@@ -144,6 +150,7 @@ const BookItem = ({
   onSelect,
   onShiftSelect,
   cacheKey,
+  gallerySize = DEFAULT_GALLERY_SIZE,
 }: BookItemProps) => {
   const [titleRef, isTitleTruncated] = useIsTruncated<HTMLDivElement>();
 
@@ -212,7 +219,8 @@ const BookItem = ({
   return (
     <div
       className={cn(
-        "w-[calc(50%-0.5rem)] sm:w-32 group/card relative",
+        "w-[calc(50%-0.5rem)] group/card relative",
+        COVER_WIDTH_CLASS[gallerySize],
         isSelectionMode && "cursor-pointer",
       )}
       key={book.id}

--- a/app/components/library/DraggableBookList.tsx
+++ b/app/components/library/DraggableBookList.tsx
@@ -22,8 +22,12 @@ import { CSS } from "@dnd-kit/utilities";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import BookItem from "@/components/library/BookItem";
+import {
+  COVER_WIDTH_CLASS,
+  DEFAULT_GALLERY_SIZE,
+} from "@/constants/gallerySize";
 import { cn } from "@/libraries/utils";
-import type { ListBook } from "@/types";
+import type { GallerySize, ListBook } from "@/types";
 
 type InsertPosition = "before" | "after" | null;
 
@@ -33,6 +37,7 @@ interface DraggableBookItemProps {
   isDragOverlay?: boolean;
   insertPosition?: InsertPosition;
   cacheKey?: number;
+  gallerySize?: GallerySize;
 }
 
 const DraggableBookItem = ({
@@ -41,6 +46,7 @@ const DraggableBookItem = ({
   isDragOverlay = false,
   insertPosition = null,
   cacheKey,
+  gallerySize = DEFAULT_GALLERY_SIZE,
 }: DraggableBookItemProps) => {
   const {
     attributes,
@@ -61,7 +67,12 @@ const DraggableBookItem = ({
   // For the drag overlay, render a clean lifted version with explicit width
   if (isDragOverlay) {
     return (
-      <div className="w-[calc(50vw-1.5rem)] sm:w-32 opacity-95 rotate-1 scale-[1.02] drop-shadow-2xl [&>*]:w-full [&>*]:sm:w-full">
+      <div
+        className={cn(
+          "w-[calc(50vw-1.5rem)] opacity-95 rotate-1 scale-[1.02] drop-shadow-2xl [&>*]:w-full [&>*]:sm:w-full",
+          COVER_WIDTH_CLASS[gallerySize],
+        )}
+      >
         <BookItem
           addedByUsername={addedByUsername}
           book={listBook.book}
@@ -75,7 +86,8 @@ const DraggableBookItem = ({
   return (
     <div
       className={cn(
-        "w-[calc(50%-0.5rem)] sm:w-32 group/drag relative cursor-grab active:cursor-grabbing touch-pan-y [&>*]:w-full [&>*]:sm:w-full",
+        "w-[calc(50%-0.5rem)] group/drag relative cursor-grab active:cursor-grabbing touch-pan-y [&>*]:w-full [&>*]:sm:w-full",
+        COVER_WIDTH_CLASS[gallerySize],
         isDragging && "opacity-30",
         // Show indicator on left when inserting before this item
         insertPosition === "before" &&
@@ -104,6 +116,7 @@ interface DraggableBookListProps {
   isOwner: boolean;
   onReorder: (bookIds: number[]) => void;
   cacheKey?: number;
+  gallerySize?: GallerySize;
 }
 
 export const DraggableBookList = ({
@@ -111,6 +124,7 @@ export const DraggableBookList = ({
   isOwner,
   onReorder,
   cacheKey,
+  gallerySize = DEFAULT_GALLERY_SIZE,
 }: DraggableBookListProps) => {
   const [items, setItems] = useState(books);
   const [activeId, setActiveId] = useState<number | null>(null);
@@ -226,6 +240,7 @@ export const DraggableBookList = ({
                 !isOwner ? listBook.added_by_user?.username : undefined
               }
               cacheKey={cacheKey}
+              gallerySize={gallerySize}
               insertPosition={getInsertPosition(listBook.book_id)}
               key={listBook.id}
               listBook={listBook}
@@ -240,6 +255,7 @@ export const DraggableBookList = ({
               !isOwner ? activeItem.added_by_user?.username : undefined
             }
             cacheKey={cacheKey}
+            gallerySize={gallerySize}
             isDragOverlay
             listBook={activeItem}
           />

--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -7,6 +7,7 @@ import {
   SquareCheckBig,
   Tags,
 } from "lucide-react";
+import { forwardRef } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -292,22 +293,30 @@ const FilterContent = ({
   </div>
 );
 
-const FilterButton = ({
-  hasActiveFilters,
-  ...props
-}: {
-  hasActiveFilters: boolean;
-} & Omit<
-  React.ComponentPropsWithoutRef<typeof Button>,
-  "hasActiveFilters"
->) => (
-  <Button aria-label="Filters" size="icon" variant="outline" {...props}>
+// forwardRef so SheetTrigger/DrawerTrigger asChild can attach its DOM ref
+// onto the underlying button. See app/CLAUDE.md →
+// "asChild trigger components must forwardRef".
+const FilterButton = forwardRef<
+  HTMLButtonElement,
+  { hasActiveFilters: boolean } & Omit<
+    React.ComponentPropsWithoutRef<typeof Button>,
+    "hasActiveFilters"
+  >
+>(({ hasActiveFilters, ...props }, ref) => (
+  <Button
+    aria-label="Filters"
+    ref={ref}
+    size="icon"
+    variant="outline"
+    {...props}
+  >
     <ListFilter className={cn("h-4 w-4", hasActiveFilters && "text-primary")} />
     {hasActiveFilters && (
       <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background" />
     )}
   </Button>
-);
+));
+FilterButton.displayName = "FilterButton";
 
 export const FilterSheet = (props: FilterSheetProps) => {
   const { onClearAll, hasActiveFilters, ...filterContentProps } = props;

--- a/app/components/library/SelectableBookItem.tsx
+++ b/app/components/library/SelectableBookItem.tsx
@@ -1,5 +1,5 @@
 import { useBulkSelection } from "@/hooks/useBulkSelection";
-import type { Book } from "@/types";
+import type { Book, GallerySize } from "@/types";
 
 import BookItem from "./BookItem";
 
@@ -11,6 +11,7 @@ interface SelectableBookItemProps {
   addedByUsername?: string;
   pageBookIds: number[];
   cacheKey?: number;
+  gallerySize?: GallerySize;
 }
 
 export const SelectableBookItem = ({
@@ -21,6 +22,7 @@ export const SelectableBookItem = ({
   addedByUsername,
   pageBookIds,
   cacheKey,
+  gallerySize,
 }: SelectableBookItemProps) => {
   const { isSelectionMode, isSelected, toggleBook, selectRange } =
     useBulkSelection();
@@ -31,6 +33,7 @@ export const SelectableBookItem = ({
       book={book}
       cacheKey={cacheKey}
       coverAspectRatio={coverAspectRatio}
+      gallerySize={gallerySize}
       isSelected={isSelected(book.id)}
       isSelectionMode={isSelectionMode}
       libraryId={libraryId}

--- a/app/components/library/SizePopover.test.tsx
+++ b/app/components/library/SizePopover.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
+
+describe("SizePopover", () => {
+  const renderPopover = (
+    overrides: Partial<{
+      effectiveSize: "s" | "m" | "l" | "xl";
+      savedSize: "s" | "m" | "l" | "xl";
+      onChange: ReturnType<typeof vi.fn>;
+      onSaveAsDefault: ReturnType<typeof vi.fn>;
+      isSaving: boolean;
+    }> = {},
+  ) => {
+    const onChange = overrides.onChange ?? vi.fn();
+    const onSaveAsDefault = overrides.onSaveAsDefault ?? vi.fn();
+    render(
+      <SizePopover
+        effectiveSize={overrides.effectiveSize ?? "m"}
+        savedSize={overrides.savedSize ?? "m"}
+        isSaving={overrides.isSaving ?? false}
+        onChange={onChange}
+        onSaveAsDefault={onSaveAsDefault}
+        trigger={<SizeButton isDirty={false} />}
+      />,
+    );
+    return { onChange, onSaveAsDefault };
+  };
+
+  it("opens when the trigger is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderPopover();
+    await user.click(screen.getByRole("button", { name: /size/i }));
+    expect(screen.getByRole("button", { name: "M" })).toBeInTheDocument();
+  });
+
+  it("hides the save-as-default card when effective size matches saved", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderPopover({ effectiveSize: "m", savedSize: "m" });
+    await user.click(screen.getByRole("button", { name: /size/i }));
+    expect(
+      screen.queryByRole("button", { name: /save as my default everywhere/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the save-as-default card when sizes differ and calls handler", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const { onSaveAsDefault } = renderPopover({
+      effectiveSize: "l",
+      savedSize: "m",
+    });
+    await user.click(screen.getByRole("button", { name: /size/i }));
+    const saveBtn = await screen.findByRole("button", {
+      name: /save as my default everywhere/i,
+    });
+    expect(
+      screen.getByText("Other users won't be affected."),
+    ).toBeInTheDocument();
+    await user.click(saveBtn);
+    expect(onSaveAsDefault).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SizeButton", () => {
+  it("shows a dirty dot when isDirty=true", () => {
+    render(<SizeButton isDirty={true} />);
+    expect(
+      screen.getByLabelText("Size differs from default"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the dirty dot when isDirty=false", () => {
+    render(<SizeButton isDirty={false} />);
+    expect(
+      screen.queryByLabelText("Size differs from default"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/components/library/SizePopover.test.tsx
+++ b/app/components/library/SizePopover.test.tsx
@@ -3,26 +3,27 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { SizeButton, SizePopover } from "@/components/library/SizePopover";
+import type { GallerySize } from "@/types";
 
 describe("SizePopover", () => {
   const renderPopover = (
     overrides: Partial<{
-      effectiveSize: "s" | "m" | "l" | "xl";
-      savedSize: "s" | "m" | "l" | "xl";
-      onChange: ReturnType<typeof vi.fn>;
-      onSaveAsDefault: ReturnType<typeof vi.fn>;
+      effectiveSize: GallerySize;
       isSaving: boolean;
+      onChange: (size: GallerySize) => void;
+      onSaveAsDefault: () => void;
+      savedSize: GallerySize;
     }> = {},
   ) => {
-    const onChange = overrides.onChange ?? vi.fn();
-    const onSaveAsDefault = overrides.onSaveAsDefault ?? vi.fn();
+    const onChange = overrides.onChange ?? vi.fn<(size: GallerySize) => void>();
+    const onSaveAsDefault = overrides.onSaveAsDefault ?? vi.fn<() => void>();
     render(
       <SizePopover
         effectiveSize={overrides.effectiveSize ?? "m"}
-        savedSize={overrides.savedSize ?? "m"}
         isSaving={overrides.isSaving ?? false}
         onChange={onChange}
         onSaveAsDefault={onSaveAsDefault}
+        savedSize={overrides.savedSize ?? "m"}
         trigger={<SizeButton isDirty={false} />}
       />,
     );

--- a/app/components/library/SizePopover.tsx
+++ b/app/components/library/SizePopover.tsx
@@ -33,7 +33,10 @@ export const SizePopover = ({
   return (
     <Popover onOpenChange={setOpen} open={open}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-      <PopoverContent align="start" className="w-auto p-3">
+      {/* z-20 keeps the popover below the sticky top nav (z-30 in
+          topNavClasses) so a long gallery scroll never lets the popover
+          float over the persistent navigation. */}
+      <PopoverContent align="start" className="z-20 w-auto p-3">
         {/* items-start (not the flex-col default of items-stretch) keeps the
             segmented control at its intrinsic width when the save-as-default
             card forces the popover wider — buttons under the user's cursor

--- a/app/components/library/SizePopover.tsx
+++ b/app/components/library/SizePopover.tsx
@@ -1,0 +1,73 @@
+import { Maximize2, Save } from "lucide-react";
+import { useState } from "react";
+
+import { SizeSelector } from "@/components/library/SizeSelector";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { GallerySize } from "@/types";
+
+interface SizePopoverProps {
+  effectiveSize: GallerySize;
+  savedSize: GallerySize;
+  isSaving: boolean;
+  onChange: (size: GallerySize) => void;
+  onSaveAsDefault: () => void;
+  trigger: React.ReactNode;
+}
+
+export const SizePopover = ({
+  effectiveSize,
+  savedSize,
+  isSaving,
+  onChange,
+  onSaveAsDefault,
+  trigger,
+}: SizePopoverProps) => {
+  const [open, setOpen] = useState(false);
+  const isDirty = effectiveSize !== savedSize;
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align="start" className="w-auto p-3">
+        <div className="flex flex-col gap-3">
+          <SizeSelector onChange={onChange} value={effectiveSize} />
+          {isDirty && (
+            <div className="border border-dashed rounded-md p-3">
+              <p className="text-xs text-muted-foreground mb-2">
+                Other users won't be affected.
+              </p>
+              <Button disabled={isSaving} onClick={onSaveAsDefault} size="sm">
+                <Save className="h-4 w-4" />
+                {isSaving ? "Saving…" : "Save as my default everywhere"}
+              </Button>
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export const SizeButton = ({
+  isDirty,
+  onClick,
+}: {
+  isDirty: boolean;
+  onClick?: () => void;
+}) => (
+  <Button className="relative" onClick={onClick} size="sm" variant="outline">
+    <Maximize2 className="h-4 w-4" />
+    Size
+    {isDirty && (
+      <span
+        aria-label="Size differs from default"
+        className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background"
+      />
+    )}
+  </Button>
+);

--- a/app/components/library/SizePopover.tsx
+++ b/app/components/library/SizePopover.tsx
@@ -35,7 +35,11 @@ export const SizePopover = ({
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent align="start" className="w-auto p-3">
         <div className="flex flex-col gap-3">
-          <SizeSelector onChange={onChange} value={effectiveSize} />
+          <SizeSelector
+            className="flex w-full"
+            onChange={onChange}
+            value={effectiveSize}
+          />
           {isDirty && (
             <div className="border border-dashed rounded-md p-3">
               <p className="text-xs text-muted-foreground mb-2">

--- a/app/components/library/SizePopover.tsx
+++ b/app/components/library/SizePopover.tsx
@@ -1,5 +1,5 @@
 import { Maximize2, Save } from "lucide-react";
-import { useState } from "react";
+import { forwardRef, useState } from "react";
 
 import { SizeSelector } from "@/components/library/SizeSelector";
 import { Button } from "@/components/ui/button";
@@ -53,14 +53,14 @@ export const SizePopover = ({
   );
 };
 
-export const SizeButton = ({
-  isDirty,
-  onClick,
-}: {
-  isDirty: boolean;
-  onClick?: () => void;
-}) => (
-  <Button className="relative" onClick={onClick} size="sm" variant="outline">
+// forwardRef is required so PopoverTrigger asChild can attach its DOM ref to
+// the underlying button — without it, Radix's Floating UI falls back to the
+// document origin and the popover renders off-screen.
+export const SizeButton = forwardRef<
+  HTMLButtonElement,
+  { isDirty: boolean } & React.ComponentPropsWithoutRef<typeof Button>
+>(({ isDirty, ...props }, ref) => (
+  <Button className="relative" ref={ref} size="sm" variant="outline" {...props}>
     <Maximize2 className="h-4 w-4" />
     Size
     {isDirty && (
@@ -70,4 +70,5 @@ export const SizeButton = ({
       />
     )}
   </Button>
-);
+));
+SizeButton.displayName = "SizeButton";

--- a/app/components/library/SizePopover.tsx
+++ b/app/components/library/SizePopover.tsx
@@ -34,12 +34,12 @@ export const SizePopover = ({
     <Popover onOpenChange={setOpen} open={open}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent align="start" className="w-auto p-3">
-        <div className="flex flex-col gap-3">
-          <SizeSelector
-            className="flex w-full"
-            onChange={onChange}
-            value={effectiveSize}
-          />
+        {/* items-start (not the flex-col default of items-stretch) keeps the
+            segmented control at its intrinsic width when the save-as-default
+            card forces the popover wider — buttons under the user's cursor
+            shouldn't resize between clicks. */}
+        <div className="flex flex-col gap-3 items-start">
+          <SizeSelector onChange={onChange} value={effectiveSize} />
           {isDirty && (
             <div className="border border-dashed rounded-md p-3">
               <p className="text-xs text-muted-foreground mb-2">

--- a/app/components/library/SizeSelector.test.tsx
+++ b/app/components/library/SizeSelector.test.tsx
@@ -6,7 +6,7 @@ import { SizeSelector } from "@/components/library/SizeSelector";
 
 describe("SizeSelector", () => {
   it("renders one button per size", () => {
-    render(<SizeSelector value="m" onChange={vi.fn()} />);
+    render(<SizeSelector onChange={vi.fn()} value="m" />);
     expect(screen.getByRole("button", { name: "S" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "M" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "L" })).toBeInTheDocument();
@@ -14,7 +14,7 @@ describe("SizeSelector", () => {
   });
 
   it("marks the active size with aria-pressed", () => {
-    render(<SizeSelector value="l" onChange={vi.fn()} />);
+    render(<SizeSelector onChange={vi.fn()} value="l" />);
     expect(screen.getByRole("button", { name: "L" })).toHaveAttribute(
       "aria-pressed",
       "true",
@@ -28,7 +28,7 @@ describe("SizeSelector", () => {
   it("calls onChange with the clicked size", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     const onChange = vi.fn();
-    render(<SizeSelector value="m" onChange={onChange} />);
+    render(<SizeSelector onChange={onChange} value="m" />);
     await user.click(screen.getByRole("button", { name: "L" }));
     expect(onChange).toHaveBeenCalledWith("l");
   });

--- a/app/components/library/SizeSelector.test.tsx
+++ b/app/components/library/SizeSelector.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SizeSelector } from "@/components/library/SizeSelector";
+
+describe("SizeSelector", () => {
+  it("renders one button per size", () => {
+    render(<SizeSelector value="m" onChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "S" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "M" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "L" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "XL" })).toBeInTheDocument();
+  });
+
+  it("marks the active size with aria-pressed", () => {
+    render(<SizeSelector value="l" onChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "L" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "M" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("calls onChange with the clicked size", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn();
+    render(<SizeSelector value="m" onChange={onChange} />);
+    await user.click(screen.getByRole("button", { name: "L" }));
+    expect(onChange).toHaveBeenCalledWith("l");
+  });
+});

--- a/app/components/library/SizeSelector.tsx
+++ b/app/components/library/SizeSelector.tsx
@@ -1,0 +1,45 @@
+import { Button } from "@/components/ui/button";
+import { GALLERY_SIZE_LABELS, GALLERY_SIZES } from "@/constants/gallerySize";
+import { cn } from "@/libraries/utils";
+import type { GallerySize } from "@/types";
+
+interface SizeSelectorProps {
+  value: GallerySize;
+  onChange: (size: GallerySize) => void;
+  className?: string;
+}
+
+export const SizeSelector = ({
+  value,
+  onChange,
+  className,
+}: SizeSelectorProps) => {
+  return (
+    <div
+      className={cn("inline-flex rounded-md border bg-background", className)}
+      role="group"
+    >
+      {GALLERY_SIZES.map((size, index) => {
+        const isActive = size === value;
+        return (
+          <Button
+            aria-pressed={isActive}
+            className={cn(
+              "h-8 rounded-none px-3 text-xs font-semibold border-0",
+              index > 0 && "border-l",
+              isActive
+                ? "bg-primary text-primary-foreground hover:bg-primary"
+                : "bg-transparent",
+            )}
+            key={size}
+            onClick={() => onChange(size)}
+            type="button"
+            variant="ghost"
+          >
+            {GALLERY_SIZE_LABELS[size]}
+          </Button>
+        );
+      })}
+    </div>
+  );
+};

--- a/app/components/library/SizeSelector.tsx
+++ b/app/components/library/SizeSelector.tsx
@@ -16,7 +16,19 @@ export const SizeSelector = ({
 }: SizeSelectorProps) => {
   return (
     <div
-      className={cn("inline-flex rounded-md border bg-background", className)}
+      // overflow-hidden clips the active button's bg to the parent's rounded
+      // corners (otherwise the first/last selected button shows square corners
+      // outside the rounded border).
+      //
+      // Default to inline-flex (intrinsic width) so the selector stays
+      // compact on the User Settings page. The popover passes
+      // className="flex w-full" to stretch buttons across the full popover
+      // width when the save-as-default card forces the popover wider than
+      // the buttons' natural size.
+      className={cn(
+        "inline-flex overflow-hidden rounded-md border bg-background",
+        className,
+      )}
       role="group"
     >
       {GALLERY_SIZES.map((size, index) => {
@@ -24,8 +36,11 @@ export const SizeSelector = ({
         return (
           <Button
             aria-pressed={isActive}
+            // flex-1 only takes effect when the parent is a full-width
+            // flex container (popover case). In intrinsic-width mode it's
+            // harmless — there's no extra space to distribute.
             className={cn(
-              "h-8 rounded-none px-3 text-xs font-semibold border-0",
+              "h-8 flex-1 rounded-none border-0 px-3 text-xs font-semibold",
               index > 0 && "border-l",
               isActive
                 ? "bg-primary text-primary-foreground hover:bg-primary"

--- a/app/components/library/SizeSelector.tsx
+++ b/app/components/library/SizeSelector.tsx
@@ -16,15 +16,19 @@ export const SizeSelector = ({
 }: SizeSelectorProps) => {
   return (
     <div
-      // overflow-hidden clips the active button's bg to the parent's rounded
-      // corners (otherwise the first/last selected button shows square corners
-      // outside the rounded border).
+      // inline-flex keeps the segmented control at its intrinsic width
+      // so clicking between sizes never resizes the buttons under the
+      // user's cursor — even when the parent (e.g. the size popover)
+      // grows or shrinks as the save-as-default card appears/disappears.
       //
-      // Default to inline-flex (intrinsic width) so the selector stays
-      // compact on the User Settings page. The popover passes
-      // className="flex w-full" to stretch buttons across the full popover
-      // width when the save-as-default card forces the popover wider than
-      // the buttons' natural size.
+      // overflow-hidden clips the active button's bg to the rounded
+      // outer corners (otherwise the first/last selected button shows
+      // square corners outside the rounded border).
+      //
+      // When the parent is itself a stretching flex container (e.g. the
+      // User Settings Appearance card uses flex flex-col), the
+      // align-items: stretch default fills the parent width naturally —
+      // no className override needed for that case.
       className={cn(
         "inline-flex overflow-hidden rounded-md border bg-background",
         className,
@@ -36,9 +40,6 @@ export const SizeSelector = ({
         return (
           <Button
             aria-pressed={isActive}
-            // flex-1 only takes effect when the parent is a full-width
-            // flex container (popover case). In intrinsic-width mode it's
-            // harmless — there's no extra space to distribute.
             className={cn(
               "h-8 flex-1 rounded-none border-0 px-3 text-xs font-semibold",
               index > 0 && "border-l",

--- a/app/components/library/SizeSelector.tsx
+++ b/app/components/library/SizeSelector.tsx
@@ -48,7 +48,13 @@ export const SizeSelector = ({
                 : "bg-transparent",
             )}
             key={size}
-            onClick={() => onChange(size)}
+            // Skip onChange when the user clicks the already-active size:
+            // callers push to ?size= or fire a server mutation, both of which
+            // are pointless no-ops here and the URL push specifically breaks
+            // the back button by stacking duplicate history entries.
+            onClick={() => {
+              if (!isActive) onChange(size);
+            }}
             type="button"
             variant="ghost"
           >

--- a/app/components/library/SortSheet.test.tsx
+++ b/app/components/library/SortSheet.test.tsx
@@ -119,7 +119,9 @@ describe("SortSheet", () => {
       />,
     );
     await user.click(screen.getByRole("button", { name: /Open Sort/i }));
-    await user.click(screen.getByRole("button", { name: /Save as default/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Save as my default/i }),
+    );
     expect(onSaveAsDefault).toHaveBeenCalled();
   });
 

--- a/app/components/library/SortSheet.tsx
+++ b/app/components/library/SortSheet.tsx
@@ -24,7 +24,7 @@ import {
   Save,
   X,
 } from "lucide-react";
-import { useState } from "react";
+import { forwardRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -334,14 +334,14 @@ const SortSheet = ({
   );
 };
 
-export const SortButton = ({
-  isDirty,
-  onClick,
-}: {
-  isDirty: boolean;
-  onClick?: () => void;
-}) => (
-  <Button className="relative" onClick={onClick} size="sm" variant="outline">
+// forwardRef + spread so SheetTrigger/DrawerTrigger asChild can attach its DOM
+// ref and merge handlers onto the underlying button. See app/CLAUDE.md →
+// "asChild trigger components must forwardRef".
+export const SortButton = forwardRef<
+  HTMLButtonElement,
+  { isDirty: boolean } & React.ComponentPropsWithoutRef<typeof Button>
+>(({ isDirty, ...props }, ref) => (
+  <Button className="relative" ref={ref} size="sm" variant="outline" {...props}>
     <ArrowDownUp className="h-4 w-4" />
     Sort
     {isDirty && (
@@ -351,6 +351,7 @@ export const SortButton = ({
       />
     )}
   </Button>
-);
+));
+SortButton.displayName = "SortButton";
 
 export default SortSheet;

--- a/app/components/library/SortSheet.tsx
+++ b/app/components/library/SortSheet.tsx
@@ -283,12 +283,12 @@ const SortSheetContent = ({
 
       {isDirty && (
         <div className="border border-dashed rounded-md p-3">
-          <p className="text-sm text-muted-foreground mb-2">
-            Save this as the default for this library?
+          <p className="text-xs text-muted-foreground mb-2">
+            Other users won't be affected.
           </p>
           <Button disabled={isSaving} onClick={onSaveAsDefault} size="sm">
             <Save className="h-4 w-4" />
-            {isSaving ? "Saving…" : "Save as default"}
+            {isSaving ? "Saving…" : "Save as my default for this library"}
           </Button>
         </div>
       )}

--- a/app/components/pages/EPUBReader.test.tsx
+++ b/app/components/pages/EPUBReader.test.tsx
@@ -6,8 +6,8 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { useEpubBlob } from "@/hooks/queries/epub";
 import {
-  useUpdateViewerSettings,
-  useViewerSettings,
+  useUpdateUserSettings,
+  useUserSettings,
 } from "@/hooks/queries/settings";
 
 import EPUBReader from "./EPUBReader";
@@ -37,8 +37,8 @@ beforeAll(() => {
 });
 
 vi.mock("@/hooks/queries/settings", () => ({
-  useViewerSettings: vi.fn(() => ({ data: undefined, isLoading: true })),
-  useUpdateViewerSettings: vi.fn(() => ({ mutate: vi.fn() })),
+  useUserSettings: vi.fn(() => ({ data: undefined, isLoading: true })),
+  useUpdateUserSettings: vi.fn(() => ({ mutate: vi.fn() })),
 }));
 
 const renderReader = () => {
@@ -111,7 +111,7 @@ describe("EPUBReader", () => {
   it("updates settings when the theme button is clicked", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const mutate = vi.fn();
-    vi.mocked(useViewerSettings).mockReturnValue({
+    vi.mocked(useUserSettings).mockReturnValue({
       data: {
         preload_count: 3,
         fit_mode: "fit-height",
@@ -121,7 +121,7 @@ describe("EPUBReader", () => {
       },
       isLoading: false,
     } as never);
-    vi.mocked(useUpdateViewerSettings).mockReturnValue({ mutate } as never);
+    vi.mocked(useUpdateUserSettings).mockReturnValue({ mutate } as never);
 
     vi.mocked(useEpubBlob).mockReturnValue({
       data: new Blob(["x"], { type: "application/epub+zip" }),

--- a/app/components/pages/EPUBReader.tsx
+++ b/app/components/pages/EPUBReader.tsx
@@ -18,9 +18,9 @@ import {
 import { Slider } from "@/components/ui/slider";
 import { useEpubBlob } from "@/hooks/queries/epub";
 import {
-  useUpdateViewerSettings,
-  useViewerSettings,
-  type UpdateViewerSettingsVariables,
+  useUpdateUserSettings,
+  useUserSettings,
+  type UpdateUserSettingsVariables,
 } from "@/hooks/queries/settings";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { File } from "@/types";
@@ -75,8 +75,8 @@ export default function EPUBReader({
     refetch,
   } = useEpubBlob(file.id);
 
-  const { data: settings, isLoading: settingsLoading } = useViewerSettings();
-  const updateSettings = useUpdateViewerSettings();
+  const { data: settings, isLoading: settingsLoading } = useUserSettings();
+  const updateSettings = useUpdateUserSettings();
   const settingsReady = !settingsLoading && settings != null;
 
   const fontSize = settings?.viewer_epub_font_size ?? 100;
@@ -93,7 +93,7 @@ export default function EPUBReader({
   }, [fontSize]);
 
   const commitSettings = useCallback(
-    (partial: UpdateViewerSettingsVariables) => {
+    (partial: UpdateUserSettingsVariables) => {
       updateSettings.mutate(partial);
     },
     [updateSettings],

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -87,7 +87,7 @@ const GenreDetail = () => {
 
   usePageTitle(genreQuery.data?.name ?? "Genre");
   const genreBooksQuery = useGenreBooks(genreId, {
-    enabled: userSettingsResolved,
+    enabled: userSettingsResolved && Boolean(genreId),
   });
 
   const [editOpen, setEditOpen] = useState(false);

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -1,6 +1,6 @@
 import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
 import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
@@ -9,8 +9,13 @@ import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
 import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
 import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
 import {
   useDeleteGenre,
   useGenre,
@@ -20,19 +25,73 @@ import {
   useUpdateGenre,
 } from "@/hooks/queries/genres";
 import { useLibrary } from "@/hooks/queries/libraries";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
+import type { GallerySize } from "@/types";
 
 const GenreDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const genreId = id ? parseInt(id, 10) : undefined;
+
+  const userSettingsQuery = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+
+  const urlSize: GallerySize | null = parseGallerySize(
+    searchParams.get("size"),
+  );
+  const savedSize: GallerySize =
+    userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+  const effectiveSize: GallerySize = urlSize ?? savedSize;
+  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+
+  const userSettingsResolved =
+    userSettingsQuery.isSuccess || userSettingsQuery.isError;
+
+  const offset = 0;
+
+  const applyGallerySize = (next: GallerySize) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (next === savedSize) {
+        params.delete("size");
+      } else {
+        params.set("size", next);
+      }
+      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+      params.set("page", String(newPage));
+      return params;
+    });
+  };
+
+  const handleSaveSizeAsDefault = () => {
+    updateUserSettings.mutate(
+      { gallery_size: effectiveSize },
+      {
+        onSuccess: () => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.delete("size");
+            return params;
+          });
+        },
+      },
+    );
+  };
 
   const libraryQuery = useLibrary(libraryId);
   const genreQuery = useGenre(genreId);
 
   usePageTitle(genreQuery.data?.name ?? "Genre");
-  const genreBooksQuery = useGenreBooks(genreId);
+  const genreBooksQuery = useGenreBooks(genreId, {
+    enabled: userSettingsResolved,
+  });
 
   const [editOpen, setEditOpen] = useState(false);
   const [mergeOpen, setMergeOpen] = useState(false);
@@ -157,7 +216,19 @@ const GenreDetail = () => {
       {/* Books with this Genre */}
       {bookCount > 0 && (
         <section className="mb-10">
-          <h2 className="text-xl font-semibold mb-4">Books</h2>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">Books</h2>
+            <div className="hidden sm:flex">
+              <SizePopover
+                effectiveSize={effectiveSize}
+                isSaving={updateUserSettings.isPending}
+                onChange={applyGallerySize}
+                onSaveAsDefault={handleSaveSizeAsDefault}
+                savedSize={savedSize}
+                trigger={<SizeButton isDirty={isSizeDirty} />}
+              />
+            </div>
+          </div>
           {genreBooksQuery.isLoading && <LoadingSpinner />}
           {genreBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
@@ -165,6 +236,7 @@ const GenreDetail = () => {
                 <BookItem
                   book={book}
                   cacheKey={genreBooksQuery.dataUpdatedAt}
+                  gallerySize={effectiveSize}
                   key={book.id}
                   libraryId={libraryId!}
                 />

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -12,10 +12,7 @@ import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
 import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  DEFAULT_GALLERY_SIZE,
-  ITEMS_PER_PAGE_BY_SIZE,
-} from "@/constants/gallerySize";
+import { DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
 import {
   useDeleteGenre,
   useGenre,
@@ -31,7 +28,7 @@ import {
 } from "@/hooks/queries/settings";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
+import { parseGallerySize } from "@/libraries/gallerySize";
 import type { GallerySize } from "@/types";
 
 const GenreDetail = () => {
@@ -54,8 +51,6 @@ const GenreDetail = () => {
   const userSettingsResolved =
     userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
-  const offset = 0;
-
   const applyGallerySize = (next: GallerySize) => {
     setSearchParams((prev) => {
       const params = new URLSearchParams(prev);
@@ -64,8 +59,6 @@ const GenreDetail = () => {
       } else {
         params.set("size", next);
       }
-      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
-      params.set("page", String(newPage));
       return params;
     });
   };

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -51,6 +51,10 @@ const GenreDetail = () => {
   const userSettingsResolved =
     userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
+  // No page recalc here — this gallery is unpaginated (single unbounded
+  // fetch). The paginated pages (Home / SeriesList / ListDetail) call
+  // pageForSizeChange to preserve the user's first-visible book across
+  // size changes; that math is meaningless when there's only one page.
   const applyGallerySize = (next: GallerySize) => {
     setSearchParams((prev) => {
       const params = new URLSearchParams(prev);

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -9,10 +9,15 @@ import LibraryLayout from "@/components/library/LibraryLayout";
 import { SearchInput } from "@/components/library/SearchInput";
 import { SelectableBookItem } from "@/components/library/SelectableBookItem";
 import { SelectionToolbar } from "@/components/library/SelectionToolbar";
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import SortedByChips from "@/components/library/SortedByChips";
 import SortSheet, { SortButton } from "@/components/library/SortSheet";
 import { Button } from "@/components/ui/button";
 import { FILE_TYPE_OPTIONS } from "@/constants/fileTypes";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
 import { getLanguageName } from "@/constants/languages";
 import { BulkSelectionProvider } from "@/contexts/BulkSelection";
 import { useBooks } from "@/hooks/queries/books";
@@ -23,10 +28,15 @@ import {
   useUpdateLibrarySettings,
 } from "@/hooks/queries/librarySettings";
 import { useSeries } from "@/hooks/queries/series";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
 import { useTagsList } from "@/hooks/queries/tags";
 import { useBulkSelection } from "@/hooks/useBulkSelection";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
 import {
   BUILTIN_DEFAULT_SORT,
   parseSortSpec,
@@ -34,9 +44,7 @@ import {
   sortSpecsEqual,
   type SortLevel,
 } from "@/libraries/sortSpec";
-import type { Book, Genre, Tag } from "@/types";
-
-const ITEMS_PER_PAGE = 24;
+import type { Book, GallerySize, Genre, Tag } from "@/types";
 
 const HomeContent = () => {
   const { libraryId } = useParams();
@@ -115,6 +123,17 @@ const HomeContent = () => {
   const librarySettingsQuery = useLibrarySettings(libraryIdNum ?? 0);
   const updateLibrarySettings = useUpdateLibrarySettings(libraryIdNum ?? 0);
 
+  const userSettingsQuery = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+
+  const sizeParam = searchParams.get("size");
+  const urlSize: GallerySize | null = parseGallerySize(sizeParam);
+  const savedSize: GallerySize =
+    userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+  const effectiveSize: GallerySize = urlSize ?? savedSize;
+  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+  const itemsPerPage = ITEMS_PER_PAGE_BY_SIZE[effectiveSize];
+
   // Resolve effective sort: URL wins if valid; else stored preference; else builtin.
   const storedSort: SortLevel[] | null = librarySettingsQuery.data?.sort_spec
     ? parseSortSpec(librarySettingsQuery.data.sort_spec)
@@ -127,12 +146,15 @@ const HomeContent = () => {
   // "Dirty" = a sort was explicitly provided via URL and differs from default.
   const isSortDirty = urlSort !== null && !sortSpecsEqual(urlSort, defaultSort);
 
-  // Gate gallery render on the settings query having resolved, so we
-  // don't flash the builtin default before the stored preference loads.
-  const settingsResolved =
+  // Gate gallery render on the settings queries having resolved, so we
+  // don't flash the builtin defaults before the stored preferences load.
+  const librarySettingsResolved =
     libraryIdNum === undefined ||
     librarySettingsQuery.isSuccess ||
     librarySettingsQuery.isError;
+  const userSettingsResolved =
+    userSettingsQuery.isSuccess || userSettingsQuery.isError;
+  const settingsResolved = librarySettingsResolved && userSettingsResolved;
 
   // Group languages by base subtag for the filter dropdown.
   // If a library has both "en" and "en-US", show only "English" (the bare "en" subsumes variants).
@@ -230,7 +252,7 @@ const HomeContent = () => {
     .filter((t): t is Tag => t !== undefined);
 
   // Calculate pagination parameters
-  const limit = ITEMS_PER_PAGE;
+  const limit = itemsPerPage;
   const offset = (currentPage - 1) * limit;
 
   const seriesId = seriesIdParam ? parseInt(seriesIdParam, 10) : undefined;
@@ -339,6 +361,35 @@ const HomeContent = () => {
       params.set("page", "1");
       return params;
     });
+  };
+
+  const applyGallerySize = (next: GallerySize) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (next === savedSize) {
+        params.delete("size");
+      } else {
+        params.set("size", next);
+      }
+      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+      params.set("page", String(newPage));
+      return params;
+    });
+  };
+
+  const handleSaveSizeAsDefault = () => {
+    updateUserSettings.mutate(
+      { gallery_size: effectiveSize },
+      {
+        onSuccess: () => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.delete("size");
+            return params;
+          });
+        },
+      },
+    );
   };
 
   const hasActiveFilters =
@@ -451,6 +502,7 @@ const HomeContent = () => {
       book={book}
       cacheKey={booksQuery.dataUpdatedAt}
       coverAspectRatio={coverAspectRatio}
+      gallerySize={effectiveSize}
       key={book.id}
       libraryId={libraryId!}
       pageBookIds={pageBookIds}
@@ -513,6 +565,16 @@ const HomeContent = () => {
             onSaveAsDefault={handleSaveSortAsDefault}
             trigger={<SortButton isDirty={isSortDirty} />}
           />
+          <div className="hidden sm:flex">
+            <SizePopover
+              effectiveSize={effectiveSize}
+              isSaving={updateUserSettings.isPending}
+              onChange={applyGallerySize}
+              onSaveAsDefault={handleSaveSizeAsDefault}
+              savedSize={savedSize}
+              trigger={<SizeButton isDirty={isSizeDirty} />}
+            />
+          </div>
           <div className="flex-1" />
           {isSelectionMode ? (
             <Button onClick={exitSelectionMode} variant="outline">
@@ -572,7 +634,7 @@ const HomeContent = () => {
           }
           itemLabel="books"
           items={booksQuery.data?.books ?? []}
-          itemsPerPage={ITEMS_PER_PAGE}
+          itemsPerPage={itemsPerPage}
           renderItem={renderBookItem}
           total={booksQuery.data?.total ?? 0}
         />

--- a/app/components/pages/ListDetail.tsx
+++ b/app/components/pages/ListDetail.tsx
@@ -126,7 +126,7 @@ const ListDetail = () => {
   const listBooksQuery = useListBooks(
     listId,
     { sort, limit, offset },
-    { enabled: userSettingsResolved },
+    { enabled: userSettingsResolved && Boolean(listId) },
   );
   const updateListMutation = useUpdateList();
   const deleteListMutation = useDeleteList();

--- a/app/components/pages/ListDetail.tsx
+++ b/app/components/pages/ListDetail.tsx
@@ -10,6 +10,7 @@ import { DraggableBookList } from "@/components/library/DraggableBookList";
 import Gallery from "@/components/library/Gallery";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { ShareListDialog } from "@/components/library/ShareListDialog";
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import TopNav from "@/components/library/TopNav";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -22,13 +23,22 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
+import {
   useDeleteList,
   useList,
   useListBooks,
   useReorderListBooks,
   useUpdateList,
 } from "@/hooks/queries/lists";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
 import {
   ListSortAddedAtAsc,
   ListSortAddedAtDesc,
@@ -36,11 +46,10 @@ import {
   ListSortAuthorDesc,
   ListSortTitleAsc,
   ListSortTitleDesc,
+  type GallerySize,
   type ListBook,
   type UpdateListPayload,
 } from "@/types";
-
-const ITEMS_PER_PAGE = 24;
 
 const SORT_OPTIONS = [
   { value: ListSortAddedAtDesc, label: "Recently Added" },
@@ -54,13 +63,57 @@ const SORT_OPTIONS = [
 const ListDetail = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const listId = id ? parseInt(id, 10) : undefined;
+
+  const userSettingsQuery = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+
+  const urlSize: GallerySize | null = parseGallerySize(
+    searchParams.get("size"),
+  );
+  const savedSize: GallerySize =
+    userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+  const effectiveSize: GallerySize = urlSize ?? savedSize;
+  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+  const itemsPerPage = ITEMS_PER_PAGE_BY_SIZE[effectiveSize];
+
+  const userSettingsResolved =
+    userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
   // Get current page from URL
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const limit = ITEMS_PER_PAGE;
+  const limit = itemsPerPage;
   const offset = (currentPage - 1) * limit;
+
+  const applyGallerySize = (next: GallerySize) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (next === savedSize) {
+        params.delete("size");
+      } else {
+        params.set("size", next);
+      }
+      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+      params.set("page", String(newPage));
+      return params;
+    });
+  };
+
+  const handleSaveSizeAsDefault = () => {
+    updateUserSettings.mutate(
+      { gallery_size: effectiveSize },
+      {
+        onSuccess: () => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.delete("size");
+            return params;
+          });
+        },
+      },
+    );
+  };
 
   const [sort, setSort] = useState<string | undefined>(undefined);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
@@ -70,7 +123,11 @@ const ListDetail = () => {
   const listQuery = useList(listId);
 
   usePageTitle(listQuery.data?.list?.name ?? "List");
-  const listBooksQuery = useListBooks(listId, { sort, limit, offset });
+  const listBooksQuery = useListBooks(
+    listId,
+    { sort, limit, offset },
+    { enabled: userSettingsResolved },
+  );
   const updateListMutation = useUpdateList();
   const deleteListMutation = useDeleteList();
   const reorderMutation = useReorderListBooks();
@@ -253,22 +310,34 @@ const ListDetail = () => {
         {/* Books in List */}
         {bookCount > 0 && (
           <section className="mb-10">
-            <h2 className="text-xl font-semibold mb-4">
-              Books
-              {list.is_ordered &&
-                canEdit &&
-                currentPage === 1 &&
-                bookCount <= ITEMS_PER_PAGE && (
-                  <span className="text-sm font-normal text-muted-foreground ml-2">
-                    (drag to reorder)
-                  </span>
-                )}
-            </h2>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-xl font-semibold">
+                Books
+                {list.is_ordered &&
+                  canEdit &&
+                  currentPage === 1 &&
+                  bookCount <= itemsPerPage && (
+                    <span className="text-sm font-normal text-muted-foreground ml-2">
+                      (drag to reorder)
+                    </span>
+                  )}
+              </h2>
+              <div className="hidden sm:flex">
+                <SizePopover
+                  effectiveSize={effectiveSize}
+                  isSaving={updateUserSettings.isPending}
+                  onChange={applyGallerySize}
+                  onSaveAsDefault={handleSaveSizeAsDefault}
+                  savedSize={savedSize}
+                  trigger={<SizeButton isDirty={isSizeDirty} />}
+                />
+              </div>
+            </div>
             {/* Use DraggableBookList for ordered lists when on page 1 and all books fit */}
             {list.is_ordered &&
             canEdit &&
             currentPage === 1 &&
-            bookCount <= ITEMS_PER_PAGE ? (
+            bookCount <= itemsPerPage ? (
               listBooksQuery.isLoading ? (
                 <LoadingSpinner />
               ) : listBooksQuery.isSuccess ? (
@@ -287,7 +356,7 @@ const ListDetail = () => {
                 isSuccess={listBooksQuery.isSuccess}
                 itemLabel="books"
                 items={books}
-                itemsPerPage={ITEMS_PER_PAGE}
+                itemsPerPage={itemsPerPage}
                 renderItem={(listBook: ListBook) =>
                   listBook.book ? (
                     <BookItem
@@ -296,6 +365,7 @@ const ListDetail = () => {
                       }
                       book={listBook.book}
                       cacheKey={listBooksQuery.dataUpdatedAt}
+                      gallerySize={effectiveSize}
                       key={listBook.id}
                       libraryId={listBook.book.library_id.toString()}
                     />

--- a/app/components/pages/ListDetail.tsx
+++ b/app/components/pages/ListDetail.tsx
@@ -344,6 +344,7 @@ const ListDetail = () => {
                 <DraggableBookList
                   books={books}
                   cacheKey={listBooksQuery.dataUpdatedAt}
+                  gallerySize={effectiveSize}
                   isOwner={isOwner}
                   onReorder={handleReorder}
                 />

--- a/app/components/pages/PageReader.tsx
+++ b/app/components/pages/PageReader.tsx
@@ -23,8 +23,8 @@ import {
 import { Slider } from "@/components/ui/slider";
 import { useFileChapters } from "@/hooks/queries/chapters";
 import {
-  useUpdateViewerSettings,
-  useViewerSettings,
+  useUpdateUserSettings,
+  useUserSettings,
 } from "@/hooks/queries/settings";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { Chapter } from "@/types";
@@ -89,8 +89,8 @@ export default function PageReader({
   const flatChapters = useMemo(() => flattenChapters(chapters), [chapters]);
 
   // Fetch and update viewer settings
-  const { data: settings, isLoading: settingsLoading } = useViewerSettings();
-  const updateSettings = useUpdateViewerSettings();
+  const { data: settings, isLoading: settingsLoading } = useUserSettings();
+  const updateSettings = useUpdateUserSettings();
   const preloadCount = settings?.preload_count ?? 3;
   const fitMode = settings?.fit_mode ?? "fit-height";
   const settingsReady = !settingsLoading && settings != null;

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -94,7 +94,7 @@ const PersonDetail = () => {
 
   usePageTitle(personQuery.data?.name ?? "Person");
   const authoredBooksQuery = usePersonAuthoredBooks(personId, {
-    enabled: userSettingsResolved,
+    enabled: userSettingsResolved && Boolean(personId),
   });
   const narratedFilesQuery = usePersonNarratedFiles(personId);
 

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -58,6 +58,10 @@ const PersonDetail = () => {
   const userSettingsResolved =
     userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
+  // No page recalc here — this gallery is unpaginated (single unbounded
+  // fetch). The paginated pages (Home / SeriesList / ListDetail) call
+  // pageForSizeChange to preserve the user's first-visible book across
+  // size changes; that math is meaningless when there's only one page.
   const applyGallerySize = (next: GallerySize) => {
     setSearchParams((prev) => {
       const params = new URLSearchParams(prev);

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -17,10 +17,7 @@ import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
 import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  DEFAULT_GALLERY_SIZE,
-  ITEMS_PER_PAGE_BY_SIZE,
-} from "@/constants/gallerySize";
+import { DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
 import { useLibrary } from "@/hooks/queries/libraries";
 import {
   useDeletePerson,
@@ -37,7 +34,7 @@ import {
 } from "@/hooks/queries/settings";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
+import { parseGallerySize } from "@/libraries/gallerySize";
 import type { GallerySize } from "@/types";
 
 const PersonDetail = () => {
@@ -61,8 +58,6 @@ const PersonDetail = () => {
   const userSettingsResolved =
     userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
-  const offset = 0;
-
   const applyGallerySize = (next: GallerySize) => {
     setSearchParams((prev) => {
       const params = new URLSearchParams(prev);
@@ -71,8 +66,6 @@ const PersonDetail = () => {
       } else {
         params.set("size", next);
       }
-      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
-      params.set("page", String(newPage));
       return params;
     });
   };

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -1,6 +1,11 @@
 import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
 import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
@@ -9,8 +14,13 @@ import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
 import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
 import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
 import { useLibrary } from "@/hooks/queries/libraries";
 import {
   useDeletePerson,
@@ -21,20 +31,74 @@ import {
   usePersonNarratedFiles,
   useUpdatePerson,
 } from "@/hooks/queries/people";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
+import type { GallerySize } from "@/types";
 
 const PersonDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
   const personId = id ? parseInt(id, 10) : undefined;
 
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const userSettingsQuery = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+
+  const urlSize: GallerySize | null = parseGallerySize(
+    searchParams.get("size"),
+  );
+  const savedSize: GallerySize =
+    userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+  const effectiveSize: GallerySize = urlSize ?? savedSize;
+  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+
+  const userSettingsResolved =
+    userSettingsQuery.isSuccess || userSettingsQuery.isError;
+
+  const offset = 0;
+
+  const applyGallerySize = (next: GallerySize) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (next === savedSize) {
+        params.delete("size");
+      } else {
+        params.set("size", next);
+      }
+      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+      params.set("page", String(newPage));
+      return params;
+    });
+  };
+
+  const handleSaveSizeAsDefault = () => {
+    updateUserSettings.mutate(
+      { gallery_size: effectiveSize },
+      {
+        onSuccess: () => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.delete("size");
+            return params;
+          });
+        },
+      },
+    );
+  };
 
   const libraryQuery = useLibrary(libraryId);
   const personQuery = usePerson(personId);
 
   usePageTitle(personQuery.data?.name ?? "Person");
-  const authoredBooksQuery = usePersonAuthoredBooks(personId);
+  const authoredBooksQuery = usePersonAuthoredBooks(personId, {
+    enabled: userSettingsResolved,
+  });
   const narratedFilesQuery = usePersonNarratedFiles(personId);
 
   const [editOpen, setEditOpen] = useState(false);
@@ -180,7 +244,19 @@ const PersonDetail = () => {
       {/* Authored Books Section */}
       {person.authored_book_count > 0 && (
         <section className="mb-10">
-          <h2 className="text-xl font-semibold mb-4">Books Authored</h2>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">Books Authored</h2>
+            <div className="hidden sm:flex">
+              <SizePopover
+                effectiveSize={effectiveSize}
+                isSaving={updateUserSettings.isPending}
+                onChange={applyGallerySize}
+                onSaveAsDefault={handleSaveSizeAsDefault}
+                savedSize={savedSize}
+                trigger={<SizeButton isDirty={isSizeDirty} />}
+              />
+            </div>
+          </div>
           {authoredBooksQuery.isLoading && <LoadingSpinner />}
           {authoredBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
@@ -188,6 +264,7 @@ const PersonDetail = () => {
                 <BookItem
                   book={book}
                   cacheKey={authoredBooksQuery.dataUpdatedAt}
+                  gallerySize={effectiveSize}
                   key={book.id}
                   libraryId={libraryId!}
                 />

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -1,6 +1,6 @@
 import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
 import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
@@ -9,8 +9,13 @@ import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
 import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
 import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
 import { useLibrary } from "@/hooks/queries/libraries";
 import {
   useDeleteSeries,
@@ -20,19 +25,73 @@ import {
   useSeriesList,
   useUpdateSeries,
 } from "@/hooks/queries/series";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
+import type { GallerySize } from "@/types";
 
 const SeriesDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const seriesId = id ? parseInt(id, 10) : undefined;
+
+  const userSettingsQuery = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+
+  const urlSize: GallerySize | null = parseGallerySize(
+    searchParams.get("size"),
+  );
+  const savedSize: GallerySize =
+    userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+  const effectiveSize: GallerySize = urlSize ?? savedSize;
+  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+
+  const userSettingsResolved =
+    userSettingsQuery.isSuccess || userSettingsQuery.isError;
+
+  const offset = 0;
+
+  const applyGallerySize = (next: GallerySize) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (next === savedSize) {
+        params.delete("size");
+      } else {
+        params.set("size", next);
+      }
+      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+      params.set("page", String(newPage));
+      return params;
+    });
+  };
+
+  const handleSaveSizeAsDefault = () => {
+    updateUserSettings.mutate(
+      { gallery_size: effectiveSize },
+      {
+        onSuccess: () => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.delete("size");
+            return params;
+          });
+        },
+      },
+    );
+  };
 
   const libraryQuery = useLibrary(libraryId);
   const seriesQuery = useSeries(seriesId);
 
   usePageTitle(seriesQuery.data?.name ?? "Series");
-  const seriesBooksQuery = useSeriesBooks(seriesId);
+  const seriesBooksQuery = useSeriesBooks(seriesId, {
+    enabled: userSettingsResolved,
+  });
 
   const [editOpen, setEditOpen] = useState(false);
   const [mergeOpen, setMergeOpen] = useState(false);
@@ -168,7 +227,19 @@ const SeriesDetail = () => {
       {/* Books in Series */}
       {series.book_count > 0 && (
         <section className="mb-10">
-          <h2 className="text-xl font-semibold mb-4">Books in Series</h2>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">Books in Series</h2>
+            <div className="hidden sm:flex">
+              <SizePopover
+                effectiveSize={effectiveSize}
+                isSaving={updateUserSettings.isPending}
+                onChange={applyGallerySize}
+                onSaveAsDefault={handleSaveSizeAsDefault}
+                savedSize={savedSize}
+                trigger={<SizeButton isDirty={isSizeDirty} />}
+              />
+            </div>
+          </div>
           {seriesBooksQuery.isLoading && <LoadingSpinner />}
           {seriesBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
@@ -176,6 +247,7 @@ const SeriesDetail = () => {
                 <BookItem
                   book={book}
                   cacheKey={seriesBooksQuery.dataUpdatedAt}
+                  gallerySize={effectiveSize}
                   key={book.id}
                   libraryId={libraryId!}
                   seriesId={seriesId}

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -12,10 +12,7 @@ import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
 import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  DEFAULT_GALLERY_SIZE,
-  ITEMS_PER_PAGE_BY_SIZE,
-} from "@/constants/gallerySize";
+import { DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
 import { useLibrary } from "@/hooks/queries/libraries";
 import {
   useDeleteSeries,
@@ -31,7 +28,7 @@ import {
 } from "@/hooks/queries/settings";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
+import { parseGallerySize } from "@/libraries/gallerySize";
 import type { GallerySize } from "@/types";
 
 const SeriesDetail = () => {
@@ -54,8 +51,6 @@ const SeriesDetail = () => {
   const userSettingsResolved =
     userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
-  const offset = 0;
-
   const applyGallerySize = (next: GallerySize) => {
     setSearchParams((prev) => {
       const params = new URLSearchParams(prev);
@@ -64,8 +59,6 @@ const SeriesDetail = () => {
       } else {
         params.set("size", next);
       }
-      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
-      params.set("page", String(newPage));
       return params;
     });
   };

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -87,7 +87,7 @@ const SeriesDetail = () => {
 
   usePageTitle(seriesQuery.data?.name ?? "Series");
   const seriesBooksQuery = useSeriesBooks(seriesId, {
-    enabled: userSettingsResolved,
+    enabled: userSettingsResolved && Boolean(seriesId),
   });
 
   const [editOpen, setEditOpen] = useState(false);

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -51,6 +51,10 @@ const SeriesDetail = () => {
   const userSettingsResolved =
     userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
+  // No page recalc here — this gallery is unpaginated (single unbounded
+  // fetch). The paginated pages (Home / SeriesList / ListDetail) call
+  // pageForSizeChange to preserve the user's first-visible book across
+  // size changes; that math is meaningless when there's only one page.
   const applyGallerySize = (next: GallerySize) => {
     setSearchParams((prev) => {
       const params = new URLSearchParams(prev);

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -13,6 +13,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+  COVER_WIDTH_CLASS,
   DEFAULT_GALLERY_SIZE,
   ITEMS_PER_PAGE_BY_SIZE,
 } from "@/constants/gallerySize";
@@ -50,6 +51,7 @@ interface SeriesCardProps {
   aspectClass: string;
   isAudiobook: boolean;
   cacheKey?: number;
+  gallerySize?: GallerySize;
 }
 
 const SeriesCard = ({
@@ -58,6 +60,7 @@ const SeriesCard = ({
   aspectClass,
   isAudiobook,
   cacheKey,
+  gallerySize = DEFAULT_GALLERY_SIZE,
 }: SeriesCardProps) => {
   const [titleRef, isTitleTruncated] = useIsTruncated<HTMLDivElement>();
   const coverUrl = cacheKey
@@ -76,7 +79,7 @@ const SeriesCard = ({
 
   return (
     <div
-      className="w-[calc(50%-0.5rem)] sm:w-32"
+      className={cn("w-[calc(50%-0.5rem)]", COVER_WIDTH_CLASS[gallerySize])}
       title={`${seriesItem.name}${showSortName ? `\nSort: ${seriesItem.sort_name}` : ""}\n${bookCount} book${bookCount !== 1 ? "s" : ""}`}
     >
       <Link
@@ -238,6 +241,7 @@ const SeriesList = () => {
       <SeriesCard
         aspectClass={aspectClass}
         cacheKey={seriesQuery.dataUpdatedAt}
+        gallerySize={effectiveSize}
         isAudiobook={isAudiobook}
         key={seriesItem.id}
         libraryId={libraryId ?? ""}

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -5,18 +5,28 @@ import CoverPlaceholder from "@/components/library/CoverPlaceholder";
 import Gallery from "@/components/library/Gallery";
 import LibraryLayout from "@/components/library/LibraryLayout";
 import { SearchInput } from "@/components/library/SearchInput";
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
 import { useLibrary } from "@/hooks/queries/libraries";
 import { useSeriesList } from "@/hooks/queries/series";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
 import { useIsTruncated } from "@/hooks/useIsTruncated";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
 import { cn } from "@/libraries/utils";
-import type { Series } from "@/types";
+import type { GallerySize, Series } from "@/types";
 import { isCoverLoaded, markCoverLoaded } from "@/utils/coverCache";
 
 // For series, we don't have access to the underlying files, so we use the
@@ -33,8 +43,6 @@ const getSeriesAspectRatioClass = (coverAspectRatio: string): string => {
       return "aspect-[2/3]";
   }
 };
-
-const ITEMS_PER_PAGE = 24;
 
 interface SeriesCardProps {
   seriesItem: Series;
@@ -149,18 +157,65 @@ const SeriesList = () => {
     }
   };
 
-  const limit = ITEMS_PER_PAGE;
+  const userSettingsQuery = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+
+  const urlSize: GallerySize | null = parseGallerySize(
+    searchParams.get("size"),
+  );
+  const savedSize: GallerySize =
+    userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+  const effectiveSize: GallerySize = urlSize ?? savedSize;
+  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+  const itemsPerPage = ITEMS_PER_PAGE_BY_SIZE[effectiveSize];
+
+  const userSettingsResolved =
+    userSettingsQuery.isSuccess || userSettingsQuery.isError;
+
+  const limit = itemsPerPage;
   const offset = (currentPage - 1) * limit;
+
+  const applyGallerySize = (next: GallerySize) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (next === savedSize) {
+        params.delete("size");
+      } else {
+        params.set("size", next);
+      }
+      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+      params.set("page", String(newPage));
+      return params;
+    });
+  };
+
+  const handleSaveSizeAsDefault = () => {
+    updateUserSettings.mutate(
+      { gallery_size: effectiveSize },
+      {
+        onSuccess: () => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.delete("size");
+            return params;
+          });
+        },
+      },
+    );
+  };
 
   const libraryQuery = useLibrary(libraryId);
   const coverAspectRatio = libraryQuery.data?.cover_aspect_ratio ?? "book";
 
-  const seriesQuery = useSeriesList({
-    limit,
-    offset,
-    library_id: libraryId ? parseInt(libraryId, 10) : undefined,
-    search: debouncedSearch || undefined,
-  });
+  const seriesQuery = useSeriesList(
+    {
+      limit,
+      offset,
+      library_id: libraryId ? parseInt(libraryId, 10) : undefined,
+      search: debouncedSearch || undefined,
+    },
+    { enabled: userSettingsResolved },
+  );
 
   // Track the search value that produced the currently displayed data
   const [confirmedSearch, setConfirmedSearch] = useState<string | null>(null);
@@ -200,12 +255,22 @@ const SeriesList = () => {
         </p>
       </div>
 
-      <div className="mb-6">
+      <div className="mb-6 flex flex-wrap items-center gap-3">
         <SearchInput
           initialValue={searchQuery}
           onDebouncedChange={handleDebouncedSearchChange}
           placeholder="Search series..."
         />
+        <div className="hidden sm:flex">
+          <SizePopover
+            effectiveSize={effectiveSize}
+            isSaving={updateUserSettings.isPending}
+            onChange={applyGallerySize}
+            onSaveAsDefault={handleSaveSizeAsDefault}
+            savedSize={savedSize}
+            trigger={<SizeButton isDirty={isSizeDirty} />}
+          />
+        </div>
       </div>
 
       <Gallery
@@ -222,7 +287,7 @@ const SeriesList = () => {
         }
         itemLabel="series"
         items={seriesQuery.data?.series ?? []}
-        itemsPerPage={ITEMS_PER_PAGE}
+        itemsPerPage={itemsPerPage}
         renderItem={renderSeriesItem}
         total={seriesQuery.data?.total ?? 0}
       />

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -12,10 +12,7 @@ import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
 import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  DEFAULT_GALLERY_SIZE,
-  ITEMS_PER_PAGE_BY_SIZE,
-} from "@/constants/gallerySize";
+import { DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
 import { useLibrary } from "@/hooks/queries/libraries";
 import {
   useUpdateUserSettings,
@@ -31,7 +28,7 @@ import {
 } from "@/hooks/queries/tags";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
+import { parseGallerySize } from "@/libraries/gallerySize";
 import type { GallerySize } from "@/types";
 
 const TagDetail = () => {
@@ -54,8 +51,6 @@ const TagDetail = () => {
   const userSettingsResolved =
     userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
-  const offset = 0;
-
   const applyGallerySize = (next: GallerySize) => {
     setSearchParams((prev) => {
       const params = new URLSearchParams(prev);
@@ -64,8 +59,6 @@ const TagDetail = () => {
       } else {
         params.set("size", next);
       }
-      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
-      params.set("page", String(newPage));
       return params;
     });
   };

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -86,7 +86,9 @@ const TagDetail = () => {
   const tagQuery = useTag(tagId);
 
   usePageTitle(tagQuery.data?.name ?? "Tag");
-  const tagBooksQuery = useTagBooks(tagId, { enabled: userSettingsResolved });
+  const tagBooksQuery = useTagBooks(tagId, {
+    enabled: userSettingsResolved && Boolean(tagId),
+  });
 
   const [editOpen, setEditOpen] = useState(false);
   const [mergeOpen, setMergeOpen] = useState(false);

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -51,6 +51,10 @@ const TagDetail = () => {
   const userSettingsResolved =
     userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
+  // No page recalc here — this gallery is unpaginated (single unbounded
+  // fetch). The paginated pages (Home / SeriesList / ListDetail) call
+  // pageForSizeChange to preserve the user's first-visible book across
+  // size changes; that math is meaningless when there's only one page.
   const applyGallerySize = (next: GallerySize) => {
     setSearchParams((prev) => {
       const params = new URLSearchParams(prev);

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -1,6 +1,6 @@
 import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import BookItem from "@/components/library/BookItem";
 import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
@@ -9,9 +9,18 @@ import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
 import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
 import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
 import { useLibrary } from "@/hooks/queries/libraries";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
 import {
   useDeleteTag,
   useMergeTag,
@@ -22,17 +31,65 @@ import {
 } from "@/hooks/queries/tags";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
+import type { GallerySize } from "@/types";
 
 const TagDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const tagId = id ? parseInt(id, 10) : undefined;
+
+  const userSettingsQuery = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+
+  const urlSize: GallerySize | null = parseGallerySize(
+    searchParams.get("size"),
+  );
+  const savedSize: GallerySize =
+    userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+  const effectiveSize: GallerySize = urlSize ?? savedSize;
+  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+
+  const userSettingsResolved =
+    userSettingsQuery.isSuccess || userSettingsQuery.isError;
+
+  const offset = 0;
+
+  const applyGallerySize = (next: GallerySize) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (next === savedSize) {
+        params.delete("size");
+      } else {
+        params.set("size", next);
+      }
+      const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+      params.set("page", String(newPage));
+      return params;
+    });
+  };
+
+  const handleSaveSizeAsDefault = () => {
+    updateUserSettings.mutate(
+      { gallery_size: effectiveSize },
+      {
+        onSuccess: () => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.delete("size");
+            return params;
+          });
+        },
+      },
+    );
+  };
 
   const libraryQuery = useLibrary(libraryId);
   const tagQuery = useTag(tagId);
 
   usePageTitle(tagQuery.data?.name ?? "Tag");
-  const tagBooksQuery = useTagBooks(tagId);
+  const tagBooksQuery = useTagBooks(tagId, { enabled: userSettingsResolved });
 
   const [editOpen, setEditOpen] = useState(false);
   const [mergeOpen, setMergeOpen] = useState(false);
@@ -155,7 +212,19 @@ const TagDetail = () => {
       {/* Books with this Tag */}
       {bookCount > 0 && (
         <section className="mb-10">
-          <h2 className="text-xl font-semibold mb-4">Books</h2>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-semibold">Books</h2>
+            <div className="hidden sm:flex">
+              <SizePopover
+                effectiveSize={effectiveSize}
+                isSaving={updateUserSettings.isPending}
+                onChange={applyGallerySize}
+                onSaveAsDefault={handleSaveSizeAsDefault}
+                savedSize={savedSize}
+                trigger={<SizeButton isDirty={isSizeDirty} />}
+              />
+            </div>
+          </div>
           {tagBooksQuery.isLoading && <LoadingSpinner />}
           {tagBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
@@ -163,6 +232,7 @@ const TagDetail = () => {
                 <BookItem
                   book={book}
                   cacheKey={tagBooksQuery.dataUpdatedAt}
+                  gallerySize={effectiveSize}
                   key={book.id}
                   libraryId={libraryId!}
                 />

--- a/app/components/pages/UserSettings.test.tsx
+++ b/app/components/pages/UserSettings.test.tsx
@@ -99,6 +99,9 @@ describe("UserSettings – gallery size section", () => {
 
     await user.click(screen.getByRole("button", { name: "XL" }));
 
-    expect(mutate).toHaveBeenCalledWith({ gallery_size: "xl" });
+    expect(mutate).toHaveBeenCalledWith(
+      { gallery_size: "xl" },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
   });
 });

--- a/app/components/pages/UserSettings.test.tsx
+++ b/app/components/pages/UserSettings.test.tsx
@@ -1,0 +1,104 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
+
+import UserSettings from "./UserSettings";
+
+vi.mock("@/hooks/queries/settings", () => ({
+  useUserSettings: vi.fn(),
+  useUpdateUserSettings: vi.fn(),
+}));
+
+// TopNav (rendered inside UserSettings) calls useAuth and useMobileNav; mock
+// both so tests don't require a full AuthProvider / MobileNavProvider.
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ hasPermission: () => false, user: null }),
+}));
+
+vi.mock("@/contexts/MobileNav/useMobileNav", () => ({
+  useMobileNav: () => ({
+    isOpen: false,
+    open: vi.fn(),
+    close: vi.fn(),
+    toggle: vi.fn(),
+  }),
+}));
+
+// UserSettings uses useTheme from the Theme context; the default context value
+// (theme: "dark", setTheme: noop) is sufficient for these tests — no provider
+// needed.
+
+const renderPage = () => {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <UserSettings />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+describe("UserSettings – gallery size section", () => {
+  it("renders four size buttons (S, M, L, XL)", () => {
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: { gallery_size: "m" },
+      isLoading: false,
+    } as never);
+    vi.mocked(useUpdateUserSettings).mockReturnValue({
+      mutate: vi.fn(),
+    } as never);
+
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "S" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "M" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "L" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "XL" })).toBeInTheDocument();
+  });
+
+  it("active button reflects the saved size from useUserSettings", () => {
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: { gallery_size: "l" },
+      isLoading: false,
+    } as never);
+    vi.mocked(useUpdateUserSettings).mockReturnValue({
+      mutate: vi.fn(),
+    } as never);
+
+    renderPage();
+
+    expect(screen.getByRole("button", { name: "L" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "M" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("clicking a different size calls the update mutation with the right payload", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const mutate = vi.fn();
+
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: { gallery_size: "m" },
+      isLoading: false,
+    } as never);
+    vi.mocked(useUpdateUserSettings).mockReturnValue({ mutate } as never);
+
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "XL" }));
+
+    expect(mutate).toHaveBeenCalledWith({ gallery_size: "xl" });
+  });
+});

--- a/app/components/pages/UserSettings.tsx
+++ b/app/components/pages/UserSettings.tsx
@@ -2,9 +2,16 @@ import { Check, KeyRound, Moon, Sun } from "lucide-react";
 import { Link } from "react-router-dom";
 
 import { useTheme, type Theme } from "@/components/contexts/Theme/context";
+import { SizeSelector } from "@/components/library/SizeSelector";
 import TopNav from "@/components/library/TopNav";
 import { Button } from "@/components/ui/button";
+import { DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import type { GallerySize } from "@/types";
 
 interface ThemeOptionProps {
   theme: Theme;
@@ -40,6 +47,14 @@ const UserSettings = () => {
   usePageTitle("User Settings");
 
   const { theme, setTheme } = useTheme();
+  const userSettingsQuery = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+  const gallerySize: GallerySize =
+    userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+
+  const handleGallerySizeChange = (next: GallerySize) => {
+    updateUserSettings.mutate({ gallery_size: next });
+  };
 
   return (
     <div>
@@ -83,6 +98,20 @@ const UserSettings = () => {
                 onSelect={setTheme}
                 theme="system"
               />
+              <div className="mt-6 flex flex-col gap-2">
+                <label className="text-sm font-medium">
+                  Gallery cover size
+                </label>
+                <SizeSelector
+                  onChange={handleGallerySizeChange}
+                  value={gallerySize}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Applies to every gallery page. Used as your default; changes
+                  made inline on a gallery page override this until you save
+                  them.
+                </p>
+              </div>
             </div>
           </div>
 

--- a/app/components/pages/UserSettings.tsx
+++ b/app/components/pages/UserSettings.tsx
@@ -1,5 +1,6 @@
 import { Check, KeyRound, Moon, Sun } from "lucide-react";
 import { Link } from "react-router-dom";
+import { toast } from "sonner";
 
 import { useTheme, type Theme } from "@/components/contexts/Theme/context";
 import { SizeSelector } from "@/components/library/SizeSelector";
@@ -53,7 +54,17 @@ const UserSettings = () => {
     userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
 
   const handleGallerySizeChange = (next: GallerySize) => {
-    updateUserSettings.mutate({ gallery_size: next });
+    updateUserSettings.mutate(
+      { gallery_size: next },
+      {
+        onError: (error) =>
+          toast.error(
+            error instanceof Error
+              ? error.message
+              : "Failed to update gallery size",
+          ),
+      },
+    );
   };
 
   return (

--- a/app/constants/gallerySize.ts
+++ b/app/constants/gallerySize.ts
@@ -1,0 +1,30 @@
+import type { GallerySize } from "@/types";
+
+export const GALLERY_SIZES: readonly GallerySize[] = ["s", "m", "l", "xl"];
+
+export const DEFAULT_GALLERY_SIZE: GallerySize = "m";
+
+export const GALLERY_SIZE_LABELS: Record<GallerySize, string> = {
+  s: "S",
+  m: "M",
+  l: "L",
+  xl: "XL",
+};
+
+// sm: applies at >= 640px. Below sm:, BookItem uses w-[calc(50%-0.5rem)]
+// (forced 2-col), so size has no visual effect on mobile.
+export const COVER_WIDTH_CLASS: Record<GallerySize, string> = {
+  s: "sm:w-24",
+  m: "sm:w-32",
+  l: "sm:w-44",
+  xl: "sm:w-56",
+};
+
+// Backend max list limit is 50. If you raise any of these to >50 the API
+// will silently clip and pagination will break.
+export const ITEMS_PER_PAGE_BY_SIZE: Record<GallerySize, number> = {
+  s: 48,
+  m: 24,
+  l: 16,
+  xl: 12,
+};

--- a/app/constants/gallerySize.ts
+++ b/app/constants/gallerySize.ts
@@ -20,11 +20,16 @@ export const COVER_WIDTH_CLASS: Record<GallerySize, string> = {
   xl: "sm:w-56",
 };
 
+// Counts are tuned to fill exactly 3 rows at the column count each size
+// produces on a typical desktop gallery width (S=11, M=8, L=6, XL=5). Three
+// rows everywhere keeps perceived density consistent across sizes and avoids
+// half-empty trailing rows.
+//
 // Backend max list limit is 50. If you raise any of these to >50 the API
 // will silently clip and pagination will break.
 export const ITEMS_PER_PAGE_BY_SIZE: Record<GallerySize, number> = {
-  s: 48,
+  s: 33,
   m: 24,
-  l: 16,
-  xl: 12,
+  l: 18,
+  xl: 15,
 };

--- a/app/hooks/queries/settings.ts
+++ b/app/hooks/queries/settings.ts
@@ -8,7 +8,7 @@ import {
 import { API, ShishoAPIError } from "@/libraries/api";
 import type { EpubFlow, EpubTheme, FitMode } from "@/types";
 
-export interface ViewerSettings {
+export interface UserSettings {
   preload_count: number;
   fit_mode: FitMode;
   viewer_epub_font_size: number;
@@ -17,28 +17,28 @@ export interface ViewerSettings {
 }
 
 export enum QueryKey {
-  ViewerSettings = "ViewerSettings",
+  UserSettings = "UserSettings",
 }
 
-export const useViewerSettings = (
+export const useUserSettings = (
   options: Omit<
-    UseQueryOptions<ViewerSettings, ShishoAPIError>,
+    UseQueryOptions<UserSettings, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<ViewerSettings, ShishoAPIError>({
+  return useQuery<UserSettings, ShishoAPIError>({
     ...options,
-    queryKey: [QueryKey.ViewerSettings],
+    queryKey: [QueryKey.UserSettings],
     queryFn: ({ signal }) => {
-      return API.request("GET", "/settings/viewer", null, null, signal);
+      return API.request("GET", "/settings/user", null, null, signal);
     },
   });
 };
 
 // Partial update: callers send only the fields they want to change. Omitted
 // (or undefined) fields are left untouched on the server. Mirrors the backend
-// ViewerSettingsPayload shape, which has all fields as omitempty pointers.
-export interface UpdateViewerSettingsVariables {
+// UserSettingsPayload shape, which has all fields as omitempty pointers.
+export interface UpdateUserSettingsVariables {
   preload_count?: number;
   fit_mode?: FitMode;
   viewer_epub_font_size?: number;
@@ -46,19 +46,17 @@ export interface UpdateViewerSettingsVariables {
   viewer_epub_flow?: EpubFlow;
 }
 
-export const useUpdateViewerSettings = () => {
+export const useUpdateUserSettings = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<
-    ViewerSettings,
-    ShishoAPIError,
-    UpdateViewerSettingsVariables
-  >({
-    mutationFn: (payload) => {
-      return API.request("PUT", "/settings/viewer", payload, null);
+  return useMutation<UserSettings, ShishoAPIError, UpdateUserSettingsVariables>(
+    {
+      mutationFn: (payload) => {
+        return API.request("PUT", "/settings/user", payload, null);
+      },
+      onSuccess: (data) => {
+        queryClient.setQueryData([QueryKey.UserSettings], data);
+      },
     },
-    onSuccess: (data) => {
-      queryClient.setQueryData([QueryKey.ViewerSettings], data);
-    },
-  });
+  );
 };

--- a/app/hooks/queries/settings.ts
+++ b/app/hooks/queries/settings.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { EpubFlow, EpubTheme, FitMode } from "@/types";
+import type { EpubFlow, EpubTheme, FitMode, GallerySize } from "@/types";
 
 export interface UserSettings {
   preload_count: number;
@@ -14,6 +14,7 @@ export interface UserSettings {
   viewer_epub_font_size: number;
   viewer_epub_theme: EpubTheme;
   viewer_epub_flow: EpubFlow;
+  gallery_size: GallerySize;
 }
 
 export enum QueryKey {
@@ -44,6 +45,7 @@ export interface UpdateUserSettingsVariables {
   viewer_epub_font_size?: number;
   viewer_epub_theme?: EpubTheme;
   viewer_epub_flow?: EpubFlow;
+  gallery_size?: GallerySize;
 }
 
 export const useUpdateUserSettings = () => {

--- a/app/libraries/gallerySize.test.ts
+++ b/app/libraries/gallerySize.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
+
+describe("parseGallerySize", () => {
+  it("accepts the four valid sizes", () => {
+    expect(parseGallerySize("s")).toBe("s");
+    expect(parseGallerySize("m")).toBe("m");
+    expect(parseGallerySize("l")).toBe("l");
+    expect(parseGallerySize("xl")).toBe("xl");
+  });
+
+  it("rejects nullish input", () => {
+    expect(parseGallerySize(null)).toBeNull();
+    expect(parseGallerySize("")).toBeNull();
+  });
+
+  it("is case-sensitive (matches sort behavior)", () => {
+    expect(parseGallerySize("S")).toBeNull();
+    expect(parseGallerySize("Medium")).toBeNull();
+  });
+
+  it("rejects unknown values", () => {
+    expect(parseGallerySize("xxl")).toBeNull();
+    expect(parseGallerySize("huge")).toBeNull();
+  });
+});
+
+describe("pageForSizeChange", () => {
+  it("preserves the first-visible item across size changes", () => {
+    expect(pageForSizeChange(96, 48)).toBe(3);
+    expect(pageForSizeChange(96, 16)).toBe(7);
+    expect(pageForSizeChange(96, 12)).toBe(9);
+  });
+
+  it("errs backward when boundaries don't align", () => {
+    expect(pageForSizeChange(99, 12)).toBe(9);
+  });
+
+  it("returns page 1 at offset 0", () => {
+    expect(pageForSizeChange(0, 48)).toBe(1);
+    expect(pageForSizeChange(0, 12)).toBe(1);
+  });
+
+  it("returns page 1 when offset < new_limit", () => {
+    expect(pageForSizeChange(11, 12)).toBe(1);
+  });
+});

--- a/app/libraries/gallerySize.ts
+++ b/app/libraries/gallerySize.ts
@@ -1,0 +1,16 @@
+import { GALLERY_SIZES } from "@/constants/gallerySize";
+import type { GallerySize } from "@/types";
+
+export const parseGallerySize = (raw: string | null): GallerySize | null => {
+  if (!raw) return null;
+  return (GALLERY_SIZES as readonly string[]).includes(raw)
+    ? (raw as GallerySize)
+    : null;
+};
+
+export const pageForSizeChange = (
+  oldOffset: number,
+  newLimit: number,
+): number => {
+  return Math.floor(oldOffset / newLimit) + 1;
+};

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -55,7 +55,7 @@ export {
   type ListBooksQuery as ListBooksInListQuery,
 } from "./generated/lists";
 
-export type { ViewerSettings } from "@/hooks/queries/settings";
+export type { UserSettings } from "@/hooks/queries/settings";
 
 // Delete operation types
 // TODO: Move these to validators.go and regenerate via tygo

--- a/docs/superpowers/plans/2026-04-25-gallery-size.md
+++ b/docs/superpowers/plans/2026-04-25-gallery-size.md
@@ -1,0 +1,1671 @@
+# Gallery Size Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-user `gallery_size` preference (S/M/L/XL) that resizes book covers across every gallery page, with an in-toolbar popover for ad-hoc and saved-default control plus a User Settings entry. Bundle a copy fix to the existing sort save-as-default UI.
+
+**Architecture:**
+- Backend: add `gallery_size TEXT NOT NULL DEFAULT 'm'` to `user_settings`; rename the existing `/settings/viewer` endpoint to `/settings/user` (the row was always per-user, the endpoint name was a premature scope choice).
+- Frontend: shared constants + pure utils, a single `SizeSelector` component reused by both the gallery toolbar (`SizePopover`) and the User Settings page; per-page wiring resolves effective size from URL `?size=` → saved → default `'m'`, mirroring how sort already works.
+- Items-per-page scales with size (S=48, M=24, L=16, XL=12); switching size mid-page preserves the user's first-visible book via `floor(old_offset / new_limit) + 1`.
+
+**Tech Stack:** Go (Echo, Bun, SQLite), React 19 + TypeScript, Tanstack Query, TailwindCSS, shadcn/ui, Vitest, Docusaurus.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-gallery-size-design.md`
+
+---
+
+## Sequencing notes
+
+- Backend migration + model change land first (Tasks 1–2); without them, frontend can't be wired.
+- The `/viewer` → `/user` rename (Task 3) is a coordinated rename across backend files, validator types, service methods, and route — all in one commit so the build is never broken at HEAD.
+- Frontend hook rename (Task 8) similarly lands in one commit covering the hook, the EPUB viewer call sites, the query key, and the URL.
+- Once backend + hook foundations are in place, the gallery feature itself stacks cleanly: constants → utils → UI components → page wiring → docs.
+- Sort copy fix (Task 16) is a tiny standalone change but conceptually pairs with this feature; landed alongside.
+
+---
+
+## Task 1: Backend migration — add `gallery_size` column
+
+**Files:**
+- Create: `pkg/migrations/20260425000000_add_user_gallery_size.go`
+
+- [ ] **Step 1: Create the migration file**
+
+```go
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`
+			ALTER TABLE user_settings ADD COLUMN gallery_size TEXT NOT NULL DEFAULT 'm'
+		`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec("ALTER TABLE user_settings DROP COLUMN gallery_size")
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}
+```
+
+- [ ] **Step 2: Verify migration applies and rolls back**
+
+Run: `mise db:migrate && mise db:rollback && mise db:migrate`
+Expected: all three succeed; final `mise db:migrate` leaves the column present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/migrations/20260425000000_add_user_gallery_size.go
+git commit -m "[Backend] Add gallery_size column to user_settings"
+```
+
+---
+
+## Task 2: Backend model — `UserSettings.GallerySize`
+
+**Files:**
+- Modify: `pkg/models/user_settings.go`
+
+- [ ] **Step 1: Add `GallerySize` constants and field**
+
+Add this block above the existing `EpubFlow*` constants:
+
+```go
+const (
+	//tygo:emit export type GallerySize = typeof GallerySizeSmall | typeof GallerySizeMedium | typeof GallerySizeLarge | typeof GallerySizeExtraLarge;
+	GallerySizeSmall      = "s"
+	GallerySizeMedium     = "m"
+	GallerySizeLarge      = "l"
+	GallerySizeExtraLarge = "xl"
+)
+```
+
+Add `GallerySize string` to the struct with a default tag matching the migration:
+
+```go
+GallerySize        string    `bun:",notnull,default:'m'" json:"gallery_size" tstype:"GallerySize"`
+```
+
+Place it after `EpubFlow` to match the migration column order.
+
+Update `DefaultUserSettings()` to set the new field:
+
+```go
+return &UserSettings{
+	ViewerPreloadCount: 3,
+	ViewerFitMode:      FitModeHeight,
+	EpubFontSize:       100,
+	EpubTheme:          EpubThemeLight,
+	EpubFlow:           EpubFlowPaginated,
+	GallerySize:        GallerySizeMedium,
+}
+```
+
+- [ ] **Step 2: Regenerate TS types**
+
+Run: `mise tygo`
+Expected: either silent success or "skipping, outputs are up-to-date" (which is normal). Verify the change shows up in `app/types/generated/`:
+
+Run: `grep -n "GallerySize" app/types/generated/*.ts`
+Expected: matches in the generated settings file showing the new `GallerySize` literal type and `gallery_size` field.
+
+`app/types/generated/` is gitignored — the regenerated TS files don't get committed. Tests and the dev server pick them up locally; CI regenerates from the Go source.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/models/user_settings.go
+git commit -m "[Backend] Add GallerySize field to UserSettings model"
+```
+
+---
+
+## Task 3: Backend rename — `/settings/viewer` → `/settings/user`
+
+This task does not add any new behavior — it renames the wrapper around the existing `user_settings` row so adding non-viewer fields (gallery_size in Task 4) has a sensible home.
+
+**Files:**
+- Rename: `pkg/settings/handlers.go` stays put but its types/methods rename
+- Rename: `pkg/settings/viewer_handlers_test.go` → `pkg/settings/user_handlers_test.go`
+- Rename: `pkg/settings/viewer_service_test.go` → `pkg/settings/user_service_test.go`
+- Modify: `pkg/settings/handlers.go`
+- Modify: `pkg/settings/service.go`
+- Modify: `pkg/settings/validators.go`
+- Modify: `pkg/settings/routes.go`
+
+- [ ] **Step 1: Run existing tests to confirm baseline pass**
+
+Run: `go test ./pkg/settings/...`
+Expected: PASS.
+
+- [ ] **Step 2: Rename test files on disk**
+
+```bash
+git mv pkg/settings/viewer_handlers_test.go pkg/settings/user_handlers_test.go
+git mv pkg/settings/viewer_service_test.go pkg/settings/user_service_test.go
+```
+
+- [ ] **Step 3: Rename validator types**
+
+In `pkg/settings/validators.go`, rename:
+- `ViewerSettingsPayload` → `UserSettingsPayload`
+- `ViewerSettingsResponse` → `UserSettingsResponse`
+
+Update doc comments to say "user settings" instead of "viewer settings". Field names stay (they keep their `viewer_` prefix because those genuinely are viewer fields).
+
+- [ ] **Step 4: Rename service method and update struct**
+
+In `pkg/settings/service.go`:
+- `GetViewerSettings` → `GetUserSettings`
+- `UpdateViewerSettings` → `UpdateUserSettings`
+- `ViewerSettingsUpdate` → `UserSettingsUpdate`
+- Update doc comment block above `UpdateUserSettings` to say "user settings".
+
+- [ ] **Step 5: Rename handler methods**
+
+In `pkg/settings/handlers.go`:
+- `getViewerSettings` → `getUserSettings`
+- `updateViewerSettings` → `updateUserSettings`
+- Update call sites to use the renamed service methods and validator types.
+
+The handler struct stays named `handler` (it's package-scoped).
+
+- [ ] **Step 6: Rename routes**
+
+In `pkg/settings/routes.go`, change:
+
+```go
+viewerH := &handler{settingsService: svc}
+// ...
+g.GET("/viewer", viewerH.getViewerSettings)
+g.PUT("/viewer", viewerH.updateViewerSettings)
+```
+
+to:
+
+```go
+userH := &handler{settingsService: svc}
+// ...
+g.GET("/user", userH.getUserSettings)
+g.PUT("/user", userH.updateUserSettings)
+```
+
+- [ ] **Step 7: Update test files to use renamed identifiers**
+
+In `pkg/settings/user_handlers_test.go` and `pkg/settings/user_service_test.go`:
+- Replace all references to renamed types/methods (`ViewerSettingsPayload` → `UserSettingsPayload`, `getViewerSettings` → `getUserSettings`, `/settings/viewer` → `/settings/user`, etc.).
+
+Use this command to find any stragglers:
+
+```bash
+grep -rn "ViewerSettings\|getViewerSettings\|updateViewerSettings\|/settings/viewer\|/viewer" pkg/settings/
+```
+
+Expected: zero matches after this step.
+
+- [ ] **Step 8: Run tests**
+
+Run: `go test ./pkg/settings/...`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/settings/
+git commit -m "[Backend] Rename /settings/viewer to /settings/user
+
+The user_settings row was always per-user; the endpoint name was a
+premature scope choice from when only EPUB viewer fields lived there.
+Rename in advance of adding gallery_size."
+```
+
+---
+
+## Task 4: Backend — add `gallery_size` to validators, handler, service
+
+**Files:**
+- Modify: `pkg/settings/validators.go`
+- Modify: `pkg/settings/handlers.go`
+- Modify: `pkg/settings/service.go`
+
+- [ ] **Step 1: Add validator helper**
+
+In `pkg/settings/validators.go`, add at the bottom of the existing helpers:
+
+```go
+// IsValidGallerySize returns true if the size is a supported gallery size.
+func IsValidGallerySize(size string) bool {
+	switch size {
+	case models.GallerySizeSmall, models.GallerySizeMedium,
+		models.GallerySizeLarge, models.GallerySizeExtraLarge:
+		return true
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Add `GallerySize` to payload and response**
+
+In `pkg/settings/validators.go`, extend `UserSettingsPayload`:
+
+```go
+type UserSettingsPayload struct {
+	PreloadCount *int    `json:"preload_count,omitempty"`
+	FitMode      *string `json:"fit_mode,omitempty"`
+	EpubFontSize *int    `json:"viewer_epub_font_size,omitempty"`
+	EpubTheme    *string `json:"viewer_epub_theme,omitempty"`
+	EpubFlow     *string `json:"viewer_epub_flow,omitempty"`
+	GallerySize  *string `json:"gallery_size,omitempty"`
+}
+```
+
+And `UserSettingsResponse`:
+
+```go
+type UserSettingsResponse struct {
+	PreloadCount int    `json:"preload_count"`
+	FitMode      string `json:"fit_mode"`
+	EpubFontSize int    `json:"viewer_epub_font_size"`
+	EpubTheme    string `json:"viewer_epub_theme"`
+	EpubFlow     string `json:"viewer_epub_flow"`
+	GallerySize  string `json:"gallery_size"`
+}
+```
+
+- [ ] **Step 3: Add `GallerySize` to `UserSettingsUpdate`**
+
+In `pkg/settings/service.go`, append to the struct:
+
+```go
+type UserSettingsUpdate struct {
+	PreloadCount *int
+	FitMode      *string
+	EpubFontSize *int
+	EpubTheme    *string
+	EpubFlow     *string
+	GallerySize  *string
+}
+```
+
+The handler casts `UserSettingsPayload` to `UserSettingsUpdate` directly (`UserSettingsUpdate(payload)`), so the field order MUST stay identical to the payload.
+
+- [ ] **Step 4: Apply gallery_size in service merge + upsert**
+
+In `pkg/settings/service.go`, inside `UpdateUserSettings`, add the merge:
+
+```go
+if update.GallerySize != nil {
+	current.GallerySize = *update.GallerySize
+}
+```
+
+Place it just below the `EpubFlow` block to match field order.
+
+In the same function, add to the `INSERT ON CONFLICT` chain:
+
+```go
+Set("gallery_size = EXCLUDED.gallery_size").
+```
+
+Place it just before `Returning("*")`.
+
+- [ ] **Step 5: Add validation and pass-through in handler**
+
+In `pkg/settings/handlers.go` `updateUserSettings`, add the validation block alongside the other field validators:
+
+```go
+if payload.GallerySize != nil && !IsValidGallerySize(*payload.GallerySize) {
+	return errcodes.ValidationError("gallery_size must be 's', 'm', 'l', or 'xl'")
+}
+```
+
+Update both `getUserSettings` and `updateUserSettings` response builders to include the new field:
+
+```go
+return c.JSON(http.StatusOK, UserSettingsResponse{
+	PreloadCount: settings.ViewerPreloadCount,
+	FitMode:      settings.ViewerFitMode,
+	EpubFontSize: settings.EpubFontSize,
+	EpubTheme:    settings.EpubTheme,
+	EpubFlow:     settings.EpubFlow,
+	GallerySize:  settings.GallerySize,
+})
+```
+
+- [ ] **Step 6: Write failing tests for gallery_size handling**
+
+Add three new top-level test functions in `pkg/settings/user_handlers_test.go`, following the existing flat-function style (not subtests-of-one). The file uses helpers `setupTestDB`, `createTestUser`, `newTestEcho` — already proven by the existing `TestUpdateUserSettings_*` tests.
+
+```go
+func TestUpdateUserSettings_AcceptsValidGallerySize(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	user := createTestUser(t, db, "gally-valid")
+
+	e := newTestEcho(t)
+	h := &handler{settingsService: NewService(db)}
+
+	body := `{"gallery_size": "l"}`
+	req := httptest.NewRequest(http.MethodPut, "/settings/user", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	require.NoError(t, h.updateUserSettings(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp UserSettingsResponse
+	require.NoError(t, json.NewDecoder(strings.NewReader(rec.Body.String())).Decode(&resp))
+	assert.Equal(t, models.GallerySizeLarge, resp.GallerySize)
+}
+
+func TestUpdateUserSettings_RejectsInvalidGallerySize(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	user := createTestUser(t, db, "gally-bad")
+
+	e := newTestEcho(t)
+	h := &handler{settingsService: NewService(db)}
+
+	body := `{"gallery_size": "huge"}`
+	req := httptest.NewRequest(http.MethodPut, "/settings/user", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	err := h.updateUserSettings(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gallery_size")
+}
+
+func TestGetUserSettings_DefaultsToMediumGallerySize(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	user := createTestUser(t, db, "gally-default")
+
+	e := newTestEcho(t)
+	h := &handler{settingsService: NewService(db)}
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/user", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	require.NoError(t, h.getUserSettings(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp UserSettingsResponse
+	require.NoError(t, json.NewDecoder(strings.NewReader(rec.Body.String())).Decode(&resp))
+	assert.Equal(t, models.GallerySizeMedium, resp.GallerySize)
+}
+```
+
+- [ ] **Step 7: Run tests to verify failures**
+
+Run: `go test ./pkg/settings/... -run UserSettings -v`
+Expected: the three new sub-tests FAIL (the validator handler isn't returning the right values yet — actually this depends on whether you completed Steps 4–5 first; if you did, they should already PASS, which is fine).
+
+If the implementation steps were already done, the tests should PASS now. The intent of writing them is to lock the behavior in; either order is acceptable as long as both implementation and tests land together.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pkg/settings/
+git commit -m "[Backend] Persist and validate user gallery_size"
+```
+
+---
+
+## Task 5: Frontend — rename `useViewerSettings` → `useUserSettings`
+
+This task just renames the existing hook + URL to match the backend rename in Task 3. No behavior change.
+
+**Files:**
+- Modify: `app/hooks/queries/settings.ts`
+- Modify: `app/components/pages/PageReader.tsx`
+- Modify: `app/components/pages/EPUBReader.tsx`
+- Modify: `app/components/pages/EPUBReader.test.tsx`
+
+- [ ] **Step 1: Run baseline tests**
+
+Run: `mise check:quiet`
+Expected: PASS (this is the pre-rename baseline).
+
+- [ ] **Step 2: Rename in the hook file**
+
+In `app/hooks/queries/settings.ts`:
+- `interface ViewerSettings` → `interface UserSettings`
+- `enum QueryKey { ViewerSettings = "ViewerSettings" }` → `enum QueryKey { UserSettings = "UserSettings" }`
+- `useViewerSettings` → `useUserSettings`
+- `useUpdateViewerSettings` → `useUpdateUserSettings`
+- `UpdateViewerSettingsVariables` → `UpdateUserSettingsVariables`
+- `UseQueryOptions<ViewerSettings, ...>` → `UseQueryOptions<UserSettings, ...>` etc.
+- URLs `"/settings/viewer"` → `"/settings/user"`
+- All internal `[QueryKey.ViewerSettings]` array references → `[QueryKey.UserSettings]`
+
+- [ ] **Step 3: Update call-sites**
+
+```bash
+grep -rln "useViewerSettings\|useUpdateViewerSettings\|ViewerSettings" app/ --include="*.ts" --include="*.tsx"
+```
+
+Expected files (besides the hook itself and the regenerated `app/types/generated/settings.ts`):
+- `app/components/pages/PageReader.tsx`
+- `app/components/pages/EPUBReader.tsx`
+- `app/components/pages/EPUBReader.test.tsx`
+- `app/types/index.ts` (re-export)
+
+In each file, replace:
+- `useViewerSettings` → `useUserSettings`
+- `useUpdateViewerSettings` → `useUpdateUserSettings`
+- `ViewerSettings` (the interface) → `UserSettings`
+
+In `app/types/index.ts`, update any re-export of `ViewerSettings` to `UserSettings`.
+
+- [ ] **Step 4: Verify no stragglers**
+
+Run: `grep -rn "ViewerSettings\|useViewerSettings\|/settings/viewer" app/ --include="*.ts" --include="*.tsx"`
+Expected: zero matches.
+
+- [ ] **Step 5: Run all checks**
+
+Run: `mise check:quiet`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/
+git commit -m "[Frontend] Rename useViewerSettings to useUserSettings
+
+Mirrors the backend rename of /settings/viewer to /settings/user in
+preparation for adding gallery_size and other future per-user prefs."
+```
+
+---
+
+## Task 6: Frontend — extend `UserSettings` hook with `gallery_size`
+
+**Files:**
+- Modify: `app/hooks/queries/settings.ts`
+
+- [ ] **Step 1: Add `gallery_size` to interface and update payload**
+
+```ts
+import type { EpubFlow, EpubTheme, FitMode, GallerySize } from "@/types";
+
+export interface UserSettings {
+  preload_count: number;
+  fit_mode: FitMode;
+  viewer_epub_font_size: number;
+  viewer_epub_theme: EpubTheme;
+  viewer_epub_flow: EpubFlow;
+  gallery_size: GallerySize;
+}
+
+export interface UpdateUserSettingsVariables {
+  preload_count?: number;
+  fit_mode?: FitMode;
+  viewer_epub_font_size?: number;
+  viewer_epub_theme?: EpubTheme;
+  viewer_epub_flow?: EpubFlow;
+  gallery_size?: GallerySize;
+}
+```
+
+If `GallerySize` isn't re-exported from `@/types`, add it to `app/types/index.ts` next to `EpubTheme`.
+
+- [ ] **Step 2: Verify TS compiles**
+
+Run: `pnpm lint:types`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/hooks/queries/settings.ts app/types/index.ts
+git commit -m "[Frontend] Add gallery_size to UserSettings hook"
+```
+
+---
+
+## Task 7: Frontend constants — `app/constants/gallerySize.ts`
+
+**Files:**
+- Create: `app/constants/gallerySize.ts`
+
+- [ ] **Step 1: Write the constants file**
+
+```ts
+import type { GallerySize } from "@/types";
+
+export const GALLERY_SIZES: readonly GallerySize[] = ["s", "m", "l", "xl"];
+
+export const DEFAULT_GALLERY_SIZE: GallerySize = "m";
+
+export const GALLERY_SIZE_LABELS: Record<GallerySize, string> = {
+  s: "S",
+  m: "M",
+  l: "L",
+  xl: "XL",
+};
+
+// sm: applies at >= 640px. Below sm:, BookItem uses w-[calc(50%-0.5rem)]
+// (forced 2-col), so size has no visual effect on mobile.
+export const COVER_WIDTH_CLASS: Record<GallerySize, string> = {
+  s: "sm:w-24",
+  m: "sm:w-32",
+  l: "sm:w-44",
+  xl: "sm:w-56",
+};
+
+// Backend max list limit is 50. If you raise any of these to >50 the API
+// will silently clip and pagination will break.
+export const ITEMS_PER_PAGE_BY_SIZE: Record<GallerySize, number> = {
+  s: 48,
+  m: 24,
+  l: 16,
+  xl: 12,
+};
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm lint:types`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/constants/gallerySize.ts
+git commit -m "[Frontend] Add gallery size constants"
+```
+
+---
+
+## Task 8: Frontend pure utils — `app/libraries/gallerySize.ts` (TDD)
+
+**Files:**
+- Create: `app/libraries/gallerySize.test.ts`
+- Create: `app/libraries/gallerySize.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+`app/libraries/gallerySize.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+
+import {
+  pageForSizeChange,
+  parseGallerySize,
+} from "@/libraries/gallerySize";
+
+describe("parseGallerySize", () => {
+  it("accepts the four valid sizes", () => {
+    expect(parseGallerySize("s")).toBe("s");
+    expect(parseGallerySize("m")).toBe("m");
+    expect(parseGallerySize("l")).toBe("l");
+    expect(parseGallerySize("xl")).toBe("xl");
+  });
+
+  it("rejects nullish input", () => {
+    expect(parseGallerySize(null)).toBeNull();
+    expect(parseGallerySize("")).toBeNull();
+  });
+
+  it("is case-sensitive (matches sort behavior)", () => {
+    expect(parseGallerySize("S")).toBeNull();
+    expect(parseGallerySize("Medium")).toBeNull();
+  });
+
+  it("rejects unknown values", () => {
+    expect(parseGallerySize("xxl")).toBeNull();
+    expect(parseGallerySize("huge")).toBeNull();
+  });
+});
+
+describe("pageForSizeChange", () => {
+  it("preserves the first-visible item across size changes", () => {
+    // M page 5 = offset 96. Switch to S (limit 48) -> page 3, which
+    // covers offsets 96-143. First-visible book stays at top.
+    expect(pageForSizeChange(96, 48)).toBe(3);
+    // M page 5 = offset 96. Switch to L (limit 16) -> page 7, covers 96-111.
+    expect(pageForSizeChange(96, 16)).toBe(7);
+    // M page 5 = offset 96. Switch to XL (limit 12) -> page 9, covers 96-107.
+    expect(pageForSizeChange(96, 12)).toBe(9);
+  });
+
+  it("errs backward when boundaries don't align", () => {
+    // offset 99, new limit 12 -> floor(99/12)=8 -> page 9 covers 96-107.
+    // User sees their old book #99 plus three earlier books — never skips ahead.
+    expect(pageForSizeChange(99, 12)).toBe(9);
+  });
+
+  it("returns page 1 at offset 0", () => {
+    expect(pageForSizeChange(0, 48)).toBe(1);
+    expect(pageForSizeChange(0, 12)).toBe(1);
+  });
+
+  it("returns page 1 when offset < new_limit", () => {
+    expect(pageForSizeChange(11, 12)).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run app/libraries/gallerySize.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the utils**
+
+`app/libraries/gallerySize.ts`:
+
+```ts
+import { GALLERY_SIZES } from "@/constants/gallerySize";
+import type { GallerySize } from "@/types";
+
+export const parseGallerySize = (raw: string | null): GallerySize | null => {
+  if (!raw) return null;
+  return (GALLERY_SIZES as readonly string[]).includes(raw)
+    ? (raw as GallerySize)
+    : null;
+};
+
+export const pageForSizeChange = (
+  oldOffset: number,
+  newLimit: number,
+): number => {
+  return Math.floor(oldOffset / newLimit) + 1;
+};
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `pnpm vitest run app/libraries/gallerySize.test.ts`
+Expected: PASS, 8 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/libraries/gallerySize.ts app/libraries/gallerySize.test.ts
+git commit -m "[Frontend] Add gallerySize parse and page-preservation utils"
+```
+
+---
+
+## Task 9: Frontend — `SizeSelector` component (TDD)
+
+The shared 4-button segmented control reused by `SizePopover` and `UserSettings.tsx`.
+
+**Files:**
+- Create: `app/components/library/SizeSelector.tsx`
+- Create: `app/components/library/SizeSelector.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SizeSelector } from "@/components/library/SizeSelector";
+
+describe("SizeSelector", () => {
+  it("renders one button per size", () => {
+    render(<SizeSelector value="m" onChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "S" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "M" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "L" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "XL" })).toBeInTheDocument();
+  });
+
+  it("marks the active size with aria-pressed", () => {
+    render(<SizeSelector value="l" onChange={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "L" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "M" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("calls onChange with the clicked size", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn();
+    render(<SizeSelector value="m" onChange={onChange} />);
+    await user.click(screen.getByRole("button", { name: "L" }));
+    expect(onChange).toHaveBeenCalledWith("l");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify fail**
+
+Run: `pnpm vitest run app/components/library/SizeSelector.test.tsx`
+Expected: FAIL — component not found.
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+import { Button } from "@/components/ui/button";
+import {
+  GALLERY_SIZE_LABELS,
+  GALLERY_SIZES,
+} from "@/constants/gallerySize";
+import { cn } from "@/libraries/utils";
+import type { GallerySize } from "@/types";
+
+interface SizeSelectorProps {
+  value: GallerySize;
+  onChange: (size: GallerySize) => void;
+  className?: string;
+}
+
+export const SizeSelector = ({
+  value,
+  onChange,
+  className,
+}: SizeSelectorProps) => {
+  return (
+    <div
+      className={cn("inline-flex rounded-md border bg-background", className)}
+      role="group"
+    >
+      {GALLERY_SIZES.map((size, index) => {
+        const isActive = size === value;
+        return (
+          <Button
+            aria-pressed={isActive}
+            className={cn(
+              "h-8 rounded-none px-3 text-xs font-semibold border-0",
+              index > 0 && "border-l",
+              isActive
+                ? "bg-primary text-primary-foreground hover:bg-primary"
+                : "bg-transparent",
+            )}
+            key={size}
+            onClick={() => onChange(size)}
+            type="button"
+            variant="ghost"
+          >
+            {GALLERY_SIZE_LABELS[size]}
+          </Button>
+        );
+      })}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pnpm vitest run app/components/library/SizeSelector.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/SizeSelector.tsx app/components/library/SizeSelector.test.tsx
+git commit -m "[Frontend] Add SizeSelector segmented-button component"
+```
+
+---
+
+## Task 10: Frontend — `SizePopover` and `SizeButton` (TDD)
+
+**Files:**
+- Create: `app/components/library/SizePopover.tsx`
+- Create: `app/components/library/SizePopover.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  SizeButton,
+  SizePopover,
+} from "@/components/library/SizePopover";
+
+describe("SizePopover", () => {
+  const renderPopover = (overrides: Partial<{
+    effectiveSize: "s" | "m" | "l" | "xl";
+    savedSize: "s" | "m" | "l" | "xl";
+    onChange: ReturnType<typeof vi.fn>;
+    onSaveAsDefault: ReturnType<typeof vi.fn>;
+    isSaving: boolean;
+  }> = {}) => {
+    const onChange = overrides.onChange ?? vi.fn();
+    const onSaveAsDefault = overrides.onSaveAsDefault ?? vi.fn();
+    render(
+      <SizePopover
+        effectiveSize={overrides.effectiveSize ?? "m"}
+        savedSize={overrides.savedSize ?? "m"}
+        isSaving={overrides.isSaving ?? false}
+        onChange={onChange}
+        onSaveAsDefault={onSaveAsDefault}
+        trigger={<SizeButton isDirty={false} />}
+      />,
+    );
+    return { onChange, onSaveAsDefault };
+  };
+
+  it("opens when the trigger is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderPopover();
+    await user.click(screen.getByRole("button", { name: /size/i }));
+    expect(screen.getByRole("button", { name: "M" })).toBeInTheDocument();
+  });
+
+  it("hides the save-as-default card when effective size matches saved", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderPopover({ effectiveSize: "m", savedSize: "m" });
+    await user.click(screen.getByRole("button", { name: /size/i }));
+    expect(
+      screen.queryByRole("button", { name: /save as my default everywhere/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the save-as-default card when sizes differ and calls handler", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const { onSaveAsDefault } = renderPopover({
+      effectiveSize: "l",
+      savedSize: "m",
+    });
+    await user.click(screen.getByRole("button", { name: /size/i }));
+    const saveBtn = await screen.findByRole("button", {
+      name: /save as my default everywhere/i,
+    });
+    expect(
+      screen.getByText("Other users won't be affected."),
+    ).toBeInTheDocument();
+    await user.click(saveBtn);
+    expect(onSaveAsDefault).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SizeButton", () => {
+  it("shows a dirty dot when isDirty=true", () => {
+    render(<SizeButton isDirty={true} />);
+    expect(
+      screen.getByLabelText("Size differs from default"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the dirty dot when isDirty=false", () => {
+    render(<SizeButton isDirty={false} />);
+    expect(
+      screen.queryByLabelText("Size differs from default"),
+    ).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify fail**
+
+Run: `pnpm vitest run app/components/library/SizePopover.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the components**
+
+```tsx
+import { Maximize2, Save } from "lucide-react";
+import { useState } from "react";
+
+import { SizeSelector } from "@/components/library/SizeSelector";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import type { GallerySize } from "@/types";
+
+interface SizePopoverProps {
+  effectiveSize: GallerySize;
+  savedSize: GallerySize;
+  isSaving: boolean;
+  onChange: (size: GallerySize) => void;
+  onSaveAsDefault: () => void;
+  trigger: React.ReactNode;
+}
+
+export const SizePopover = ({
+  effectiveSize,
+  savedSize,
+  isSaving,
+  onChange,
+  onSaveAsDefault,
+  trigger,
+}: SizePopoverProps) => {
+  const [open, setOpen] = useState(false);
+  const isDirty = effectiveSize !== savedSize;
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent align="start" className="w-auto p-3">
+        <div className="flex flex-col gap-3">
+          <SizeSelector onChange={onChange} value={effectiveSize} />
+          {isDirty && (
+            <div className="border border-dashed rounded-md p-3">
+              <p className="text-xs text-muted-foreground mb-2">
+                Other users won't be affected.
+              </p>
+              <Button
+                disabled={isSaving}
+                onClick={onSaveAsDefault}
+                size="sm"
+              >
+                <Save className="h-4 w-4" />
+                {isSaving ? "Saving…" : "Save as my default everywhere"}
+              </Button>
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export const SizeButton = ({
+  isDirty,
+  onClick,
+}: {
+  isDirty: boolean;
+  onClick?: () => void;
+}) => (
+  <Button className="relative" onClick={onClick} size="sm" variant="outline">
+    <Maximize2 className="h-4 w-4" />
+    Size
+    {isDirty && (
+      <span
+        aria-label="Size differs from default"
+        className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background"
+      />
+    )}
+  </Button>
+);
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `pnpm vitest run app/components/library/SizePopover.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/SizePopover.tsx app/components/library/SizePopover.test.tsx
+git commit -m "[Frontend] Add SizePopover and SizeButton"
+```
+
+---
+
+## Task 11: Frontend — thread `gallerySize` through `BookItem` + `SelectableBookItem`
+
+**Files:**
+- Modify: `app/components/library/BookItem.tsx`
+- Modify: `app/components/library/SelectableBookItem.tsx`
+
+- [ ] **Step 1: Update `BookItem` to accept and apply `gallerySize`**
+
+In `app/components/library/BookItem.tsx`:
+
+Add to imports:
+
+```ts
+import { COVER_WIDTH_CLASS, DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
+import type { GallerySize } from "@/types";
+```
+
+Add to `BookItemProps`:
+
+```ts
+gallerySize?: GallerySize;
+```
+
+Add to the destructuring with the default:
+
+```ts
+const BookItem = ({
+  // ... existing props
+  gallerySize = DEFAULT_GALLERY_SIZE,
+  // ...
+}: BookItemProps) => {
+```
+
+Replace the wrapping `<div>`'s `className` (currently `"w-[calc(50%-0.5rem)] sm:w-32 group/card relative"`) with:
+
+```tsx
+className={cn(
+  "w-[calc(50%-0.5rem)] group/card relative",
+  COVER_WIDTH_CLASS[gallerySize],
+  isSelectionMode && "cursor-pointer",
+)}
+```
+
+- [ ] **Step 2: Update `SelectableBookItem` to forward the prop**
+
+In `app/components/library/SelectableBookItem.tsx`:
+
+Add to imports:
+
+```ts
+import type { GallerySize } from "@/types";
+```
+
+Add to `SelectableBookItemProps`:
+
+```ts
+gallerySize?: GallerySize;
+```
+
+Add to the destructuring and pass through to `BookItem`:
+
+```tsx
+gallerySize,
+// ...
+<BookItem
+  // ... existing
+  gallerySize={gallerySize}
+  // ...
+/>
+```
+
+- [ ] **Step 3: Verify TS and tests still pass**
+
+Run: `pnpm vitest run app/components/library/`
+Expected: PASS (existing BookItem callers unaffected because the prop has a default).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/library/BookItem.tsx app/components/library/SelectableBookItem.tsx
+git commit -m "[Frontend] Thread gallerySize prop through BookItem"
+```
+
+---
+
+## Task 12: Frontend — wire size into `Home.tsx`
+
+The library home is the most complex page (also reads library settings for sort). It's the template for all other gallery pages — get this right and the others are mechanical.
+
+**Files:**
+- Modify: `app/components/pages/Home.tsx`
+
+- [ ] **Step 1: Add imports**
+
+Append to the existing imports block:
+
+```ts
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
+import {
+  pageForSizeChange,
+  parseGallerySize,
+} from "@/libraries/gallerySize";
+import type { GallerySize } from "@/types";
+```
+
+- [ ] **Step 2: Remove the hard-coded `ITEMS_PER_PAGE` constant**
+
+Delete the line:
+
+```ts
+const ITEMS_PER_PAGE = 24;
+```
+
+We'll compute it from the effective size.
+
+- [ ] **Step 3: Add user-settings hooks and resolve effective size**
+
+Inside `HomeContent`, after the existing `librarySettingsQuery` / `updateLibrarySettings` block, add:
+
+```ts
+const userSettingsQuery = useUserSettings();
+const updateUserSettings = useUpdateUserSettings();
+
+const sizeParam = searchParams.get("size");
+const urlSize: GallerySize | null = parseGallerySize(sizeParam);
+const savedSize: GallerySize =
+  userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+const effectiveSize: GallerySize = urlSize ?? savedSize;
+const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+const itemsPerPage = ITEMS_PER_PAGE_BY_SIZE[effectiveSize];
+```
+
+- [ ] **Step 4: Update the `settingsResolved` gate to also wait for user settings**
+
+Replace:
+
+```ts
+const settingsResolved =
+  libraryIdNum === undefined ||
+  librarySettingsQuery.isSuccess ||
+  librarySettingsQuery.isError;
+```
+
+with:
+
+```ts
+const librarySettingsResolved =
+  libraryIdNum === undefined ||
+  librarySettingsQuery.isSuccess ||
+  librarySettingsQuery.isError;
+const userSettingsResolved =
+  userSettingsQuery.isSuccess || userSettingsQuery.isError;
+const settingsResolved = librarySettingsResolved && userSettingsResolved;
+```
+
+- [ ] **Step 5: Replace `ITEMS_PER_PAGE` references with `itemsPerPage`**
+
+Search inside `Home.tsx`:
+
+```bash
+grep -n "ITEMS_PER_PAGE" app/components/pages/Home.tsx
+```
+
+Replace each occurrence with `itemsPerPage`. Three sites:
+- `const limit = ITEMS_PER_PAGE;` → `const limit = itemsPerPage;`
+- `itemsPerPage={ITEMS_PER_PAGE}` (passed to `<Gallery>`) → `itemsPerPage={itemsPerPage}`
+
+- [ ] **Step 6: Add size-change handler and save-as-default handler**
+
+Below the existing `handleSaveSortAsDefault`/`applySortLevels` definitions, add:
+
+```ts
+const applyGallerySize = (next: GallerySize) => {
+  setSearchParams((prev) => {
+    const params = new URLSearchParams(prev);
+    if (next === savedSize) {
+      params.delete("size");
+    } else {
+      params.set("size", next);
+    }
+    const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+    params.set("page", String(newPage));
+    return params;
+  });
+};
+
+const handleSaveSizeAsDefault = () => {
+  updateUserSettings.mutate(
+    { gallery_size: effectiveSize },
+    {
+      onSuccess: () => {
+        setSearchParams((prev) => {
+          const params = new URLSearchParams(prev);
+          params.delete("size");
+          return params;
+        });
+      },
+    },
+  );
+};
+```
+
+- [ ] **Step 7: Add `<SizePopover>` to the toolbar**
+
+In the toolbar JSX block, find the `<SortSheet ... />` element and place the size popover immediately after it, wrapped to hide on mobile:
+
+```tsx
+<div className="hidden sm:flex">
+  <SizePopover
+    effectiveSize={effectiveSize}
+    isSaving={updateUserSettings.isPending}
+    onChange={applyGallerySize}
+    onSaveAsDefault={handleSaveSizeAsDefault}
+    savedSize={savedSize}
+    trigger={<SizeButton isDirty={isSizeDirty} />}
+  />
+</div>
+```
+
+- [ ] **Step 8: Pass `gallerySize` to the rendered book items**
+
+In `renderBookItem`:
+
+```tsx
+const renderBookItem = (book: Book) => (
+  <SelectableBookItem
+    book={book}
+    cacheKey={booksQuery.dataUpdatedAt}
+    coverAspectRatio={coverAspectRatio}
+    gallerySize={effectiveSize}
+    key={book.id}
+    libraryId={libraryId!}
+    pageBookIds={pageBookIds}
+    seriesId={seriesId}
+  />
+);
+```
+
+- [ ] **Step 9: Run checks**
+
+Run: `mise check:quiet`
+Expected: PASS.
+
+- [ ] **Step 10: Manual smoke test**
+
+Run: `mise start`
+Open `http://localhost:5173/libraries/1` in a browser. Verify:
+- Size button appears in the toolbar (between Sort and Select).
+- Clicking it opens the popover with four buttons; default highlight is M.
+- Picking L makes covers larger and bumps `?size=l` into the URL.
+- Save-as-default card appears; clicking it removes `?size=l` and persists the choice (refresh: covers stay L).
+- Switching from L on page 5 to S preserves position (lands on page near same books).
+
+If `mise start` isn't running here, say so explicitly rather than skipping.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add app/components/pages/Home.tsx
+git commit -m "[Frontend] Wire gallery size into library home"
+```
+
+---
+
+## Task 13: Frontend — wire size into the other 6 gallery pages
+
+The pattern is identical to Task 12 minus the library-settings (sort) wiring. Only Home + SeriesList + SeriesDetail + GenreDetail + TagDetail + PersonDetail + ListDetail render the book gallery — text-list pages (GenresList, TagsList, PersonList, etc.) don't.
+
+**Files:**
+- Modify: `app/components/pages/SeriesList.tsx`
+- Modify: `app/components/pages/SeriesDetail.tsx`
+- Modify: `app/components/pages/GenreDetail.tsx`
+- Modify: `app/components/pages/TagDetail.tsx`
+- Modify: `app/components/pages/PersonDetail.tsx`
+- Modify: `app/components/pages/ListDetail.tsx`
+
+For **each** of the six files, perform Steps 1–6 below. The diff shape is the same; only the surrounding code differs.
+
+- [ ] **Step 1: Add imports**
+
+Add to the imports block:
+
+```ts
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
+import {
+  pageForSizeChange,
+  parseGallerySize,
+} from "@/libraries/gallerySize";
+import type { GallerySize } from "@/types";
+```
+
+- [ ] **Step 2: Delete the hard-coded `ITEMS_PER_PAGE` constant**
+
+Each file currently declares `const ITEMS_PER_PAGE = 24;` near the top. Delete it.
+
+- [ ] **Step 3: Resolve effective size**
+
+Inside the page's main component, near where `searchParams` / `currentPage` are derived, add:
+
+```ts
+const userSettingsQuery = useUserSettings();
+const updateUserSettings = useUpdateUserSettings();
+
+const urlSize: GallerySize | null = parseGallerySize(searchParams.get("size"));
+const savedSize: GallerySize =
+  userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+const effectiveSize: GallerySize = urlSize ?? savedSize;
+const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+const itemsPerPage = ITEMS_PER_PAGE_BY_SIZE[effectiveSize];
+```
+
+If the page doesn't already use `useSearchParams`, add the standard `const [searchParams, setSearchParams] = useSearchParams();` line.
+
+- [ ] **Step 4: Replace `ITEMS_PER_PAGE` with `itemsPerPage` (and gate on settings)**
+
+Replace each `ITEMS_PER_PAGE` reference with `itemsPerPage` (typically: `const limit = itemsPerPage;` and `<Gallery itemsPerPage={itemsPerPage} />`).
+
+If the page renders `<Gallery>` directly without an explicit settings gate, gate the books query enable on user-settings being resolved:
+
+```ts
+const userSettingsResolved =
+  userSettingsQuery.isSuccess || userSettingsQuery.isError;
+// ... existing query opts
+{
+  enabled: userSettingsResolved && /* existing conditions */,
+}
+```
+
+If the page doesn't pass `enabled` today (the books query is unconditional), add it. Without the gate, users with a saved L would see a flash of M-sized covers before settings load.
+
+- [ ] **Step 5: Add the size handlers and the popover**
+
+Add the handlers (same as Task 12 Step 6):
+
+```ts
+const offset = (currentPage - 1) * itemsPerPage;
+
+const applyGallerySize = (next: GallerySize) => {
+  setSearchParams((prev) => {
+    const params = new URLSearchParams(prev);
+    if (next === savedSize) {
+      params.delete("size");
+    } else {
+      params.set("size", next);
+    }
+    const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+    params.set("page", String(newPage));
+    return params;
+  });
+};
+
+const handleSaveSizeAsDefault = () => {
+  updateUserSettings.mutate(
+    { gallery_size: effectiveSize },
+    {
+      onSuccess: () => {
+        setSearchParams((prev) => {
+          const params = new URLSearchParams(prev);
+          params.delete("size");
+          return params;
+        });
+      },
+    },
+  );
+};
+```
+
+Place the popover next to whatever toolbar/header exists. If the page has no toolbar (e.g. PersonDetail/GenreDetail), add a single-row toolbar above the gallery:
+
+```tsx
+<div className="hidden sm:flex justify-end mb-4">
+  <SizePopover
+    effectiveSize={effectiveSize}
+    isSaving={updateUserSettings.isPending}
+    onChange={applyGallerySize}
+    onSaveAsDefault={handleSaveSizeAsDefault}
+    savedSize={savedSize}
+    trigger={<SizeButton isDirty={isSizeDirty} />}
+  />
+</div>
+```
+
+- [ ] **Step 6: Pass `gallerySize` to book items rendered on this page**
+
+Find every `<BookItem ... />` or `<SelectableBookItem ... />` rendered by this page and add the `gallerySize={effectiveSize}` prop. Some pages use raw `BookItem` (PersonDetail, GenreDetail, TagDetail, ListDetail), others use `SelectableBookItem` (Home/SeriesList/SeriesDetail style); both accept the prop now.
+
+- [ ] **Step 7: Per-file lint + test pass**
+
+After updating all six files, run:
+
+Run: `mise check:quiet`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/components/pages/SeriesList.tsx app/components/pages/SeriesDetail.tsx app/components/pages/GenreDetail.tsx app/components/pages/TagDetail.tsx app/components/pages/PersonDetail.tsx app/components/pages/ListDetail.tsx
+git commit -m "[Frontend] Wire gallery size into Series/Genre/Tag/Person/List galleries"
+```
+
+---
+
+## Task 14: Frontend — Gallery Size on User Settings page
+
+**Files:**
+- Modify: `app/components/pages/UserSettings.tsx`
+
+- [ ] **Step 1: Add imports**
+
+```ts
+import { SizeSelector } from "@/components/library/SizeSelector";
+import { DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
+import type { GallerySize } from "@/types";
+```
+
+- [ ] **Step 2: Read user settings and wire change handler**
+
+Inside the `UserSettings` component, alongside the existing `useTheme()`:
+
+```ts
+const userSettingsQuery = useUserSettings();
+const updateUserSettings = useUpdateUserSettings();
+const gallerySize: GallerySize =
+  userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+
+const handleGallerySizeChange = (next: GallerySize) => {
+  updateUserSettings.mutate({ gallery_size: next });
+};
+```
+
+- [ ] **Step 3: Add the row inside the existing Appearance section**
+
+Inside the `<section>` containing the theme picker, below the theme rows, add:
+
+```tsx
+<div className="mt-6 flex flex-col gap-2">
+  <label className="text-sm font-medium">Gallery cover size</label>
+  <SizeSelector
+    onChange={handleGallerySizeChange}
+    value={gallerySize}
+  />
+  <p className="text-xs text-muted-foreground">
+    Applies to every gallery page. Used as your default; changes made
+    inline on a gallery page override this until you save them.
+  </p>
+</div>
+```
+
+The exact JSX shape may need to adapt to existing markup in the section — match the surrounding patterns (labels, helper text styling).
+
+- [ ] **Step 4: Run checks**
+
+Run: `mise check:quiet`
+Expected: PASS.
+
+- [ ] **Step 5: Manual smoke test**
+
+If `mise start` is running, navigate to `/settings/user-settings` (or wherever UserSettings is routed — confirm via `app/router.tsx`) and verify:
+- Four S/M/L/XL buttons appear under the Appearance section.
+- Clicking one persists immediately (refresh page; choice sticks).
+- Choice is reflected next time you open a gallery page (no `?size=` URL param).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/components/pages/UserSettings.tsx
+git commit -m "[Frontend] Add gallery size picker to User Settings"
+```
+
+---
+
+## Task 15: Sort copy fix in `SortSheet.tsx`
+
+**Files:**
+- Modify: `app/components/library/SortSheet.tsx`
+
+- [ ] **Step 1: Update the "Save as default" card copy**
+
+Find the dirty-state JSX block (currently lines ~284–294):
+
+```tsx
+{isDirty && (
+  <div className="border border-dashed rounded-md p-3">
+    <p className="text-sm text-muted-foreground mb-2">
+      Save this as the default for this library?
+    </p>
+    <Button disabled={isSaving} onClick={onSaveAsDefault} size="sm">
+      <Save className="h-4 w-4" />
+      {isSaving ? "Saving…" : "Save as default"}
+    </Button>
+  </div>
+)}
+```
+
+Replace with:
+
+```tsx
+{isDirty && (
+  <div className="border border-dashed rounded-md p-3">
+    <p className="text-xs text-muted-foreground mb-2">
+      Other users won't be affected.
+    </p>
+    <Button disabled={isSaving} onClick={onSaveAsDefault} size="sm">
+      <Save className="h-4 w-4" />
+      {isSaving ? "Saving…" : "Save as my default for this library"}
+    </Button>
+  </div>
+)}
+```
+
+- [ ] **Step 2: Run checks**
+
+Run: `mise check:quiet`
+Expected: PASS. (No tests assert on this string today; if any do, update them to match.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/library/SortSheet.tsx
+git commit -m "[Frontend] Clarify sort save-as-default is per-user"
+```
+
+---
+
+## Task 16: Docs — new `gallery-size.md` page + sort cross-link
+
+**Files:**
+- Create: `website/docs/gallery-size.md`
+- Modify: `website/docs/gallery-sort.md`
+
+- [ ] **Step 1: Create the new page**
+
+Use `sidebar_position: 155` so it slots immediately after `gallery-sort.md` (position 150) without renumbering anything else.
+
+```md
+---
+sidebar_position: 155
+---
+
+# Gallery Size
+
+Pick how large book covers display in your gallery — Small, Medium, Large, or Extra Large. The choice applies everywhere you see covers (library home, series, genres, tags, people, lists).
+
+## Using the Size popover
+
+Click **Size** in the gallery toolbar to open the size popover. Pick S / M / L / XL — covers resize immediately and the gallery jumps to a page that contains the book you were last looking at, so you don't lose your place.
+
+A dot on the Size button means your current size differs from your saved default.
+
+The popover is hidden on small screens, where covers always render two per row regardless of size. Edit your saved default from User Settings on a phone, and it'll apply next time you're on a wider screen.
+
+## Sizes
+
+| Size | Cover width (desktop) | Books per page |
+|------|----------------------|----------------|
+| S    | 96px                 | 48 |
+| M    | 128px (default)      | 24 |
+| L    | 176px                | 16 |
+| XL   | 224px                | 12 |
+
+Items per page scale so screen density stays roughly constant — bigger covers, fewer per page.
+
+## URL-addressable size
+
+Non-default sizes live in the URL as `?size=s|m|l|xl`. You can share or bookmark a sized view and it loads at that size — for that recipient on that page only.
+
+```
+?size=l
+```
+
+When the URL has no `size` parameter, the gallery uses your saved default (or **M** if you haven't saved one).
+
+## Saving a default
+
+When your current size differs from your saved default, the size popover shows a **Save as my default everywhere** button. Clicking it:
+
+1. Saves your current size as your new default for every gallery page.
+2. Clears the `?size=` parameter from the URL — you're now viewing the default.
+
+Defaults are per user — saving doesn't affect other users.
+
+You can also edit the default from your **User Settings** page under Appearance.
+
+## See also
+
+- [Gallery Sort](./gallery-sort.md) for sorting books by author, series, date added, and more.
+```
+
+- [ ] **Step 2: Cross-link from gallery-sort.md**
+
+In `website/docs/gallery-sort.md`, add a "See also" section at the bottom (or extend the existing "How this affects other surfaces" section):
+
+```md
+## See also
+
+- [Gallery Size](./gallery-size.md) for resizing book covers in the gallery.
+```
+
+- [ ] **Step 3: Verify docs build**
+
+Run: `cd website && pnpm build`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/docs/gallery-size.md website/docs/gallery-sort.md
+git commit -m "[Docs] Add gallery size docs page"
+```
+
+---
+
+## Task 17: Final sweep
+
+- [ ] **Step 1: Full check**
+
+Run: `mise check:quiet`
+Expected: PASS.
+
+- [ ] **Step 2: Verify worktree state**
+
+Run: `git status` and `git log --oneline master..HEAD`
+Expected: working tree clean; commit history shows the migration → backend rename → backend gallery_size → frontend rename → frontend hook extension → constants → utils → SizeSelector → SizePopover → BookItem → Home → other pages → UserSettings → sort copy → docs progression.
+
+- [ ] **Step 3: Squash-merge readiness**
+
+The branch is ready to hand to `squash-merge-worktree` skill (or the user's preferred merge flow). No new task needed here.

--- a/docs/superpowers/specs/2026-04-25-gallery-size-design.md
+++ b/docs/superpowers/specs/2026-04-25-gallery-size-design.md
@@ -1,0 +1,303 @@
+# Gallery Size — Per-User Cover Sizing
+
+## Problem
+
+The book gallery renders covers at a fixed width (`sm:w-32`, 128px), producing roughly 8×3 books per page on a wide desktop. That density works for skimming a large library but is too small when the user wants to study covers (illustrated comics, art books, audiobook art, etc.). Users have no way to make covers larger or smaller.
+
+## Goal
+
+Let each user pick their preferred gallery cover size — Small, Medium, Large, or Extra Large — applied across every gallery page they see. Changeable on-the-fly via a toolbar popover, persistable as their saved default, and also editable from User Settings.
+
+Sort's existing "Save as default" copy is bundled into this PR to fix an adjacent UX gap (the current wording reads as if it sets a library-wide default for all users; it actually only sets the current user's default).
+
+## Non-goals
+
+- Per-library size overrides. (User-global only. Trade-off documented in Decisions.)
+- Sizing for non-book gallery pages (Genres list, Tags list, People list, Publishers list, Imprints list — these are text rows, not cover grids).
+- Virtualized scrolling or infinite scroll.
+- Mobile (sub-`sm:`) sizing — covers stay 2-col on mobile regardless of saved size; the popover is hidden.
+- Server-side cover thumbnailing. Source covers are large enough that 224px display works without resampling.
+
+## Decisions
+
+### Scope: per-user, global
+
+Stored on the existing `user_settings` row (one per user). The same value applies to every gallery page the user views.
+
+Trade-off considered and accepted: a user with both a comics library and a text library can't have different defaults for each. Mitigated by the in-toolbar popover + URL-based ad-hoc state — a user can switch sizes per-session without overwriting their saved default.
+
+### Sizes and widths
+
+Four named sizes. Width is the cover container width applied at `sm:` (640px) and above. Below `sm:`, the existing `w-[calc(50%-0.5rem)]` mobile rule continues to apply (forced 2-col), so size has no visual effect on mobile.
+
+| Size | Tailwind | Width |
+|------|----------|-------|
+| S    | `sm:w-24` | 96px  |
+| M    | `sm:w-32` | 128px (current default) |
+| L    | `sm:w-44` | 176px |
+| XL   | `sm:w-56` | 224px |
+
+Default is **M** so existing users see no visual change.
+
+Cover height continues to be derived from `library.cover_aspect_ratio` (book = 2:3, audiobook = 1:1). Width-driven sizing keeps the existing aspect-ratio system untouched.
+
+### Items per page
+
+Items per page scales with size to keep perceived screen density roughly constant:
+
+| Size | Items/page |
+|------|------------|
+| S    | 48         |
+| M    | 24 (current) |
+| L    | 16         |
+| XL   | 12         |
+
+Backend's max list limit is 50, so S=48 is within bounds. The constants file includes a comment guarding against bumps that would clip silently.
+
+### Pagination preservation on size change
+
+When the user switches size mid-page, the new page lands at or before their current first-visible item:
+
+```
+new_page = floor(old_offset / new_limit) + 1
+```
+
+Example: at M (limit 24) on page 5, `old_offset = 96`. Switching to S (limit 48): `new_page = floor(96/48) + 1 = 3`. Page 3 covers offsets 96–143, so the user sees their first-visible book at the top of the new page.
+
+Same direction-agnostic behavior holds for any size change — the new page always starts at offset `<= old_offset`, so the user never "skips ahead" past books they hadn't seen.
+
+### Storage
+
+Add `gallery_size` column to `user_settings`:
+
+- Type: `TEXT NOT NULL DEFAULT 'm'`
+- Allowed values: `'s' | 'm' | 'l' | 'xl'`
+- Tygo emits a TS literal `GallerySize` type, mirroring how `EpubTheme` is currently emitted from `pkg/models/user_settings.go`.
+
+### API endpoint rename
+
+The current `/settings/viewer` endpoint reads/writes the `user_settings` row but is named for the EPUB viewer because that was the only field stored. Adding `gallery_size` makes the name semantically wrong.
+
+Rename in this PR:
+- Backend route `/settings/viewer` → `/settings/user`
+- Files `pkg/settings/viewer_handlers.go` → `user_handlers.go`, `viewer_service_test.go` → `user_service_test.go`, `viewer_handlers_test.go` → `user_handlers_test.go`
+- Validator types `ViewerSettingsPayload` → `UserSettingsPayload`, `ViewerSettingsResponse` → `UserSettingsResponse`
+- Frontend hook `useViewerSettings` → `useUserSettings`, mutation `useUpdateViewerSettings` → `useUpdateUserSettings`, query key `ViewerSettings` → `UserSettings`
+- Interface `ViewerSettings` → `UserSettings`
+
+Existing field names within the row (`viewer_epub_*`) keep their `viewer_` prefix — those genuinely are viewer fields, the rename is only about the row-level wrapper.
+
+### Toolbar control: SizePopover
+
+A new popover-triggered control in the gallery toolbar, placed alongside Sort/Filter:
+
+- **Trigger:** small button with a "size" icon and text label "Size", showing a dirty dot when the active size differs from the user's saved default. Mirrors `SortButton`'s pattern.
+- **Popover content:** a row of four segmented buttons labeled S / M / L / XL. The active button is highlighted. Clicking a button updates the URL `?size=` param immediately (ad-hoc state).
+- **Save-as-default affordance:** when the active size differs from the saved default, a dashed-bordered card appears below the buttons with:
+  - Body text: "Other users won't be affected."
+  - Button: "Save as my default everywhere"
+- **Mobile:** popover trigger is `hidden sm:flex`. Below `sm:`, the user can only edit via the User Settings page (since size has no visual effect on mobile anyway).
+
+### URL parameter
+
+`?size=s|m|l|xl` carries ad-hoc state on a single page. Resolution order on every gallery page:
+
+1. Valid `?size=` URL param wins
+2. Else user's saved `gallery_size` from `user_settings`
+3. Else default `'m'`
+
+Invalid values fall through silently to step 2 (matches sort's resolution behavior).
+
+The URL param is **per-page** — clicking a `<Link>` to another page does not carry it. To make a change persistent across pages, the user clicks "Save as my default everywhere".
+
+When the user saves a new default, the `?size=` URL param is cleared (since it now matches saved), matching how `handleSaveSortAsDefault` clears `?sort=`.
+
+### Settings load gating
+
+Each gallery page that reads `gallery_size` must wait for `useUserSettings()` to resolve before rendering, or the user with a saved L would see a flash of M-sized covers. The library home page additionally waits for `librarySettingsQuery` (the existing sort gate). Both must resolve; `Loader2` spinner during the wait, identical to today's behavior.
+
+### Sort copy fix (bundled)
+
+The existing `SortSheet` "Save as default" card reads:
+
+> "Save this as the default for this library?"
+> [Save as default]
+
+…which is ambiguous about per-user vs. library-wide. Updated copy in this PR:
+
+> "Other users won't be affected."
+> [Save as my default for this library]
+
+Same `<Save>` icon, same dirty-state gating, same handler. Two lines of JSX.
+
+### User Settings page integration
+
+`UserSettings.tsx` already has an **Appearance** section (theme picker). Add Gallery Size to the same section, below the theme row:
+
+- Label: "Gallery cover size"
+- Control: same four segmented buttons as the popover, reused as a shared `SizeSelector` component
+- Wired to `useUserSettings()` + `useUpdateUserSettings()`
+
+No saved-as-default affordance needed here — every change persists immediately, the page is the settings UI itself.
+
+## Scope of pages affected
+
+Apply the size + items-per-page logic to every page that renders the book Gallery:
+
+- `app/components/pages/Home.tsx` (library books gallery)
+- `app/components/pages/SeriesList.tsx`
+- `app/components/pages/SeriesDetail.tsx`
+- `app/components/pages/GenreDetail.tsx`
+- `app/components/pages/TagDetail.tsx`
+- `app/components/pages/PersonDetail.tsx`
+- `app/components/pages/ListDetail.tsx`
+
+(Cross-checked: these are the call sites of `<Gallery>` rendering book items. The text list pages — GenresList, TagsList, PersonList, PublishersList, ImprintsList — are excluded; they have no covers.)
+
+## Architecture sketch
+
+### New constants and utils
+
+`app/constants/gallerySize.ts`:
+```ts
+export const GALLERY_SIZES = ["s", "m", "l", "xl"] as const;
+export type GallerySize = (typeof GALLERY_SIZES)[number];
+export const DEFAULT_GALLERY_SIZE: GallerySize = "m";
+
+// sm: applies at >= 640px; below sm: w-[calc(50%-0.5rem)] (forced 2-col) takes over.
+export const COVER_WIDTH_CLASS: Record<GallerySize, string> = {
+  s: "sm:w-24",
+  m: "sm:w-32",
+  l: "sm:w-44",
+  xl: "sm:w-56",
+};
+
+// Backend max limit is 50. If you increase any of these to >50, the API will
+// silently clip and pagination will break.
+export const ITEMS_PER_PAGE_BY_SIZE: Record<GallerySize, number> = {
+  s: 48,
+  m: 24,
+  l: 16,
+  xl: 12,
+};
+```
+
+`app/libraries/gallerySize.ts` (pure functions, easy to unit-test):
+```ts
+export const parseGallerySize = (raw: string | null): GallerySize | null => { ... };
+export const pageForSizeChange = (oldOffset: number, newLimit: number): number => { ... };
+```
+
+### New components
+
+- `app/components/library/SizePopover.tsx` — popover with 4 segmented buttons + dirty-state save-as-default card. Same desktop-popover / mobile-drawer split as `SortSheet`, except the popover is hidden below `sm:` so we can use a plain Popover and skip the drawer entirely.
+- `app/components/library/SizeButton.tsx` — toolbar trigger with dirty dot. Mirrors `SortButton`.
+- `app/components/library/SizeSelector.tsx` — the four segmented buttons themselves, reused by both `SizePopover` and `UserSettings.tsx`.
+
+### Hook rename
+
+`app/hooks/queries/settings.ts`:
+- `ViewerSettings` interface → `UserSettings`
+- `ViewerSettings` enum value → `UserSettings`
+- `useViewerSettings` → `useUserSettings`
+- `useUpdateViewerSettings` → `useUpdateUserSettings`
+- Add `gallery_size: GallerySize` to interface and update payload
+- Update endpoint URLs `"/settings/viewer"` → `"/settings/user"`
+- Update all callers (EPUB viewer + new gallery pages)
+
+### Page-level wiring (representative diff for Home.tsx)
+
+```ts
+const userSettingsQuery = useUserSettings();
+const updateUserSettings = useUpdateUserSettings();
+
+const urlSize = parseGallerySize(searchParams.get("size"));
+const savedSize = userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+const effectiveSize: GallerySize = urlSize ?? savedSize;
+const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+
+const itemsPerPage = ITEMS_PER_PAGE_BY_SIZE[effectiveSize];
+
+// gate render — both library + user settings must resolve
+const settingsResolved =
+  (libraryIdNum === undefined || librarySettingsQuery.isSuccess || librarySettingsQuery.isError) &&
+  (userSettingsQuery.isSuccess || userSettingsQuery.isError);
+
+// Apply size change; preserve position via floor-page math
+const applyGallerySize = (next: GallerySize) => {
+  setSearchParams((prev) => {
+    const params = new URLSearchParams(prev);
+    if (next === savedSize) {
+      params.delete("size");
+    } else {
+      params.set("size", next);
+    }
+    const newPage = pageForSizeChange(offset, ITEMS_PER_PAGE_BY_SIZE[next]);
+    params.set("page", String(newPage));
+    return params;
+  });
+};
+
+const handleSaveSizeAsDefault = () => {
+  updateUserSettings.mutate(
+    { gallery_size: effectiveSize },
+    { onSuccess: () => setSearchParams((prev) => {
+        const params = new URLSearchParams(prev);
+        params.delete("size");
+        return params;
+      }) }
+  );
+};
+```
+
+`<Gallery itemsPerPage={itemsPerPage} ... />` and the renderer passes `gallerySize={effectiveSize}` down through `SelectableBookItem` → `BookItem`.
+
+### BookItem cover width
+
+Replace the hard-coded `sm:w-32` with a lookup:
+
+```ts
+className={cn(
+  "w-[calc(50%-0.5rem)] group/card relative",
+  COVER_WIDTH_CLASS[gallerySize],
+  isSelectionMode && "cursor-pointer",
+)}
+```
+
+`gallerySize` becomes a prop on `BookItem` and `SelectableBookItem`, defaulting to `'m'` for any caller that doesn't pass it (keeps existing test fixtures and any future caller from breaking).
+
+## Testing
+
+### Backend
+
+- `pkg/settings/user_handlers_test.go` (renamed from viewer): add cases for valid `gallery_size` accepted, invalid values rejected, partial updates, default returned on missing row.
+- Migration up/down round-trip is covered by the standard migration test harness.
+
+### Frontend (unit)
+
+- `app/libraries/gallerySize.test.ts`:
+  - `parseGallerySize` accepts `s|m|l|xl`, returns null for `"medium"`, `""`, `null`, `"S"` (case-sensitive — same as sort).
+  - `pageForSizeChange` math: known offsets and limits produce expected pages, including the edge cases at offset 0 and offset == old_limit.
+- `app/components/library/SizePopover.test.tsx`:
+  - Renders four segmented buttons with active highlight on the effective size.
+  - Save-as-default card is hidden when `effectiveSize === savedSize`.
+  - Save-as-default card is shown when sizes differ; clicking the button calls the save handler.
+  - Helper text "Other users won't be affected." is present.
+- `app/components/pages/UserSettings.test.tsx`: gallery size selector renders four buttons, picking one calls the update mutation with the right payload.
+
+### E2E
+
+Out of scope — the existing sort flow has no E2E coverage either, and the unit tests above plus the rename test cover the API path well enough.
+
+## Documentation
+
+- New page `website/docs/gallery-size.md`, mirroring `gallery-sort.md`'s shape: Overview, How to use, URL parameter, Saved default. Cross-link to it from the existing `gallery-sort.md`.
+- Update `website/sidebars.ts` to include the new page.
+- No `configuration.md` update — gallery size is a per-user UI preference, not a server config field.
+
+## Risks and open questions
+
+None outstanding. Two areas to be careful about during implementation:
+
+1. **API rename touches the EPUB viewer.** The frontend `useViewerSettings` hook is consumed by viewer pages. Must update those import sites at the same time as the rename, or builds break.
+2. **Settings gate AND on Home.** Home already gates on `librarySettingsQuery`; adding `userSettingsQuery` to that gate must use AND, not OR — else the gallery flashes default-M before the saved size loads.

--- a/e2e/gallery-sort.spec.ts
+++ b/e2e/gallery-sort.spec.ts
@@ -153,7 +153,7 @@ test.describe("Gallery sort", () => {
     await page
       .getByRole("button", { name: "Sort Sort differs from default" })
       .click();
-    await page.getByRole("button", { name: /Save as default/i }).click();
+    await page.getByRole("button", { name: /Save as my default/i }).click();
     await expect(page).not.toHaveURL(/[?&]sort=/);
     await expect(page.getByText(/^Sorted by:/)).not.toBeVisible();
     await expect(

--- a/pkg/migrations/20260425000000_add_user_gallery_size.go
+++ b/pkg/migrations/20260425000000_add_user_gallery_size.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`
+			ALTER TABLE user_settings ADD COLUMN gallery_size TEXT NOT NULL DEFAULT 'm'
+		`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec("ALTER TABLE user_settings DROP COLUMN gallery_size")
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/user_settings.go
+++ b/pkg/models/user_settings.go
@@ -25,6 +25,14 @@ const (
 	EpubFlowScrolled  = "scrolled"
 )
 
+const (
+	//tygo:emit export type GallerySize = typeof GallerySizeSmall | typeof GallerySizeMedium | typeof GallerySizeLarge | typeof GallerySizeExtraLarge;
+	GallerySizeSmall      = "s"
+	GallerySizeMedium     = "m"
+	GallerySizeLarge      = "l"
+	GallerySizeExtraLarge = "xl"
+)
+
 type UserSettings struct {
 	bun.BaseModel `bun:"table:user_settings,alias:us" tstype:"-"`
 
@@ -37,6 +45,7 @@ type UserSettings struct {
 	EpubFontSize       int       `bun:"viewer_epub_font_size,notnull,default:100" json:"viewer_epub_font_size"`
 	EpubTheme          string    `bun:"viewer_epub_theme,notnull,default:'light'" json:"viewer_epub_theme" tstype:"EpubTheme"`
 	EpubFlow           string    `bun:"viewer_epub_flow,notnull,default:'paginated'" json:"viewer_epub_flow" tstype:"EpubFlow"`
+	GallerySize        string    `bun:",notnull,default:'m'" json:"gallery_size" tstype:"GallerySize"`
 }
 
 // DefaultUserSettings returns a UserSettings with default values.
@@ -47,5 +56,6 @@ func DefaultUserSettings() *UserSettings {
 		EpubFontSize:       100,
 		EpubTheme:          EpubThemeLight,
 		EpubFlow:           EpubFlowPaginated,
+		GallerySize:        GallerySizeMedium,
 	}
 }

--- a/pkg/settings/handlers.go
+++ b/pkg/settings/handlers.go
@@ -13,7 +13,7 @@ type handler struct {
 	settingsService *Service
 }
 
-func (h *handler) getViewerSettings(c echo.Context) error {
+func (h *handler) getUserSettings(c echo.Context) error {
 	ctx := c.Request().Context()
 
 	user, ok := c.Get("user").(*models.User)
@@ -21,12 +21,12 @@ func (h *handler) getViewerSettings(c echo.Context) error {
 		return errcodes.Unauthorized("Authentication required")
 	}
 
-	settings, err := h.settingsService.GetViewerSettings(ctx, user.ID)
+	settings, err := h.settingsService.GetUserSettings(ctx, user.ID)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return c.JSON(http.StatusOK, ViewerSettingsResponse{
+	return c.JSON(http.StatusOK, UserSettingsResponse{
 		PreloadCount: settings.ViewerPreloadCount,
 		FitMode:      settings.ViewerFitMode,
 		EpubFontSize: settings.EpubFontSize,
@@ -35,7 +35,7 @@ func (h *handler) getViewerSettings(c echo.Context) error {
 	})
 }
 
-func (h *handler) updateViewerSettings(c echo.Context) error {
+func (h *handler) updateUserSettings(c echo.Context) error {
 	ctx := c.Request().Context()
 
 	user, ok := c.Get("user").(*models.User)
@@ -43,7 +43,7 @@ func (h *handler) updateViewerSettings(c echo.Context) error {
 		return errcodes.Unauthorized("Authentication required")
 	}
 
-	var payload ViewerSettingsPayload
+	var payload UserSettingsPayload
 	if err := c.Bind(&payload); err != nil {
 		return errors.WithStack(err)
 	}
@@ -66,13 +66,13 @@ func (h *handler) updateViewerSettings(c echo.Context) error {
 		return errcodes.ValidationError("viewer_epub_flow must be 'paginated' or 'scrolled'")
 	}
 
-	settings, err := h.settingsService.UpdateViewerSettings(
-		ctx, user.ID, ViewerSettingsUpdate(payload))
+	settings, err := h.settingsService.UpdateUserSettings(
+		ctx, user.ID, UserSettingsUpdate(payload))
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return c.JSON(http.StatusOK, ViewerSettingsResponse{
+	return c.JSON(http.StatusOK, UserSettingsResponse{
 		PreloadCount: settings.ViewerPreloadCount,
 		FitMode:      settings.ViewerFitMode,
 		EpubFontSize: settings.EpubFontSize,

--- a/pkg/settings/handlers.go
+++ b/pkg/settings/handlers.go
@@ -32,6 +32,7 @@ func (h *handler) getUserSettings(c echo.Context) error {
 		EpubFontSize: settings.EpubFontSize,
 		EpubTheme:    settings.EpubTheme,
 		EpubFlow:     settings.EpubFlow,
+		GallerySize:  settings.GallerySize,
 	})
 }
 
@@ -65,6 +66,9 @@ func (h *handler) updateUserSettings(c echo.Context) error {
 	if payload.EpubFlow != nil && !IsValidEpubFlow(*payload.EpubFlow) {
 		return errcodes.ValidationError("viewer_epub_flow must be 'paginated' or 'scrolled'")
 	}
+	if payload.GallerySize != nil && !IsValidGallerySize(*payload.GallerySize) {
+		return errcodes.ValidationError("gallery_size must be 's', 'm', 'l', or 'xl'")
+	}
 
 	settings, err := h.settingsService.UpdateUserSettings(
 		ctx, user.ID, UserSettingsUpdate(payload))
@@ -78,5 +82,6 @@ func (h *handler) updateUserSettings(c echo.Context) error {
 		EpubFontSize: settings.EpubFontSize,
 		EpubTheme:    settings.EpubTheme,
 		EpubFlow:     settings.EpubFlow,
+		GallerySize:  settings.GallerySize,
 	})
 }

--- a/pkg/settings/routes.go
+++ b/pkg/settings/routes.go
@@ -9,14 +9,14 @@ import (
 func RegisterRoutes(e *echo.Echo, db *bun.DB, authMiddleware *auth.Middleware) {
 	svc := NewService(db)
 
-	viewerH := &handler{settingsService: svc}
+	userH := &handler{settingsService: svc}
 	libraryH := &libraryHandler{settingsService: svc}
 
 	g := e.Group("/settings")
 	g.Use(authMiddleware.Authenticate)
 
-	g.GET("/viewer", viewerH.getViewerSettings)
-	g.PUT("/viewer", viewerH.updateViewerSettings)
+	g.GET("/user", userH.getUserSettings)
+	g.PUT("/user", userH.updateUserSettings)
 
 	g.GET("/libraries/:library_id", libraryH.getLibrarySettings)
 	g.PUT("/libraries/:library_id", libraryH.updateLibrarySettings)

--- a/pkg/settings/service.go
+++ b/pkg/settings/service.go
@@ -18,8 +18,8 @@ func NewService(db *bun.DB) *Service {
 	return &Service{db: db}
 }
 
-// GetViewerSettings retrieves viewer settings for a user, returning defaults if none exist.
-func (svc *Service) GetViewerSettings(ctx context.Context, userID int) (*models.UserSettings, error) {
+// GetUserSettings retrieves user settings for a user, returning defaults if none exist.
+func (svc *Service) GetUserSettings(ctx context.Context, userID int) (*models.UserSettings, error) {
 	settings := &models.UserSettings{}
 	err := svc.db.NewSelect().
 		Model(settings).
@@ -39,11 +39,11 @@ func (svc *Service) GetViewerSettings(ctx context.Context, userID int) (*models.
 	return settings, nil
 }
 
-// ViewerSettingsUpdate describes a partial update to viewer settings. Any
+// UserSettingsUpdate describes a partial update to user settings. Any
 // field left nil is left untouched; fields set to a non-nil value are
 // persisted. This lets clients change one setting without having to read
 // and echo every other setting first.
-type ViewerSettingsUpdate struct {
+type UserSettingsUpdate struct {
 	PreloadCount *int
 	FitMode      *string
 	EpubFontSize *int
@@ -51,20 +51,20 @@ type ViewerSettingsUpdate struct {
 	EpubFlow     *string
 }
 
-// UpdateViewerSettings applies a partial update to a user's viewer settings,
+// UpdateUserSettings applies a partial update to a user's settings,
 // creating a row if none exists. Runs in a transaction so that the
 // read-current-then-write-merged sequence is atomic — otherwise two
 // concurrent updates from the same user (rapid toggles in one tab, or two
 // tabs racing) could lose one of the writes.
-func (svc *Service) UpdateViewerSettings(
+func (svc *Service) UpdateUserSettings(
 	ctx context.Context,
 	userID int,
-	update ViewerSettingsUpdate,
+	update UserSettingsUpdate,
 ) (*models.UserSettings, error) {
 	var result *models.UserSettings
 	err := svc.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
 		// Load the current row inside the tx so a concurrent update can't
-		// slip in between the read and the write. GetViewerSettings doesn't
+		// slip in between the read and the write. GetUserSettings doesn't
 		// take a tx, so inline the select here.
 		current := &models.UserSettings{}
 		err := tx.NewSelect().

--- a/pkg/settings/service.go
+++ b/pkg/settings/service.go
@@ -49,6 +49,7 @@ type UserSettingsUpdate struct {
 	EpubFontSize *int
 	EpubTheme    *string
 	EpubFlow     *string
+	GallerySize  *string
 }
 
 // UpdateUserSettings applies a partial update to a user's settings,
@@ -95,6 +96,9 @@ func (svc *Service) UpdateUserSettings(
 		if update.EpubFlow != nil {
 			current.EpubFlow = *update.EpubFlow
 		}
+		if update.GallerySize != nil {
+			current.GallerySize = *update.GallerySize
+		}
 
 		now := time.Now()
 		current.UserID = userID
@@ -112,6 +116,7 @@ func (svc *Service) UpdateUserSettings(
 			Set("viewer_epub_font_size = EXCLUDED.viewer_epub_font_size").
 			Set("viewer_epub_theme = EXCLUDED.viewer_epub_theme").
 			Set("viewer_epub_flow = EXCLUDED.viewer_epub_flow").
+			Set("gallery_size = EXCLUDED.gallery_size").
 			Returning("*").
 			Exec(ctx)
 		if err != nil {

--- a/pkg/settings/user_handlers_test.go
+++ b/pkg/settings/user_handlers_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUpdateViewerSettings_RejectsBadEpubFontSize(t *testing.T) {
+func TestUpdateUserSettings_RejectsBadEpubFontSize(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	user := createTestUser(t, db, "alice")
@@ -28,18 +28,18 @@ func TestUpdateViewerSettings_RejectsBadEpubFontSize(t *testing.T) {
 		"viewer_epub_theme": "light",
 		"viewer_epub_flow": "paginated"
 	}`
-	req := httptest.NewRequest(http.MethodPut, "/settings/viewer", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPut, "/settings/user", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.Set("user", user)
 
-	err := h.updateViewerSettings(c)
+	err := h.updateUserSettings(c)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "viewer_epub_font_size")
 }
 
-func TestUpdateViewerSettings_AcceptsValidEpubPayload(t *testing.T) {
+func TestUpdateUserSettings_AcceptsValidEpubPayload(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	user := createTestUser(t, db, "bob")
@@ -54,28 +54,28 @@ func TestUpdateViewerSettings_AcceptsValidEpubPayload(t *testing.T) {
 		"viewer_epub_theme": "dark",
 		"viewer_epub_flow": "scrolled"
 	}`
-	req := httptest.NewRequest(http.MethodPut, "/settings/viewer", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPut, "/settings/user", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.Set("user", user)
 
-	require.NoError(t, h.updateViewerSettings(c))
+	require.NoError(t, h.updateUserSettings(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	var resp ViewerSettingsResponse
+	var resp UserSettingsResponse
 	require.NoError(t, json.NewDecoder(strings.NewReader(rec.Body.String())).Decode(&resp))
 	assert.Equal(t, 130, resp.EpubFontSize)
 	assert.Equal(t, models.EpubThemeDark, resp.EpubTheme)
 	assert.Equal(t, models.EpubFlowScrolled, resp.EpubFlow)
 }
 
-// TestUpdateViewerSettings_EmptyBodyIsNoop verifies the explicit no-op
+// TestUpdateUserSettings_EmptyBodyIsNoop verifies the explicit no-op
 // contract: an empty JSON object updates nothing and returns the current
 // (or default) values unchanged. Locks down the behavior so a future
 // refactor doesn't accidentally start treating nil pointers as "zero the
 // field".
-func TestUpdateViewerSettings_EmptyBodyIsNoop(t *testing.T) {
+func TestUpdateUserSettings_EmptyBodyIsNoop(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	user := createTestUser(t, db, "erin")
@@ -83,16 +83,16 @@ func TestUpdateViewerSettings_EmptyBodyIsNoop(t *testing.T) {
 	e := newTestEcho(t)
 	h := &handler{settingsService: NewService(db)}
 
-	req := httptest.NewRequest(http.MethodPut, "/settings/viewer", strings.NewReader(`{}`))
+	req := httptest.NewRequest(http.MethodPut, "/settings/user", strings.NewReader(`{}`))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.Set("user", user)
 
-	require.NoError(t, h.updateViewerSettings(c))
+	require.NoError(t, h.updateUserSettings(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	var resp ViewerSettingsResponse
+	var resp UserSettingsResponse
 	require.NoError(t, json.NewDecoder(strings.NewReader(rec.Body.String())).Decode(&resp))
 	// All fields are at their defaults — no prior row existed.
 	assert.Equal(t, 3, resp.PreloadCount)
@@ -102,10 +102,10 @@ func TestUpdateViewerSettings_EmptyBodyIsNoop(t *testing.T) {
 	assert.Equal(t, models.EpubFlowPaginated, resp.EpubFlow)
 }
 
-// TestUpdateViewerSettings_AcceptsSingleFieldPayload verifies that a payload
+// TestUpdateUserSettings_AcceptsSingleFieldPayload verifies that a payload
 // containing only one field (omitting all others) updates just that field
 // and leaves unrelated settings at their existing values.
-func TestUpdateViewerSettings_AcceptsSingleFieldPayload(t *testing.T) {
+func TestUpdateUserSettings_AcceptsSingleFieldPayload(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	user := createTestUser(t, db, "dave")
@@ -115,16 +115,16 @@ func TestUpdateViewerSettings_AcceptsSingleFieldPayload(t *testing.T) {
 
 	// Only send viewer_epub_theme. Everything else must keep its default.
 	body := `{"viewer_epub_theme": "sepia"}`
-	req := httptest.NewRequest(http.MethodPut, "/settings/viewer", strings.NewReader(body))
+	req := httptest.NewRequest(http.MethodPut, "/settings/user", strings.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.Set("user", user)
 
-	require.NoError(t, h.updateViewerSettings(c))
+	require.NoError(t, h.updateUserSettings(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	var resp ViewerSettingsResponse
+	var resp UserSettingsResponse
 	require.NoError(t, json.NewDecoder(strings.NewReader(rec.Body.String())).Decode(&resp))
 	assert.Equal(t, models.EpubThemeSepia, resp.EpubTheme)
 	// Other fields stay at defaults

--- a/pkg/settings/user_handlers_test.go
+++ b/pkg/settings/user_handlers_test.go
@@ -133,3 +133,67 @@ func TestUpdateUserSettings_AcceptsSingleFieldPayload(t *testing.T) {
 	assert.Equal(t, 100, resp.EpubFontSize)
 	assert.Equal(t, models.EpubFlowPaginated, resp.EpubFlow)
 }
+
+func TestUpdateUserSettings_AcceptsValidGallerySize(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	user := createTestUser(t, db, "gally-valid")
+
+	e := newTestEcho(t)
+	h := &handler{settingsService: NewService(db)}
+
+	body := `{"gallery_size": "l"}`
+	req := httptest.NewRequest(http.MethodPut, "/settings/user", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	require.NoError(t, h.updateUserSettings(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp UserSettingsResponse
+	require.NoError(t, json.NewDecoder(strings.NewReader(rec.Body.String())).Decode(&resp))
+	assert.Equal(t, models.GallerySizeLarge, resp.GallerySize)
+}
+
+func TestUpdateUserSettings_RejectsInvalidGallerySize(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	user := createTestUser(t, db, "gally-bad")
+
+	e := newTestEcho(t)
+	h := &handler{settingsService: NewService(db)}
+
+	body := `{"gallery_size": "huge"}`
+	req := httptest.NewRequest(http.MethodPut, "/settings/user", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	err := h.updateUserSettings(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "gallery_size")
+}
+
+func TestGetUserSettings_DefaultsToMediumGallerySize(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	user := createTestUser(t, db, "gally-default")
+
+	e := newTestEcho(t)
+	h := &handler{settingsService: NewService(db)}
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/user", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	require.NoError(t, h.getUserSettings(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp UserSettingsResponse
+	require.NoError(t, json.NewDecoder(strings.NewReader(rec.Body.String())).Decode(&resp))
+	assert.Equal(t, models.GallerySizeMedium, resp.GallerySize)
+}

--- a/pkg/settings/user_service_test.go
+++ b/pkg/settings/user_service_test.go
@@ -9,20 +9,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetViewerSettings_ReturnsEpubDefaults(t *testing.T) {
+func TestGetUserSettings_ReturnsEpubDefaults(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	user := createTestUser(t, db, "alice")
 	svc := NewService(db)
 
-	settings, err := svc.GetViewerSettings(context.Background(), user.ID)
+	settings, err := svc.GetUserSettings(context.Background(), user.ID)
 	require.NoError(t, err)
 	assert.Equal(t, 100, settings.EpubFontSize)
 	assert.Equal(t, models.EpubThemeLight, settings.EpubTheme)
 	assert.Equal(t, models.EpubFlowPaginated, settings.EpubFlow)
 }
 
-func TestUpdateViewerSettings_PersistsEpubFields(t *testing.T) {
+func TestUpdateUserSettings_PersistsEpubFields(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	user := createTestUser(t, db, "bob")
@@ -34,10 +34,10 @@ func TestUpdateViewerSettings_PersistsEpubFields(t *testing.T) {
 	theme := models.EpubThemeSepia
 	flow := models.EpubFlowScrolled
 
-	updated, err := svc.UpdateViewerSettings(
+	updated, err := svc.UpdateUserSettings(
 		context.Background(),
 		user.ID,
-		ViewerSettingsUpdate{
+		UserSettingsUpdate{
 			PreloadCount: &preload,
 			FitMode:      &fitMode,
 			EpubFontSize: &fontSize,
@@ -51,18 +51,18 @@ func TestUpdateViewerSettings_PersistsEpubFields(t *testing.T) {
 	assert.Equal(t, models.EpubFlowScrolled, updated.EpubFlow)
 
 	// Re-read to confirm persistence
-	reloaded, err := svc.GetViewerSettings(context.Background(), user.ID)
+	reloaded, err := svc.GetUserSettings(context.Background(), user.ID)
 	require.NoError(t, err)
 	assert.Equal(t, 140, reloaded.EpubFontSize)
 	assert.Equal(t, models.EpubThemeSepia, reloaded.EpubTheme)
 	assert.Equal(t, models.EpubFlowScrolled, reloaded.EpubFlow)
 }
 
-// TestUpdateViewerSettings_PartialUpdateDoesNotClobber verifies the core
-// reason ViewerSettingsUpdate uses pointer fields: a client that only
+// TestUpdateUserSettings_PartialUpdateDoesNotClobber verifies the core
+// reason UserSettingsUpdate uses pointer fields: a client that only
 // changes one setting should leave others alone, not overwrite them with
 // defaults.
-func TestUpdateViewerSettings_PartialUpdateDoesNotClobber(t *testing.T) {
+func TestUpdateUserSettings_PartialUpdateDoesNotClobber(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	user := createTestUser(t, db, "carol")
@@ -74,7 +74,7 @@ func TestUpdateViewerSettings_PartialUpdateDoesNotClobber(t *testing.T) {
 	fontSize := 130
 	theme := models.EpubThemeDark
 	flow := models.EpubFlowScrolled
-	_, err := svc.UpdateViewerSettings(context.Background(), user.ID, ViewerSettingsUpdate{
+	_, err := svc.UpdateUserSettings(context.Background(), user.ID, UserSettingsUpdate{
 		PreloadCount: &preload,
 		FitMode:      &fitMode,
 		EpubFontSize: &fontSize,
@@ -85,7 +85,7 @@ func TestUpdateViewerSettings_PartialUpdateDoesNotClobber(t *testing.T) {
 
 	// Now update just the theme; all other fields must keep their seeded value.
 	newTheme := models.EpubThemeSepia
-	updated, err := svc.UpdateViewerSettings(context.Background(), user.ID, ViewerSettingsUpdate{
+	updated, err := svc.UpdateUserSettings(context.Background(), user.ID, UserSettingsUpdate{
 		EpubTheme: &newTheme,
 	})
 	require.NoError(t, err)

--- a/pkg/settings/validators.go
+++ b/pkg/settings/validators.go
@@ -17,6 +17,7 @@ type UserSettingsPayload struct {
 	EpubFontSize *int    `json:"viewer_epub_font_size,omitempty"`
 	EpubTheme    *string `json:"viewer_epub_theme,omitempty"`
 	EpubFlow     *string `json:"viewer_epub_flow,omitempty"`
+	GallerySize  *string `json:"gallery_size,omitempty"`
 }
 
 // UserSettingsResponse is the response for user settings.
@@ -26,6 +27,7 @@ type UserSettingsResponse struct {
 	EpubFontSize int    `json:"viewer_epub_font_size"`
 	EpubTheme    string `json:"viewer_epub_theme"`
 	EpubFlow     string `json:"viewer_epub_flow"`
+	GallerySize  string `json:"gallery_size"`
 }
 
 // ValidFitModes returns all valid fit mode values.
@@ -56,6 +58,16 @@ func IsValidEpubTheme(theme string) bool {
 func IsValidEpubFlow(flow string) bool {
 	switch flow {
 	case models.EpubFlowPaginated, models.EpubFlowScrolled:
+		return true
+	}
+	return false
+}
+
+// IsValidGallerySize returns true if the size is a supported gallery size.
+func IsValidGallerySize(size string) bool {
+	switch size {
+	case models.GallerySizeSmall, models.GallerySizeMedium,
+		models.GallerySizeLarge, models.GallerySizeExtraLarge:
 		return true
 	}
 	return false

--- a/pkg/settings/validators.go
+++ b/pkg/settings/validators.go
@@ -2,16 +2,16 @@ package settings
 
 import "github.com/shishobooks/shisho/pkg/models"
 
-// ViewerSettingsPayload is the request body for updating viewer settings.
+// UserSettingsPayload is the request body for updating user settings.
 //
 // All fields are pointers so clients can send partial updates. Omitting a
 // field (or sending it as null) leaves the current value untouched; sending
 // a value updates just that field.
 //
-// Field shape must stay identical to ViewerSettingsUpdate (same field names,
+// Field shape must stay identical to UserSettingsUpdate (same field names,
 // same types, same order) — the handler converts between them with
-// `ViewerSettingsUpdate(payload)`. Drifting either one breaks that cast.
-type ViewerSettingsPayload struct {
+// `UserSettingsUpdate(payload)`. Drifting either one breaks that cast.
+type UserSettingsPayload struct {
 	PreloadCount *int    `json:"preload_count,omitempty"`
 	FitMode      *string `json:"fit_mode,omitempty"`
 	EpubFontSize *int    `json:"viewer_epub_font_size,omitempty"`
@@ -19,8 +19,8 @@ type ViewerSettingsPayload struct {
 	EpubFlow     *string `json:"viewer_epub_flow,omitempty"`
 }
 
-// ViewerSettingsResponse is the response for viewer settings.
-type ViewerSettingsResponse struct {
+// UserSettingsResponse is the response for user settings.
+type UserSettingsResponse struct {
 	PreloadCount int    `json:"preload_count"`
 	FitMode      string `json:"fit_mode"`
 	EpubFontSize int    `json:"viewer_epub_font_size"`

--- a/website/docs/gallery-size.md
+++ b/website/docs/gallery-size.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 155
+---
+
+# Gallery Size
+
+Pick how large book covers display in your gallery — Small, Medium, Large, or Extra Large. The choice applies everywhere you see covers (library home, series, genres, tags, people, lists).
+
+## Using the Size popover
+
+Click **Size** in the gallery toolbar to open the size popover. Pick S / M / L / XL — covers resize immediately and the gallery jumps to a page that contains the book you were last looking at, so you don't lose your place.
+
+A dot on the Size button means your current size differs from your saved default.
+
+The popover is hidden on small screens, where covers always render two per row regardless of size. Edit your saved default from User Settings on a phone, and it'll apply next time you're on a wider screen.
+
+## Sizes
+
+| Size | Cover width (desktop) | Books per page |
+|------|----------------------|----------------|
+| S    | 96px                 | 48 |
+| M    | 128px (default)      | 24 |
+| L    | 176px                | 16 |
+| XL   | 224px                | 12 |
+
+Items per page scale so screen density stays roughly constant — bigger covers, fewer per page.
+
+## URL-addressable size
+
+Non-default sizes live in the URL as `?size=s|m|l|xl`. You can share or bookmark a sized view and it loads at that size — for that recipient on that page only.
+
+```
+?size=l
+```
+
+When the URL has no `size` parameter, the gallery uses your saved default (or **M** if you haven't saved one).
+
+## Saving a default
+
+When your current size differs from your saved default, the size popover shows a **Save as my default everywhere** button. Clicking it:
+
+1. Saves your current size as your new default for every gallery page.
+2. Clears the `?size=` parameter from the URL — you're now viewing the default.
+
+Defaults are per user — saving doesn't affect other users.
+
+You can also edit the default from your **User Settings** page under Appearance.
+
+## See also
+
+- [Gallery Sort](./gallery-sort.md) for sorting books by author, series, date added, and more.

--- a/website/docs/gallery-size.md
+++ b/website/docs/gallery-size.md
@@ -8,7 +8,7 @@ Pick how large book covers display in your gallery — Small, Medium, Large, or 
 
 ## Using the Size popover
 
-Click **Size** in the gallery toolbar to open the size popover. Pick S / M / L / XL — covers resize immediately and the gallery jumps to a page that contains the book you were last looking at, so you don't lose your place.
+Click **Size** in the gallery toolbar to open the size popover. Pick S / M / L / XL — covers resize immediately and the gallery jumps to a page that contains the item you were last looking at, so you don't lose your place.
 
 A dot on the Size button means your current size differs from your saved default.
 
@@ -16,14 +16,14 @@ The popover is hidden on small screens, where covers always render two per row r
 
 ## Sizes
 
-| Size | Cover width (desktop) | Books per page |
+| Size | Cover width (desktop) | Items per page |
 |------|----------------------|----------------|
 | S    | 96px                 | 48 |
 | M    | 128px (default)      | 24 |
 | L    | 176px                | 16 |
 | XL   | 224px                | 12 |
 
-Items per page scale so screen density stays roughly constant — bigger covers, fewer per page.
+Items per page scale so screen density stays roughly constant — bigger covers, fewer per page. The same scale applies to series cards on the Series list and to books on every other gallery page.
 
 ## URL-addressable size
 

--- a/website/docs/gallery-size.md
+++ b/website/docs/gallery-size.md
@@ -18,12 +18,12 @@ The popover is hidden on small screens, where covers always render two per row r
 
 | Size | Cover width (desktop) | Items per page |
 |------|----------------------|----------------|
-| S    | 96px                 | 48 |
+| S    | 96px                 | 33 |
 | M    | 128px (default)      | 24 |
-| L    | 176px                | 16 |
-| XL   | 224px                | 12 |
+| L    | 176px                | 18 |
+| XL   | 224px                | 15 |
 
-Items per page scale so screen density stays roughly constant — bigger covers, fewer per page. The same scale applies to series cards on the Series list and to books on every other gallery page.
+Items per page are tuned to fill exactly three rows at each size's natural column count on a typical desktop gallery — bigger covers, fewer per row, same row count. The same scale applies to series cards on the Series list and to books on every other gallery page.
 
 ## URL-addressable size
 

--- a/website/docs/gallery-sort.md
+++ b/website/docs/gallery-sort.md
@@ -61,3 +61,7 @@ When a non-default sort is active, a **reset to default** link appears next to t
 ## How this affects other surfaces
 
 Your saved library sort also applies to the OPDS feeds and the eReader browser for that library. See [OPDS](./opds.md) and [eReader browser](./ereader-browser.md) for details.
+
+## See also
+
+- [Gallery Size](./gallery-size.md) for resizing book covers in the gallery.


### PR DESCRIPTION
## Summary
- Add per-user `gallery_size` preference (S/M/L/XL) stored in `user_settings`. Applies to every gallery page (library home, series, genres, tags, people, lists). Cover widths and items-per-page scale with size; default M = current behavior.
- New `SizePopover` in the gallery toolbar with ad-hoc URL state (`?size=`) and a "Save as my default everywhere" affordance. Switching size mid-page preserves the user's first-visible book.
- Rename the existing `/settings/viewer` endpoint and `useViewerSettings` hook to `/settings/user` / `useUserSettings` since the row was always per-user, not viewer-specific. Bundle a copy fix to Sort's "Save as default" so it reads "Save as my default for this library" with an "Other users won't be affected" helper.

## Test plan
- Open a library at desktop width. Click **Size** in the toolbar; confirm the popover opens directly below the trigger and S/M/L/XL buttons render.
- Pick L; confirm covers resize to ~176px wide, the URL gains `?size=l`, and the gallery jumps to a page containing the book that was previously first-visible.
- Confirm the **Save as my default everywhere** button appears with the helper "Other users won't be affected." Click it; confirm `?size=` clears and the saved default sticks across page reloads.
- Visit Series/SeriesDetail/GenreDetail/TagDetail/PersonDetail/ListDetail — confirm Size popover appears in each and book covers respond.
- Visit `/user/settings` → Appearance → confirm a "Gallery cover size" segmented control reflects the saved default and persists immediately on click.
- At mobile width (<640px), confirm the Size popover trigger is hidden and covers stay 2-col.
- Open the popover and click between S/M/L/XL rapidly — confirm button widths under the cursor don't change as the save card appears/disappears.
- Scroll a gallery so the popover would overlap the top nav — confirm the top nav stays in front.
- Sort sheet's save-as-default card now reads "Save as my default for this library" + "Other users won't be affected." helper.