### PR TITLE
[Frontend] Remove back button from reader UI

### DIFF
--- a/app/components/pages/EPUBReader.test.tsx
+++ b/app/components/pages/EPUBReader.test.tsx
@@ -51,7 +51,7 @@ const renderReader = () => {
   return render(
     <QueryClientProvider client={client}>
       <MemoryRouter>
-        <EPUBReader bookTitle="Test Book" file={file} libraryId="1" />
+        <EPUBReader bookTitle="Test Book" file={file} />
       </MemoryRouter>
     </QueryClientProvider>,
   );

--- a/app/components/pages/EPUBReader.tsx
+++ b/app/components/pages/EPUBReader.tsx
@@ -1,13 +1,11 @@
 import {
   AlertCircle,
-  ArrowLeft,
   ChevronLeft,
   ChevronRight,
   Loader2,
   Settings,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Link } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -29,7 +27,6 @@ import "@/libraries/foliate/view.js";
 
 interface EPUBReaderProps {
   file: File;
-  libraryId: string;
   bookTitle?: string;
 }
 
@@ -60,11 +57,7 @@ const flattenToc = (
   return out;
 };
 
-export default function EPUBReader({
-  file,
-  libraryId,
-  bookTitle,
-}: EPUBReaderProps) {
+export default function EPUBReader({ file, bookTitle }: EPUBReaderProps) {
   usePageTitle(bookTitle ? `Reading: ${bookTitle}` : "Reader");
 
   const {
@@ -277,8 +270,6 @@ export default function EPUBReader({
     return () => window.removeEventListener("keydown", handler);
   }, [bookReady, goNext, goPrev]);
 
-  const backHref = `/libraries/${libraryId}/books/${file.book_id}`;
-
   const handleTocChange = (href: string) => {
     const view = viewRef.current as
       | (HTMLElement & { goTo?: (target: string) => void })
@@ -308,35 +299,22 @@ export default function EPUBReader({
             {displayError?.message ?? "Unknown error"}
           </p>
         </div>
-        <div className="flex gap-2">
-          <Button
-            onClick={() => {
-              setLoadError(null);
-              refetch();
-            }}
-            variant="default"
-          >
-            Retry
-          </Button>
-          <Button asChild variant="outline">
-            <Link to={backHref}>Back</Link>
-          </Button>
-        </div>
+        <Button
+          onClick={() => {
+            setLoadError(null);
+            refetch();
+          }}
+          variant="default"
+        >
+          Retry
+        </Button>
       </div>
     );
   }
 
   return (
     <div className="fixed inset-0 bg-background flex flex-col">
-      <header className="flex items-center justify-between px-4 py-2 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <Link
-          className="flex items-center gap-2 text-muted-foreground hover:text-foreground"
-          to={backHref}
-        >
-          <ArrowLeft className="h-4 w-4" />
-          <span className="text-sm">Back</span>
-        </Link>
-
+      <header className="flex items-center justify-end px-4 py-2 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="flex items-center gap-2">
           {toc.length > 0 && (
             <select

--- a/app/components/pages/EPUBReader.tsx
+++ b/app/components/pages/EPUBReader.tsx
@@ -406,17 +406,17 @@ export default function EPUBReader({ file, bookTitle }: EPUBReaderProps) {
           </div>
         )}
 
-        <button
+        <Button
           aria-label="Previous page"
-          className="absolute left-0 top-0 w-1/3 h-full z-10 cursor-pointer opacity-0"
+          className="absolute left-0 top-0 w-1/3 h-full z-10 opacity-0"
           onClick={goPrev}
-          type="button"
+          variant="ghost"
         />
-        <button
+        <Button
           aria-label="Next page"
-          className="absolute right-0 top-0 w-1/3 h-full z-10 cursor-pointer opacity-0"
+          className="absolute right-0 top-0 w-1/3 h-full z-10 opacity-0"
           onClick={goNext}
-          type="button"
+          variant="ghost"
         />
 
         <foliate-view

--- a/app/components/pages/FileReader.tsx
+++ b/app/components/pages/FileReader.tsx
@@ -35,13 +35,7 @@ export default function FileReader() {
         <PDFReader bookTitle={book?.title} file={file} libraryId={libraryId!} />
       );
     case FileTypeEPUB:
-      return (
-        <EPUBReader
-          bookTitle={book?.title}
-          file={file}
-          libraryId={libraryId!}
-        />
-      );
+      return <EPUBReader bookTitle={book?.title} file={file} />;
     default:
       return (
         <div className="fixed inset-0 bg-background flex items-center justify-center">

--- a/app/components/pages/PageReader.tsx
+++ b/app/components/pages/PageReader.tsx
@@ -1,10 +1,4 @@
-import {
-  ArrowLeft,
-  ChevronLeft,
-  ChevronRight,
-  Loader2,
-  Settings,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2, Settings } from "lucide-react";
 import React, {
   useCallback,
   useEffect,
@@ -12,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -168,15 +162,7 @@ export default function PageReader({
   return (
     <div className="fixed inset-0 bg-background flex flex-col">
       {/* Header */}
-      <header className="flex items-center justify-between px-4 py-2 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-        <Link
-          className="flex items-center gap-2 text-muted-foreground hover:text-foreground"
-          to={`/libraries/${libraryId}/books/${bookId}`}
-        >
-          <ArrowLeft className="h-4 w-4" />
-          <span className="text-sm">Back</span>
-        </Link>
-
+      <header className="flex items-center justify-end px-4 py-2 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="flex items-center gap-2">
           {/* Chapter dropdown */}
           {flatChapters.length > 0 && (

--- a/app/components/pages/PageReader.tsx
+++ b/app/components/pages/PageReader.tsx
@@ -249,18 +249,18 @@ export default function PageReader({
         }`}
       >
         {/* Tap zones for mobile navigation */}
-        <button
+        <Button
           aria-label="Previous page"
-          className="absolute left-0 top-0 w-1/3 h-full z-10 cursor-pointer opacity-0"
+          className="absolute left-0 top-0 w-1/3 h-full z-10 opacity-0"
           disabled={currentPage === 0}
           onClick={() => goToPage(currentPage - 1)}
-          type="button"
+          variant="ghost"
         />
-        <button
+        <Button
           aria-label="Next page"
-          className="absolute right-0 top-0 w-1/3 h-full z-10 cursor-pointer opacity-0"
+          className="absolute right-0 top-0 w-1/3 h-full z-10 opacity-0"
           onClick={() => goToPage(currentPage + 1)}
-          type="button"
+          variant="ghost"
         />
 
         {/* Loading spinner */}


### PR DESCRIPTION
## Summary
- Remove the back-arrow link from the PageReader header (CBZ/PDF) and the EPUBReader header
- Remove the Back button from the EPUBReader load-error fallback (Retry remains)
- Drop the now-unused `libraryId` prop from `EPUBReader` and update `FileReader` + tests

## Test plan
- Open a CBZ or PDF book in the reader; confirm the header no longer shows a Back link and the chapter dropdown / settings popover stay right-aligned
- Open an EPUB book in the reader; confirm the header no longer shows a Back link
- Force an EPUB load error (e.g., bad file id) and confirm only the Retry button is shown
- Browser back still navigates back to the book detail page