### PR TITLE
[Test] Pin mold dive requirement for slice-of-struct payloads

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -280,6 +280,8 @@ var payload setOrderPayload
 if err := c.Bind(&payload); err != nil { ... }
 ```
 
+- **Slice fields need `mod:"dive"` for inner modifiers to fire**: `mold/v4` (used by the binder for `mod:"trim"` etc.) treats slice/array/map/pointer-to-slice fields as opaque single values by default. If a payload field is shaped like `[]Inner` or `*[]Inner` and `Inner` has any `mod:"..."` tags on its fields, the parent slice field must carry `mod:"dive"` — otherwise the inner modifiers are silently no-ops. This mirrors `validator/v10`'s `dive`, but the two are independent: both tags are required on the same field when both validation and modification need to traverse. Reference: `UpdateFilePayload.Identifiers *[]IdentifierPayload` in `pkg/books/validators.go` (carries `mod:"dive" validate:"omitempty,dive"`); regression test in `pkg/binder/binder_test.go` (`TestBind_DiveRequiredForSliceModTraversal`).
+
 - **Bun table aliases in WHERE/ORDER clauses**: Bun auto-aliases tables using the first letter of the table name (e.g., `books` → `b`, `files` → `f`, `persons` → `p`). Always use these aliases in `Where()`, `Order()`, and other SQL clauses — never use the full table name:
 
 ```go

--- a/pkg/binder/binder_test.go
+++ b/pkg/binder/binder_test.go
@@ -85,6 +85,11 @@ func TestBind_DiveRequiredForSliceModTraversal(t *testing.T) {
 	type withDive struct {
 		Items []inner `json:"items" mod:"dive"`
 	}
+	// withDivePtrSlice mirrors the exact shape used in production by
+	// UpdateFilePayload.Identifiers (*[]IdentifierPayload).
+	type withDivePtrSlice struct {
+		Items *[]inner `json:"items" mod:"dive"`
+	}
 
 	body := `{"items":[{"value":"  hi  "}]}`
 
@@ -102,6 +107,15 @@ func TestBind_DiveRequiredForSliceModTraversal(t *testing.T) {
 		require.NoError(tt, b.Bind(&p, c))
 		require.Len(tt, p.Items, 1)
 		assert.Equal(tt, "hi", p.Items[0].Value, "with mod:\"dive\", inner modifiers must fire on each element")
+	})
+
+	t.Run("with dive on pointer-to-slice, inner mod:trim is applied", func(tt *testing.T) {
+		c := newContext(body, echo.MIMEApplicationJSON)
+		p := withDivePtrSlice{}
+		require.NoError(tt, b.Bind(&p, c))
+		require.NotNil(tt, p.Items)
+		require.Len(tt, *p.Items, 1)
+		assert.Equal(tt, "hi", (*p.Items)[0].Value, "with mod:\"dive\" on *[]Inner, inner modifiers must fire (matches UpdateFilePayload.Identifiers shape)")
 	})
 }
 

--- a/pkg/binder/binder_test.go
+++ b/pkg/binder/binder_test.go
@@ -65,6 +65,46 @@ func TestNew(t *testing.T) {
 	})
 }
 
+// TestBind_DiveRequiredForSliceModTraversal documents that mold/v4 only
+// applies inner-field modifiers (e.g. mod:"trim") to slice elements when the
+// parent slice field carries mod:"dive". Without dive, the modifiers on the
+// inner struct are silently no-ops. This is the latent gap PR #153 closed
+// for UpdateFilePayload.Identifiers; this test pins the underlying behavior
+// so future regressions surface here at the binder level.
+func TestBind_DiveRequiredForSliceModTraversal(t *testing.T) {
+	t.Parallel()
+	b, err := New()
+	require.NoError(t, err)
+
+	type inner struct {
+		Value string `json:"value" mod:"trim"`
+	}
+	type withoutDive struct {
+		Items []inner `json:"items"`
+	}
+	type withDive struct {
+		Items []inner `json:"items" mod:"dive"`
+	}
+
+	body := `{"items":[{"value":"  hi  "}]}`
+
+	t.Run("without dive, inner mod:trim is a no-op", func(tt *testing.T) {
+		c := newContext(body, echo.MIMEApplicationJSON)
+		p := withoutDive{}
+		require.NoError(tt, b.Bind(&p, c))
+		require.Len(tt, p.Items, 1)
+		assert.Equal(tt, "  hi  ", p.Items[0].Value, "without mod:\"dive\", inner modifiers must not fire")
+	})
+
+	t.Run("with dive, inner mod:trim is applied", func(tt *testing.T) {
+		c := newContext(body, echo.MIMEApplicationJSON)
+		p := withDive{}
+		require.NoError(tt, b.Bind(&p, c))
+		require.Len(tt, p.Items, 1)
+		assert.Equal(tt, "hi", p.Items[0].Value, "with mod:\"dive\", inner modifiers must fire on each element")
+	})
+}
+
 func newContext(payload, mime string) echo.Context {
 	e := echo.New()
 	req := httptest.NewRequest(echo.POST, "/", strings.NewReader(payload))


### PR DESCRIPTION
## Summary
- Audited all `pkg/` payloads for slice fields whose inner element types carry `mod:"..."` tags but are missing `mod:"dive"` on the parent. Outcome: only `IdentifierPayload` has inner `mod:` tags, and its sole slice usage (`UpdateFilePayload.Identifiers`) already carries `mod:"dive"` from #153 — no code fix needed.
- Added a binder-level regression test (`TestBind_DiveRequiredForSliceModTraversal`) that pins mold/v4's behavior with two synthetic structs (without/with `mod:"dive"`), so future drift surfaces here at the binder layer instead of as silent no-ops in payloads.
- Added a note to `pkg/CLAUDE.md` under API Conventions explaining the requirement, with a pointer to the reference payload and the regression test.

Closes the audit task in Notion.

## Test plan
- `mise check:quiet` passes locally (lint, Go tests, JS tests, JS lint).
- `go test ./pkg/binder/ -run TestBind_DiveRequiredForSliceModTraversal -v` shows both subtests pass: the without-dive case asserts the inner value is left untrimmed (`"  hi  "`), the with-dive case asserts it is trimmed (`"hi"`).