### PR TITLE
[Feature] Per-file Reviewed flag with admin-configurable criteria

### DIFF
--- a/app/components/library/ActiveFilterChips.tsx
+++ b/app/components/library/ActiveFilterChips.tsx
@@ -1,4 +1,4 @@
-import { Bookmark, File, Languages, Tags, X } from "lucide-react";
+import { Bookmark, Eye, File, Languages, Tags, X } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -12,7 +12,7 @@ interface FilterTypeConfig {
 }
 
 const FILTER_TYPES: Record<
-  "fileType" | "genre" | "tag" | "language",
+  "fileType" | "genre" | "tag" | "language" | "reviewState",
   FilterTypeConfig
 > = {
   fileType: {
@@ -31,6 +31,15 @@ const FILTER_TYPES: Record<
     icon: <Languages className="h-3 w-3 shrink-0" />,
     colorClass: "text-chart-5",
   },
+  reviewState: {
+    icon: <Eye className="h-3 w-3 shrink-0" />,
+    colorClass: "text-chart-3",
+  },
+};
+
+const REVIEWED_FILTER_LABELS: Record<string, string> = {
+  needs_review: "Needs review",
+  reviewed: "Reviewed",
 };
 
 interface ActiveFilterChipsProps {
@@ -39,10 +48,12 @@ interface ActiveFilterChipsProps {
   selectedGenres: Genre[];
   selectedTags: Tag[];
   languageParam: string;
+  reviewedFilter: string;
   onToggleFileType: (fileType: string) => void;
   onToggleGenre: (genreId: number) => void;
   onToggleTag: (tagId: number) => void;
   onClearLanguage: () => void;
+  onClearReviewedFilter: () => void;
   onClearAll: () => void;
 }
 
@@ -52,10 +63,12 @@ export const ActiveFilterChips = ({
   selectedGenres,
   selectedTags,
   languageParam,
+  reviewedFilter,
   onToggleFileType,
   onToggleGenre,
   onToggleTag,
   onClearLanguage,
+  onClearReviewedFilter,
   onClearAll,
 }: ActiveFilterChipsProps) => {
   if (!hasActiveFilters) return null;
@@ -116,6 +129,19 @@ export const ActiveFilterChips = ({
             {FILTER_TYPES.language.icon}
           </span>
           {getLanguageName(languageParam) ?? languageParam}
+          <X className="h-3 w-3 text-muted-foreground" />
+        </Badge>
+      )}
+      {reviewedFilter && reviewedFilter !== "all" && (
+        <Badge
+          className="cursor-pointer gap-1.5"
+          onClick={onClearReviewedFilter}
+          variant="secondary"
+        >
+          <span className={FILTER_TYPES.reviewState.colorClass}>
+            {FILTER_TYPES.reviewState.icon}
+          </span>
+          {REVIEWED_FILTER_LABELS[reviewedFilter] ?? reviewedFilter}
           <X className="h-3 w-3 text-muted-foreground" />
         </Badge>
       )}

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -66,9 +66,13 @@ import {
   AuthorRoleTranslator,
   AuthorRoleWriter,
   DataSourceManual,
+  FileRoleMain,
   FileTypeCBZ,
+  ReviewOverrideReviewed,
+  ReviewOverrideUnreviewed,
   type AuthorInput,
   type Book,
+  type ReviewOverride,
   type SeriesInput,
 } from "@/types";
 import { forTitle } from "@/utils/sortname";
@@ -183,6 +187,11 @@ export function BookEditDialog({
     { enabled: open && !!book.library_id },
   );
 
+  // Draft review override — toggling the panel updates this; the actual
+  // setBookReview mutation only fires on Save.
+  const [draftReviewOverride, setDraftReviewOverride] =
+    useState<ReviewOverride | null>(null);
+
   // Store initial values for change detection
   const [initialValues, setInitialValues] = useState<{
     title: string;
@@ -193,6 +202,7 @@ export function BookEditDialog({
     series: SeriesEntry[];
     genres: string[];
     tags: string[];
+    reviewOverride: ReviewOverride;
   } | null>(null);
 
   // Track previous open state to detect open transitions.
@@ -231,6 +241,15 @@ export function BookEditDialog({
     const initialTags =
       book.book_tags?.map((bt) => bt.tag?.name || "").filter(Boolean) || [];
 
+    // Aggregate reviewed state across the book's main files.
+    const mainFiles =
+      book.files?.filter((f) => f.file_role === FileRoleMain) ?? [];
+    const allReviewed =
+      mainFiles.length > 0 && mainFiles.every((f) => f.reviewed === true);
+    const initialReviewOverride: ReviewOverride = allReviewed
+      ? ReviewOverrideReviewed
+      : ReviewOverrideUnreviewed;
+
     setTitle(initialTitle);
     // Use semantic value for state (what we send to server)
     setSortTitle(semanticSortTitle);
@@ -243,6 +262,7 @@ export function BookEditDialog({
     setTags(initialTags);
     setTagSearch("");
     setAuthorSearch("");
+    setDraftReviewOverride(initialReviewOverride);
 
     // Store initial values for comparison (use effective sort title, not semantic)
     setInitialValues({
@@ -254,6 +274,7 @@ export function BookEditDialog({
       series: initialSeries,
       genres: [...initialGenres].sort(),
       tags: [...initialTags].sort(),
+      reviewOverride: initialReviewOverride,
     });
   }, [open, book]);
 
@@ -271,7 +292,8 @@ export function BookEditDialog({
       !equal(authors, initialValues.authors) ||
       !equal(seriesEntries, initialValues.series) ||
       !equal([...genres].sort(), initialValues.genres) ||
-      !equal([...tags].sort(), initialValues.tags)
+      !equal([...tags].sort(), initialValues.tags) ||
+      draftReviewOverride !== initialValues.reviewOverride
     );
   }, [
     title,
@@ -282,6 +304,7 @@ export function BookEditDialog({
     seriesEntries,
     genres,
     tags,
+    draftReviewOverride,
     initialValues,
   ]);
 
@@ -424,16 +447,29 @@ export function BookEditDialog({
       payload.tags = tags.filter((t) => t.trim());
     }
 
+    const reviewChanged =
+      draftReviewOverride !== null &&
+      draftReviewOverride !== initialValues?.reviewOverride;
+
     // Only submit if something changed
-    if (Object.keys(payload).length === 0) {
+    if (Object.keys(payload).length === 0 && !reviewChanged) {
       onOpenChange(false);
       return;
     }
 
-    await updateBookMutation.mutateAsync({
-      id: String(book.id),
-      payload,
-    });
+    if (Object.keys(payload).length > 0) {
+      await updateBookMutation.mutateAsync({
+        id: String(book.id),
+        payload,
+      });
+    }
+
+    if (reviewChanged) {
+      await setBookReviewMutation.mutateAsync({
+        bookId: book.id,
+        override: draftReviewOverride,
+      });
+    }
 
     // Reset initial values so hasChanges becomes false, then close via effect
     // Use effective sort title (not semantic) to match hasChanges comparison
@@ -446,6 +482,7 @@ export function BookEditDialog({
       series: [...seriesEntries],
       genres: [...genres].sort(),
       tags: [...tags].sort(),
+      reviewOverride: draftReviewOverride ?? ReviewOverrideUnreviewed,
     });
     requestClose();
   };
@@ -943,14 +980,13 @@ export function BookEditDialog({
             />
           </div>
 
-          {/* Review Panel — fires immediately, independent of Save button */}
+          {/* Review Panel — controlled (deferred to Save button) */}
           <ReviewPanel
             book={book}
             files={book.files ?? []}
             isPending={setBookReviewMutation.isPending}
-            onChange={(override) =>
-              setBookReviewMutation.mutate({ bookId: book.id, override })
-            }
+            onChange={(override) => setDraftReviewOverride(override)}
+            toggleValue={draftReviewOverride === ReviewOverrideReviewed}
           />
         </div>
 

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -11,6 +11,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { SortNameInput } from "@/components/common/SortNameInput";
 import { ExtractSubtitleButton } from "@/components/library/ExtractSubtitleButton";
+import { ReviewPanel } from "@/components/library/ReviewPanel";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -50,6 +51,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useUpdateBook } from "@/hooks/queries/books";
 import { useGenresList } from "@/hooks/queries/genres";
 import { usePeopleList } from "@/hooks/queries/people";
+import { useSetBookReview } from "@/hooks/queries/review";
 import { useSeriesList } from "@/hooks/queries/series";
 import { useTagsList } from "@/hooks/queries/tags";
 import { useDebounce } from "@/hooks/useDebounce";
@@ -136,6 +138,7 @@ export function BookEditDialog({
   const debouncedAuthorSearch = useDebounce(authorSearch, 200);
 
   const updateBookMutation = useUpdateBook();
+  const setBookReviewMutation = useSetBookReview();
 
   // Check if book has CBZ files (determines whether to show role selection)
   const hasCBZFiles = book.files?.some((f) => f.file_type === FileTypeCBZ);
@@ -489,6 +492,16 @@ export function BookEditDialog({
         </DialogHeader>
 
         <div className="space-y-6 py-4">
+          {/* Review Panel — fires immediately, independent of Save button */}
+          <ReviewPanel
+            book={book}
+            files={book.files ?? []}
+            isPending={setBookReviewMutation.isPending}
+            onChange={(override) =>
+              setBookReviewMutation.mutate({ bookId: book.id, override })
+            }
+          />
+
           {/* Title */}
           <div className="space-y-2">
             <Label htmlFor="title">Title</Label>

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -492,16 +492,6 @@ export function BookEditDialog({
         </DialogHeader>
 
         <div className="space-y-6 py-4">
-          {/* Review Panel — fires immediately, independent of Save button */}
-          <ReviewPanel
-            book={book}
-            files={book.files ?? []}
-            isPending={setBookReviewMutation.isPending}
-            onChange={(override) =>
-              setBookReviewMutation.mutate({ bookId: book.id, override })
-            }
-          />
-
           {/* Title */}
           <div className="space-y-2">
             <Label htmlFor="title">Title</Label>
@@ -952,6 +942,16 @@ export function BookEditDialog({
               values={tags}
             />
           </div>
+
+          {/* Review Panel — fires immediately, independent of Save button */}
+          <ReviewPanel
+            book={book}
+            files={book.files ?? []}
+            isPending={setBookReviewMutation.isPending}
+            onChange={(override) =>
+              setBookReviewMutation.mutate({ bookId: book.id, override })
+            }
+          />
         </div>
 
         <DialogFooter>

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -69,7 +69,6 @@ import {
   FileRoleMain,
   FileTypeCBZ,
   ReviewOverrideReviewed,
-  ReviewOverrideUnreviewed,
   type AuthorInput,
   type Book,
   type ReviewOverride,
@@ -202,7 +201,8 @@ export function BookEditDialog({
     series: SeriesEntry[];
     genres: string[];
     tags: string[];
-    reviewOverride: ReviewOverride;
+    /** null means "auto" — no explicit override on any main file. */
+    reviewOverride: ReviewOverride | null;
   } | null>(null);
 
   // Track previous open state to detect open transitions.
@@ -241,14 +241,21 @@ export function BookEditDialog({
     const initialTags =
       book.book_tags?.map((bt) => bt.tag?.name || "").filter(Boolean) || [];
 
-    // Aggregate reviewed state across the book's main files.
+    // Capture the actual override state (not the aggregate `reviewed`) so we
+    // can distinguish "auto-reviewed" from "explicitly reviewed". If every
+    // main file shares the same override value, use it; otherwise fall back
+    // to null ("auto" / mixed). This preserves user intent: toggling a book
+    // that's currently auto-reviewed actually persists the explicit override.
     const mainFiles =
       book.files?.filter((f) => f.file_role === FileRoleMain) ?? [];
-    const allReviewed =
-      mainFiles.length > 0 && mainFiles.every((f) => f.reviewed === true);
-    const initialReviewOverride: ReviewOverride = allReviewed
-      ? ReviewOverrideReviewed
-      : ReviewOverrideUnreviewed;
+    let initialReviewOverride: ReviewOverride | null = null;
+    if (mainFiles.length > 0) {
+      const first = mainFiles[0].review_override ?? null;
+      const allMatch = mainFiles.every(
+        (f) => (f.review_override ?? null) === first,
+      );
+      if (allMatch) initialReviewOverride = first;
+    }
 
     setTitle(initialTitle);
     // Use semantic value for state (what we send to server)
@@ -448,8 +455,8 @@ export function BookEditDialog({
     }
 
     const reviewChanged =
-      draftReviewOverride !== null &&
-      draftReviewOverride !== initialValues?.reviewOverride;
+      draftReviewOverride !== (initialValues?.reviewOverride ?? null) &&
+      draftReviewOverride !== null;
 
     // Only submit if something changed
     if (Object.keys(payload).length === 0 && !reviewChanged) {
@@ -482,7 +489,7 @@ export function BookEditDialog({
       series: [...seriesEntries],
       genres: [...genres].sort(),
       tags: [...tags].sort(),
-      reviewOverride: draftReviewOverride ?? ReviewOverrideUnreviewed,
+      reviewOverride: draftReviewOverride,
     });
     requestClose();
   };
@@ -980,13 +987,19 @@ export function BookEditDialog({
             />
           </div>
 
-          {/* Review Panel — controlled (deferred to Save button) */}
+          {/* Review Panel — controlled (deferred to Save button).
+              When draftReviewOverride is null (auto), pass undefined so the
+              panel falls back to the file-derived aggregate state. */}
           <ReviewPanel
             book={book}
             files={book.files ?? []}
             isPending={setBookReviewMutation.isPending}
             onChange={(override) => setDraftReviewOverride(override)}
-            toggleValue={draftReviewOverride === ReviewOverrideReviewed}
+            toggleValue={
+              draftReviewOverride === null
+                ? undefined
+                : draftReviewOverride === ReviewOverrideReviewed
+            }
           />
         </div>
 

--- a/app/components/library/BookItem.test.tsx
+++ b/app/components/library/BookItem.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { FileRoleMain, FileRoleSupplement, type Book } from "@/types";
+
+import BookItem from "./BookItem";
+
+beforeAll(() => {
+  // @ts-expect-error - global defined by Vite
+  globalThis.__APP_VERSION__ = "test";
+});
+
+// Mock mutation hooks — they require a running API
+vi.mock("@/hooks/queries/books", () => ({
+  useDeleteBook: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useResyncBook: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+function wrap(ui: React.ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function makeBook(overrides: Partial<Book> = {}): Book {
+  return {
+    id: 1,
+    title: "Test Book",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    library_id: 1,
+    ...overrides,
+  } as Book;
+}
+
+describe("BookItem — Needs review badge", () => {
+  it("shows badge when a main file has reviewed=false", () => {
+    const book = makeBook({
+      files: [
+        {
+          id: 10,
+          file_role: FileRoleMain,
+          file_type: "epub",
+          reviewed: false,
+        } as never,
+      ],
+    });
+    render(wrap(<BookItem book={book} libraryId="1" />));
+    expect(screen.getByText("Needs review")).toBeInTheDocument();
+  });
+
+  it("hides badge when all main files are reviewed", () => {
+    const book = makeBook({
+      files: [
+        {
+          id: 10,
+          file_role: FileRoleMain,
+          file_type: "epub",
+          reviewed: true,
+        } as never,
+      ],
+    });
+    render(wrap(<BookItem book={book} libraryId="1" />));
+    expect(screen.queryByText("Needs review")).not.toBeInTheDocument();
+  });
+
+  it("hides badge when there are no main files", () => {
+    const book = makeBook({
+      files: [
+        {
+          id: 10,
+          file_role: FileRoleSupplement,
+          file_type: "epub",
+          reviewed: false,
+        } as never,
+      ],
+    });
+    render(wrap(<BookItem book={book} libraryId="1" />));
+    expect(screen.queryByText("Needs review")).not.toBeInTheDocument();
+  });
+
+  it("hides badge when book has no files", () => {
+    const book = makeBook({ files: [] });
+    render(wrap(<BookItem book={book} libraryId="1" />));
+    expect(screen.queryByText("Needs review")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -46,6 +46,7 @@ import {
   type File,
   type GallerySize,
 } from "@/types";
+import { isBookNeedsReview } from "@/utils/book";
 import { isCoverLoaded, markCoverLoaded } from "@/utils/coverCache";
 
 interface BookItemProps {
@@ -328,6 +329,15 @@ const BookItem = ({
               onLoad={handleCoverLoad}
               src={coverUrl}
             />
+          )}
+          {/* Needs review badge */}
+          {isBookNeedsReview(book) && (
+            <Badge
+              className="absolute bottom-1 left-1 text-[10px] px-1.5 py-0 pointer-events-none"
+              variant="secondary"
+            >
+              Needs review
+            </Badge>
           )}
         </div>
         <Tooltip

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -749,18 +749,6 @@ export function FileEditDialog({
             </div>
           </div>
 
-          {/* Review Panel — fires immediately, independent of Save button */}
-          {(book ?? file.book) && (
-            <ReviewPanel
-              book={(book ?? file.book)!}
-              files={[file]}
-              isPending={setFileReviewMutation.isPending}
-              onChange={(override) =>
-                setFileReviewMutation.mutate({ fileId: file.id, override })
-              }
-            />
-          )}
-
           {/* Name */}
           <div className="space-y-2">
             <Label htmlFor="name">Name</Label>
@@ -1434,6 +1422,18 @@ export function FileEditDialog({
                 </div>
               </div>
             </>
+          )}
+
+          {/* Review Panel — fires immediately, independent of Save button */}
+          {(book ?? file.book) && (
+            <ReviewPanel
+              book={(book ?? file.book)!}
+              files={[file]}
+              isPending={setFileReviewMutation.isPending}
+              onChange={(override) =>
+                setFileReviewMutation.mutate({ fileId: file.id, override })
+              }
+            />
           )}
         </div>
 

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -78,7 +78,6 @@ import {
   FileTypeEPUB,
   FileTypeM4B,
   ReviewOverrideReviewed,
-  ReviewOverrideUnreviewed,
   type Book,
   type File,
   type FileRole,
@@ -295,6 +294,7 @@ export function FileEditDialog({
 
   // Draft review override — toggling the panel updates this; the actual
   // setFileReview mutation only fires on Save.
+  // null means "auto" (no explicit override on the file).
   const [draftReviewOverride, setDraftReviewOverride] =
     useState<ReviewOverride | null>(null);
 
@@ -311,7 +311,8 @@ export function FileEditDialog({
     coverPage: number | null;
     language: string;
     abridged: string;
-    reviewOverride: ReviewOverride;
+    /** null means "auto" — no explicit override on the file. */
+    reviewOverride: ReviewOverride | null;
   } | null>(null);
 
   // Track previous open state to detect open transitions.
@@ -350,10 +351,11 @@ export function FileEditDialog({
     // for the reasoning.
     const initialAbridged = file.abridged === true ? "true" : "";
 
-    const initialReviewOverride: ReviewOverride =
-      file.reviewed === true
-        ? ReviewOverrideReviewed
-        : ReviewOverrideUnreviewed;
+    // Capture the actual override (not the aggregate `reviewed`) so the user
+    // can toggle a currently-auto-reviewed file and have that intent persist.
+    // null = "auto" (no explicit override).
+    const initialReviewOverride: ReviewOverride | null =
+      file.review_override ?? null;
 
     setNarrators(initialNarrators);
     setNarratorSearch("");
@@ -699,10 +701,13 @@ export function FileEditDialog({
       setPendingCoverPage(null);
     }
 
-    // Apply pending review override change
+    // Apply pending review override change. Only fire if the user toggled
+    // to an explicit value that differs from the file's saved override.
+    // draftReviewOverride === null means "auto" — never set by the user
+    // gesture, only by initial load when no override exists.
     if (
       draftReviewOverride !== null &&
-      draftReviewOverride !== initialValues?.reviewOverride
+      draftReviewOverride !== (initialValues?.reviewOverride ?? null)
     ) {
       await setFileReviewMutation.mutateAsync({
         fileId: file.id,
@@ -734,7 +739,7 @@ export function FileEditDialog({
       coverPage: pendingCoverPage ?? initialValues?.coverPage ?? null,
       language: canonicalLanguage,
       abridged: canonicalAbridged,
-      reviewOverride: draftReviewOverride ?? ReviewOverrideUnreviewed,
+      reviewOverride: draftReviewOverride,
     });
     requestClose();
   };
@@ -1454,14 +1459,20 @@ export function FileEditDialog({
             </>
           )}
 
-          {/* Review Panel — controlled (deferred to Save button) */}
+          {/* Review Panel — controlled (deferred to Save button).
+              When draftReviewOverride is null (auto), pass undefined so the
+              panel falls back to the file-derived `reviewed` state. */}
           {(book ?? file.book) && (
             <ReviewPanel
               book={(book ?? file.book)!}
               files={[file]}
               isPending={setFileReviewMutation.isPending}
               onChange={(override) => setDraftReviewOverride(override)}
-              toggleValue={draftReviewOverride === ReviewOverrideReviewed}
+              toggleValue={
+                draftReviewOverride === null
+                  ? undefined
+                  : draftReviewOverride === ReviewOverrideReviewed
+              }
             />
           )}
         </div>

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -77,9 +77,12 @@ import {
   FileTypeCBZ,
   FileTypeEPUB,
   FileTypeM4B,
+  ReviewOverrideReviewed,
+  ReviewOverrideUnreviewed,
   type Book,
   type File,
   type FileRole,
+  type ReviewOverride,
 } from "@/types";
 import { formatIdentifierType } from "@/utils/format";
 import { validateIdentifier } from "@/utils/identifiers";
@@ -290,6 +293,11 @@ export function FileEditDialog({
     };
   }, []);
 
+  // Draft review override — toggling the panel updates this; the actual
+  // setFileReview mutation only fires on Save.
+  const [draftReviewOverride, setDraftReviewOverride] =
+    useState<ReviewOverride | null>(null);
+
   // Store initial values for change detection
   const [initialValues, setInitialValues] = useState<{
     narrators: string[];
@@ -303,6 +311,7 @@ export function FileEditDialog({
     coverPage: number | null;
     language: string;
     abridged: string;
+    reviewOverride: ReviewOverride;
   } | null>(null);
 
   // Track previous open state to detect open transitions.
@@ -341,6 +350,11 @@ export function FileEditDialog({
     // for the reasoning.
     const initialAbridged = file.abridged === true ? "true" : "";
 
+    const initialReviewOverride: ReviewOverride =
+      file.reviewed === true
+        ? ReviewOverrideReviewed
+        : ReviewOverrideUnreviewed;
+
     setNarrators(initialNarrators);
     setNarratorSearch("");
     setName(initialName);
@@ -360,6 +374,7 @@ export function FileEditDialog({
     setPendingCoverPage(null);
     setPendingCoverFile(null);
     updatePendingCoverPreview(null);
+    setDraftReviewOverride(initialReviewOverride);
 
     // Store initial values for comparison
     setInitialValues({
@@ -374,6 +389,7 @@ export function FileEditDialog({
       coverPage: file.cover_page ?? null,
       language: initialLanguage,
       abridged: initialAbridged,
+      reviewOverride: initialReviewOverride,
     });
   }, [open, file, updatePendingCoverPreview]);
 
@@ -393,7 +409,8 @@ export function FileEditDialog({
       abridged !== initialValues.abridged ||
       pendingCoverFile !== null ||
       (pendingCoverPage !== null &&
-        pendingCoverPage !== initialValues.coverPage)
+        pendingCoverPage !== initialValues.coverPage) ||
+      draftReviewOverride !== initialValues.reviewOverride
     );
   }, [
     narrators,
@@ -408,6 +425,7 @@ export function FileEditDialog({
     abridged,
     pendingCoverFile,
     pendingCoverPage,
+    draftReviewOverride,
     initialValues,
   ]);
 
@@ -681,6 +699,17 @@ export function FileEditDialog({
       setPendingCoverPage(null);
     }
 
+    // Apply pending review override change
+    if (
+      draftReviewOverride !== null &&
+      draftReviewOverride !== initialValues?.reviewOverride
+    ) {
+      await setFileReviewMutation.mutateAsync({
+        fileId: file.id,
+        override: draftReviewOverride,
+      });
+    }
+
     // Reset initial values so hasChanges becomes false, then close via effect.
     // For coverPage, use pendingCoverPage if set, otherwise keep the current
     // initial value. For language/abridged, use the canonicalized values
@@ -705,6 +734,7 @@ export function FileEditDialog({
       coverPage: pendingCoverPage ?? initialValues?.coverPage ?? null,
       language: canonicalLanguage,
       abridged: canonicalAbridged,
+      reviewOverride: draftReviewOverride ?? ReviewOverrideUnreviewed,
     });
     requestClose();
   };
@@ -1424,15 +1454,14 @@ export function FileEditDialog({
             </>
           )}
 
-          {/* Review Panel — fires immediately, independent of Save button */}
+          {/* Review Panel — controlled (deferred to Save button) */}
           {(book ?? file.book) && (
             <ReviewPanel
               book={(book ?? file.book)!}
               files={[file]}
               isPending={setFileReviewMutation.isPending}
-              onChange={(override) =>
-                setFileReviewMutation.mutate({ fileId: file.id, override })
-              }
+              onChange={(override) => setDraftReviewOverride(override)}
+              toggleValue={draftReviewOverride === ReviewOverrideReviewed}
             />
           )}
         </div>

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import PagePicker from "@/components/files/PagePicker";
 import CoverPlaceholder from "@/components/library/CoverPlaceholder";
 import { LanguageCombobox } from "@/components/library/LanguageCombobox";
+import { ReviewPanel } from "@/components/library/ReviewPanel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -66,6 +67,7 @@ import { useImprintsList } from "@/hooks/queries/imprints";
 import { usePeopleList } from "@/hooks/queries/people";
 import { usePluginIdentifierTypes } from "@/hooks/queries/plugins";
 import { usePublishersList } from "@/hooks/queries/publishers";
+import { useSetFileReview } from "@/hooks/queries/review";
 import { useDebounce } from "@/hooks/useDebounce";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
 import { cn, isPageBasedFileType } from "@/libraries/utils";
@@ -75,6 +77,7 @@ import {
   FileTypeCBZ,
   FileTypeEPUB,
   FileTypeM4B,
+  type Book,
   type File,
   type FileRole,
 } from "@/types";
@@ -83,6 +86,8 @@ import { validateIdentifier } from "@/utils/identifiers";
 
 interface FileEditDialogProps {
   file: File;
+  /** Parent book — used by ReviewPanel for book-level field checks */
+  book?: Book;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -109,6 +114,7 @@ const formatDateForInput = (dateString: string | undefined): string => {
 
 export function FileEditDialog({
   file,
+  book,
   open,
   onOpenChange,
 }: FileEditDialogProps) {
@@ -187,6 +193,7 @@ export function FileEditDialog({
   const updateFileMutation = useUpdateFile();
   const uploadCoverMutation = useUploadFileCover();
   const setCoverPageMutation = useSetFileCoverPage();
+  const setFileReviewMutation = useSetFileReview();
 
   // Query for publishers in this library with server-side search
   const { data: publishersData, isLoading: isLoadingPublishers } =
@@ -741,6 +748,18 @@ export function FileEditDialog({
               </span>
             </div>
           </div>
+
+          {/* Review Panel — fires immediately, independent of Save button */}
+          {(book ?? file.book) && (
+            <ReviewPanel
+              book={(book ?? file.book)!}
+              files={[file]}
+              isPending={setFileReviewMutation.isPending}
+              onChange={(override) =>
+                setFileReviewMutation.mutate({ fileId: file.id, override })
+              }
+            />
+          )}
 
           {/* Name */}
           <div className="space-y-2">

--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -1,5 +1,6 @@
 import {
   Bookmark,
+  Eye,
   File,
   Languages,
   ListFilter,
@@ -28,6 +29,8 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -70,6 +73,8 @@ interface FilterSheetProps {
   languageParam: string;
   languageOptions: { value: string; label: string }[];
   onLanguageChange: (value: string) => void;
+  reviewedFilter: string;
+  onReviewedFilterChange: (value: string) => void;
   onClearAll: () => void;
   hasActiveFilters: boolean;
 }
@@ -124,6 +129,8 @@ const FilterContent = ({
   languageParam,
   languageOptions,
   onLanguageChange,
+  reviewedFilter,
+  onReviewedFilterChange,
 }: Omit<FilterSheetProps, "onClearAll" | "hasActiveFilters">) => (
   <div className="space-y-6">
     {/* File Type */}
@@ -290,6 +297,42 @@ const FilterContent = ({
         </Select>
       </div>
     )}
+
+    {/* Review state */}
+    <div>
+      <SectionHeader
+        colorClass="bg-chart-3/20 text-chart-3"
+        icon={<Eye className="h-3 w-3" />}
+        label="Review state"
+      />
+      <RadioGroup
+        className="gap-2"
+        onValueChange={onReviewedFilterChange}
+        value={reviewedFilter || "all"}
+      >
+        <div className="flex items-center gap-2">
+          <RadioGroupItem id="review-all" value="all" />
+          <Label className="cursor-pointer font-normal" htmlFor="review-all">
+            All
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <RadioGroupItem id="review-needs" value="needs_review" />
+          <Label className="cursor-pointer font-normal" htmlFor="review-needs">
+            Needs review
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <RadioGroupItem id="review-reviewed" value="reviewed" />
+          <Label
+            className="cursor-pointer font-normal"
+            htmlFor="review-reviewed"
+          >
+            Reviewed
+          </Label>
+        </div>
+      </RadioGroup>
+    </div>
   </div>
 );
 

--- a/app/components/library/ReviewPanel.test.tsx
+++ b/app/components/library/ReviewPanel.test.tsx
@@ -118,7 +118,7 @@ describe("ReviewPanel", () => {
     expect(toggle).not.toBeChecked();
   });
 
-  it("shows Auto indicator when no overrides are set", () => {
+  it("renders status icon in green when book is reviewed", () => {
     const files: File[] = [
       { ...baseFile, reviewed: true, review_override: undefined },
     ];
@@ -127,10 +127,40 @@ describe("ReviewPanel", () => {
       wrapper,
     });
 
-    expect(screen.getByText("Auto")).toBeInTheDocument();
+    const icon = screen.getByLabelText("Reviewed status");
+    expect(icon.getAttribute("class")).toMatch(/text-green/);
   });
 
-  it("shows manually reviewed indicator when all files have reviewed override", () => {
+  it("renders status icon in muted color when book needs review", () => {
+    const files: File[] = [
+      { ...baseFile, reviewed: false, review_override: undefined },
+    ];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    const icon = screen.getByLabelText("Needs review status");
+    expect(icon.getAttribute("class")).toMatch(/text-muted-foreground/);
+  });
+
+  it("status icon has tooltip describing auto behavior when no overrides are set", async () => {
+    const files: File[] = [
+      { ...baseFile, reviewed: true, review_override: undefined },
+    ];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    const icon = screen.getByLabelText("Reviewed status");
+    const user = createUser();
+    await user.hover(icon);
+    const tip = await screen.findAllByText(/automatically from the required/);
+    expect(tip.length).toBeGreaterThan(0);
+  });
+
+  it("status icon has tooltip with date when all files have reviewed override", async () => {
     const files: File[] = [
       {
         ...baseFile,
@@ -144,10 +174,14 @@ describe("ReviewPanel", () => {
       wrapper,
     });
 
-    expect(screen.getByText(/Manually marked reviewed on/)).toBeInTheDocument();
+    const icon = screen.getByLabelText("Reviewed status");
+    const user = createUser();
+    await user.hover(icon);
+    const tip = await screen.findAllByText(/Manually marked reviewed on/);
+    expect(tip.length).toBeGreaterThan(0);
   });
 
-  it("shows manually needs review indicator when all files have unreviewed override", () => {
+  it("status icon has tooltip with date when all files have unreviewed override", async () => {
     const files: File[] = [
       {
         ...baseFile,
@@ -161,12 +195,14 @@ describe("ReviewPanel", () => {
       wrapper,
     });
 
-    expect(
-      screen.getByText(/Manually marked needs review on/),
-    ).toBeInTheDocument();
+    const icon = screen.getByLabelText("Needs review status");
+    const user = createUser();
+    await user.hover(icon);
+    const tip = await screen.findAllByText(/Manually marked needs review on/);
+    expect(tip.length).toBeGreaterThan(0);
   });
 
-  it("shows Mixed indicator when overrides differ across files", () => {
+  it("status icon has tooltip indicating mixed state when overrides differ across files", async () => {
     const files: File[] = [
       {
         ...baseFile,
@@ -190,9 +226,11 @@ describe("ReviewPanel", () => {
       wrapper,
     });
 
-    expect(
-      screen.getByText("Manually set on multiple files"),
-    ).toBeInTheDocument();
+    const icon = screen.getByLabelText("Needs review status");
+    const user = createUser();
+    await user.hover(icon);
+    const tip = await screen.findAllByText("Manually set on multiple files");
+    expect(tip.length).toBeGreaterThan(0);
   });
 
   it("shows missing fields list when book needs review", () => {

--- a/app/components/library/ReviewPanel.test.tsx
+++ b/app/components/library/ReviewPanel.test.tsx
@@ -385,4 +385,90 @@ describe("ReviewPanel", () => {
 
     expect(container.firstChild).toBeNull();
   });
+
+  describe("controlled mode (toggleValue prop)", () => {
+    it("toggle reflects toggleValue=true even when committed reviewed is false", () => {
+      const files: File[] = [
+        { ...baseFile, reviewed: false, review_override: undefined },
+      ];
+
+      render(
+        <ReviewPanel
+          book={baseBook}
+          files={files}
+          onChange={vi.fn()}
+          toggleValue={true}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByRole("switch")).toBeChecked();
+    });
+
+    it("toggle reflects toggleValue=false even when committed reviewed is true", () => {
+      const files: File[] = [
+        { ...baseFile, reviewed: true, review_override: undefined },
+      ];
+
+      render(
+        <ReviewPanel
+          book={baseBook}
+          files={files}
+          onChange={vi.fn()}
+          toggleValue={false}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByRole("switch")).not.toBeChecked();
+    });
+
+    it("falls back to committed reviewed when toggleValue is undefined", () => {
+      const files: File[] = [
+        { ...baseFile, reviewed: true, review_override: undefined },
+      ];
+
+      render(
+        <ReviewPanel
+          book={baseBook}
+          files={files}
+          onChange={vi.fn()}
+          toggleValue={undefined}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByRole("switch")).toBeChecked();
+    });
+
+    it("missing-fields hint follows committed state, not toggleValue", () => {
+      const bookWithoutDescription: Book = {
+        ...baseBook,
+        description: undefined,
+      };
+      const files: File[] = [
+        {
+          ...baseFile,
+          reviewed: false,
+          review_override: undefined,
+          cover_image_filename: "x.jpg",
+          cover_mime_type: "image/jpeg",
+        },
+      ];
+
+      // Even with toggleValue=true (drafted as reviewed), the missing-fields
+      // hint anchors to the saved data and still reports description missing.
+      render(
+        <ReviewPanel
+          book={bookWithoutDescription}
+          files={files}
+          onChange={vi.fn()}
+          toggleValue={true}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.getByText(/Missing:.*description/)).toBeInTheDocument();
+    });
+  });
 });

--- a/app/components/library/ReviewPanel.test.tsx
+++ b/app/components/library/ReviewPanel.test.tsx
@@ -1,0 +1,350 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import {
+  FileRoleMain,
+  FileTypeCBZ,
+  FileTypeEPUB,
+  FileTypeM4B,
+  ReviewOverrideReviewed,
+  ReviewOverrideUnreviewed,
+  type Book,
+  type File,
+} from "@/types";
+
+import { ReviewPanel } from "./ReviewPanel";
+
+beforeAll(() => {
+  // @ts-expect-error - global defined by Vite
+  globalThis.__APP_VERSION__ = "test";
+});
+
+// Mock review criteria hook
+const mockCriteria = {
+  book_fields: ["authors", "description", "cover", "genres"],
+  audio_fields: ["narrators"],
+  universal_candidates: [],
+  audio_candidates: [],
+  override_count: 0,
+  main_file_count: 0,
+};
+
+vi.mock("@/hooks/queries/review", () => ({
+  useReviewCriteria: () => ({ data: mockCriteria }),
+  useSetFileReview: () => ({ mutate: vi.fn(), isPending: false }),
+  useSetBookReview: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime, delay: null });
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+// Minimal Book fixture
+const baseBook: Book = {
+  id: 1,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  library_id: 1,
+  filepath: "/library/book",
+  title: "Test Book",
+  title_source: "manual",
+  sort_title: "Test Book",
+  sort_title_source: "manual",
+  author_source: "manual",
+  files: [],
+  authors: [
+    { id: 1, book_id: 1, person_id: 1, sort_order: 0, role: undefined },
+  ],
+  description: "A great book",
+  book_genres: [{ id: 1, book_id: 1, genre_id: 1 }],
+};
+
+// Minimal File fixture (main, EPUB, reviewed)
+const baseFile: File = {
+  id: 10,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+  library_id: 1,
+  book_id: 1,
+  filepath: "/library/book/book.epub",
+  file_type: FileTypeEPUB,
+  file_role: FileRoleMain,
+  filesize_bytes: 1000,
+  reviewed: true,
+  review_override: undefined,
+  review_overridden_at: undefined,
+  cover_image_filename: "book.epub.cover.jpg",
+};
+
+describe("ReviewPanel", () => {
+  it("renders Reviewed toggle ON when all main files are reviewed", () => {
+    const files: File[] = [{ ...baseFile, reviewed: true }];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toBeChecked();
+  });
+
+  it("renders Reviewed toggle OFF when any main file is not reviewed", () => {
+    const files: File[] = [
+      { ...baseFile, id: 10, reviewed: true },
+      {
+        ...baseFile,
+        id: 11,
+        file_type: FileTypeM4B,
+        reviewed: false,
+        cover_image_filename: "book.m4b.cover.jpg",
+      },
+    ];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    const toggle = screen.getByRole("switch");
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("shows Auto indicator when no overrides are set", () => {
+    const files: File[] = [
+      { ...baseFile, reviewed: true, review_override: undefined },
+    ];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    expect(screen.getByText("Auto")).toBeInTheDocument();
+  });
+
+  it("shows manually reviewed indicator when all files have reviewed override", () => {
+    const files: File[] = [
+      {
+        ...baseFile,
+        reviewed: true,
+        review_override: ReviewOverrideReviewed,
+        review_overridden_at: "2024-06-15T10:00:00Z",
+      },
+    ];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    expect(screen.getByText(/Manually marked reviewed on/)).toBeInTheDocument();
+  });
+
+  it("shows manually needs review indicator when all files have unreviewed override", () => {
+    const files: File[] = [
+      {
+        ...baseFile,
+        reviewed: false,
+        review_override: ReviewOverrideUnreviewed,
+        review_overridden_at: "2024-06-15T10:00:00Z",
+      },
+    ];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    expect(
+      screen.getByText(/Manually marked needs review on/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Mixed indicator when overrides differ across files", () => {
+    const files: File[] = [
+      {
+        ...baseFile,
+        id: 10,
+        reviewed: true,
+        review_override: ReviewOverrideReviewed,
+        review_overridden_at: "2024-06-15T10:00:00Z",
+      },
+      {
+        ...baseFile,
+        id: 11,
+        file_type: FileTypeCBZ,
+        reviewed: false,
+        review_override: ReviewOverrideUnreviewed,
+        review_overridden_at: "2024-06-10T10:00:00Z",
+        cover_image_filename: "book.cbz.cover.jpg",
+      },
+    ];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    expect(
+      screen.getByText("Manually set on multiple files"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows missing fields list when book needs review", () => {
+    const bookWithoutDescription: Book = {
+      ...baseBook,
+      description: undefined,
+    };
+
+    const files: File[] = [
+      {
+        ...baseFile,
+        reviewed: false,
+        review_override: undefined,
+        cover_image_filename: undefined,
+        cover_mime_type: undefined,
+      },
+    ];
+
+    render(
+      <ReviewPanel
+        book={bookWithoutDescription}
+        files={files}
+        onChange={vi.fn()}
+      />,
+      { wrapper },
+    );
+
+    // Should show missing fields: description and cover (from criteria: authors, description, cover, genres)
+    // Authors are present in baseBook, genres are present, so only description and cover missing
+    expect(screen.getByText(/Missing:/)).toBeInTheDocument();
+    expect(screen.getByText(/description/)).toBeInTheDocument();
+    expect(screen.getByText(/cover/)).toBeInTheDocument();
+  });
+
+  it("shows missing fields aggregated across files without qualifier when missing on all", () => {
+    const bookNoDescription: Book = {
+      ...baseBook,
+      description: undefined,
+    };
+
+    // Two files both missing description (book-level) and cover (file-level)
+    const files: File[] = [
+      {
+        ...baseFile,
+        id: 10,
+        file_type: FileTypeEPUB,
+        reviewed: false,
+        cover_image_filename: undefined,
+        cover_mime_type: undefined,
+      },
+      {
+        ...baseFile,
+        id: 11,
+        file_type: FileTypeCBZ,
+        reviewed: false,
+        cover_image_filename: undefined,
+        cover_mime_type: undefined,
+      },
+    ];
+
+    render(
+      <ReviewPanel book={bookNoDescription} files={files} onChange={vi.fn()} />,
+      { wrapper },
+    );
+
+    // description is book-level → missing on both → listed once without qualifier
+    // cover is file-level → missing on both → listed once without qualifier
+    const hint = screen.getByText(/Missing:/);
+    expect(hint.textContent).not.toMatch(/EPUB/);
+    expect(hint.textContent).not.toMatch(/CBZ/);
+    expect(hint.textContent).toMatch(/description/);
+    expect(hint.textContent).toMatch(/cover/);
+  });
+
+  it("qualifies missing fields with file type when missing on only some files", () => {
+    // EPUB is missing cover, M4B has cover but missing narrators
+    const files: File[] = [
+      {
+        ...baseFile,
+        id: 10,
+        file_type: FileTypeEPUB,
+        reviewed: false,
+        cover_image_filename: undefined,
+        cover_mime_type: undefined,
+      },
+      {
+        ...baseFile,
+        id: 11,
+        file_type: FileTypeM4B,
+        reviewed: false,
+        cover_image_filename: "book.m4b.cover.jpg",
+        narrators: [],
+      },
+    ];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    // cover is only missing on EPUB → should be qualified
+    // narrators is only missing on M4B → should be qualified
+    const hint = screen.getByText(/Missing:/);
+    expect(hint.textContent).toMatch(/cover.*EPUB|EPUB.*cover/);
+    expect(hint.textContent).toMatch(/narrators.*M4B|M4B.*narrators/);
+  });
+
+  it("does not show missing fields hint when book is fully reviewed", () => {
+    const files: File[] = [{ ...baseFile, reviewed: true }];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={vi.fn()} />, {
+      wrapper,
+    });
+
+    expect(screen.queryByText(/Missing:/)).not.toBeInTheDocument();
+  });
+
+  it("toggle click fires onChange with reviewed override when toggling on", async () => {
+    const user = createUser();
+    const onChange = vi.fn();
+    const files: File[] = [{ ...baseFile, reviewed: false }];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={onChange} />, {
+      wrapper,
+    });
+
+    const toggle = screen.getByRole("switch");
+    await user.click(toggle);
+
+    expect(onChange).toHaveBeenCalledWith(ReviewOverrideReviewed);
+  });
+
+  it("toggle click fires onChange with unreviewed override when toggling off", async () => {
+    const user = createUser();
+    const onChange = vi.fn();
+    const files: File[] = [{ ...baseFile, reviewed: true }];
+
+    render(<ReviewPanel book={baseBook} files={files} onChange={onChange} />, {
+      wrapper,
+    });
+
+    const toggle = screen.getByRole("switch");
+    await user.click(toggle);
+
+    expect(onChange).toHaveBeenCalledWith(ReviewOverrideUnreviewed);
+  });
+
+  it("returns null when there are no main files", () => {
+    const { container } = render(
+      <ReviewPanel book={baseBook} files={[]} onChange={vi.fn()} />,
+      { wrapper },
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/app/components/library/ReviewPanel.tsx
+++ b/app/components/library/ReviewPanel.tsx
@@ -1,6 +1,12 @@
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useReviewCriteria } from "@/hooks/queries/review";
 import { cn } from "@/libraries/utils";
 import {
@@ -199,6 +205,7 @@ export function ReviewPanel({
 
   let indicatorText: string;
   let indicatorVariant: "secondary" | "success" | "outline" = "secondary";
+  const isAuto = allNoOverride;
 
   if (allNoOverride) {
     indicatorText = "Auto";
@@ -231,6 +238,15 @@ export function ReviewPanel({
     onChange(checked ? ReviewOverrideReviewed : ReviewOverrideUnreviewed);
   };
 
+  const indicatorBadge = (
+    <Badge
+      className={cn("text-xs", isAuto && "cursor-help")}
+      variant={indicatorVariant}
+    >
+      {indicatorText}
+    </Badge>
+  );
+
   return (
     <div className="border rounded-md p-4 space-y-2 bg-muted/30">
       <div className="flex items-center gap-3">
@@ -250,9 +266,26 @@ export function ReviewPanel({
         >
           Reviewed
         </Label>
-        <Badge className="ml-1 text-xs" variant={indicatorVariant}>
-          {indicatorText}
-        </Badge>
+      </div>
+
+      <div>
+        {isAuto ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>{indicatorBadge}</TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p>
+                  Reviewed state is determined automatically from the required
+                  fields configured in Server Settings. Fill in all required
+                  fields and this will flip to reviewed; remove one and it flips
+                  back. Toggle manually to override.
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          indicatorBadge
+        )}
       </div>
 
       {missingHint && (

--- a/app/components/library/ReviewPanel.tsx
+++ b/app/components/library/ReviewPanel.tsx
@@ -1,0 +1,263 @@
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { useReviewCriteria } from "@/hooks/queries/review";
+import { cn } from "@/libraries/utils";
+import {
+  FileRoleMain,
+  FileTypeM4B,
+  ReviewOverrideReviewed,
+  ReviewOverrideUnreviewed,
+  type Book,
+  type File,
+  type ReviewOverride,
+} from "@/types";
+import { formatDate } from "@/utils/format";
+
+interface ReviewPanelProps {
+  book: Book;
+  files: File[];
+  onChange: (override: ReviewOverride) => void;
+  isPending?: boolean;
+}
+
+/**
+ * Determine which fields are missing for a given file + book pair, given the
+ * active review criteria.
+ *
+ * Book-level fields: authors, description, genres, tags, series, subtitle
+ * File-level fields: cover, publisher, imprint, identifiers, release_date, language, url
+ * Audio-only fields: narrators, chapters, abridged
+ */
+function getMissingFields(
+  file: File,
+  book: Book,
+  bookFields: string[],
+  audioFields: string[],
+): string[] {
+  const isAudio = file.file_type === FileTypeM4B;
+  const missing: string[] = [];
+
+  for (const field of bookFields) {
+    switch (field) {
+      case "authors":
+        if (!book.authors || book.authors.length === 0) missing.push(field);
+        break;
+      case "description":
+        if (!book.description) missing.push(field);
+        break;
+      case "genres":
+        if (!book.book_genres || book.book_genres.length === 0)
+          missing.push(field);
+        break;
+      case "tags":
+        if (!book.book_tags || book.book_tags.length === 0) missing.push(field);
+        break;
+      case "series":
+        if (!book.book_series || book.book_series.length === 0)
+          missing.push(field);
+        break;
+      case "subtitle":
+        if (!book.subtitle) missing.push(field);
+        break;
+      case "cover":
+        if (!file.cover_image_filename && !file.cover_mime_type)
+          missing.push(field);
+        break;
+      case "publisher":
+        if (!file.publisher) missing.push(field);
+        break;
+      case "imprint":
+        if (!file.imprint) missing.push(field);
+        break;
+      case "identifiers":
+        if (!file.identifiers || file.identifiers.length === 0)
+          missing.push(field);
+        break;
+      case "release_date":
+        if (!file.release_date) missing.push(field);
+        break;
+      case "language":
+        if (!file.language) missing.push(field);
+        break;
+      case "url":
+        if (!file.url) missing.push(field);
+        break;
+    }
+  }
+
+  if (isAudio) {
+    for (const field of audioFields) {
+      switch (field) {
+        case "narrators":
+          if (!file.narrators || file.narrators.length === 0)
+            missing.push(field);
+          break;
+        case "chapters":
+          if (!file.chapters || file.chapters.length === 0) missing.push(field);
+          break;
+        case "abridged":
+          if (file.abridged == null) missing.push(field);
+          break;
+      }
+    }
+  }
+
+  return missing;
+}
+
+/**
+ * Build the "Missing: ..." hint string aggregated across all main files that
+ * need review.
+ *
+ * - If a field is missing on all files → list once without qualifier
+ * - If different files miss different fields → qualify with file type
+ *   e.g. "cover (EPUB), narrators (M4B)"
+ */
+function buildMissingHint(
+  needsReviewFiles: File[],
+  book: Book,
+  bookFields: string[],
+  audioFields: string[],
+): string | null {
+  if (needsReviewFiles.length === 0) return null;
+
+  // Collect missing fields per file
+  const missingPerFile: Map<number, string[]> = new Map();
+  for (const file of needsReviewFiles) {
+    const missing = getMissingFields(file, book, bookFields, audioFields);
+    if (missing.length > 0) {
+      missingPerFile.set(file.id, missing);
+    }
+  }
+
+  if (missingPerFile.size === 0) return null;
+
+  // Gather all unique fields across all files
+  const allFields = new Set<string>();
+  for (const fields of missingPerFile.values()) {
+    for (const f of fields) allFields.add(f);
+  }
+
+  // For each unique field, check if it's missing on ALL files
+  const fieldCount = needsReviewFiles.length;
+  const parts: string[] = [];
+
+  for (const field of allFields) {
+    const filesWithField = needsReviewFiles.filter((f) =>
+      missingPerFile.get(f.id)?.includes(field),
+    );
+
+    if (filesWithField.length === fieldCount) {
+      // Missing on all files — list without qualifier
+      parts.push(field);
+    } else {
+      // Missing on some files — qualify with file type (uppercase)
+      for (const file of filesWithField) {
+        parts.push(`${field} (${file.file_type.toUpperCase()})`);
+      }
+    }
+  }
+
+  if (parts.length === 0) return null;
+  return `Missing: ${parts.join(", ")}`;
+}
+
+export function ReviewPanel({
+  book,
+  files,
+  onChange,
+  isPending = false,
+}: ReviewPanelProps) {
+  const { data: criteria } = useReviewCriteria();
+
+  // Only consider main files
+  const mainFiles = files.filter((f) => f.file_role === FileRoleMain);
+
+  if (mainFiles.length === 0) return null;
+
+  // Aggregate reviewed state: true iff ALL main files are reviewed
+  const allReviewed =
+    mainFiles.length > 0 && mainFiles.every((f) => f.reviewed === true);
+
+  // Determine override indicator
+  const allOverrideReviewed = mainFiles.every(
+    (f) => f.review_override === ReviewOverrideReviewed,
+  );
+  const allOverrideUnreviewed = mainFiles.every(
+    (f) => f.review_override === ReviewOverrideUnreviewed,
+  );
+  const hasAnyOverride = mainFiles.some((f) => f.review_override != null);
+  const allNoOverride = mainFiles.every((f) => f.review_override == null);
+
+  // Find most recent override date
+  const sortedDates = mainFiles
+    .filter((f) => f.review_overridden_at != null)
+    .map((f) => f.review_overridden_at!)
+    .sort();
+  const mostRecentDate = sortedDates[sortedDates.length - 1];
+
+  let indicatorText: string;
+  let indicatorVariant: "secondary" | "success" | "outline" = "secondary";
+
+  if (allNoOverride) {
+    indicatorText = "Auto";
+  } else if (allOverrideReviewed && mostRecentDate) {
+    indicatorText = `Manually marked reviewed on ${formatDate(mostRecentDate)}`;
+    indicatorVariant = "success";
+  } else if (allOverrideUnreviewed && mostRecentDate) {
+    indicatorText = `Manually marked needs review on ${formatDate(mostRecentDate)}`;
+  } else if (hasAnyOverride) {
+    indicatorText = "Manually set on multiple files";
+  } else {
+    indicatorText = "Auto";
+  }
+
+  // Build missing-fields hint (only when book needs review)
+  const needsReview = !allReviewed;
+  let missingHint: string | null = null;
+
+  if (needsReview && criteria) {
+    const needsReviewFiles = mainFiles.filter((f) => f.reviewed === false);
+    missingHint = buildMissingHint(
+      needsReviewFiles,
+      book,
+      criteria.book_fields,
+      criteria.audio_fields,
+    );
+  }
+
+  const handleToggle = (checked: boolean) => {
+    onChange(checked ? ReviewOverrideReviewed : ReviewOverrideUnreviewed);
+  };
+
+  return (
+    <div className="border rounded-md p-4 space-y-2 bg-muted/30">
+      <div className="flex items-center gap-3">
+        <Switch
+          checked={allReviewed}
+          className="cursor-pointer"
+          disabled={isPending}
+          id="review-toggle"
+          onCheckedChange={handleToggle}
+        />
+        <Label
+          className={cn(
+            "cursor-pointer font-medium",
+            isPending && "opacity-50",
+          )}
+          htmlFor="review-toggle"
+        >
+          Reviewed
+        </Label>
+        <Badge className="ml-1 text-xs" variant={indicatorVariant}>
+          {indicatorText}
+        </Badge>
+      </div>
+
+      {missingHint && (
+        <p className="text-xs text-muted-foreground pl-0">{missingHint}</p>
+      )}
+    </div>
+  );
+}

--- a/app/components/library/ReviewPanel.tsx
+++ b/app/components/library/ReviewPanel.tsx
@@ -276,9 +276,9 @@ export function ReviewPanel({
               <TooltipContent className="max-w-xs">
                 <p>
                   Reviewed state is determined automatically from the required
-                  fields configured in Server Settings. Fill in all required
-                  fields and this will flip to reviewed; remove one and it flips
-                  back. Toggle manually to override.
+                  fields configured on the Review Criteria settings page. Fill
+                  in all required fields and this will flip to reviewed; remove
+                  one and it flips back. Toggle manually to override.
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/app/components/library/ReviewPanel.tsx
+++ b/app/components/library/ReviewPanel.tsx
@@ -1,4 +1,5 @@
-import { Badge } from "@/components/ui/badge";
+import { CircleCheck } from "lucide-react";
+
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -193,7 +194,6 @@ export function ReviewPanel({
   const allOverrideUnreviewed = mainFiles.every(
     (f) => f.review_override === ReviewOverrideUnreviewed,
   );
-  const hasAnyOverride = mainFiles.some((f) => f.review_override != null);
   const allNoOverride = mainFiles.every((f) => f.review_override == null);
 
   // Find most recent override date
@@ -203,21 +203,18 @@ export function ReviewPanel({
     .sort();
   const mostRecentDate = sortedDates[sortedDates.length - 1];
 
-  let indicatorText: string;
-  let indicatorVariant: "secondary" | "success" | "outline" = "secondary";
   const isAuto = allNoOverride;
 
-  if (allNoOverride) {
-    indicatorText = "Auto";
+  let tooltipText: string;
+  if (isAuto) {
+    tooltipText =
+      "Reviewed state is determined automatically from the required fields configured on the Review Criteria settings page. Fill in all required fields and this will flip to reviewed; remove one and it flips back. Toggle manually to override.";
   } else if (allOverrideReviewed && mostRecentDate) {
-    indicatorText = `Manually marked reviewed on ${formatDate(mostRecentDate)}`;
-    indicatorVariant = "success";
+    tooltipText = `Manually marked reviewed on ${formatDate(mostRecentDate)}`;
   } else if (allOverrideUnreviewed && mostRecentDate) {
-    indicatorText = `Manually marked needs review on ${formatDate(mostRecentDate)}`;
-  } else if (hasAnyOverride) {
-    indicatorText = "Manually set on multiple files";
+    tooltipText = `Manually marked needs review on ${formatDate(mostRecentDate)}`;
   } else {
-    indicatorText = "Auto";
+    tooltipText = "Manually set on multiple files";
   }
 
   // Build missing-fields hint (only when book needs review)
@@ -238,15 +235,6 @@ export function ReviewPanel({
     onChange(checked ? ReviewOverrideReviewed : ReviewOverrideUnreviewed);
   };
 
-  const indicatorBadge = (
-    <Badge
-      className={cn("text-xs", isAuto && "cursor-help")}
-      variant={indicatorVariant}
-    >
-      {indicatorText}
-    </Badge>
-  );
-
   return (
     <div className="border rounded-md p-4 space-y-2 bg-muted/30">
       <div className="flex items-center gap-3">
@@ -266,26 +254,26 @@ export function ReviewPanel({
         >
           Reviewed
         </Label>
-      </div>
-
-      <div>
-        {isAuto ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>{indicatorBadge}</TooltipTrigger>
-              <TooltipContent className="max-w-xs">
-                <p>
-                  Reviewed state is determined automatically from the required
-                  fields configured on the Review Criteria settings page. Fill
-                  in all required fields and this will flip to reviewed; remove
-                  one and it flips back. Toggle manually to override.
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        ) : (
-          indicatorBadge
-        )}
+        <TooltipProvider delayDuration={0}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <CircleCheck
+                aria-label={
+                  allReviewed ? "Reviewed status" : "Needs review status"
+                }
+                className={cn(
+                  "h-4 w-4 cursor-help",
+                  allReviewed
+                    ? "text-green-600 dark:text-green-500"
+                    : "text-muted-foreground",
+                )}
+              />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">
+              <p>{tooltipText}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
 
       {missingHint && (

--- a/app/components/library/ReviewPanel.tsx
+++ b/app/components/library/ReviewPanel.tsx
@@ -26,6 +26,14 @@ interface ReviewPanelProps {
   files: File[];
   onChange: (override: ReviewOverride) => void;
   isPending?: boolean;
+  /**
+   * When provided, the toggle (and the status icon's color) reflects this
+   * value instead of the aggregate `reviewed` state computed from `files`.
+   * Use for controlled / draft mode (e.g. edit dialogs that defer to Save).
+   * The committed-state-driven tooltip text and missing-fields hint are
+   * unaffected.
+   */
+  toggleValue?: boolean;
 }
 
 /**
@@ -175,6 +183,7 @@ export function ReviewPanel({
   files,
   onChange,
   isPending = false,
+  toggleValue,
 }: ReviewPanelProps) {
   const { data: criteria } = useReviewCriteria();
 
@@ -183,9 +192,14 @@ export function ReviewPanel({
 
   if (mainFiles.length === 0) return null;
 
-  // Aggregate reviewed state: true iff ALL main files are reviewed
-  const allReviewed =
+  // Committed aggregate reviewed state: true iff ALL main files are reviewed.
+  // Used for the missing-fields hint (which always reflects saved state).
+  const committedAllReviewed =
     mainFiles.length > 0 && mainFiles.every((f) => f.reviewed === true);
+
+  // The toggle's checked state and the icon's color follow `toggleValue`
+  // when caller is in controlled mode; otherwise default to committed state.
+  const allReviewed = toggleValue ?? committedAllReviewed;
 
   // Determine override indicator
   const allOverrideReviewed = mainFiles.every(
@@ -217,8 +231,10 @@ export function ReviewPanel({
     tooltipText = "Manually set on multiple files";
   }
 
-  // Build missing-fields hint (only when book needs review)
-  const needsReview = !allReviewed;
+  // Build missing-fields hint (only when book needs review).
+  // Uses committed state — the hint reflects what's actually missing on disk,
+  // not the draft toggle state in controlled mode.
+  const needsReview = !committedAllReviewed;
   let missingHint: string | null = null;
 
   if (needsReview && criteria) {

--- a/app/components/library/SelectionToolbar.test.tsx
+++ b/app/components/library/SelectionToolbar.test.tsx
@@ -1,0 +1,124 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { SelectionToolbar } from "./SelectionToolbar";
+
+beforeAll(() => {
+  // @ts-expect-error - global defined by Vite
+  globalThis.__APP_VERSION__ = "test";
+});
+
+// ---- hook mocks ----
+
+const mockExitSelectionMode = vi.fn();
+const mockClearSelection = vi.fn();
+
+vi.mock("@/hooks/useBulkSelection", () => ({
+  useBulkSelection: () => ({
+    selectedBookIds: [1, 2, 3],
+    exitSelectionMode: mockExitSelectionMode,
+    clearSelection: mockClearSelection,
+  }),
+}));
+
+vi.mock("@/hooks/useBulkDownload", () => ({
+  useBulkDownload: () => ({ startDownload: vi.fn() }),
+}));
+
+vi.mock("@/hooks/queries/books", () => ({
+  useBooks: () => ({ data: { books: [] }, isLoading: false }),
+  useDeleteBooks: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/queries/jobs", () => ({
+  useCreateJob: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/queries/lists", () => ({
+  useListLists: () => ({ data: { lists: [] }, isLoading: false }),
+  useAddBooksToList: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateList: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+const mockBulkSetReviewMutateAsync = vi.fn();
+
+vi.mock("@/hooks/queries/review", () => ({
+  useBulkSetReview: () => ({
+    mutateAsync: mockBulkSetReviewMutateAsync,
+    isPending: false,
+  }),
+}));
+
+// ---- helpers ----
+
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime, delay: null });
+
+function wrap(ui: React.ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ---- tests ----
+
+describe("SelectionToolbar — More popover bulk review actions", () => {
+  it("renders the More button", () => {
+    render(wrap(<SelectionToolbar />));
+    expect(screen.getByRole("button", { name: /more/i })).toBeInTheDocument();
+  });
+
+  it("opens the More popover when clicked and shows both actions", async () => {
+    const user = createUser();
+    render(wrap(<SelectionToolbar />));
+
+    await user.click(screen.getByRole("button", { name: /more/i }));
+
+    expect(
+      screen.getByRole("button", { name: /mark reviewed/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /mark needs review/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls useBulkSetReview with reviewed override and exits selection mode", async () => {
+    const user = createUser();
+    mockBulkSetReviewMutateAsync.mockResolvedValueOnce(undefined);
+    render(wrap(<SelectionToolbar />));
+
+    await user.click(screen.getByRole("button", { name: /more/i }));
+    await user.click(screen.getByRole("button", { name: /mark reviewed/i }));
+
+    expect(mockBulkSetReviewMutateAsync).toHaveBeenCalledWith({
+      bookIds: [1, 2, 3],
+      override: "reviewed",
+    });
+    expect(mockExitSelectionMode).toHaveBeenCalled();
+  });
+
+  it("calls useBulkSetReview with unreviewed override and exits selection mode", async () => {
+    const user = createUser();
+    mockBulkSetReviewMutateAsync.mockResolvedValueOnce(undefined);
+    render(wrap(<SelectionToolbar />));
+
+    await user.click(screen.getByRole("button", { name: /more/i }));
+    await user.click(
+      screen.getByRole("button", { name: /mark needs review/i }),
+    );
+
+    expect(mockBulkSetReviewMutateAsync).toHaveBeenCalledWith({
+      bookIds: [1, 2, 3],
+      override: "unreviewed",
+    });
+    expect(mockExitSelectionMode).toHaveBeenCalled();
+  });
+});

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -1,8 +1,11 @@
 import {
+  CheckCircle,
+  Circle,
   Download,
   GitMerge,
   List,
   Loader2,
+  MoreHorizontal,
   Plus,
   Trash2,
   X,
@@ -26,9 +29,10 @@ import {
   useCreateList,
   useListLists,
 } from "@/hooks/queries/lists";
+import { useBulkSetReview } from "@/hooks/queries/review";
 import { useBulkDownload } from "@/hooks/useBulkDownload";
 import { useBulkSelection } from "@/hooks/useBulkSelection";
-import type { CreateListPayload, Library } from "@/types";
+import type { CreateListPayload, Library, ReviewOverride } from "@/types";
 import { formatFileSize } from "@/utils/format";
 
 interface SelectionToolbarProps {
@@ -39,6 +43,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
   const { selectedBookIds, exitSelectionMode, clearSelection } =
     useBulkSelection();
   const [popoverOpen, setPopoverOpen] = useState(false);
+  const [morePopoverOpen, setMorePopoverOpen] = useState(false);
   const [addingToListId, setAddingToListId] = useState<number | null>(null);
   const [showMergeDialog, setShowMergeDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -51,6 +56,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
   const addToListMutation = useAddBooksToList();
   const createListMutation = useCreateList();
   const deleteBooksMutation = useDeleteBooks();
+  const bulkSetReviewMutation = useBulkSetReview();
 
   // Fetch all selected books (not just current page) for download info and delete dialog
   const allSelectedBooksQuery = useBooks(
@@ -155,6 +161,28 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
         error instanceof Error ? error.message : "Failed to create list";
       toast.error(message);
       throw error; // Re-throw so CreateListDialog knows it failed
+    }
+  };
+
+  const handleBulkReview = async (override: ReviewOverride) => {
+    try {
+      await bulkSetReviewMutation.mutateAsync({
+        bookIds: selectedBookIds,
+        override,
+      });
+      const count = selectedBookIds.length;
+      const label = override === "reviewed" ? "reviewed" : "needs review";
+      toast.success(
+        `Marked ${count} book${count !== 1 ? "s" : ""} as ${label}`,
+      );
+      setMorePopoverOpen(false);
+      exitSelectionMode();
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to update review state";
+      toast.error(message);
     }
   };
 
@@ -288,6 +316,33 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
         <Trash2 className="h-4 w-4" />
         Delete
       </Button>
+
+      <Popover onOpenChange={setMorePopoverOpen} open={morePopoverOpen}>
+        <PopoverTrigger asChild>
+          <Button size="sm" variant="default">
+            <MoreHorizontal className="h-4 w-4" />
+            More
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="center" className="w-56 p-1" side="top">
+          <button
+            className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent text-left w-full text-sm cursor-pointer"
+            onClick={() => handleBulkReview("reviewed")}
+            type="button"
+          >
+            <CheckCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">Mark reviewed</span>
+          </button>
+          <button
+            className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent text-left w-full text-sm cursor-pointer"
+            onClick={() => handleBulkReview("unreviewed")}
+            type="button"
+          >
+            <Circle className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">Mark needs review</span>
+          </button>
+        </PopoverContent>
+      </Popover>
 
       <Button onClick={clearSelection} size="sm" variant="ghost">
         Clear

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -325,22 +325,24 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
           </Button>
         </PopoverTrigger>
         <PopoverContent align="center" className="w-56 p-1" side="top">
-          <button
-            className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent text-left w-full text-sm cursor-pointer"
+          <Button
+            className="w-full justify-start gap-2 font-normal"
             onClick={() => handleBulkReview("reviewed")}
-            type="button"
+            size="sm"
+            variant="ghost"
           >
             <CheckCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="truncate">Mark reviewed</span>
-          </button>
-          <button
-            className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent text-left w-full text-sm cursor-pointer"
+          </Button>
+          <Button
+            className="w-full justify-start gap-2 font-normal"
             onClick={() => handleBulkReview("unreviewed")}
-            type="button"
+            size="sm"
+            variant="ghost"
           >
             <Circle className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="truncate">Mark needs review</span>
-          </button>
+          </Button>
         </PopoverContent>
       </Popover>
 

--- a/app/components/pages/AdminReviewCriteria.test.tsx
+++ b/app/components/pages/AdminReviewCriteria.test.tsx
@@ -4,8 +4,8 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import AdminReviewCriteria from "./AdminReviewCriteria";
 import { humanizeField } from "./review-criteria-utils";
-import ReviewCriteriaSection from "./ReviewCriteriaSection";
 
 beforeAll(() => {
   // @ts-expect-error - global defined by Vite
@@ -82,7 +82,7 @@ describe("humanizeField", () => {
   });
 });
 
-describe("ReviewCriteriaSection", () => {
+describe("AdminReviewCriteria", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCriteriaData.override_count = 0;
@@ -90,7 +90,7 @@ describe("ReviewCriteriaSection", () => {
 
   it("renders checked checkboxes for current book_fields", () => {
     mockCriteriaData.override_count = 0;
-    wrap(<ReviewCriteriaSection />);
+    wrap(<AdminReviewCriteria />);
 
     // authors and cover are in book_fields → checked
     expect(screen.getByRole("checkbox", { name: "Authors" })).toBeChecked();
@@ -103,7 +103,7 @@ describe("ReviewCriteriaSection", () => {
 
   it("renders checked checkbox for current audio_fields", () => {
     mockCriteriaData.override_count = 0;
-    wrap(<ReviewCriteriaSection />);
+    wrap(<AdminReviewCriteria />);
 
     expect(screen.getByRole("checkbox", { name: "Narrators" })).toBeChecked();
     expect(
@@ -113,7 +113,7 @@ describe("ReviewCriteriaSection", () => {
 
   it("Save button is disabled when no changes", () => {
     mockCriteriaData.override_count = 0;
-    wrap(<ReviewCriteriaSection />);
+    wrap(<AdminReviewCriteria />);
 
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
@@ -121,7 +121,7 @@ describe("ReviewCriteriaSection", () => {
   it("Save button enables after toggling a checkbox", async () => {
     const user = createUser();
     mockCriteriaData.override_count = 0;
-    wrap(<ReviewCriteriaSection />);
+    wrap(<AdminReviewCriteria />);
 
     await user.click(screen.getByRole("checkbox", { name: "Description" }));
 
@@ -133,7 +133,7 @@ describe("ReviewCriteriaSection", () => {
     mockCriteriaData.override_count = 0;
     mockUpdateMutateAsync.mockResolvedValueOnce(undefined);
 
-    wrap(<ReviewCriteriaSection />);
+    wrap(<AdminReviewCriteria />);
 
     // Toggle description on
     await user.click(screen.getByRole("checkbox", { name: "Description" }));
@@ -152,7 +152,7 @@ describe("ReviewCriteriaSection", () => {
     const user = createUser();
     mockCriteriaData.override_count = 3;
 
-    wrap(<ReviewCriteriaSection />);
+    wrap(<AdminReviewCriteria />);
 
     // Toggle description to enable the Save button
     await user.click(screen.getByRole("checkbox", { name: "Description" }));
@@ -175,7 +175,7 @@ describe("ReviewCriteriaSection", () => {
     mockCriteriaData.override_count = 3;
     mockUpdateMutateAsync.mockResolvedValueOnce(undefined);
 
-    wrap(<ReviewCriteriaSection />);
+    wrap(<AdminReviewCriteria />);
 
     // Toggle a field to make Save enabled, then click Save
     await user.click(screen.getByRole("checkbox", { name: "Description" }));
@@ -209,7 +209,7 @@ describe("ReviewCriteriaSection", () => {
     mockCriteriaData.override_count = 0;
     mockCreateJobMutateAsync.mockResolvedValueOnce({ id: 42 });
 
-    wrap(<ReviewCriteriaSection />);
+    wrap(<AdminReviewCriteria />);
 
     await user.click(screen.getByRole("button", { name: "Recompute now" }));
 
@@ -227,7 +227,7 @@ describe("ReviewCriteriaSection", () => {
     const user = createUser();
     mockCriteriaData.override_count = 5;
 
-    wrap(<ReviewCriteriaSection />);
+    wrap(<AdminReviewCriteria />);
 
     await user.click(screen.getByRole("button", { name: "Recompute now" }));
 

--- a/app/components/pages/AdminReviewCriteria.tsx
+++ b/app/components/pages/AdminReviewCriteria.tsx
@@ -20,6 +20,7 @@ import {
   useReviewCriteria,
   useUpdateReviewCriteria,
 } from "@/hooks/queries/review";
+import { usePageTitle } from "@/hooks/usePageTitle";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { JobTypeRecomputeReview } from "@/types";
 
@@ -99,7 +100,8 @@ const RecomputeDialog = ({
   );
 };
 
-const ReviewCriteriaSection = () => {
+const AdminReviewCriteria = () => {
+  usePageTitle("Review Criteria");
   const criteriaQuery = useReviewCriteria();
   const updateMutation = useUpdateReviewCriteria();
   const createJobMutation = useCreateJob();
@@ -220,12 +222,22 @@ const ReviewCriteriaSection = () => {
     }
   };
 
+  const pageHeader = (
+    <div className="mb-6 md:mb-8">
+      <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
+        Review Criteria
+      </h1>
+      <p className="text-sm md:text-base text-muted-foreground">
+        Choose which metadata fields must be present for a book to be considered
+        reviewed.
+      </p>
+    </div>
+  );
+
   if (criteriaQuery.isLoading) {
     return (
-      <div className="border border-border rounded-md p-4 md:p-6">
-        <h2 className="text-base md:text-lg font-semibold mb-3 md:mb-4">
-          Review Criteria
-        </h2>
+      <div>
+        {pageHeader}
         <LoadingSpinner />
       </div>
     );
@@ -233,10 +245,8 @@ const ReviewCriteriaSection = () => {
 
   if (criteriaQuery.isError || !criteriaQuery.data) {
     return (
-      <div className="border border-border rounded-md p-4 md:p-6">
-        <h2 className="text-base md:text-lg font-semibold mb-3 md:mb-4">
-          Review Criteria
-        </h2>
+      <div>
+        {pageHeader}
         <p className="text-sm text-muted-foreground">
           Failed to load review criteria.
         </p>
@@ -253,15 +263,8 @@ const ReviewCriteriaSection = () => {
 
   return (
     <>
+      {pageHeader}
       <div className="border border-border rounded-md p-4 md:p-6">
-        <h2 className="text-base md:text-lg font-semibold mb-1 md:mb-2">
-          Review Criteria
-        </h2>
-        <p className="text-sm text-muted-foreground mb-4 md:mb-6">
-          Choose which metadata fields must be present for a book to be
-          considered reviewed.
-        </p>
-
         <div className="space-y-6">
           {/* Universal fields */}
           <div className="space-y-3">
@@ -394,4 +397,4 @@ const ReviewCriteriaSection = () => {
   );
 };
 
-export default ReviewCriteriaSection;
+export default AdminReviewCriteria;

--- a/app/components/pages/AdminReviewCriteria.tsx
+++ b/app/components/pages/AdminReviewCriteria.tsx
@@ -163,7 +163,7 @@ const AdminReviewCriteria = () => {
       clear_overrides: overrideClear,
     });
     setInitialValues({ bookFields, audioFields });
-    toast.success("Review state recompute queued.");
+    toast.success("Saved. Recompute queued.");
   };
 
   const handleSave = async () => {

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -2,8 +2,6 @@ import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { useConfig } from "@/hooks/queries/config";
 import { usePageTitle } from "@/hooks/usePageTitle";
 
-import ReviewCriteriaSection from "./ReviewCriteriaSection";
-
 const formatDuration = (nanoseconds: number): string => {
   const seconds = nanoseconds / 1_000_000_000;
   if (seconds < 60) {
@@ -79,9 +77,6 @@ const AdminSettings = () => {
       </div>
 
       <div className="grid gap-6">
-        {/* Review Criteria (editable) */}
-        <ReviewCriteriaSection />
-
         {/* Database Settings */}
         <div className="border border-border rounded-md p-4 md:p-6">
           <h2 className="text-base md:text-lg font-semibold mb-3 md:mb-4">

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -2,6 +2,8 @@ import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { useConfig } from "@/hooks/queries/config";
 import { usePageTitle } from "@/hooks/usePageTitle";
 
+import ReviewCriteriaSection from "./ReviewCriteriaSection";
+
 const formatDuration = (nanoseconds: number): string => {
   const seconds = nanoseconds / 1_000_000_000;
   if (seconds < 60) {
@@ -77,6 +79,9 @@ const AdminSettings = () => {
       </div>
 
       <div className="grid gap-6">
+        {/* Review Criteria (editable) */}
+        <ReviewCriteriaSection />
+
         {/* Database Settings */}
         <div className="border border-border rounded-md p-4 md:p-6">
           <h2 className="text-base md:text-lg font-semibold mb-3 md:mb-4">

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -35,6 +35,7 @@ import LoadingSpinner from "@/components/library/LoadingSpinner";
 import { MergeIntoDialog } from "@/components/library/MergeIntoDialog";
 import { MoveFilesDialog } from "@/components/library/MoveFilesDialog";
 import { RescanDialog } from "@/components/library/RescanDialog";
+import { ReviewPanel } from "@/components/library/ReviewPanel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -70,6 +71,7 @@ import {
 import { useLibrary } from "@/hooks/queries/libraries";
 import { usePluginIdentifierTypes } from "@/hooks/queries/plugins";
 import { type RescanMode } from "@/hooks/queries/resync";
+import { useSetBookReview } from "@/hooks/queries/review";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { cn } from "@/libraries/utils";
 import {
@@ -734,6 +736,7 @@ const BookDetail = () => {
   const deleteBookMutation = useDeleteBook();
   const deleteFileMutation = useDeleteFile();
   const setPrimaryFileMutation = useSetPrimaryFile();
+  const setBookReviewMutation = useSetBookReview();
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [showBookRescanDialog, setShowBookRescanDialog] = useState(false);
   const [rescanFileId, setRescanFileId] = useState<number | null>(null);
@@ -1183,6 +1186,18 @@ const BookDetail = () => {
             )}
           </div>
 
+          {/* Review Panel — visible when book has files, fires mutation immediately */}
+          {(book.files?.length ?? 0) > 0 && (
+            <ReviewPanel
+              book={book}
+              files={book.files ?? []}
+              isPending={setBookReviewMutation.isPending}
+              onChange={(override) =>
+                setBookReviewMutation.mutate({ bookId: book.id, override })
+              }
+            />
+          )}
+
           <div className="space-y-4 md:space-y-6">
             {/* Authors */}
             {book.authors &&
@@ -1490,6 +1505,7 @@ const BookDetail = () => {
 
       {editingFile && (
         <FileEditDialog
+          book={book}
           file={editingFile}
           onOpenChange={(open) => {
             if (!open) setEditingFile(null);

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1073,7 +1073,7 @@ const BookDetail = () => {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 md:gap-8">
         {/* Book Cover */}
-        <div className="lg:col-span-1">
+        <div className="lg:col-span-1 space-y-4 md:space-y-6">
           {mainFiles.length > 1 ? (
             /* Multiple files - show cover gallery with tabs */
             <CoverGalleryTabs cacheKey={coverCacheKey} files={mainFiles} />
@@ -1101,6 +1101,18 @@ const BookDetail = () => {
                 />
               )}
             </div>
+          )}
+
+          {/* Review Panel — visible when book has files, fires mutation immediately */}
+          {(book.files?.length ?? 0) > 0 && (
+            <ReviewPanel
+              book={book}
+              files={book.files ?? []}
+              isPending={setBookReviewMutation.isPending}
+              onChange={(override) =>
+                setBookReviewMutation.mutate({ bookId: book.id, override })
+              }
+            />
           )}
         </div>
 
@@ -1185,18 +1197,6 @@ const BookDetail = () => {
               </p>
             )}
           </div>
-
-          {/* Review Panel — visible when book has files, fires mutation immediately */}
-          {(book.files?.length ?? 0) > 0 && (
-            <ReviewPanel
-              book={book}
-              files={book.files ?? []}
-              isPending={setBookReviewMutation.isPending}
-              onChange={(override) =>
-                setBookReviewMutation.mutate({ bookId: book.id, override })
-              }
-            />
-          )}
 
           <div className="space-y-4 md:space-y-6">
             {/* Authors */}

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -61,6 +61,7 @@ const HomeContent = () => {
   const genreIdsParam = searchParams.get("genre_ids") ?? "";
   const tagIdsParam = searchParams.get("tag_ids") ?? "";
   const languageParam = searchParams.get("language") ?? "";
+  const reviewedFilterParam = searchParams.get("reviewed_filter") ?? "";
   const sortParam = searchParams.get("sort") ?? "";
   const urlSort: SortLevel[] | null = sortParam
     ? parseSortSpec(sortParam)
@@ -320,6 +321,20 @@ const HomeContent = () => {
     });
   };
 
+  // Set reviewed filter
+  const setReviewedFilter = (value: string) => {
+    setSearchParams((prev) => {
+      const newParams = new URLSearchParams(prev);
+      if (value && value !== "all") {
+        newParams.set("reviewed_filter", value);
+      } else {
+        newParams.delete("reviewed_filter");
+      }
+      newParams.set("page", "1");
+      return newParams;
+    });
+  };
+
   const clearAllFilters = () => {
     setSearchParams((prev) => {
       const newParams = new URLSearchParams(prev);
@@ -327,6 +342,7 @@ const HomeContent = () => {
       newParams.delete("genre_ids");
       newParams.delete("tag_ids");
       newParams.delete("language");
+      newParams.delete("reviewed_filter");
       newParams.set("page", "1");
       return newParams;
     });
@@ -396,7 +412,8 @@ const HomeContent = () => {
     selectedFileTypes.length > 0 ||
     selectedGenreIds.length > 0 ||
     selectedTagIds.length > 0 ||
-    Boolean(languageParam);
+    Boolean(languageParam) ||
+    Boolean(reviewedFilterParam && reviewedFilterParam !== "all");
 
   // Build query with search and file types
   const booksQueryParams: Parameters<typeof useBooks>[0] = {
@@ -431,6 +448,11 @@ const HomeContent = () => {
     booksQueryParams.language = languageParam;
   }
 
+  // Add reviewed filter if present
+  if (reviewedFilterParam && reviewedFilterParam !== "all") {
+    booksQueryParams.reviewed_filter = reviewedFilterParam;
+  }
+
   // Sort: serialize only the effective (possibly resolved-from-default) sort.
   // Always sending a sort query param makes server-side sort explicit and deterministic.
   const serializedSort = serializeSortSpec(effectiveSort);
@@ -450,6 +472,7 @@ const HomeContent = () => {
     genreIds: selectedGenreIds,
     tagIds: selectedTagIds,
     language: languageParam,
+    reviewedFilter: reviewedFilterParam,
     sort: sortParam,
   });
   const [confirmedFilterKey, setConfirmedFilterKey] = useState<string | null>(
@@ -467,7 +490,8 @@ const HomeContent = () => {
           selectedFileTypes.length > 0 ||
           selectedGenreIds.length > 0 ||
           selectedTagIds.length > 0 ||
-          languageParam !== "",
+          languageParam !== "" ||
+          (reviewedFilterParam !== "" && reviewedFilterParam !== "all"),
       );
     }
   }, [
@@ -479,6 +503,7 @@ const HomeContent = () => {
     selectedGenreIds.length,
     selectedTagIds.length,
     languageParam,
+    reviewedFilterParam,
     sortParam,
   ]);
 
@@ -545,10 +570,12 @@ const HomeContent = () => {
             onClearAll={clearAllFilters}
             onGenreSearchChange={setGenreSearchInput}
             onLanguageChange={setLanguageFilter}
+            onReviewedFilterChange={setReviewedFilter}
             onTagSearchChange={setTagSearchInput}
             onToggleFileType={toggleFileType}
             onToggleGenre={toggleGenreFilter}
             onToggleTag={toggleTagFilter}
+            reviewedFilter={reviewedFilterParam}
             selectedFileTypes={selectedFileTypes}
             selectedGenreIds={selectedGenreIds}
             selectedTagIds={selectedTagIds}
@@ -592,9 +619,11 @@ const HomeContent = () => {
           languageParam={languageParam}
           onClearAll={clearAllFilters}
           onClearLanguage={() => setLanguageFilter("all")}
+          onClearReviewedFilter={() => setReviewedFilter("all")}
           onToggleFileType={toggleFileType}
           onToggleGenre={toggleGenreFilter}
           onToggleTag={toggleTagFilter}
+          reviewedFilter={reviewedFilterParam}
           selectedFileTypes={selectedFileTypes}
           selectedGenres={selectedGenres}
           selectedTags={selectedTags}

--- a/app/components/pages/ReviewCriteriaSection.test.tsx
+++ b/app/components/pages/ReviewCriteriaSection.test.tsx
@@ -1,0 +1,244 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { humanizeField } from "./review-criteria-utils";
+import ReviewCriteriaSection from "./ReviewCriteriaSection";
+
+beforeAll(() => {
+  // @ts-expect-error - global defined by Vite
+  globalThis.__APP_VERSION__ = "test";
+});
+
+// Mock useUnsavedChanges (uses react-router's useBlocker which requires a data router).
+vi.mock("@/hooks/useUnsavedChanges", () => ({
+  useUnsavedChanges: () => ({
+    cancelNavigation: vi.fn(),
+    proceedNavigation: vi.fn(),
+    showBlockerDialog: false,
+  }),
+}));
+
+// Configurable mock data so individual tests can override override_count
+const mockCriteriaData = {
+  book_fields: ["authors", "cover"],
+  audio_fields: ["narrators"],
+  universal_candidates: ["authors", "cover", "description"],
+  audio_candidates: ["narrators", "release_date"],
+  override_count: 0,
+  main_file_count: 10,
+};
+
+const mockUpdateMutateAsync = vi.fn();
+const mockCreateJobMutateAsync = vi.fn();
+
+vi.mock("@/hooks/queries/review", () => ({
+  useReviewCriteria: () => ({
+    isLoading: false,
+    isSuccess: true,
+    isError: false,
+    data: mockCriteriaData,
+  }),
+  useUpdateReviewCriteria: () => ({
+    mutateAsync: mockUpdateMutateAsync,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/queries/jobs", () => ({
+  useCreateJob: () => ({
+    mutateAsync: mockCreateJobMutateAsync,
+    isPending: false,
+  }),
+}));
+
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime, delay: null });
+
+function wrap(ui: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("humanizeField", () => {
+  it("capitalizes single word", () => {
+    expect(humanizeField("cover")).toBe("Cover");
+  });
+
+  it("converts snake_case to sentence case", () => {
+    expect(humanizeField("release_date")).toBe("Release date");
+  });
+
+  it("handles multi-word snake_case", () => {
+    expect(humanizeField("book_genres")).toBe("Book genres");
+  });
+});
+
+describe("ReviewCriteriaSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCriteriaData.override_count = 0;
+  });
+
+  it("renders checked checkboxes for current book_fields", () => {
+    mockCriteriaData.override_count = 0;
+    wrap(<ReviewCriteriaSection />);
+
+    // authors and cover are in book_fields → checked
+    expect(screen.getByRole("checkbox", { name: "Authors" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Cover" })).toBeChecked();
+    // description is not in book_fields → unchecked
+    expect(
+      screen.getByRole("checkbox", { name: "Description" }),
+    ).not.toBeChecked();
+  });
+
+  it("renders checked checkbox for current audio_fields", () => {
+    mockCriteriaData.override_count = 0;
+    wrap(<ReviewCriteriaSection />);
+
+    expect(screen.getByRole("checkbox", { name: "Narrators" })).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Release date" }),
+    ).not.toBeChecked();
+  });
+
+  it("Save button is disabled when no changes", () => {
+    mockCriteriaData.override_count = 0;
+    wrap(<ReviewCriteriaSection />);
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("Save button enables after toggling a checkbox", async () => {
+    const user = createUser();
+    mockCriteriaData.override_count = 0;
+    wrap(<ReviewCriteriaSection />);
+
+    await user.click(screen.getByRole("checkbox", { name: "Description" }));
+
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+  });
+
+  it("saves with updated arrays and clear_overrides:false when no overrides exist", async () => {
+    const user = createUser();
+    mockCriteriaData.override_count = 0;
+    mockUpdateMutateAsync.mockResolvedValueOnce(undefined);
+
+    wrap(<ReviewCriteriaSection />);
+
+    // Toggle description on
+    await user.click(screen.getByRole("checkbox", { name: "Description" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+        book_fields: ["authors", "cover", "description"],
+        audio_fields: ["narrators"],
+        clear_overrides: false,
+      });
+    });
+  });
+
+  it("opens confirmation dialog before saving when overrides exist", async () => {
+    const user = createUser();
+    mockCriteriaData.override_count = 3;
+
+    wrap(<ReviewCriteriaSection />);
+
+    // Toggle description to enable the Save button
+    await user.click(screen.getByRole("checkbox", { name: "Description" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // Dialog should appear with override count info
+    await waitFor(() => {
+      expect(screen.getByText("Recompute review state?")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/3 reviewed-overrides set out of 10/),
+    ).toBeInTheDocument();
+
+    // mutation should NOT have fired yet
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("passes clear_overrides:true when checkbox is checked in confirmation dialog", async () => {
+    const user = createUser();
+    mockCriteriaData.override_count = 3;
+    mockUpdateMutateAsync.mockResolvedValueOnce(undefined);
+
+    wrap(<ReviewCriteriaSection />);
+
+    // Toggle a field to make Save enabled, then click Save
+    await user.click(screen.getByRole("checkbox", { name: "Description" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // Wait for dialog
+    await waitFor(() => {
+      expect(screen.getByText("Recompute review state?")).toBeInTheDocument();
+    });
+
+    // Check the "Also clear manual overrides" checkbox
+    const clearCheckbox = screen.getByRole("checkbox", {
+      name: "Also clear manual overrides",
+    });
+    await user.click(clearCheckbox);
+
+    // Confirm
+    await user.click(screen.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() => {
+      expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+        book_fields: ["authors", "cover", "description"],
+        audio_fields: ["narrators"],
+        clear_overrides: true,
+      });
+    });
+  });
+
+  it("Recompute now button queues a recompute_review job with clear_overrides:false", async () => {
+    const user = createUser();
+    mockCriteriaData.override_count = 0;
+    mockCreateJobMutateAsync.mockResolvedValueOnce({ id: 42 });
+
+    wrap(<ReviewCriteriaSection />);
+
+    await user.click(screen.getByRole("button", { name: "Recompute now" }));
+
+    await waitFor(() => {
+      expect(mockCreateJobMutateAsync).toHaveBeenCalledWith({
+        payload: {
+          type: "recompute_review",
+          data: { clear_overrides: false },
+        },
+      });
+    });
+  });
+
+  it("Recompute now button opens confirmation dialog when overrides exist", async () => {
+    const user = createUser();
+    mockCriteriaData.override_count = 5;
+
+    wrap(<ReviewCriteriaSection />);
+
+    await user.click(screen.getByRole("button", { name: "Recompute now" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Recompute review state?")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/5 reviewed-overrides set out of 10/),
+    ).toBeInTheDocument();
+
+    // job should NOT have fired yet
+    expect(mockCreateJobMutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/pages/ReviewCriteriaSection.tsx
+++ b/app/components/pages/ReviewCriteriaSection.tsx
@@ -1,0 +1,397 @@
+import equal from "fast-deep-equal";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import LoadingSpinner from "@/components/library/LoadingSpinner";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { UnsavedChangesDialog } from "@/components/ui/unsaved-changes-dialog";
+import { useCreateJob } from "@/hooks/queries/jobs";
+import {
+  useReviewCriteria,
+  useUpdateReviewCriteria,
+} from "@/hooks/queries/review";
+import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
+import { JobTypeRecomputeReview } from "@/types";
+
+import { humanizeField } from "./review-criteria-utils";
+
+interface RecomputeDialogProps {
+  open: boolean;
+  overrideCount: number;
+  mainFileCount: number;
+  clearOverrides: boolean;
+  onClearOverridesChange: (value: boolean) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isPending: boolean;
+}
+
+const RecomputeDialog = ({
+  open,
+  overrideCount,
+  mainFileCount,
+  clearOverrides,
+  onClearOverridesChange,
+  onConfirm,
+  onCancel,
+  isPending,
+}: RecomputeDialogProps) => {
+  return (
+    <Dialog
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+      open={open}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Recompute review state?</DialogTitle>
+          <DialogDescription asChild>
+            <div>
+              <p>
+                Auto-detected reviewed status will refresh based on the new
+                criteria. You currently have{" "}
+                <strong>
+                  {overrideCount} reviewed-override
+                  {overrideCount !== 1 ? "s" : ""} set out of {mainFileCount}{" "}
+                  total main file{mainFileCount !== 1 ? "s" : ""}
+                </strong>
+                .
+              </p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex items-center space-x-2 py-2">
+          <Checkbox
+            checked={clearOverrides}
+            id="clear-overrides"
+            onCheckedChange={(checked) =>
+              onClearOverridesChange(checked as boolean)
+            }
+          />
+          <Label
+            className="text-sm font-normal cursor-pointer"
+            htmlFor="clear-overrides"
+          >
+            Also clear manual overrides
+          </Label>
+        </div>
+        <DialogFooter>
+          <Button disabled={isPending} onClick={onCancel} variant="outline">
+            Cancel
+          </Button>
+          <Button disabled={isPending} onClick={onConfirm}>
+            {isPending ? "Saving..." : "Confirm"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const ReviewCriteriaSection = () => {
+  const criteriaQuery = useReviewCriteria();
+  const updateMutation = useUpdateReviewCriteria();
+  const createJobMutation = useCreateJob();
+
+  const [bookFields, setBookFields] = useState<string[]>([]);
+  const [audioFields, setAudioFields] = useState<string[]>([]);
+  const [initialValues, setInitialValues] = useState<{
+    bookFields: string[];
+    audioFields: string[];
+  } | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Confirmation dialog state
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [recomputeDialogOpen, setRecomputeDialogOpen] = useState(false);
+  const [clearOverrides, setClearOverrides] = useState(false);
+
+  // Initialize form when data loads
+  useEffect(() => {
+    if (criteriaQuery.isSuccess && criteriaQuery.data && !isInitialized) {
+      const fields = criteriaQuery.data.book_fields;
+      const audio = criteriaQuery.data.audio_fields;
+      setBookFields(fields);
+      setAudioFields(audio);
+      setInitialValues({ bookFields: fields, audioFields: audio });
+      setIsInitialized(true);
+    }
+  }, [criteriaQuery.isSuccess, criteriaQuery.data, isInitialized]);
+
+  // Compute dirty state
+  const hasChanges = useMemo(() => {
+    if (!initialValues || !isInitialized) return false;
+    return (
+      !equal(bookFields, initialValues.bookFields) ||
+      !equal(audioFields, initialValues.audioFields)
+    );
+  }, [bookFields, audioFields, initialValues, isInitialized]);
+
+  const { showBlockerDialog, proceedNavigation, cancelNavigation } =
+    useUnsavedChanges(hasChanges);
+
+  const toggleField = (
+    fields: string[],
+    setFields: (v: string[]) => void,
+    fieldName: string,
+    checked: boolean,
+  ) => {
+    if (checked) {
+      setFields([...fields, fieldName]);
+    } else {
+      setFields(fields.filter((f) => f !== fieldName));
+    }
+  };
+
+  const executeSave = async (overrideClear: boolean) => {
+    await updateMutation.mutateAsync({
+      book_fields: bookFields,
+      audio_fields: audioFields,
+      clear_overrides: overrideClear,
+    });
+    setInitialValues({ bookFields, audioFields });
+    toast.success("Review state recompute queued.");
+  };
+
+  const handleSave = async () => {
+    const overrideCount = criteriaQuery.data?.override_count ?? 0;
+    if (overrideCount > 0) {
+      setClearOverrides(false);
+      setSaveDialogOpen(true);
+      return;
+    }
+    try {
+      await executeSave(false);
+    } catch {
+      toast.error("Failed to save review criteria.");
+    }
+  };
+
+  const handleSaveConfirm = async () => {
+    setSaveDialogOpen(false);
+    try {
+      await executeSave(clearOverrides);
+    } catch {
+      toast.error("Failed to save review criteria.");
+    }
+  };
+
+  const executeRecompute = async (overrideClear: boolean) => {
+    await createJobMutation.mutateAsync({
+      payload: {
+        type: JobTypeRecomputeReview,
+        data: { clear_overrides: overrideClear },
+      },
+    });
+    toast.success("Review state recompute queued.");
+  };
+
+  const handleRecomputeNow = async () => {
+    const overrideCount = criteriaQuery.data?.override_count ?? 0;
+    if (overrideCount > 0) {
+      setClearOverrides(false);
+      setRecomputeDialogOpen(true);
+      return;
+    }
+    try {
+      await executeRecompute(false);
+    } catch {
+      toast.error("Failed to queue recompute job.");
+    }
+  };
+
+  const handleRecomputeConfirm = async () => {
+    setRecomputeDialogOpen(false);
+    try {
+      await executeRecompute(clearOverrides);
+    } catch {
+      toast.error("Failed to queue recompute job.");
+    }
+  };
+
+  if (criteriaQuery.isLoading) {
+    return (
+      <div className="border border-border rounded-md p-4 md:p-6">
+        <h2 className="text-base md:text-lg font-semibold mb-3 md:mb-4">
+          Review Criteria
+        </h2>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (criteriaQuery.isError || !criteriaQuery.data) {
+    return (
+      <div className="border border-border rounded-md p-4 md:p-6">
+        <h2 className="text-base md:text-lg font-semibold mb-3 md:mb-4">
+          Review Criteria
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Failed to load review criteria.
+        </p>
+      </div>
+    );
+  }
+
+  const {
+    universal_candidates,
+    audio_candidates,
+    override_count,
+    main_file_count,
+  } = criteriaQuery.data;
+
+  return (
+    <>
+      <div className="border border-border rounded-md p-4 md:p-6">
+        <h2 className="text-base md:text-lg font-semibold mb-1 md:mb-2">
+          Review Criteria
+        </h2>
+        <p className="text-sm text-muted-foreground mb-4 md:mb-6">
+          Choose which metadata fields must be present for a book to be
+          considered reviewed.
+        </p>
+
+        <div className="space-y-6">
+          {/* Universal fields */}
+          <div className="space-y-3">
+            <h3 className="text-sm font-medium">Required for all books</h3>
+            <div className="space-y-2">
+              {universal_candidates.map((field) => (
+                <div className="flex items-center space-x-2" key={field}>
+                  <Checkbox
+                    checked={bookFields.includes(field)}
+                    id={`book-field-${field}`}
+                    onCheckedChange={(checked) =>
+                      toggleField(
+                        bookFields,
+                        setBookFields,
+                        field,
+                        checked as boolean,
+                      )
+                    }
+                  />
+                  <Label
+                    className="text-sm font-normal cursor-pointer"
+                    htmlFor={`book-field-${field}`}
+                  >
+                    {humanizeField(field)}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Audio-specific fields */}
+          <div className="space-y-3">
+            <div>
+              <h3 className="text-sm font-medium">
+                Required for audiobooks (additional)
+              </h3>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                These apply when a book has any audiobook file.
+              </p>
+            </div>
+            <div className="space-y-2">
+              {audio_candidates.map((field) => (
+                <div className="flex items-center space-x-2" key={field}>
+                  <Checkbox
+                    checked={audioFields.includes(field)}
+                    id={`audio-field-${field}`}
+                    onCheckedChange={(checked) =>
+                      toggleField(
+                        audioFields,
+                        setAudioFields,
+                        field,
+                        checked as boolean,
+                      )
+                    }
+                  />
+                  <Label
+                    className="text-sm font-normal cursor-pointer"
+                    htmlFor={`audio-field-${field}`}
+                  >
+                    {humanizeField(field)}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Save button */}
+        <div className="flex justify-end pt-6">
+          <Button
+            disabled={!hasChanges || updateMutation.isPending}
+            onClick={handleSave}
+          >
+            {updateMutation.isPending ? "Saving..." : "Save"}
+          </Button>
+        </div>
+
+        {/* Recompute now button */}
+        <div className="border-t border-border pt-4 mt-4">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium">Recompute review state now</p>
+              <p className="text-xs text-muted-foreground">
+                Re-evaluate all books against the current criteria and update
+                their reviewed status.
+              </p>
+            </div>
+            <Button
+              className="shrink-0"
+              disabled={createJobMutation.isPending}
+              onClick={handleRecomputeNow}
+              variant="outline"
+            >
+              {createJobMutation.isPending ? "Queuing..." : "Recompute now"}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Save confirmation dialog (when overrides exist) */}
+      <RecomputeDialog
+        clearOverrides={clearOverrides}
+        isPending={updateMutation.isPending}
+        mainFileCount={main_file_count}
+        onCancel={() => setSaveDialogOpen(false)}
+        onClearOverridesChange={setClearOverrides}
+        onConfirm={handleSaveConfirm}
+        open={saveDialogOpen}
+        overrideCount={override_count}
+      />
+
+      {/* Recompute-now confirmation dialog (when overrides exist) */}
+      <RecomputeDialog
+        clearOverrides={clearOverrides}
+        isPending={createJobMutation.isPending}
+        mainFileCount={main_file_count}
+        onCancel={() => setRecomputeDialogOpen(false)}
+        onClearOverridesChange={setClearOverrides}
+        onConfirm={handleRecomputeConfirm}
+        open={recomputeDialogOpen}
+        overrideCount={override_count}
+      />
+
+      <UnsavedChangesDialog
+        onDiscard={proceedNavigation}
+        onStay={cancelNavigation}
+        open={showBlockerDialog}
+      />
+    </>
+  );
+};
+
+export default ReviewCriteriaSection;

--- a/app/components/pages/review-criteria-utils.ts
+++ b/app/components/pages/review-criteria-utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Convert a snake_case field name to a human-readable label.
+ * e.g. "release_date" → "Release date", "cover" → "Cover"
+ */
+export function humanizeField(name: string): string {
+  const label = name.replace(/_/g, " ");
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}

--- a/app/components/pages/review-criteria-utils.ts
+++ b/app/components/pages/review-criteria-utils.ts
@@ -1,8 +1,19 @@
 /**
+ * Field-name fragments that should render in all-caps when humanizing.
+ */
+const ACRONYMS = new Set(["url"]);
+
+/**
  * Convert a snake_case field name to a human-readable label.
- * e.g. "release_date" → "Release date", "cover" → "Cover"
+ * e.g. "release_date" → "Release date", "url" → "URL", "source_url" → "Source URL"
  */
 export function humanizeField(name: string): string {
-  const label = name.replace(/_/g, " ");
-  return label.charAt(0).toUpperCase() + label.slice(1);
+  const words = name.split("_");
+  return words
+    .map((word, i) => {
+      if (ACRONYMS.has(word)) return word.toUpperCase();
+      if (i === 0) return word.charAt(0).toUpperCase() + word.slice(1);
+      return word;
+    })
+    .join(" ");
 }

--- a/app/components/pages/useAdminNavItems.ts
+++ b/app/components/pages/useAdminNavItems.ts
@@ -1,4 +1,5 @@
 import {
+  BookCheck,
   Briefcase,
   Cog,
   HardDrive,
@@ -45,6 +46,13 @@ export const useAdminNavItems = (): AdminNavItem[] => {
       label: "Libraries",
       isActive: location.pathname.startsWith("/settings/libraries"),
       show: canViewLibraries,
+    },
+    {
+      to: "/settings/review-criteria",
+      Icon: BookCheck,
+      label: "Review Criteria",
+      isActive: location.pathname.startsWith("/settings/review-criteria"),
+      show: canViewConfig,
     },
     {
       to: "/settings/users",

--- a/app/hooks/queries/review.ts
+++ b/app/hooks/queries/review.ts
@@ -1,0 +1,101 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { API, ShishoAPIError } from "@/libraries/api";
+import type { Book, File, ReviewOverride } from "@/types";
+
+import { QueryKey as BooksQueryKey } from "./books";
+
+export enum QueryKey {
+  ReviewCriteria = "ReviewCriteria",
+}
+
+export interface ReviewCriteriaResponse {
+  book_fields: string[];
+  audio_fields: string[];
+  universal_candidates: string[];
+  audio_candidates: string[];
+  override_count: number;
+  main_file_count: number;
+}
+
+export interface UpdateReviewCriteriaVariables {
+  book_fields: string[];
+  audio_fields: string[];
+  clear_overrides: boolean;
+}
+
+export const useReviewCriteria = () =>
+  useQuery<ReviewCriteriaResponse, ShishoAPIError>({
+    queryKey: [QueryKey.ReviewCriteria],
+    queryFn: ({ signal }) =>
+      API.request("GET", "/settings/review-criteria", null, null, signal),
+  });
+
+export const useUpdateReviewCriteria = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, ShishoAPIError, UpdateReviewCriteriaVariables>({
+    mutationFn: (payload) =>
+      API.request("PUT", "/settings/review-criteria", payload, null),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKey.ReviewCriteria] });
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+    },
+  });
+};
+
+interface SetFileReviewVariables {
+  fileId: number;
+  override: ReviewOverride | null;
+}
+
+export const useSetFileReview = () => {
+  const queryClient = useQueryClient();
+  return useMutation<File, ShishoAPIError, SetFileReviewVariables>({
+    mutationFn: ({ fileId, override }) =>
+      API.request("PATCH", `/books/files/${fileId}/review`, { override }, null),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+    },
+  });
+};
+
+interface SetBookReviewVariables {
+  bookId: number;
+  override: ReviewOverride | null;
+}
+
+export const useSetBookReview = () => {
+  const queryClient = useQueryClient();
+  return useMutation<Book, ShishoAPIError, SetBookReviewVariables>({
+    mutationFn: ({ bookId, override }) =>
+      API.request("PATCH", `/books/${bookId}/review`, { override }, null),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+    },
+  });
+};
+
+interface BulkSetReviewVariables {
+  bookIds: number[];
+  override: ReviewOverride | null;
+}
+
+export const useBulkSetReview = () => {
+  const queryClient = useQueryClient();
+  return useMutation<void, ShishoAPIError, BulkSetReviewVariables>({
+    mutationFn: ({ bookIds, override }) =>
+      API.request(
+        "POST",
+        "/books/bulk/review",
+        { book_ids: bookIds, override },
+        null,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+    },
+  });
+};

--- a/app/hooks/useSSE.ts
+++ b/app/hooks/useSSE.ts
@@ -69,6 +69,17 @@ export function useSSE() {
           });
         }
 
+        // When a recompute_review job completes, refresh book lists and
+        // detail views so the new reviewed states show up.
+        if (data.status === "completed" && data.type === "recompute_review") {
+          queryClient.invalidateQueries({
+            queryKey: [BooksQueryKey.ListBooks],
+          });
+          queryClient.invalidateQueries({
+            queryKey: [BooksQueryKey.RetrieveBook],
+          });
+        }
+
         // Handle bulk download completion/failure
         const bd = bulkDownloadRef.current;
         if (data.type === "bulk_download" && bd) {

--- a/app/router.tsx
+++ b/app/router.tsx
@@ -7,6 +7,7 @@ import AdminLayout from "@/components/pages/AdminLayout";
 import AdminLibraries from "@/components/pages/AdminLibraries";
 import AdminLogs from "@/components/pages/AdminLogs";
 import AdminPlugins from "@/components/pages/AdminPlugins";
+import AdminReviewCriteria from "@/components/pages/AdminReviewCriteria";
 import AdminSettings from "@/components/pages/AdminSettings";
 import AdminUsers from "@/components/pages/AdminUsers";
 import BookDetail from "@/components/pages/BookDetail";
@@ -218,6 +219,16 @@ export const router = createBrowserRouter([
                 requiredPermission={{ resource: "config", operation: "read" }}
               >
                 <AdminLogs />
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: "review-criteria",
+            element: (
+              <ProtectedRoute
+                requiredPermission={{ resource: "config", operation: "read" }}
+              >
+                <AdminReviewCriteria />
               </ProtectedRoute>
             ),
           },

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -26,6 +26,7 @@ export interface ListBooksQuery {
   language?: string;
   ids?: number[];
   sort?: string;
+  reviewed_filter?: string; // "" or "all" = all books, "needs_review", "reviewed"
 }
 export * from "./generated/filesystem";
 export * from "./generated/jobs";

--- a/app/utils/book.test.ts
+++ b/app/utils/book.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { FileRoleMain, FileRoleSupplement } from "@/types";
+
+import { isBookNeedsReview } from "./book";
+
+describe("isBookNeedsReview", () => {
+  it("returns false for a book with no files", () => {
+    expect(isBookNeedsReview({ id: 1, title: "A" } as never)).toBe(false);
+  });
+
+  it("returns false for a book with no main files (only supplement)", () => {
+    expect(
+      isBookNeedsReview({
+        id: 1,
+        title: "A",
+        files: [{ id: 10, file_role: FileRoleSupplement, reviewed: false }],
+      } as never),
+    ).toBe(false);
+  });
+
+  it("returns true when a main file has reviewed=false", () => {
+    expect(
+      isBookNeedsReview({
+        id: 1,
+        title: "A",
+        files: [{ id: 10, file_role: FileRoleMain, reviewed: false }],
+      } as never),
+    ).toBe(true);
+  });
+
+  it("returns true when a main file has reviewed=undefined", () => {
+    expect(
+      isBookNeedsReview({
+        id: 1,
+        title: "A",
+        files: [{ id: 10, file_role: FileRoleMain }],
+      } as never),
+    ).toBe(true);
+  });
+
+  it("returns false when all main files are reviewed", () => {
+    expect(
+      isBookNeedsReview({
+        id: 1,
+        title: "A",
+        files: [
+          { id: 10, file_role: FileRoleMain, reviewed: true },
+          { id: 11, file_role: FileRoleMain, reviewed: true },
+        ],
+      } as never),
+    ).toBe(false);
+  });
+
+  it("returns true when at least one main file is not reviewed (mixed)", () => {
+    expect(
+      isBookNeedsReview({
+        id: 1,
+        title: "A",
+        files: [
+          { id: 10, file_role: FileRoleMain, reviewed: true },
+          { id: 11, file_role: FileRoleMain, reviewed: false },
+        ],
+      } as never),
+    ).toBe(true);
+  });
+});

--- a/app/utils/book.ts
+++ b/app/utils/book.ts
@@ -1,0 +1,11 @@
+import type { Book } from "@/types";
+
+/**
+ * Returns true when a book has at least one main file that has not been reviewed.
+ * A book with no main files does not need review.
+ */
+export const isBookNeedsReview = (book: Book): boolean => {
+  const mains = (book.files ?? []).filter((f) => f.file_role === "main");
+  if (mains.length === 0) return false;
+  return mains.some((f) => f.reviewed !== true);
+};

--- a/app/utils/book.ts
+++ b/app/utils/book.ts
@@ -1,11 +1,11 @@
-import type { Book } from "@/types";
+import { FileRoleMain, type Book } from "@/types";
 
 /**
  * Returns true when a book has at least one main file that has not been reviewed.
  * A book with no main files does not need review.
  */
 export const isBookNeedsReview = (book: Book): boolean => {
-  const mains = (book.files ?? []).filter((f) => f.file_role === "main");
+  const mains = (book.files ?? []).filter((f) => f.file_role === FileRoleMain);
   if (mains.length === 0) return false;
   return mains.some((f) => f.reviewed !== true);
 };

--- a/docs/superpowers/plans/2026-04-25-reviewed-flag.md
+++ b/docs/superpowers/plans/2026-04-25-reviewed-flag.md
@@ -1,0 +1,3158 @@
+# Reviewed Flag — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a per-file `Reviewed` state with admin-configurable required fields, sticky manual overrides, automatic recompute on metadata changes, a library "needs review" filter, and corresponding badges/UI in the book and file detail views.
+
+**Architecture:** Three new columns on `files` (`review_override`, `review_overridden_at`, `reviewed`). A new `app_settings` key/value table holds the runtime-mutable review criteria (universal + audio-only). A `pkg/books/review` package centralizes the completeness rule and recompute helpers. A new `recompute_review` background job populates `files.reviewed` after migrations and on settings changes. PATCH endpoints (file/book/bulk) set overrides and trigger recompute. Frontend adds a filter sheet entry, a card badge, review panels in `BookDetail` / `BookEditDialog` / `FileEditDialog`, an overflow popover in the bulk selection toolbar, and a Review Criteria section in `AdminSettings`.
+
+**Tech Stack:** Go + Echo + Bun + SQLite (backend), React 19 + TanStack Query + Tailwind/shadcn (frontend), Vitest + Playwright (tests).
+
+**Reference spec:** `docs/superpowers/specs/2026-04-25-reviewed-flag-design.md`
+
+---
+
+## Before starting
+
+Establish a green baseline before touching code:
+
+```bash
+mise check:quiet
+```
+
+Expected: all checks pass.
+
+Generate types after any Go struct changes:
+
+```bash
+mise tygo
+```
+
+If it prints "skipping, outputs are up-to-date", that's normal — see CLAUDE.md.
+
+---
+
+## Phase 1 — Foundation: app_settings table
+
+The spec requires runtime-mutable server-level settings (admin can change without restart). The codebase doesn't yet have a generic mechanism for this — we introduce one with `app_settings`, a JSON key/value store.
+
+### Task 1: Migration — `app_settings` table
+
+**Files:**
+- Create: `pkg/migrations/20260425100000_add_app_settings.go`
+
+- [ ] **Step 1.1: Write the migration**
+
+```go
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		_, err := db.ExecContext(ctx, `
+			CREATE TABLE app_settings (
+				key TEXT PRIMARY KEY NOT NULL,
+				value TEXT NOT NULL,
+				updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)
+		`)
+		return errors.WithStack(err)
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		_, err := db.ExecContext(ctx, `DROP TABLE app_settings`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}
+```
+
+- [ ] **Step 1.2: Run migrations to verify**
+
+```bash
+mise db:migrate
+mise db:rollback
+mise db:migrate
+```
+
+Expected: no errors.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add pkg/migrations/20260425100000_add_app_settings.go
+git commit -m "[Backend] Add app_settings runtime config table"
+```
+
+---
+
+### Task 2: AppSetting model and Service
+
+**Files:**
+- Create: `pkg/models/app-setting.go`
+- Create: `pkg/appsettings/service.go`
+- Create: `pkg/appsettings/service_test.go`
+
+- [ ] **Step 2.1: Write the model**
+
+`pkg/models/app-setting.go`:
+
+```go
+package models
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type AppSetting struct {
+	bun.BaseModel `bun:"table:app_settings,alias:as" tstype:"-"`
+
+	Key       string    `bun:",pk,nullzero" json:"key"`
+	Value     string    `bun:",notnull" json:"value"`
+	UpdatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"updated_at"`
+}
+```
+
+- [ ] **Step 2.2: Write the service test (failing)**
+
+`pkg/appsettings/service_test.go`:
+
+```go
+package appsettings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/database"
+	"github.com/stretchr/testify/require"
+)
+
+type sampleConfig struct {
+	BookFields  []string `json:"book_fields"`
+	AudioFields []string `json:"audio_fields"`
+}
+
+func TestGetSetJSON_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+	svc := NewService(db)
+
+	want := sampleConfig{
+		BookFields:  []string{"authors", "description"},
+		AudioFields: []string{"narrators"},
+	}
+	require.NoError(t, svc.SetJSON(ctx, "review_criteria", want))
+
+	var got sampleConfig
+	ok, err := svc.GetJSON(ctx, "review_criteria", &got)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, want, got)
+}
+
+func TestGetJSON_Missing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+	svc := NewService(db)
+
+	var got sampleConfig
+	ok, err := svc.GetJSON(ctx, "missing_key", &got)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestSetJSON_Overwrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+	svc := NewService(db)
+
+	require.NoError(t, svc.SetJSON(ctx, "k", sampleConfig{BookFields: []string{"a"}}))
+	require.NoError(t, svc.SetJSON(ctx, "k", sampleConfig{BookFields: []string{"b"}}))
+
+	var got sampleConfig
+	_, err := svc.GetJSON(ctx, "k", &got)
+	require.NoError(t, err)
+	require.Equal(t, []string{"b"}, got.BookFields)
+}
+```
+
+- [ ] **Step 2.3: Run tests to verify failure**
+
+```bash
+go test ./pkg/appsettings/...
+```
+
+Expected: FAIL — package missing.
+
+- [ ] **Step 2.4: Implement the service**
+
+`pkg/appsettings/service.go`:
+
+```go
+package appsettings
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/uptrace/bun"
+)
+
+type Service struct {
+	db *bun.DB
+}
+
+func NewService(db *bun.DB) *Service {
+	return &Service{db: db}
+}
+
+// GetJSON loads the JSON-encoded value for key into out. Returns (false, nil) if no row exists.
+func (svc *Service) GetJSON(ctx context.Context, key string, out interface{}) (bool, error) {
+	row := &models.AppSetting{}
+	err := svc.db.NewSelect().Model(row).Where("key = ?", key).Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, errors.WithStack(err)
+	}
+	if err := json.Unmarshal([]byte(row.Value), out); err != nil {
+		return false, errors.WithStack(err)
+	}
+	return true, nil
+}
+
+// SetJSON stores the JSON-encoded value at key. Upserts on conflict.
+func (svc *Service) SetJSON(ctx context.Context, key string, value interface{}) error {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	row := &models.AppSetting{Key: key, Value: string(encoded)}
+	_, err = svc.db.NewInsert().
+		Model(row).
+		On("CONFLICT (key) DO UPDATE").
+		Set("value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP").
+		Exec(ctx)
+	return errors.WithStack(err)
+}
+```
+
+- [ ] **Step 2.5: Run tests to verify pass**
+
+```bash
+go test ./pkg/appsettings/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add pkg/models/app-setting.go pkg/appsettings/
+git commit -m "[Backend] Add AppSetting model and JSON-keyed service"
+```
+
+---
+
+## Phase 2 — Schema: file review columns
+
+### Task 3: Migration — files review columns
+
+**Files:**
+- Create: `pkg/migrations/20260425100100_add_file_review_fields.go`
+
+- [ ] **Step 3.1: Write the migration**
+
+```go
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		stmts := []string{
+			`ALTER TABLE files ADD COLUMN review_override TEXT
+				CHECK (review_override IS NULL OR review_override IN ('reviewed','unreviewed'))`,
+			`ALTER TABLE files ADD COLUMN review_overridden_at TIMESTAMP`,
+			`ALTER TABLE files ADD COLUMN reviewed BOOLEAN`,
+			`CREATE INDEX idx_files_book_reviewed
+				ON files(book_id, reviewed)
+				WHERE file_role = 'main'`,
+		}
+		for _, s := range stmts {
+			if _, err := db.ExecContext(ctx, s); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		stmts := []string{
+			`DROP INDEX IF EXISTS idx_files_book_reviewed`,
+			`ALTER TABLE files DROP COLUMN reviewed`,
+			`ALTER TABLE files DROP COLUMN review_overridden_at`,
+			`ALTER TABLE files DROP COLUMN review_override`,
+		}
+		for _, s := range stmts {
+			if _, err := db.ExecContext(ctx, s); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	}
+
+	Migrations.MustRegister(up, down)
+}
+```
+
+- [ ] **Step 3.2: Verify roundtrip**
+
+```bash
+mise db:migrate && mise db:rollback && mise db:migrate
+```
+
+Expected: no errors.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add pkg/migrations/20260425100100_add_file_review_fields.go
+git commit -m "[Backend] Add review fields and index to files table"
+```
+
+---
+
+### Task 4: Update File model
+
+**Files:**
+- Modify: `pkg/models/file.go`
+
+- [ ] **Step 4.1: Add the new fields**
+
+In `pkg/models/file.go`, add the constants near the top (after `FileRoleSupplement`):
+
+```go
+const (
+	//tygo:emit export type ReviewOverride = typeof ReviewOverrideReviewed | typeof ReviewOverrideUnreviewed;
+	ReviewOverrideReviewed   = "reviewed"
+	ReviewOverrideUnreviewed = "unreviewed"
+)
+```
+
+In the `File` struct, add (alphabetically in the existing block, or grouped at the end of the struct):
+
+```go
+ReviewOverride     *string    `json:"review_override" tstype:"ReviewOverride"`
+ReviewOverriddenAt *time.Time `json:"review_overridden_at"`
+Reviewed           *bool      `json:"reviewed"`
+```
+
+- [ ] **Step 4.2: Regenerate types**
+
+```bash
+mise tygo
+```
+
+Expected: `app/types/generated/` is updated to include the new fields.
+
+- [ ] **Step 4.3: Verify compile**
+
+```bash
+go build ./...
+```
+
+Expected: no errors.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add pkg/models/file.go app/types/generated/
+git commit -m "[Backend] Add review fields to File model"
+```
+
+---
+
+## Phase 3 — Completeness logic
+
+### Task 5: `pkg/books/review` package — completeness rule
+
+**Files:**
+- Create: `pkg/books/review/criteria.go`
+- Create: `pkg/books/review/criteria_test.go`
+- Create: `pkg/books/review/completeness.go`
+- Create: `pkg/books/review/completeness_test.go`
+
+- [ ] **Step 5.1: Write criteria definition**
+
+`pkg/books/review/criteria.go`:
+
+```go
+package review
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/appsettings"
+)
+
+const SettingsKey = "review_criteria"
+
+// Field constants — every name must be in either UniversalCandidates or AudioCandidates.
+const (
+	FieldAuthors     = "authors"
+	FieldDescription = "description"
+	FieldCover       = "cover"
+	FieldGenres      = "genres"
+	FieldTags        = "tags"
+	FieldSeries      = "series"
+	FieldSubtitle    = "subtitle"
+	FieldPublisher   = "publisher"
+	FieldImprint     = "imprint"
+	FieldIdentifiers = "identifiers"
+	FieldReleaseDate = "release_date"
+	FieldLanguage    = "language"
+	FieldURL         = "url"
+	FieldNarrators   = "narrators"
+	FieldChapters    = "chapters"
+	FieldAbridged    = "abridged"
+)
+
+// UniversalCandidates is the set of fields that can be required for all books.
+var UniversalCandidates = []string{
+	FieldAuthors, FieldDescription, FieldCover, FieldGenres, FieldTags,
+	FieldSeries, FieldSubtitle, FieldPublisher, FieldImprint, FieldIdentifiers,
+	FieldReleaseDate, FieldLanguage, FieldURL,
+}
+
+// AudioCandidates is the set of fields that can be required only when the book has at least one audio file.
+var AudioCandidates = []string{FieldNarrators, FieldChapters, FieldAbridged}
+
+type Criteria struct {
+	BookFields  []string `json:"book_fields"`
+	AudioFields []string `json:"audio_fields"`
+}
+
+// Default returns the seeded review criteria.
+func Default() Criteria {
+	return Criteria{
+		BookFields:  []string{FieldAuthors, FieldDescription, FieldCover, FieldGenres},
+		AudioFields: []string{FieldNarrators},
+	}
+}
+
+// Load reads the criteria from app settings, falling back to Default if unset.
+func Load(ctx context.Context, settings *appsettings.Service) (Criteria, error) {
+	var c Criteria
+	ok, err := settings.GetJSON(ctx, SettingsKey, &c)
+	if err != nil {
+		return Criteria{}, errors.WithStack(err)
+	}
+	if !ok {
+		return Default(), nil
+	}
+	// Defensive: if either slice is nil from older serializations, use defaults for that side.
+	if c.BookFields == nil {
+		c.BookFields = Default().BookFields
+	}
+	if c.AudioFields == nil {
+		c.AudioFields = Default().AudioFields
+	}
+	return c, nil
+}
+
+// Save persists the criteria.
+func Save(ctx context.Context, settings *appsettings.Service, c Criteria) error {
+	return errors.WithStack(settings.SetJSON(ctx, SettingsKey, c))
+}
+
+// Validate returns an error if any field name in the criteria isn't a known candidate.
+func Validate(c Criteria) error {
+	if err := validateAgainst(c.BookFields, UniversalCandidates); err != nil {
+		return errors.Wrap(err, "book_fields")
+	}
+	if err := validateAgainst(c.AudioFields, AudioCandidates); err != nil {
+		return errors.Wrap(err, "audio_fields")
+	}
+	return nil
+}
+
+func validateAgainst(fields []string, allowed []string) error {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		allowedSet[a] = struct{}{}
+	}
+	for _, f := range fields {
+		if _, ok := allowedSet[f]; !ok {
+			return errors.Errorf("unknown field %q", f)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5.2: Write criteria tests**
+
+`pkg/books/review/criteria_test.go`:
+
+```go
+package review
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/database"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefault_HasExpectedFields(t *testing.T) {
+	t.Parallel()
+	d := Default()
+	require.ElementsMatch(t, []string{"authors", "description", "cover", "genres"}, d.BookFields)
+	require.ElementsMatch(t, []string{"narrators"}, d.AudioFields)
+}
+
+func TestLoad_FallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+	svc := appsettings.NewService(db)
+
+	c, err := Load(ctx, svc)
+	require.NoError(t, err)
+	require.Equal(t, Default(), c)
+}
+
+func TestLoad_ReadsSavedValue(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+	svc := appsettings.NewService(db)
+
+	want := Criteria{BookFields: []string{"authors"}, AudioFields: []string{}}
+	require.NoError(t, Save(ctx, svc, want))
+
+	got, err := Load(ctx, svc)
+	require.NoError(t, err)
+	require.Equal(t, want.BookFields, got.BookFields)
+	require.Equal(t, want.AudioFields, got.AudioFields)
+}
+
+func TestValidate_RejectsUnknownField(t *testing.T) {
+	t.Parallel()
+	err := Validate(Criteria{BookFields: []string{"made_up_field"}})
+	require.Error(t, err)
+}
+
+func TestValidate_RejectsAudioFieldInUniversal(t *testing.T) {
+	t.Parallel()
+	err := Validate(Criteria{BookFields: []string{"narrators"}})
+	require.Error(t, err)
+}
+
+func TestValidate_AcceptsKnown(t *testing.T) {
+	t.Parallel()
+	err := Validate(Default())
+	require.NoError(t, err)
+}
+```
+
+- [ ] **Step 5.3: Run criteria tests**
+
+```bash
+go test ./pkg/books/review/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 5.4: Write completeness function**
+
+`pkg/books/review/completeness.go`:
+
+```go
+package review
+
+import (
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// MissingFields returns the list of required-field names that are not satisfied
+// for a single main file. The book and file must have all relations loaded.
+//
+// For supplements, returns nil.
+//
+// The criteria's BookFields apply to every file; AudioFields apply when the
+// containing book has at least one m4b file.
+func MissingFields(book *models.Book, file *models.File, criteria Criteria) []string {
+	if file.FileRole == models.FileRoleSupplement {
+		return nil
+	}
+	missing := make([]string, 0)
+	for _, f := range criteria.BookFields {
+		if !isPresent(book, file, f) {
+			missing = append(missing, f)
+		}
+	}
+	if file.FileType == models.FileTypeM4B {
+		for _, f := range criteria.AudioFields {
+			if !isPresent(book, file, f) {
+				missing = append(missing, f)
+			}
+		}
+	}
+	return missing
+}
+
+// IsComplete returns true iff MissingFields returns an empty slice for a main file.
+func IsComplete(book *models.Book, file *models.File, criteria Criteria) bool {
+	return len(MissingFields(book, file, criteria)) == 0
+}
+
+func isPresent(book *models.Book, file *models.File, field string) bool {
+	switch field {
+	case FieldAuthors:
+		return len(book.Authors) > 0
+	case FieldDescription:
+		return book.Description != nil && *book.Description != ""
+	case FieldGenres:
+		return len(book.BookGenres) > 0
+	case FieldTags:
+		return len(book.BookTags) > 0
+	case FieldSeries:
+		return len(book.BookSeries) > 0
+	case FieldSubtitle:
+		return book.Subtitle != nil && *book.Subtitle != ""
+	case FieldCover:
+		return file.CoverImageFilename != nil && *file.CoverImageFilename != ""
+	case FieldPublisher:
+		return file.PublisherID != nil
+	case FieldImprint:
+		return file.ImprintID != nil
+	case FieldIdentifiers:
+		return len(file.Identifiers) > 0
+	case FieldReleaseDate:
+		return file.ReleaseDate != nil
+	case FieldLanguage:
+		return file.Language != nil && *file.Language != ""
+	case FieldURL:
+		return file.URL != nil && *file.URL != ""
+	case FieldNarrators:
+		return len(file.Narrators) > 0
+	case FieldChapters:
+		return len(file.Chapters) > 0
+	case FieldAbridged:
+		return file.Abridged != nil
+	}
+	return false
+}
+```
+
+- [ ] **Step 5.5: Write completeness tests**
+
+`pkg/books/review/completeness_test.go`:
+
+```go
+package review
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func ptrStr(s string) *string { return &s }
+func ptrInt(i int) *int       { return &i }
+func ptrBool(b bool) *bool    { return &b }
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func TestMissingFields_Supplement_NoCheck(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{}
+	file := &models.File{FileRole: models.FileRoleSupplement}
+	require.Nil(t, MissingFields(book, file, Default()))
+}
+
+func TestMissingFields_EpubMissingAll_Default(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{}
+	file := &models.File{FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain}
+	missing := MissingFields(book, file, Default())
+	require.ElementsMatch(t, []string{"authors", "description", "cover", "genres"}, missing)
+}
+
+func TestMissingFields_EpubComplete(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		Description: ptrStr("desc"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("cover.jpg"),
+	}
+	require.Empty(t, MissingFields(book, file, Default()))
+}
+
+func TestMissingFields_M4BNeedsNarrators(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		Description: ptrStr("desc"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeM4B,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("cover.jpg"),
+	}
+	require.Contains(t, MissingFields(book, file, Default()), "narrators")
+}
+
+func TestMissingFields_M4BComplete(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		Description: ptrStr("desc"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeM4B,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("cover.jpg"),
+		Narrators:          []*models.Narrator{{}},
+	}
+	require.Empty(t, MissingFields(book, file, Default()))
+}
+
+func TestMissingFields_NonAudio_DoesNotCheckAudioFields(t *testing.T) {
+	t.Parallel()
+	criteria := Criteria{
+		BookFields:  []string{},
+		AudioFields: []string{"narrators"},
+	}
+	book := &models.Book{}
+	file := &models.File{FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain}
+	require.Empty(t, MissingFields(book, file, criteria))
+}
+
+func TestMissingFields_AllFields(t *testing.T) {
+	t.Parallel()
+	criteria := Criteria{
+		BookFields: []string{
+			FieldAuthors, FieldDescription, FieldCover, FieldGenres, FieldTags,
+			FieldSeries, FieldSubtitle, FieldPublisher, FieldImprint,
+			FieldIdentifiers, FieldReleaseDate, FieldLanguage, FieldURL,
+		},
+		AudioFields: []string{FieldNarrators, FieldChapters, FieldAbridged},
+	}
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		BookTags:    []*models.BookTag{{}},
+		BookSeries:  []*models.BookSeries{{}},
+		Description: ptrStr("desc"),
+		Subtitle:    ptrStr("sub"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeM4B,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("c.jpg"),
+		PublisherID:        ptrInt(1),
+		ImprintID:          ptrInt(1),
+		Identifiers:        []*models.FileIdentifier{{}},
+		ReleaseDate:        ptrTime(time.Now()),
+		Language:           ptrStr("en"),
+		URL:                ptrStr("https://example"),
+		Narrators:          []*models.Narrator{{}},
+		Chapters:           []*models.Chapter{{}},
+		Abridged:           ptrBool(false),
+	}
+	require.Empty(t, MissingFields(book, file, criteria))
+}
+
+func TestIsComplete_True(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		Description: ptrStr("d"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("c.jpg"),
+	}
+	require.True(t, IsComplete(book, file, Default()))
+}
+
+func TestIsComplete_False(t *testing.T) {
+	t.Parallel()
+	require.False(t, IsComplete(&models.Book{}, &models.File{
+		FileType: models.FileTypeEPUB,
+		FileRole: models.FileRoleMain,
+	}, Default()))
+}
+```
+
+- [ ] **Step 5.6: Run tests**
+
+```bash
+go test ./pkg/books/review/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add pkg/books/review/
+git commit -m "[Backend] Add review criteria and completeness rule"
+```
+
+---
+
+### Task 6: Recompute helpers
+
+**Files:**
+- Create: `pkg/books/review/recompute.go`
+- Create: `pkg/books/review/recompute_test.go`
+
+- [ ] **Step 6.1: Write the recompute helpers**
+
+`pkg/books/review/recompute.go`:
+
+```go
+package review
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/uptrace/bun"
+)
+
+// RecomputeForFile reloads the file (with relations needed by completeness),
+// computes its `reviewed` value, and persists. Override-set rows short-circuit.
+// Supplements get reviewed=NULL.
+func RecomputeForFile(ctx context.Context, db bun.IDB, fileID int, criteria Criteria) error {
+	file := &models.File{}
+	err := db.NewSelect().
+		Model(file).
+		Where("f.id = ?", fileID).
+		Relation("Narrators").
+		Relation("Identifiers").
+		Relation("Chapters").
+		Scan(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if file.FileRole == models.FileRoleSupplement {
+		_, err := db.NewUpdate().
+			Model((*models.File)(nil)).
+			Set("reviewed = NULL").
+			Where("id = ?", fileID).
+			Exec(ctx)
+		return errors.WithStack(err)
+	}
+
+	book := &models.Book{}
+	err = db.NewSelect().
+		Model(book).
+		Where("b.id = ?", file.BookID).
+		Relation("Authors").
+		Relation("BookSeries").
+		Relation("BookGenres").
+		Relation("BookTags").
+		Scan(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	reviewed := computeReviewedValue(book, file, criteria)
+	_, err = db.NewUpdate().
+		Model((*models.File)(nil)).
+		Set("reviewed = ?", reviewed).
+		Where("id = ?", fileID).
+		Exec(ctx)
+	return errors.WithStack(err)
+}
+
+// RecomputeForBook recomputes reviewed for every file belonging to the book.
+func RecomputeForBook(ctx context.Context, db bun.IDB, bookID int, criteria Criteria) error {
+	var fileIDs []int
+	err := db.NewSelect().
+		Model((*models.File)(nil)).
+		Column("id").
+		Where("book_id = ?", bookID).
+		Scan(ctx, &fileIDs)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, id := range fileIDs {
+		if err := RecomputeForFile(ctx, db, id, criteria); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetOverride writes an explicit override and the timestamp, then writes the
+// effective `reviewed` value. Pass override=nil to clear (then completeness
+// drives reviewed).
+func SetOverride(ctx context.Context, db bun.IDB, fileID int, override *string, criteria Criteria) error {
+	if override != nil && *override != models.ReviewOverrideReviewed && *override != models.ReviewOverrideUnreviewed {
+		return errors.Errorf("invalid override value: %q", *override)
+	}
+	now := time.Now().UTC()
+	q := db.NewUpdate().Model((*models.File)(nil)).Where("id = ?", fileID)
+	if override == nil {
+		q = q.Set("review_override = NULL").Set("review_overridden_at = NULL")
+	} else {
+		q = q.Set("review_override = ?", *override).Set("review_overridden_at = ?", now)
+	}
+	if _, err := q.Exec(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+	return RecomputeForFile(ctx, db, fileID, criteria)
+}
+
+// computeReviewedValue returns the effective reviewed value for a (book, main-file)
+// pair given the override and completeness. Returns nil for supplements (caller
+// is responsible for that branch).
+func computeReviewedValue(book *models.Book, file *models.File, criteria Criteria) *bool {
+	if file.ReviewOverride != nil {
+		switch *file.ReviewOverride {
+		case models.ReviewOverrideReviewed:
+			t := true
+			return &t
+		case models.ReviewOverrideUnreviewed:
+			f := false
+			return &f
+		}
+	}
+	v := IsComplete(book, file, criteria)
+	return &v
+}
+```
+
+- [ ] **Step 6.2: Write the recompute test**
+
+`pkg/books/review/recompute_test.go`:
+
+```go
+package review
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/database"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecomputeForFile_Incomplete_SetsFalse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	file := &models.File{
+		LibraryID: library.ID,
+		BookID:    book.ID,
+		Filepath:  "/tmp/x.epub",
+		FileType:  models.FileTypeEPUB,
+		FileRole:  models.FileRoleMain,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, RecomputeForFile(ctx, db, file.ID, Default()))
+
+	var got bool
+	err = db.NewSelect().Table("files").Column("reviewed").Where("id = ?", file.ID).Scan(ctx, &got)
+	require.NoError(t, err)
+	require.False(t, got)
+}
+
+func TestRecomputeForFile_OverrideReviewed_ShortCircuits(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	override := models.ReviewOverrideReviewed
+	file := &models.File{
+		LibraryID:      library.ID,
+		BookID:         book.ID,
+		Filepath:       "/tmp/x.epub",
+		FileType:       models.FileTypeEPUB,
+		FileRole:       models.FileRoleMain,
+		ReviewOverride: &override,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// File has no metadata, but override should win
+	require.NoError(t, RecomputeForFile(ctx, db, file.ID, Default()))
+
+	var got bool
+	err = db.NewSelect().Table("files").Column("reviewed").Where("id = ?", file.ID).Scan(ctx, &got)
+	require.NoError(t, err)
+	require.True(t, got)
+}
+
+func TestRecomputeForFile_Supplement_SetsNull(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	file := &models.File{
+		LibraryID: library.ID,
+		BookID:    book.ID,
+		Filepath:  "/tmp/x.pdf",
+		FileType:  models.FileTypePDF,
+		FileRole:  models.FileRoleSupplement,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, RecomputeForFile(ctx, db, file.ID, Default()))
+
+	var got *bool
+	err = db.NewSelect().Table("files").Column("reviewed").Where("id = ?", file.ID).Scan(ctx, &got)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestSetOverride_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	file := &models.File{
+		LibraryID: library.ID,
+		BookID:    book.ID,
+		Filepath:  "/tmp/x.epub",
+		FileType:  models.FileTypeEPUB,
+		FileRole:  models.FileRoleMain,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	v := models.ReviewOverrideReviewed
+	require.NoError(t, SetOverride(ctx, db, file.ID, &v, Default()))
+
+	var got models.File
+	err = db.NewSelect().Model(&got).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, got.ReviewOverride)
+	require.Equal(t, "reviewed", *got.ReviewOverride)
+	require.NotNil(t, got.ReviewOverriddenAt)
+	require.NotNil(t, got.Reviewed)
+	require.True(t, *got.Reviewed)
+
+	// Clear
+	require.NoError(t, SetOverride(ctx, db, file.ID, nil, Default()))
+	err = db.NewSelect().Model(&got).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	require.Nil(t, got.ReviewOverride)
+	require.Nil(t, got.ReviewOverriddenAt)
+	// Now driven by completeness — incomplete book → false
+	require.False(t, *got.Reviewed)
+}
+```
+
+- [ ] **Step 6.3: Run tests**
+
+```bash
+go test ./pkg/books/review/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 6.4: Commit**
+
+```bash
+git add pkg/books/review/recompute.go pkg/books/review/recompute_test.go
+git commit -m "[Backend] Add review recompute and override helpers"
+```
+
+---
+
+## Phase 4 — Recompute job
+
+### Task 7: Add `recompute_review` job type
+
+**Files:**
+- Modify: `pkg/models/job.go`
+
+- [ ] **Step 7.1: Add the constant and payload**
+
+In `pkg/models/job.go`:
+
+Update the `tygo:emit` line:
+
+```go
+//tygo:emit export type JobType = typeof JobTypeExport | typeof JobTypeScan | typeof JobTypeBulkDownload | typeof JobTypeHashGeneration | typeof JobTypeRecomputeReview;
+```
+
+Add the constant in the same `const` block:
+
+```go
+JobTypeRecomputeReview = "recompute_review"
+```
+
+Update the `tstype` on `DataParsed`:
+
+```go
+DataParsed interface{} `bun:"-" json:"data" tstype:"JobExportData | JobScanData | JobBulkDownloadData | JobHashGenerationData | JobRecomputeReviewData"`
+```
+
+Add the `case` to `UnmarshalData`:
+
+```go
+case JobTypeRecomputeReview:
+	job.DataParsed = &JobRecomputeReviewData{}
+```
+
+Add the payload struct at the end of the file:
+
+```go
+type JobRecomputeReviewData struct {
+	// ClearOverrides, when true, sets review_override and review_overridden_at to NULL
+	// for every main file before recomputing reviewed.
+	ClearOverrides bool `json:"clear_overrides"`
+}
+```
+
+- [ ] **Step 7.2: Regenerate types**
+
+```bash
+mise tygo
+```
+
+- [ ] **Step 7.3: Verify build**
+
+```bash
+go build ./...
+```
+
+Expected: no errors.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+git add pkg/models/job.go app/types/generated/
+git commit -m "[Backend] Add recompute_review job type"
+```
+
+---
+
+### Task 8: Worker handler `ProcessRecomputeReviewJob`
+
+**Files:**
+- Create: `pkg/worker/recompute_review.go`
+- Create: `pkg/worker/recompute_review_test.go`
+- Modify: `pkg/worker/worker.go` (registration)
+
+- [ ] **Step 8.1: Write the failing test first**
+
+`pkg/worker/recompute_review_test.go`:
+
+```go
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessRecomputeReviewJob_PopulatesReviewed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	w := newTestWorker(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := w.db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T"}
+	_, err = w.db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	main := &models.File{
+		LibraryID: library.ID, BookID: book.ID, Filepath: "/tmp/m.epub",
+		FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain,
+	}
+	_, err = w.db.NewInsert().Model(main).Exec(ctx)
+	require.NoError(t, err)
+	supp := &models.File{
+		LibraryID: library.ID, BookID: book.ID, Filepath: "/tmp/s.pdf",
+		FileType: models.FileTypePDF, FileRole: models.FileRoleSupplement,
+	}
+	_, err = w.db.NewInsert().Model(supp).Exec(ctx)
+	require.NoError(t, err)
+
+	job := &models.Job{
+		Type:   models.JobTypeRecomputeReview,
+		Status: models.JobStatusPending,
+		Data:   `{"clear_overrides":false}`,
+	}
+	_, err = w.db.NewInsert().Model(job).Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, w.ProcessRecomputeReviewJob(ctx, job))
+
+	var mainReviewed *bool
+	require.NoError(t, w.db.NewSelect().Table("files").Column("reviewed").Where("id = ?", main.ID).Scan(ctx, &mainReviewed))
+	require.NotNil(t, mainReviewed)
+	require.False(t, *mainReviewed)
+
+	var suppReviewed *bool
+	require.NoError(t, w.db.NewSelect().Table("files").Column("reviewed").Where("id = ?", supp.ID).Scan(ctx, &suppReviewed))
+	require.Nil(t, suppReviewed)
+}
+
+func TestProcessRecomputeReviewJob_ClearOverrides(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	w := newTestWorker(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := w.db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T"}
+	_, err = w.db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	override := models.ReviewOverrideReviewed
+	file := &models.File{
+		LibraryID: library.ID, BookID: book.ID, Filepath: "/tmp/x.epub",
+		FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain,
+		ReviewOverride: &override,
+	}
+	_, err = w.db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	job := &models.Job{
+		Type:   models.JobTypeRecomputeReview,
+		Status: models.JobStatusPending,
+		Data:   `{"clear_overrides":true}`,
+	}
+	_, err = w.db.NewInsert().Model(job).Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, w.ProcessRecomputeReviewJob(ctx, job))
+
+	var got models.File
+	require.NoError(t, w.db.NewSelect().Model(&got).Where("id = ?", file.ID).Scan(ctx))
+	require.Nil(t, got.ReviewOverride)
+	require.Nil(t, got.ReviewOverriddenAt)
+	require.NotNil(t, got.Reviewed)
+	require.False(t, *got.Reviewed)
+}
+
+// Note: newTestWorker is the existing helper in pkg/worker/testhelpers_test.go.
+// If it doesn't already wire an appsettings service, extend it as part of this task.
+// The recompute job needs access to appsettings.Service to load criteria.
+var _ = appsettings.NewService
+var _ = review.Default
+```
+
+- [ ] **Step 8.2: Run test to verify failure**
+
+```bash
+go test -run TestProcessRecomputeReviewJob ./pkg/worker/... -race
+```
+
+Expected: FAIL — undefined: ProcessRecomputeReviewJob.
+
+- [ ] **Step 8.3: Write the worker method**
+
+`pkg/worker/recompute_review.go`:
+
+```go
+package worker
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// ProcessRecomputeReviewJob iterates every file in the database and recomputes
+// `reviewed`. When ClearOverrides is set, it first wipes overrides for all main
+// files. Supplements get reviewed=NULL.
+//
+// Progress: emits 1..100 as integer percent based on processed/total files.
+func (w *Worker) ProcessRecomputeReviewJob(ctx context.Context, job *models.Job) error {
+	var data models.JobRecomputeReviewData
+	if err := json.Unmarshal([]byte(job.Data), &data); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if data.ClearOverrides {
+		if _, err := w.db.NewUpdate().
+			Model((*models.File)(nil)).
+			Set("review_override = NULL").
+			Set("review_overridden_at = NULL").
+			Where("file_role = ?", models.FileRoleMain).
+			Exec(ctx); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	criteria, err := review.Load(ctx, w.appSettingsService)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	var fileIDs []int
+	if err := w.db.NewSelect().
+		Model((*models.File)(nil)).
+		Column("id").
+		Order("id ASC").
+		Scan(ctx, &fileIDs); err != nil {
+		return errors.WithStack(err)
+	}
+
+	total := len(fileIDs)
+	for i, id := range fileIDs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := review.RecomputeForFile(ctx, w.db, id, criteria); err != nil {
+			return errors.WithStack(err)
+		}
+		if total > 0 {
+			pct := int(float64(i+1) / float64(total) * 100)
+			if err := w.jobService.UpdateProgress(ctx, job.ID, pct); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 8.4: Wire the appsettings service into the worker**
+
+In `pkg/worker/worker.go`:
+
+1. Add an `appSettingsService *appsettings.Service` field to the `Worker` struct.
+2. Add `appSettingsService *appsettings.Service` parameter to `New(...)` and assign it.
+3. In the dispatch map, add: `models.JobTypeRecomputeReview: w.ProcessRecomputeReviewJob,`.
+4. Update every caller of `worker.New(...)` (typically `cmd/api/main.go`) to pass an `appsettings.NewService(db)` instance.
+
+(The exact form depends on the current `New` signature. Match the pattern of other `*Service` fields like `jobService`, `bookService`, etc.)
+
+- [ ] **Step 8.5: Update the test helper**
+
+In `pkg/worker/testhelpers_test.go` (existing helper used by other worker tests), wire an `appsettings.Service` into `newTestWorker`. The expected signature change is to instantiate `appsettings.NewService(db)` and pass it through to `worker.New(...)`.
+
+- [ ] **Step 8.6: Run tests**
+
+```bash
+go test ./pkg/worker/... -race
+mise check:quiet
+```
+
+Expected: all pass.
+
+- [ ] **Step 8.7: Commit**
+
+```bash
+git add pkg/worker/ cmd/api/
+git commit -m "[Backend] Add recompute_review worker handler"
+```
+
+---
+
+## Phase 5 — Migration enqueues recompute
+
+### Task 9: Initial population migration step
+
+**Files:**
+- Create: `pkg/migrations/20260425100200_seed_review_criteria_and_enqueue_recompute.go`
+
+- [ ] **Step 9.1: Write the migration**
+
+```go
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		// Seed default review criteria.
+		defaultJSON, err := json.Marshal(map[string]interface{}{
+			"book_fields":  []string{"authors", "description", "cover", "genres"},
+			"audio_fields": []string{"narrators"},
+		})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO app_settings (key, value, updated_at)
+			VALUES ('review_criteria', ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(key) DO NOTHING
+		`, string(defaultJSON)); err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Enqueue a recompute job so the worker fills in files.reviewed
+		// asynchronously after migrations finish. Until then, files.reviewed
+		// is NULL and the books/list query treats NULL as needs-review.
+		jobData, err := json.Marshal(map[string]interface{}{"clear_overrides": false})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO jobs (type, status, data, progress, created_at, updated_at)
+			VALUES ('recompute_review', 'pending', ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		`, string(jobData)); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		stmts := []string{
+			`DELETE FROM jobs WHERE type = 'recompute_review'`,
+			`DELETE FROM app_settings WHERE key = 'review_criteria'`,
+		}
+		for _, s := range stmts {
+			if _, err := db.ExecContext(ctx, s); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	}
+
+	Migrations.MustRegister(up, down)
+}
+```
+
+- [ ] **Step 9.2: Verify roundtrip**
+
+```bash
+mise db:rollback && mise db:rollback && mise db:rollback && mise db:migrate
+```
+
+Expected: no errors. (The triple-rollback is to undo the migrations from this plan; adjust based on what's currently applied.)
+
+- [ ] **Step 9.3: Commit**
+
+```bash
+git add pkg/migrations/20260425100200_seed_review_criteria_and_enqueue_recompute.go
+git commit -m "[Backend] Seed default review criteria and enqueue initial recompute"
+```
+
+---
+
+## Phase 6 — Books service: hook recompute into mutations
+
+### Task 10: Service-level recompute helpers
+
+**Files:**
+- Modify: `pkg/books/service.go`
+
+We'll add two thin wrappers that load the current criteria and call into `pkg/books/review`. These are the call sites every mutation will use.
+
+- [ ] **Step 10.1: Add Service field**
+
+In `pkg/books/service.go`, add `appSettingsService *appsettings.Service` to the `Service` struct (along with the existing dependencies). Update `NewService` to accept and store it. Update every caller of `books.NewService(...)` (search the repo for `books.NewService(`) to pass an appsettings instance.
+
+- [ ] **Step 10.2: Add wrappers**
+
+In `pkg/books/service.go`, add at the bottom of the file:
+
+```go
+// recomputeReviewedForFile loads the active criteria and refreshes files.reviewed
+// for the given file. Errors are logged but do not propagate to the caller —
+// review state is non-critical metadata.
+func (svc *Service) recomputeReviewedForFile(ctx context.Context, fileID int) {
+	criteria, err := review.Load(ctx, svc.appSettingsService)
+	if err != nil {
+		logger.Warn(ctx, "review: load criteria failed", logger.Data{"err": err.Error()})
+		return
+	}
+	if err := review.RecomputeForFile(ctx, svc.db, fileID, criteria); err != nil {
+		logger.Warn(ctx, "review: recompute for file failed", logger.Data{"err": err.Error(), "file_id": fileID})
+	}
+}
+
+// recomputeReviewedForBook refreshes files.reviewed for every file of the book.
+func (svc *Service) recomputeReviewedForBook(ctx context.Context, bookID int) {
+	criteria, err := review.Load(ctx, svc.appSettingsService)
+	if err != nil {
+		logger.Warn(ctx, "review: load criteria failed", logger.Data{"err": err.Error()})
+		return
+	}
+	if err := review.RecomputeForBook(ctx, svc.db, bookID, criteria); err != nil {
+		logger.Warn(ctx, "review: recompute for book failed", logger.Data{"err": err.Error(), "book_id": bookID})
+	}
+}
+```
+
+Add the imports: `github.com/shishobooks/shisho/pkg/appsettings`, `github.com/shishobooks/shisho/pkg/books/review`, and the project's `logger` package (match what's already imported in `service.go`).
+
+- [ ] **Step 10.3: Hook into write paths**
+
+Add a call to the appropriate wrapper at the end of each successful mutation inside `pkg/books/service.go`:
+
+- `CreateFile` → `svc.recomputeReviewedForFile(ctx, file.ID)`
+- `UpdateFile` → `svc.recomputeReviewedForFile(ctx, file.ID)`
+- `UpdateBook` → `svc.recomputeReviewedForBook(ctx, book.ID)`
+- `DeleteFile` / `DeleteFilesByIDs` → no-op (file is gone — nothing to recompute)
+- `CreateFileIdentifier`, `DeleteFileIdentifiers` → `svc.recomputeReviewedForFile(ctx, fileID)`
+
+For the book-relation services living in their own packages (`pkg/genres/service.go`, `pkg/tags/service.go`, `pkg/authors/service.go`, `pkg/series/service.go`, `pkg/people/service.go`, `pkg/publishers/service.go`, `pkg/imprints/service.go`, `pkg/chapters/service.go`, `pkg/narrators/`, `pkg/identifiers/`), each FindOrCreate / Delete / Replace / Update method that mutates a book or file relation should call back into `bookService.RecomputeReviewedForBook(...)` (book-level relations) or `bookService.RecomputeReviewedForFile(...)` (file-level relations). Promote `recomputeReviewedForFile` / `recomputeReviewedForBook` to **exported** methods (`RecomputeReviewedForFile` / `RecomputeReviewedForBook`) so the other packages can call them. The wrappers' implementations stay the same; only the receiver method names change.
+
+Touch points (search for the relation name in handlers/services to confirm exhaustive coverage):
+
+| Relation | Service / Function | Recompute target |
+|---|---|---|
+| Authors | `pkg/books/handlers.go: updateBookAuthors` (or wherever authors are replaced for a book) | book |
+| Genres | `pkg/genres/service.go: AssociateGenresToBook` (and any direct INSERT into `book_genres`) | book |
+| Tags | `pkg/tags/service.go: AssociateTagsToBook` (and direct INSERT into `book_tags`) | book |
+| Series | `pkg/series/service.go: AssociateSeriesToBook` (and `book_series` writes) | book |
+| Narrators | `pkg/narrators/...` or wherever they're attached to a file | file |
+| Identifiers | `pkg/books/service.go: CreateFileIdentifier`, `DeleteFileIdentifiers` | file (already covered above) |
+| Chapters | `pkg/chapters/service.go: ReplaceChapters` | file |
+| Publisher / Imprint | `pkg/books/service.go: UpdateFile` (already covered, since these are file columns) | file |
+
+If you find a relation-mutation path that doesn't go through the books service, add a `bookService` dependency to its package the same way `searchService` is wired up today and call the recompute helper there.
+
+- [ ] **Step 10.4: Verify build and tests**
+
+```bash
+mise check:quiet
+```
+
+Expected: PASS.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add pkg/
+git commit -m "[Backend] Recompute reviewed on book/file mutations"
+```
+
+---
+
+### Task 11: Hook recompute into scan/enrichment
+
+**Files:**
+- Modify: `pkg/worker/scan_unified.go`
+
+- [ ] **Step 11.1: Identify the enrich apply path**
+
+Open `pkg/worker/scan_unified.go` and find the spot inside `runMetadataEnrichers` (or its called helpers) where enricher metadata is persisted to the file/book. After the persist, call `review.RecomputeForFile(ctx, w.db, file.ID, criteria)`. Load `criteria` once near the top of the enrichment phase using `review.Load(ctx, w.appSettingsService)`; reuse the same value for every file in the batch.
+
+- [ ] **Step 11.2: Add explicit recompute after the scan-level mutations**
+
+Anywhere the scan job creates or updates files (`scanFileCreateNew`, `scanFileByPath` update branch, etc.) and the call doesn't already go through `bookService.CreateFile` / `bookService.UpdateFile`, add a recompute call right after the persist. Use the criteria value loaded at the top of the scan.
+
+- [ ] **Step 11.3: Add a test**
+
+Extend `pkg/worker/scan_enricher_test.go` (or a sibling test if more appropriate) with a case asserting that enricher results that fill all required fields produce `files.reviewed = TRUE`, and partial enrichment (missing one required field) produces `files.reviewed = FALSE`. Use `t.Parallel()`.
+
+- [ ] **Step 11.4: Run tests**
+
+```bash
+go test ./pkg/worker/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add pkg/worker/
+git commit -m "[Backend] Recompute reviewed after scan and enrichment"
+```
+
+---
+
+## Phase 7 — API endpoints
+
+### Task 12: PATCH /books/files/:id/review
+
+**Files:**
+- Modify: `pkg/books/handlers.go` (or split into `handlers_review.go` if `handlers.go` is already large — current file is large, split is preferred)
+- Create: `pkg/books/handlers_review.go`
+- Modify: `pkg/books/routes.go`
+- Create: `pkg/books/handlers_review_test.go`
+
+- [ ] **Step 12.1: Write the failing handler test**
+
+`pkg/books/handlers_review_test.go`:
+
+```go
+package books
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetFileReview_SetsOverride(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	h, db := newTestHandler(t) // existing helper
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	file := &models.File{
+		LibraryID: library.ID, BookID: book.ID, Filepath: "/tmp/x.epub",
+		FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	body := []byte(`{"override":"reviewed"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	c.SetPath("/books/files/:id/review")
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(file.ID))
+	setUserOnContext(c, &models.User{ID: 1, /* admin user setup */})
+
+	require.NoError(t, h.setFileReview(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got models.File
+	require.NoError(t, db.NewSelect().Model(&got).Where("id = ?", file.ID).Scan(ctx))
+	require.NotNil(t, got.ReviewOverride)
+	require.Equal(t, "reviewed", *got.ReviewOverride)
+	require.NotNil(t, got.Reviewed)
+	require.True(t, *got.Reviewed)
+}
+
+func TestSetFileReview_ClearsOverride(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	h, db := newTestHandler(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	override := models.ReviewOverrideUnreviewed
+	file := &models.File{
+		LibraryID: library.ID, BookID: book.ID, Filepath: "/tmp/x.epub",
+		FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain,
+		ReviewOverride: &override,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	body := []byte(`{"override":null}`)
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	c.SetPath("/books/files/:id/review")
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(file.ID))
+	setUserOnContext(c, &models.User{ID: 1})
+
+	require.NoError(t, h.setFileReview(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got models.File
+	require.NoError(t, db.NewSelect().Model(&got).Where("id = ?", file.ID).Scan(ctx))
+	require.Nil(t, got.ReviewOverride)
+	require.Nil(t, got.ReviewOverriddenAt)
+}
+```
+
+(The test uses an existing `newTestHandler` helper — if one doesn't exist, add it modeled on `handlers_test.go` setup.)
+
+- [ ] **Step 12.2: Run to verify failure**
+
+```bash
+go test -run TestSetFileReview ./pkg/books/... -race
+```
+
+Expected: FAIL — undefined: `setFileReview`.
+
+- [ ] **Step 12.3: Implement the handler**
+
+`pkg/books/handlers_review.go`:
+
+```go
+package books
+
+import (
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// SetReviewPayload is shared by the file, book, and bulk endpoints.
+type SetReviewPayload struct {
+	// Override: nil clears the override. "reviewed" or "unreviewed" sets it.
+	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
+}
+
+func (h *Handler) setFileReview(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.BadRequest("Invalid file id")
+	}
+
+	var payload SetReviewPayload
+	if err := c.Bind(&payload); err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context()
+	file, err := h.bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: id})
+	if err != nil {
+		return err
+	}
+	if user, ok := c.Get("user").(*models.User); ok {
+		if !user.HasLibraryAccess(file.LibraryID) {
+			return errcodes.Forbidden("You don't have access to this library")
+		}
+	}
+
+	criteria, err := review.Load(ctx, h.appSettingsService)
+	if err != nil {
+		return err
+	}
+	if err := review.SetOverride(ctx, h.bookService.DB(), id, payload.Override, criteria); err != nil {
+		return err
+	}
+
+	updated, err := h.bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: id})
+	if err != nil {
+		return err
+	}
+	return c.JSON(200, updated)
+}
+```
+
+Notes:
+- Add `appSettingsService *appsettings.Service` to the books `Handler` struct and wire it in `NewHandler`. Update every caller of `NewHandler`.
+- If `bookService.DB()` doesn't exist, expose it via a small accessor `func (svc *Service) DB() *bun.DB { return svc.db }`. The function is the simplest way to give the handler the DB without leaking the field.
+
+- [ ] **Step 12.4: Register the route**
+
+In `pkg/books/routes.go`, add inside the books group with `books:write` permission and library-access middleware (matching neighbors like `setPrimaryFile`):
+
+```go
+g.PATCH("/files/:id/review", h.setFileReview, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
+```
+
+- [ ] **Step 12.5: Run test to verify pass**
+
+```bash
+go test -run TestSetFileReview ./pkg/books/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 12.6: Commit**
+
+```bash
+git add pkg/books/
+git commit -m "[Backend] Add PATCH /books/files/:id/review endpoint"
+```
+
+---
+
+### Task 13: PATCH /books/:id/review (cascade)
+
+**Files:**
+- Modify: `pkg/books/handlers_review.go`
+- Modify: `pkg/books/routes.go`
+- Modify: `pkg/books/handlers_review_test.go`
+
+- [ ] **Step 13.1: Write a test**
+
+Add to `pkg/books/handlers_review_test.go`:
+
+```go
+func TestSetBookReview_CascadesToAllFiles(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	h, db := newTestHandler(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	for _, ft := range []string{models.FileTypeEPUB, models.FileTypeM4B} {
+		f := &models.File{
+			LibraryID: library.ID, BookID: book.ID,
+			Filepath: "/tmp/" + ft, FileType: ft, FileRole: models.FileRoleMain,
+		}
+		_, err = db.NewInsert().Model(f).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	body := []byte(`{"override":"reviewed"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	c.SetPath("/books/:id/review")
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(book.ID))
+	setUserOnContext(c, &models.User{ID: 1})
+
+	require.NoError(t, h.setBookReview(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var rows []*models.File
+	require.NoError(t, db.NewSelect().Model(&rows).Where("book_id = ?", book.ID).Scan(ctx))
+	for _, f := range rows {
+		require.NotNil(t, f.ReviewOverride)
+		require.Equal(t, "reviewed", *f.ReviewOverride)
+	}
+}
+```
+
+- [ ] **Step 13.2: Implement cascade**
+
+In `pkg/books/handlers_review.go`:
+
+```go
+func (h *Handler) setBookReview(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.BadRequest("Invalid book id")
+	}
+
+	var payload SetReviewPayload
+	if err := c.Bind(&payload); err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context()
+	book, err := h.bookService.RetrieveBook(ctx, RetrieveBookOptions{ID: id})
+	if err != nil {
+		return err
+	}
+	if user, ok := c.Get("user").(*models.User); ok {
+		if !user.HasLibraryAccess(book.LibraryID) {
+			return errcodes.Forbidden("You don't have access to this library")
+		}
+	}
+
+	criteria, err := review.Load(ctx, h.appSettingsService)
+	if err != nil {
+		return err
+	}
+	for _, f := range book.Files {
+		if f.FileRole != models.FileRoleMain {
+			continue
+		}
+		if err := review.SetOverride(ctx, h.bookService.DB(), f.ID, payload.Override, criteria); err != nil {
+			return err
+		}
+	}
+
+	updated, err := h.bookService.RetrieveBook(ctx, RetrieveBookOptions{ID: id})
+	if err != nil {
+		return err
+	}
+	return c.JSON(200, updated)
+}
+```
+
+- [ ] **Step 13.3: Register the route**
+
+In `pkg/books/routes.go`:
+
+```go
+g.PATCH("/:id/review", h.setBookReview, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
+```
+
+- [ ] **Step 13.4: Run tests**
+
+```bash
+go test -run TestSetBookReview ./pkg/books/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 13.5: Commit**
+
+```bash
+git add pkg/books/
+git commit -m "[Backend] Add PATCH /books/:id/review cascade endpoint"
+```
+
+---
+
+### Task 14: POST /books/bulk/review
+
+**Files:**
+- Modify: `pkg/books/handlers_review.go`
+- Modify: `pkg/books/routes.go`
+- Modify: `pkg/books/handlers_review_test.go`
+
+- [ ] **Step 14.1: Write the test**
+
+Add to `pkg/books/handlers_review_test.go`:
+
+```go
+func TestBulkSetReview_AppliesToAllSpecifiedBooks(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	h, db := newTestHandler(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	bookIDs := make([]int, 0, 2)
+	for i := 0; i < 2; i++ {
+		book := &models.Book{LibraryID: library.ID, Title: "T" + strconv.Itoa(i)}
+		_, err = db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+		bookIDs = append(bookIDs, book.ID)
+		f := &models.File{
+			LibraryID: library.ID, BookID: book.ID,
+			Filepath: "/tmp/" + strconv.Itoa(i), FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain,
+		}
+		_, err = db.NewInsert().Model(f).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	payload := []byte(`{"book_ids":[` + strconv.Itoa(bookIDs[0]) + `,` + strconv.Itoa(bookIDs[1]) + `],"override":"reviewed"}`)
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	c.SetPath("/books/bulk/review")
+	setUserOnContext(c, &models.User{ID: 1})
+
+	require.NoError(t, h.bulkSetReview(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var files []*models.File
+	require.NoError(t, db.NewSelect().Model(&files).Where("book_id IN (?)", bun.In(bookIDs)).Scan(ctx))
+	for _, f := range files {
+		require.NotNil(t, f.ReviewOverride)
+		require.Equal(t, "reviewed", *f.ReviewOverride)
+	}
+}
+```
+
+- [ ] **Step 14.2: Implement the handler**
+
+In `pkg/books/handlers_review.go`:
+
+```go
+type BulkSetReviewPayload struct {
+	BookIDs  []int   `json:"book_ids" validate:"required,min=1,max=500"`
+	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
+}
+
+func (h *Handler) bulkSetReview(c echo.Context) error {
+	var payload BulkSetReviewPayload
+	if err := c.Bind(&payload); err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context()
+	user, _ := c.Get("user").(*models.User)
+
+	criteria, err := review.Load(ctx, h.appSettingsService)
+	if err != nil {
+		return err
+	}
+
+	for _, bookID := range payload.BookIDs {
+		book, err := h.bookService.RetrieveBook(ctx, RetrieveBookOptions{ID: bookID})
+		if err != nil {
+			continue // silently skip missing books — consistent with bulk delete
+		}
+		if user != nil && !user.HasLibraryAccess(book.LibraryID) {
+			continue
+		}
+		for _, f := range book.Files {
+			if f.FileRole != models.FileRoleMain {
+				continue
+			}
+			if err := review.SetOverride(ctx, h.bookService.DB(), f.ID, payload.Override, criteria); err != nil {
+				return err
+			}
+		}
+	}
+	return c.NoContent(204)
+}
+```
+
+- [ ] **Step 14.3: Register the route**
+
+In `pkg/books/routes.go`:
+
+```go
+g.POST("/bulk/review", h.bulkSetReview, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
+```
+
+- [ ] **Step 14.4: Run tests**
+
+```bash
+go test -run TestBulkSetReview ./pkg/books/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add pkg/books/
+git commit -m "[Backend] Add POST /books/bulk/review endpoint"
+```
+
+---
+
+### Task 15: Add `reviewed_filter` query param to GET /books
+
+**Files:**
+- Modify: `pkg/books/service.go` (`ListBooksOptions`, `listBooksWithTotal`)
+- Modify: `pkg/books/handlers.go` (extract param)
+- Modify: `pkg/books/service_filter_test.go` (extend)
+
+- [ ] **Step 15.1: Add the option**
+
+In `pkg/books/service.go` `ListBooksOptions`:
+
+```go
+ReviewedFilter string // "" (default = all), "needs_review", "reviewed"
+```
+
+- [ ] **Step 15.2: Add a failing filter test**
+
+In `pkg/books/service_filter_test.go`, add:
+
+```go
+func TestListBooks_ReviewedFilter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	svc := newTestService(t) // existing helper
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := svc.db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	mkBook := func(reviewed *bool) int {
+		book := &models.Book{LibraryID: library.ID, Title: "T"}
+		_, err := svc.db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+		f := &models.File{
+			LibraryID: library.ID, BookID: book.ID, Filepath: "/tmp/" + strconv.Itoa(book.ID),
+			FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain,
+			Reviewed: reviewed,
+		}
+		_, err = svc.db.NewInsert().Model(f).Exec(ctx)
+		require.NoError(t, err)
+		return book.ID
+	}
+	tru := true
+	fal := false
+	_ = mkBook(&tru)
+	bookFalse := mkBook(&fal)
+	bookNull := mkBook(nil)
+
+	books, _, err := svc.ListBooksWithTotal(ctx, ListBooksOptions{LibraryID: &library.ID, ReviewedFilter: "needs_review"})
+	require.NoError(t, err)
+	gotIDs := make([]int, 0, len(books))
+	for _, b := range books {
+		gotIDs = append(gotIDs, b.ID)
+	}
+	require.ElementsMatch(t, []int{bookFalse, bookNull}, gotIDs)
+}
+```
+
+- [ ] **Step 15.3: Apply filter in `listBooksWithTotal`**
+
+In `pkg/books/service.go`, inside `listBooksWithTotal`, after the existing filter-application section:
+
+```go
+switch opts.ReviewedFilter {
+case "needs_review":
+	q = q.Where(`EXISTS (
+		SELECT 1 FROM files f_rev
+		WHERE f_rev.book_id = b.id
+		  AND f_rev.file_role = 'main'
+		  AND (f_rev.reviewed = FALSE OR f_rev.reviewed IS NULL)
+	)`)
+case "reviewed":
+	q = q.Where(`NOT EXISTS (
+		SELECT 1 FROM files f_rev
+		WHERE f_rev.book_id = b.id
+		  AND f_rev.file_role = 'main'
+		  AND (f_rev.reviewed = FALSE OR f_rev.reviewed IS NULL)
+	)`).Where(`EXISTS (
+		SELECT 1 FROM files f_rev2
+		WHERE f_rev2.book_id = b.id AND f_rev2.file_role = 'main'
+	)`)
+}
+```
+
+- [ ] **Step 15.4: Wire the handler**
+
+In `pkg/books/handlers.go` `list` (or whichever method binds query options), parse `c.QueryParam("reviewed_filter")` into `ListBooksOptions.ReviewedFilter`. Validate it's in `{"", "all", "needs_review", "reviewed"}`; treat `"all"` as empty.
+
+- [ ] **Step 15.5: Run tests**
+
+```bash
+go test -run TestListBooks_ReviewedFilter ./pkg/books/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 15.6: Commit**
+
+```bash
+git add pkg/books/
+git commit -m "[Backend] Add reviewed_filter query param to book list"
+```
+
+---
+
+## Phase 8 — Settings API
+
+### Task 16: GET / PUT /settings/review-criteria
+
+**Files:**
+- Create: `pkg/settings/review_criteria_handlers.go`
+- Modify: `pkg/settings/routes.go`
+- Modify: `pkg/settings/handlers.go` (or handlers struct definition) to inject `appSettingsService` + `jobsService`
+- Create: `pkg/settings/review_criteria_handlers_test.go`
+
+- [ ] **Step 16.1: Write the failing test**
+
+`pkg/settings/review_criteria_handlers_test.go`:
+
+```go
+package settings
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/database"
+	"github.com/shishobooks/shisho/pkg/jobs"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetReviewCriteria_ReturnsDefault(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+	apps := appsettings.NewService(db)
+	jobsSvc := jobs.NewService(db)
+	h := NewHandler(NewService(db), apps, jobsSvc /* match real signature */)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	require.NoError(t, h.getReviewCriteria(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), `"authors"`)
+	_ = ctx
+	_ = review.Default
+	_ = models.JobTypeRecomputeReview
+}
+
+func TestPutReviewCriteria_PersistsAndEnqueuesJob(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := database.NewTestDB(t)
+	apps := appsettings.NewService(db)
+	jobsSvc := jobs.NewService(db)
+	h := NewHandler(NewService(db), apps, jobsSvc)
+
+	body := []byte(`{"book_fields":["authors"],"audio_fields":[],"clear_overrides":false}`)
+	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	require.NoError(t, h.putReviewCriteria(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var saved review.Criteria
+	_, err := apps.GetJSON(ctx, review.SettingsKey, &saved)
+	require.NoError(t, err)
+	require.Equal(t, []string{"authors"}, saved.BookFields)
+
+	var jobCount int
+	require.NoError(t, db.NewSelect().Table("jobs").ColumnExpr("count(*)").Where("type = ?", models.JobTypeRecomputeReview).Scan(ctx, &jobCount))
+	require.Equal(t, 1, jobCount)
+}
+```
+
+- [ ] **Step 16.2: Implement handlers**
+
+`pkg/settings/review_criteria_handlers.go`:
+
+```go
+package settings
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/segmentio/encoding/json"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+type reviewCriteriaResponse struct {
+	BookFields           []string `json:"book_fields"`
+	AudioFields          []string `json:"audio_fields"`
+	UniversalCandidates  []string `json:"universal_candidates"`
+	AudioCandidates      []string `json:"audio_candidates"`
+	OverrideCount        int      `json:"override_count"`
+	MainFileCount        int      `json:"main_file_count"`
+}
+
+type putReviewCriteriaPayload struct {
+	BookFields     []string `json:"book_fields" validate:"required"`
+	AudioFields    []string `json:"audio_fields" validate:"required"`
+	ClearOverrides bool     `json:"clear_overrides"`
+}
+
+func (h *Handler) getReviewCriteria(c echo.Context) error {
+	ctx := c.Request().Context()
+	criteria, err := review.Load(ctx, h.appSettingsService)
+	if err != nil {
+		return err
+	}
+	resp := reviewCriteriaResponse{
+		BookFields:          criteria.BookFields,
+		AudioFields:         criteria.AudioFields,
+		UniversalCandidates: review.UniversalCandidates,
+		AudioCandidates:     review.AudioCandidates,
+	}
+	if err := h.appSettingsService.DB(). /* expose accessor or pass db */ NewSelect().
+		Table("files").ColumnExpr("count(*)").Where("file_role = 'main' AND review_override IS NOT NULL").Scan(ctx, &resp.OverrideCount); err != nil {
+		return err
+	}
+	if err := h.appSettingsService.DB().NewSelect().
+		Table("files").ColumnExpr("count(*)").Where("file_role = 'main'").Scan(ctx, &resp.MainFileCount); err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *Handler) putReviewCriteria(c echo.Context) error {
+	var payload putReviewCriteriaPayload
+	if err := c.Bind(&payload); err != nil {
+		return err
+	}
+	criteria := review.Criteria{BookFields: payload.BookFields, AudioFields: payload.AudioFields}
+	if err := review.Validate(criteria); err != nil {
+		return errcodes.BadRequest(err.Error())
+	}
+
+	ctx := c.Request().Context()
+	if err := review.Save(ctx, h.appSettingsService, criteria); err != nil {
+		return err
+	}
+	jobData, _ := json.Marshal(models.JobRecomputeReviewData{ClearOverrides: payload.ClearOverrides})
+	if _, err := h.jobsService.CreateJob(ctx, &models.Job{
+		Type:   models.JobTypeRecomputeReview,
+		Status: models.JobStatusPending,
+		Data:   string(jobData),
+	}); err != nil {
+		return err
+	}
+	return c.NoContent(http.StatusOK)
+}
+```
+
+(The `appSettingsService.DB()` calls assume a `DB()` accessor on the appsettings service. Either add the accessor or pass the `*bun.DB` directly into the handler — pick whichever is cleaner with what already exists.)
+
+Update the `Handler` struct in `pkg/settings/handlers.go` to include `appSettingsService *appsettings.Service` and `jobsService *jobs.Service`. Update `NewHandler` and all callers.
+
+- [ ] **Step 16.3: Register routes**
+
+In `pkg/settings/routes.go`:
+
+```go
+g.GET("/review-criteria", h.getReviewCriteria, authMiddleware.RequirePermission(models.ResourceConfig, models.OperationRead))
+g.PUT("/review-criteria", h.putReviewCriteria, authMiddleware.RequirePermission(models.ResourceConfig, models.OperationWrite))
+```
+
+(If `ResourceConfig` doesn't have a `write` operation registered, fall back to `ResourceUsers`/admin-only — match how other admin-only settings endpoints are gated.)
+
+- [ ] **Step 16.4: Run tests**
+
+```bash
+go test ./pkg/settings/... -race
+```
+
+Expected: PASS.
+
+- [ ] **Step 16.5: Commit**
+
+```bash
+git add pkg/settings/
+git commit -m "[Backend] Add review-criteria settings endpoints"
+```
+
+---
+
+### Task 17: Manual recompute endpoint via existing jobs route
+
+The existing `POST /jobs` already supports custom job types. No new endpoint needed — confirm `recompute_review` works through it and add a small handler test if missing.
+
+**Files:**
+- Modify: `pkg/jobs/handlers_test.go` (or add `pkg/jobs/recompute_review_test.go`)
+
+- [ ] **Step 17.1: Add a handler test**
+
+```go
+func TestCreateJob_RecomputeReview(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	h, db := newTestHandler(t)
+
+	body := []byte(`{"type":"recompute_review","data":{"clear_overrides":true}}`)
+	req := httptest.NewRequest(http.MethodPost, "/jobs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	setUserOnContext(c, &models.User{ID: 1 /* admin */})
+
+	require.NoError(t, h.create(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got models.Job
+	require.NoError(t, db.NewSelect().Model(&got).Where("type = ?", models.JobTypeRecomputeReview).Scan(ctx))
+	require.Equal(t, models.JobStatusPending, got.Status)
+}
+```
+
+- [ ] **Step 17.2: Run**
+
+```bash
+go test ./pkg/jobs/... -race
+```
+
+Expected: PASS. If `create` rejects unknown types, add `recompute_review` to the allowlist.
+
+- [ ] **Step 17.3: Commit**
+
+```bash
+git add pkg/jobs/
+git commit -m "[Backend] Allow recompute_review jobs from POST /jobs"
+```
+
+---
+
+## Phase 9 — Frontend types & query hooks
+
+### Task 18: Query hooks
+
+**Files:**
+- Create: `app/hooks/queries/review.ts`
+- Modify: `app/libraries/api.ts` (add fetcher functions)
+
+- [ ] **Step 18.1: Add fetchers**
+
+In `app/libraries/api.ts`, append:
+
+```ts
+export interface ReviewCriteriaResponse {
+  book_fields: string[];
+  audio_fields: string[];
+  universal_candidates: string[];
+  audio_candidates: string[];
+  override_count: number;
+  main_file_count: number;
+}
+
+export const getReviewCriteria = (): Promise<ReviewCriteriaResponse> =>
+  apiGet("/api/settings/review-criteria");
+
+export const putReviewCriteria = (payload: {
+  book_fields: string[];
+  audio_fields: string[];
+  clear_overrides: boolean;
+}): Promise<void> => apiPut("/api/settings/review-criteria", payload);
+
+export const setFileReview = (
+  fileId: number,
+  override: "reviewed" | "unreviewed" | null,
+): Promise<File> =>
+  apiPatch(`/api/books/files/${fileId}/review`, { override });
+
+export const setBookReview = (
+  bookId: number,
+  override: "reviewed" | "unreviewed" | null,
+): Promise<Book> =>
+  apiPatch(`/api/books/${bookId}/review`, { override });
+
+export const bulkSetReview = (
+  bookIds: number[],
+  override: "reviewed" | "unreviewed" | null,
+): Promise<void> =>
+  apiPost("/api/books/bulk/review", { book_ids: bookIds, override });
+```
+
+(Match the actual `apiGet` / `apiPost` / `apiPatch` / `apiPut` helper names used elsewhere — if `apiPatch` doesn't exist, add it modeled on `apiPost`.)
+
+- [ ] **Step 18.2: Add hooks**
+
+`app/hooks/queries/review.ts`:
+
+```ts
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  bulkSetReview,
+  getReviewCriteria,
+  putReviewCriteria,
+  setBookReview,
+  setFileReview,
+} from "@/libraries/api";
+import { QueryKey as BooksQueryKey } from "@/hooks/queries/books";
+
+export const QueryKey = {
+  ReviewCriteria: ["review-criteria"] as const,
+};
+
+export const useReviewCriteria = () =>
+  useQuery({ queryKey: QueryKey.ReviewCriteria, queryFn: getReviewCriteria });
+
+export const useUpdateReviewCriteria = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: putReviewCriteria,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: QueryKey.ReviewCriteria });
+      qc.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      qc.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+    },
+  });
+};
+
+export const useSetFileReview = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      fileId,
+      override,
+    }: {
+      fileId: number;
+      override: "reviewed" | "unreviewed" | null;
+    }) => setFileReview(fileId, override),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      qc.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+    },
+  });
+};
+
+export const useSetBookReview = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      bookId,
+      override,
+    }: {
+      bookId: number;
+      override: "reviewed" | "unreviewed" | null;
+    }) => setBookReview(bookId, override),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      qc.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+    },
+  });
+};
+
+export const useBulkSetReview = () => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      bookIds,
+      override,
+    }: {
+      bookIds: number[];
+      override: "reviewed" | "unreviewed" | null;
+    }) => bulkSetReview(bookIds, override),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
+      qc.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+    },
+  });
+};
+```
+
+- [ ] **Step 18.3: Verify types**
+
+```bash
+pnpm lint:types
+```
+
+Expected: no errors.
+
+- [ ] **Step 18.4: Commit**
+
+```bash
+git add app/
+git commit -m "[Frontend] Add review query hooks and API fetchers"
+```
+
+---
+
+### Task 19: Reviewed-filter param in book list query
+
+**Files:**
+- Modify: `app/hooks/queries/books.ts` (the `useBooks` hook)
+- Modify: `app/libraries/api.ts` (`getBooks`)
+
+- [ ] **Step 19.1: Add the option**
+
+In `app/libraries/api.ts`, extend the `GetBooksOptions` (or matching name) interface to include `reviewed_filter?: "all" | "needs_review" | "reviewed"`. Pass it through to the URL query string.
+
+In `app/hooks/queries/books.ts`, accept the same option in the hook's input and pass it down.
+
+- [ ] **Step 19.2: Verify**
+
+```bash
+pnpm lint:types
+```
+
+Expected: no errors.
+
+- [ ] **Step 19.3: Commit**
+
+```bash
+git add app/
+git commit -m "[Frontend] Plumb reviewed_filter through book list query"
+```
+
+---
+
+## Phase 10 — Frontend UI
+
+### Task 20: Review panel in `BookEditDialog`
+
+**Files:**
+- Modify: `app/components/library/BookEditDialog.tsx`
+
+- [ ] **Step 20.1: Add the panel**
+
+Add a new section inside the dialog body, near the top of the form (above existing fields):
+
+```tsx
+<ReviewPanel
+  files={book.files ?? []}
+  onChange={(override) =>
+    setBookReviewMutation.mutate({ bookId: book.id, override })
+  }
+/>
+```
+
+Build the `ReviewPanel` component as a new sub-component file (`app/components/library/ReviewPanel.tsx`). It accepts `files` and `onChange`. It computes:
+
+- Aggregate "Reviewed" boolean: `true` iff every main file has `reviewed === true`.
+- Mixed state: aggregate is mixed if some main files are `true` and some are `false`/`null`.
+- Indicator label: "Auto" / "Manually marked reviewed on {date}" / "Manually marked needs review on {date}" / "Mixed" — derive from `review_override` and `review_overridden_at` across the book's main files.
+- Missing-fields hint: aggregated across files (use the spec format `Missing on EPUB: cover; Missing on M4B: narrators`). Use the per-file `reviewed === false` files; for each, derive missing fields by inspecting which required fields are empty (read criteria from `useReviewCriteria()`).
+
+Render a `Switch` (shadcn) bound to the aggregate. When toggled, call `onChange("reviewed")` or `onChange("unreviewed")` based on the new state.
+
+- [ ] **Step 20.2: Add a unit test**
+
+`app/components/library/ReviewPanel.test.tsx` covers:
+
+- All files reviewed → toggle is on, indicator says "Auto" or "Manually marked reviewed".
+- Some files reviewed, some not → indicator says "Mixed".
+- File missing fields → missing-fields list rendered.
+
+- [ ] **Step 20.3: Run lint and tests**
+
+```bash
+pnpm lint:eslint && pnpm lint:types && pnpm test:unit -- ReviewPanel
+```
+
+Expected: PASS.
+
+- [ ] **Step 20.4: Commit**
+
+```bash
+git add app/components/library/
+git commit -m "[Frontend] Add review panel to BookEditDialog"
+```
+
+---
+
+### Task 21: Review panel in `FileEditDialog`
+
+**Files:**
+- Modify: `app/components/library/FileEditDialog.tsx`
+
+- [ ] **Step 21.1: Add the panel**
+
+Reuse `ReviewPanel` if practical; otherwise create `FileReviewPanel.tsx` for the per-file scope:
+
+- Accepts a single `file` prop.
+- Computes the indicator (Auto / Manually set on {date}).
+- Renders a `Switch` bound to `file.reviewed === true` that calls `useSetFileReview()`.
+- Shows missing fields specifically for that file.
+
+- [ ] **Step 21.2: Add unit test**
+
+Add a test asserting toggle off + on triggers the mutation with `"reviewed"` / `"unreviewed"`.
+
+- [ ] **Step 21.3: Run checks**
+
+```bash
+pnpm lint:eslint && pnpm lint:types && pnpm test:unit -- FileReviewPanel
+```
+
+Expected: PASS.
+
+- [ ] **Step 21.4: Commit**
+
+```bash
+git add app/components/library/
+git commit -m "[Frontend] Add review panel to FileEditDialog"
+```
+
+---
+
+### Task 22: "Needs review" badge on book cards
+
+**Files:**
+- Modify: `app/components/library/BookItem.tsx` (and/or wherever the cover card is composed in `Gallery`)
+
+- [ ] **Step 22.1: Compute aggregate state**
+
+Add a helper `isBookNeedsReview(book: Book): boolean` to `app/utilities/book.ts` (or similar):
+
+```ts
+export const isBookNeedsReview = (book: Book): boolean => {
+  const mains = (book.files ?? []).filter((f) => f.file_role === "main");
+  if (mains.length === 0) return false;
+  return mains.some((f) => f.reviewed !== true);
+};
+```
+
+- [ ] **Step 22.2: Render the badge**
+
+In `BookItem.tsx`, when `isBookNeedsReview(book)` is true, render a small `Badge variant="secondary"` overlaid on the cover (bottom-right corner) saying "Needs review".
+
+Use the existing badge styles. Cover positioning matches existing overlays (e.g., the file-count badge if one exists).
+
+- [ ] **Step 22.3: Test**
+
+Add a test in `BookItem.test.tsx` (or sibling) asserting the badge appears for a book with a `reviewed=false` file and is absent for an all-reviewed book.
+
+- [ ] **Step 22.4: Commit**
+
+```bash
+git add app/
+git commit -m "[Frontend] Add Needs review badge to book cards"
+```
+
+---
+
+### Task 23: Filter sheet entry
+
+**Files:**
+- Modify: `app/components/library/FilterSheet.tsx`
+- Modify: `app/components/library/ActiveFilterChips.tsx`
+
+- [ ] **Step 23.1: Add the section**
+
+In `FilterSheet.tsx`, add a new section "Review state" with three radio buttons:
+
+```tsx
+<section>
+  <h3>Review state</h3>
+  <RadioGroup value={reviewedFilter} onValueChange={setReviewedFilter}>
+    <Radio value="all">All</Radio>
+    <Radio value="needs_review">Needs review</Radio>
+    <Radio value="reviewed">Reviewed</Radio>
+  </RadioGroup>
+</section>
+```
+
+`reviewedFilter` is plumbed through the same mechanism as existing filters (typically a context, query string, or prop).
+
+- [ ] **Step 23.2: Add chip**
+
+In `ActiveFilterChips.tsx`, render a chip for the active value when it's not "all". Closing the chip resets to "all".
+
+- [ ] **Step 23.3: Wire filter into the gallery query**
+
+In whichever component drives the gallery query (typically `Library.tsx` or similar), pass `reviewed_filter` to `useBooks(...)`.
+
+- [ ] **Step 23.4: Run checks**
+
+```bash
+pnpm lint:eslint && pnpm lint:types && pnpm test:unit -- FilterSheet
+```
+
+Expected: PASS.
+
+- [ ] **Step 23.5: Commit**
+
+```bash
+git add app/
+git commit -m "[Frontend] Add review state filter to FilterSheet"
+```
+
+---
+
+### Task 24: Bulk "More" overflow popover in `SelectionToolbar`
+
+**Files:**
+- Modify: `app/components/library/SelectionToolbar.tsx`
+
+- [ ] **Step 24.1: Add the popover**
+
+Add a new button next to the existing actions, before "Clear":
+
+```tsx
+<Popover>
+  <PopoverTrigger asChild>
+    <Button size="sm" variant="default">
+      <MoreHorizontal className="h-4 w-4" />
+      More
+    </Button>
+  </PopoverTrigger>
+  <PopoverContent align="center" className="w-56 p-1" side="top">
+    <button
+      className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent text-left w-full text-sm cursor-pointer"
+      onClick={() => bulkSetReviewMutation.mutate({ bookIds: selectedBookIds, override: "reviewed" })}
+    >
+      <CheckCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <span className="truncate">Mark reviewed</span>
+    </button>
+    <button
+      className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent text-left w-full text-sm cursor-pointer"
+      onClick={() => bulkSetReviewMutation.mutate({ bookIds: selectedBookIds, override: "unreviewed" })}
+    >
+      <Circle className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <span className="truncate">Mark needs review</span>
+    </button>
+  </PopoverContent>
+</Popover>
+```
+
+After mutation success, `exitSelectionMode()` and show a toast.
+
+- [ ] **Step 24.2: Test**
+
+Extend the existing toolbar test to assert the new actions appear and trigger the right mutation.
+
+- [ ] **Step 24.3: Run checks**
+
+```bash
+pnpm lint:eslint && pnpm lint:types && pnpm test:unit -- SelectionToolbar
+```
+
+Expected: PASS.
+
+- [ ] **Step 24.4: Commit**
+
+```bash
+git add app/components/library/
+git commit -m "[Frontend] Add bulk review actions to selection toolbar"
+```
+
+---
+
+### Task 25: Review Criteria section in `AdminSettings`
+
+**Files:**
+- Modify: `app/components/pages/AdminSettings.tsx`
+- Create: `app/components/pages/ReviewCriteriaSection.tsx`
+
+- [ ] **Step 25.1: Build the section component**
+
+`ReviewCriteriaSection.tsx`:
+
+- Loads `useReviewCriteria()`.
+- Renders two checkbox groups: "Required for all books" (UniversalCandidates) and "Required for audiobooks (additional)" (AudioCandidates). Each checkbox is checked iff the field is in the active criteria.
+- Tracks dirty state. Save button is disabled until changed.
+- On Save: if `override_count > 0`, opens a `ConfirmDialog` showing the count: "Recompute review state? Auto-detected reviewed status will refresh based on the new criteria. You currently have **{override_count} reviewed-overrides set out of {main_file_count} total main files**." with a "Also clear manual overrides" checkbox. On confirm, calls `useUpdateReviewCriteria()` with `clear_overrides` from the checkbox.
+- If `override_count === 0`, Save fires `useUpdateReviewCriteria({clear_overrides: false})` directly without the dialog.
+- Show toast on success: "Review state recompute queued."
+- Below the form, render a "Recompute review state now" button that queues a `recompute_review` job via the jobs API (POST `/api/jobs`). Same confirm dialog when overrides exist.
+
+Use the project's existing `useUnsavedChanges` pattern (see `app/CLAUDE.md`) since this is an admin page with editable form state.
+
+- [ ] **Step 25.2: Place in AdminSettings**
+
+In `AdminSettings.tsx`, render `<ReviewCriteriaSection />` as a new top-level card section between existing cards.
+
+- [ ] **Step 25.3: Test**
+
+Add `ReviewCriteriaSection.test.tsx` covering:
+- Default values render with the right checkboxes checked.
+- Toggling a checkbox and saving fires the mutation with the new arrays.
+- Save with `override_count > 0` opens the confirmation dialog.
+- "Clear manual overrides" checkbox flows through to the mutation payload.
+
+- [ ] **Step 25.4: Run checks**
+
+```bash
+pnpm lint:eslint && pnpm lint:types && pnpm test:unit -- ReviewCriteriaSection
+```
+
+Expected: PASS.
+
+- [ ] **Step 25.5: Commit**
+
+```bash
+git add app/
+git commit -m "[Frontend] Add Review Criteria section to AdminSettings"
+```
+
+---
+
+### Task 26: Review panel placement in `BookDetail`
+
+**Files:**
+- Modify: `app/components/pages/BookDetail.tsx`
+
+- [ ] **Step 26.1: Render `<ReviewPanel />`**
+
+Render the same component used in `BookEditDialog` near the top of the page (below the actions row, above the description). Hidden when `book.files` is empty.
+
+- [ ] **Step 26.2: Run checks**
+
+```bash
+pnpm lint:eslint && pnpm lint:types && pnpm test:unit
+```
+
+Expected: PASS.
+
+- [ ] **Step 26.3: Commit**
+
+```bash
+git add app/components/pages/BookDetail.tsx
+git commit -m "[Frontend] Show review panel on BookDetail"
+```
+
+---
+
+## Phase 11 — Documentation
+
+### Task 27: Add review state docs page
+
+**Files:**
+- Create: `website/docs/review-state.md`
+- Modify: `website/docs/metadata.md` (cross-link)
+- Modify: `website/sidebars.ts` (or equivalent — add to nav)
+
+- [ ] **Step 27.1: Write the page**
+
+`website/docs/review-state.md`:
+
+```markdown
+---
+sidebar_position: 9
+---
+
+# Review state
+
+Each book and file in your library has a **Reviewed** state that helps you track which books still need your attention. The library gallery offers a "Needs review" filter so you can work through books one at a time without losing track.
+
+## Auto-flip
+
+Files automatically flip to **Reviewed** when they have all the metadata fields you've marked as required. The defaults are:
+
+- **All books:** authors, description, cover, genres
+- **Audiobooks (additional):** narrators
+
+If a file is missing any of these, it stays in your "Needs review" queue.
+
+When you fill in a missing field — through the edit dialog, a plugin enrichment, or the identify dialog — the flag flips automatically. If you delete a field, the file returns to the queue (unless you've manually marked it).
+
+## Manual override
+
+If you want to keep a book in the queue regardless of completeness, or sign off on a book that will never have certain fields, use the toggle on the book or file edit page. Manual choices are sticky in both directions and persist until you change them again.
+
+## Filter and badge
+
+The library gallery shows a small **Needs review** badge on books that have at least one main file outstanding. Open the **Filter** sheet to switch between "All", "Needs review", and "Reviewed".
+
+## Bulk actions
+
+When multi-selecting books in the gallery, use the **More** menu in the action bar to mark all selected books as reviewed (or needs review) at once.
+
+## Configuring required fields
+
+Admins can change the required-field set in **Server Settings → Review Criteria**. Saving updated criteria triggers a background recompute of every main file. If you have manual overrides, you'll see a prompt asking whether to clear them — pick what fits your situation.
+
+## Cross-reference
+
+- [Metadata](./metadata.md) — what each field means.
+- [Plugins](./plugins/) — plugins fill in metadata that drives review state.
+```
+
+- [ ] **Step 27.2: Add cross-links**
+
+In `website/docs/metadata.md`, add a "See also" link to `review-state.md` near the top.
+
+- [ ] **Step 27.3: Add to sidebar**
+
+In `website/sidebars.ts` (or the auto-loaded equivalent), insert `"review-state"` in the appropriate position.
+
+- [ ] **Step 27.4: Build the docs site to verify**
+
+```bash
+mise docs &
+# Open http://localhost:3000 and confirm the page renders and is linked
+```
+
+- [ ] **Step 27.5: Commit**
+
+```bash
+git add website/
+git commit -m "[Docs] Add review-state docs page and cross-links"
+```
+
+---
+
+## Phase 12 — End-to-end test
+
+### Task 28: E2E spec
+
+**Files:**
+- Create: `e2e/review-flag.spec.ts`
+
+- [ ] **Step 28.1: Write the test**
+
+```ts
+import { test, expect } from "./fixtures";
+
+test.describe("Review flag", () => {
+  test("book missing required fields shows up in Needs review filter and drops out when filled", async ({
+    page,
+    seedLibrary,
+  }) => {
+    // Seed a book with NO description, cover, genres, narrators
+    const book = await seedLibrary.book({ title: "Incomplete", description: null });
+    await page.goto("/library/" + seedLibrary.id);
+
+    // Open filter sheet, select Needs review
+    await page.getByRole("button", { name: /filter/i }).click();
+    await page.getByLabel(/needs review/i).check();
+    await page.getByRole("button", { name: /apply/i }).click();
+
+    // Book should appear
+    await expect(page.getByText("Incomplete")).toBeVisible();
+
+    // Open the book, fill in required fields
+    await page.getByText("Incomplete").click();
+    await page.getByRole("button", { name: /edit/i }).click();
+    await page.getByLabel("Description").fill("A complete description");
+    // ...fill in genres, attach a cover, etc...
+    await page.getByRole("button", { name: /save/i }).click();
+
+    // Go back to the library, filter should no longer include this book
+    await page.goto("/library/" + seedLibrary.id + "?reviewed_filter=needs_review");
+    await expect(page.getByText("Incomplete")).not.toBeVisible();
+  });
+
+  test("manual mark needs review keeps complete book in queue", async ({
+    page,
+    seedLibrary,
+  }) => {
+    const book = await seedLibrary.book({
+      title: "Complete",
+      description: "ok",
+      genres: ["Fiction"],
+      coverPath: "fixtures/cover.jpg",
+      authors: ["Author"],
+    });
+    await page.goto("/library/" + seedLibrary.id + "/books/" + book.id);
+    // Toggle "Reviewed" off
+    await page.getByLabel("Reviewed").click();
+    // Filter should now show this book
+    await page.goto("/library/" + seedLibrary.id + "?reviewed_filter=needs_review");
+    await expect(page.getByText("Complete")).toBeVisible();
+  });
+
+  test("bulk mark reviewed cascades to all selected books", async ({
+    page,
+    seedLibrary,
+  }) => {
+    await seedLibrary.book({ title: "Bulk1" });
+    await seedLibrary.book({ title: "Bulk2" });
+    await page.goto("/library/" + seedLibrary.id + "?reviewed_filter=needs_review");
+
+    await page.getByText("Bulk1").click({ modifiers: ["Shift"] });
+    await page.getByText("Bulk2").click({ modifiers: ["Shift"] });
+    await page.getByRole("button", { name: /more/i }).click();
+    await page.getByRole("menuitem", { name: /mark reviewed/i }).click();
+
+    await page.goto("/library/" + seedLibrary.id + "?reviewed_filter=needs_review");
+    await expect(page.getByText("Bulk1")).not.toBeVisible();
+    await expect(page.getByText("Bulk2")).not.toBeVisible();
+  });
+});
+```
+
+(Replace `seedLibrary.book` etc. with the actual fixture API used in `e2e/`. Look at neighboring specs for the right shape.)
+
+- [ ] **Step 28.2: Run E2E**
+
+```bash
+mise test:e2e
+```
+
+Expected: PASS.
+
+- [ ] **Step 28.3: Commit**
+
+```bash
+git add e2e/
+git commit -m "[E2E] Add review-flag end-to-end test"
+```
+
+---
+
+## Phase 13 — Final integration check
+
+### Task 29: Full check & manual smoke test
+
+- [ ] **Step 29.1: Run full check suite**
+
+```bash
+mise check:quiet
+```
+
+Expected: PASS.
+
+- [ ] **Step 29.2: Manual smoke (dev server)**
+
+```bash
+mise start
+```
+
+Walk through:
+
+1. Drop a known-incomplete book into the library path. Confirm it appears with "Needs review" badge.
+2. Filter to "Needs review" — book is visible. Filter to "Reviewed" — book is not visible.
+3. Open book detail, fill in missing fields, save. Refresh. Badge gone, book moves out of needs-review filter.
+4. Toggle "Reviewed" off manually. Book reappears in needs-review.
+5. Multi-select two books. Use the "More" → "Mark reviewed". Both drop out.
+6. Open Server Settings → Review Criteria. Toggle "Tags" on. Save → confirm dialog if overrides exist. Confirm. Verify some books with no tags now appear in needs-review.
+7. Click "Recompute review state now". Watch the job in the jobs page.
+
+- [ ] **Step 29.3: No commit needed (verification only)**
+
+The plan is complete.
+
+---
+
+## Summary
+
+This plan adds a per-file `Reviewed` state with admin-configurable required fields, sticky manual overrides, automatic recompute on metadata changes, and the corresponding UI surfaces (filter, badge, panels, settings page, bulk action). It introduces a new `app_settings` runtime-mutable settings table, a new `recompute_review` background job, and a `pkg/books/review` package that owns the completeness rule. Migrations are designed to populate the new state via the existing job system rather than synchronously, keeping deploys fast.

--- a/docs/superpowers/specs/2026-04-25-reviewed-flag-design.md
+++ b/docs/superpowers/specs/2026-04-25-reviewed-flag-design.md
@@ -1,0 +1,389 @@
+# Reviewed Flag
+
+## Summary
+
+Add a per-file `Reviewed` state that tracks whether a file's metadata is "good enough" to leave alone. State is driven by an admin-configurable set of required fields ("review criteria"); a file is auto-flipped to reviewed once all required fields are populated, and back to unreviewed if a required field becomes empty. Users can also manually override either way; manual overrides are sticky in both directions. The work-queue use case is supported by a "Needs review" filter and a per-card badge in the library gallery, plus a "Missing fields" hint on the book/file detail views so users can fix gaps quickly. Bulk multi-select cascades to all files of all selected books.
+
+## Goals
+
+- Surface a shrinking work queue of books that need attention as new content is added or existing content is updated.
+- Auto-detect "done" without forcing the user to manually mark every book.
+- Let the user manually override when their judgment differs (e.g., a book that will never have a cover).
+- Make missing-field diagnosis fast on the detail page.
+- Avoid changing default browse behavior — the gallery still shows all books.
+
+## Non-goals
+
+- Per-user review state. The flag is a property of the collection, not the viewer.
+- Per-library review criteria. Server-level only for v1; revisit if real demand emerges.
+- Surfacing review state to OPDS / Kobo sync / eReader browser. This is a curation concept, not a sync concept.
+- Automatic re-running of plugin matching ("identify") when something falls out of review. Identify remains an explicit user action.
+- A separate "review queue" page or sidebar item. The filter sheet entry plus the badge are the only UX surfaces.
+- A confidence-based gate beyond what already exists. The plugin confidence threshold continues to gate whether enrichment data is *applied*; review state then derives from completeness as usual.
+
+## Mental model
+
+A file's `reviewed` state is the disjunction of two signals:
+
+1. **Auto-completeness** — does the file (plus its book's shared fields) have everything the admin marked as required?
+2. **Manual override** — did a user say "yes, reviewed" or "no, still needs review" explicitly?
+
+Manual override wins when present. Otherwise, completeness drives the state. New files start with no override and the auto signal in effect; bulk and book-level user gestures cascade to set overrides on all files.
+
+## Schema
+
+### `files` table — new columns
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `review_override` | TEXT | yes | `'reviewed'`, `'unreviewed'`, or NULL. NULL means "follow auto-completeness." |
+| `review_overridden_at` | TIMESTAMP | yes | Set whenever `review_override` is set; cleared when override is cleared. Drives the "Manually set on Apr 10" indicator. |
+| `reviewed` | BOOLEAN | yes | Denormalized cache for fast filtering. NULL for supplements (`file_role = 'supplement'`); BOOLEAN for main files. Recomputed on every event listed in [Auto-evaluation triggers](#auto-evaluation-triggers). |
+
+Index: `CREATE INDEX idx_files_book_reviewed ON files(book_id, reviewed) WHERE file_role = 'main';` — supports the book-level aggregation queries.
+
+CHECK constraint on `review_override`: must be one of `'reviewed'`, `'unreviewed'`, or NULL.
+
+### `app_settings` (or equivalent) — new keys
+
+Required-fields config lives at the server level. Storage uses the same mechanism the existing config system uses for runtime-mutable settings (kept distinct from `pkg/config/config.go` static config). Keys:
+
+- `review_criteria.book_fields` — JSON array of universal field names that are required.
+- `review_criteria.audio_fields` — JSON array of audio-only field names required (applies when book has at least one M4B file).
+
+Default values:
+
+```json
+{
+  "review_criteria": {
+    "book_fields": ["authors", "description", "cover", "genres"],
+    "audio_fields": ["narrators"]
+  }
+}
+```
+
+Candidate fields (the set the admin can choose from):
+
+- **Universal:** `authors`, `description`, `cover`, `genres`, `tags`, `series`, `subtitle`, `publisher`, `imprint`, `identifiers`, `release_date`, `language`, `url`
+- **Audio-only:** `narrators`, `chapters`, `abridged`
+
+Excluded from candidate list (auto-derived, intrinsic, or low-signal): `title` (always derivable from filename — always present, no-op to check), `sort_title`, `page_count`, `audiobook_duration_seconds`, `audiobook_bitrate_bps`, `audiobook_codec`, `cover_mime_type`, `name`.
+
+## Completeness rule
+
+For a main file `f` belonging to book `b`, `f` is **complete** when **every** field in the active criteria evaluates as "present":
+
+```
+for each field in review_criteria.book_fields:
+  must be present on b (or on f for fields that live on the file — see field locations below)
+for each field in review_criteria.audio_fields:
+  if any file in b is type m4b:
+    must be present on every m4b file of b
+```
+
+### Field locations
+
+Some fields are book-level (shared across all of the book's files), some are file-level. The completeness check pulls each field from the right place:
+
+| Field | Lives on | Notes |
+|---|---|---|
+| authors | book | non-empty `Authors` relation |
+| description | book | non-null, non-empty `Description` |
+| genres | book | non-empty `BookGenres` relation |
+| tags | book | non-empty `BookTags` relation |
+| series | book | non-empty `BookSeries` relation |
+| subtitle | book | non-null, non-empty `Subtitle` |
+| cover | file | non-null `CoverImageFilename` |
+| publisher | file | non-null `PublisherID` |
+| imprint | file | non-null `ImprintID` |
+| identifiers | file | non-empty `Identifiers` relation |
+| release_date | file | non-null `ReleaseDate` |
+| language | file | non-null, non-empty `Language` |
+| url | file | non-null, non-empty `URL` |
+| narrators | file (audio only) | non-empty `Narrators` relation |
+| chapters | file (audio only) | non-empty `Chapters` relation |
+| abridged | file (audio only) | non-null `Abridged` |
+
+## Effective `reviewed` value
+
+```
+reviewed_for(file f) =
+  if f.file_role = 'supplement': NULL
+  else if f.review_override = 'reviewed': TRUE
+  else if f.review_override = 'unreviewed': FALSE
+  else: completeness_for(f)
+```
+
+Stored in `files.reviewed`. Recomputed whenever any input changes.
+
+## Book-level aggregation
+
+Used for filtering and the book-detail view. Books are not stored with their own `reviewed` column; aggregation runs at query time:
+
+- **A book is "reviewed"** iff every main file has `reviewed = TRUE`.
+- **A book "needs review"** iff at least one main file has `reviewed = FALSE`.
+- **A book with zero main files** is degenerate (typically transient during scan); not in either bucket.
+
+Query patterns:
+
+```sql
+-- Books needing review (treats NULL as needs-review during migration gap):
+SELECT b.* FROM books b
+WHERE EXISTS (
+  SELECT 1 FROM files f
+  WHERE f.book_id = b.id
+    AND f.file_role = 'main'
+    AND (f.reviewed = FALSE OR f.reviewed IS NULL)
+);
+
+-- Reviewed books (require all main files to be explicitly TRUE):
+SELECT b.* FROM books b
+WHERE NOT EXISTS (
+  SELECT 1 FROM files f
+  WHERE f.book_id = b.id
+    AND f.file_role = 'main'
+    AND (f.reviewed = FALSE OR f.reviewed IS NULL)
+)
+AND EXISTS (
+  SELECT 1 FROM files f
+  WHERE f.book_id = b.id AND f.file_role = 'main'
+);
+```
+
+## Auto-evaluation triggers
+
+The `files.reviewed` column is recomputed on any event that could change a file's completeness. Centralized in a `pkg/books/review.RecomputeReviewedForFile(ctx, fileID)` helper called from:
+
+- File create (scan finds a new file): `pkg/books/service.go: CreateFile`
+- File update (manual edit, plugin enrichment, scanner overwrite): `pkg/books/service.go: UpdateFile` and `pkg/worker/scan_unified.go` enrich path.
+- Book update (book-level fields change → cascades to all files of book): `pkg/books/service.go: UpdateBook` calls `RecomputeReviewedForBook(ctx, bookID)` which iterates main files.
+- Identify dialog apply: existing `pkg/plugins/handler_persist_metadata.go` and the `IdentifyBookDialog` apply path.
+- Chapters PUT: `pkg/chapters/handlers.go`.
+- File-relation changes: anything that mutates the relations checked by completeness — narrators, identifiers, genres, tags, authors, series, publisher, imprint changes.
+- File move between books: `MoveFilesToBook` triggers recompute on source files (because their book context is gone) and target book's files (because shared book-level fields may differ).
+
+The override (`review_override`) is set/cleared via dedicated endpoints. Setting an override does **not** itself recompute completeness — the override short-circuits the result. But after clearing an override, completeness is recomputed.
+
+The review-criteria settings change triggers a background job (see [Background recompute job](#background-recompute-job)).
+
+## Auto-evaluation behavior
+
+- Auto-flip can move `reviewed` from FALSE → TRUE when completeness becomes met (no override present).
+- Auto-flip can move `reviewed` from TRUE → FALSE when a required field becomes empty (no override present).
+- Manual override (`'reviewed'` or `'unreviewed'`) suppresses both directions until cleared.
+- Adding a new file to a previously-reviewed book: the new file gets `review_override = NULL`, `reviewed = computed`. The book aggregate flips back to "needs review" if the new file is incomplete. Existing files' overrides are untouched.
+
+## Manual override semantics
+
+User-facing toggle is binary (`Reviewed: yes/no`). Behind the scenes, every click on a review toggle (book-level, file-level, or bulk) sets `review_override` to the chosen value (`'reviewed'` or `'unreviewed'`) and updates `review_overridden_at`. The override is **sticky in both directions** until another user gesture changes it.
+
+Override clearing happens only in two paths, neither of which is part of the common toggle gesture:
+- The admin "Recompute review state" action with `clear_overrides = true` (settings change with the checkbox ticked, or the manual recompute button with the option enabled). Clears overrides for all main files in scope.
+- Internal callers (e.g., test helpers).
+
+The user is not given a per-book "clear override" UI in v1. If they want to drop a stale override, they re-toggle the book in their preferred direction and let auto take it from there on the next field change. If real demand emerges for a "Reset to auto" gesture, add a menu item later.
+
+## Settings: review criteria
+
+New section in `AdminSettings.tsx` titled **"Review Criteria"**. Two checkbox groups:
+
+- **Required for all books** — checkboxes for each universal candidate field. Default-on: authors, description, cover, genres.
+- **Required for audiobooks (additional)** — checkboxes for each audio-only candidate field. Default-on: narrators. Help text: "These apply when a book has any audiobook file."
+
+A **Save** button persists the new criteria, then triggers the background recompute. If `count(files where review_override IS NOT NULL AND library is current/all) > 0`, the save action shows a confirmation dialog **before** persisting:
+
+> Recompute review state?
+>
+> Auto-detected reviewed status will refresh based on the new criteria. You currently have **N reviewed-overrides set out of M total main files**.
+>
+> ☐ Also clear manual overrides (default off)
+>
+> [Cancel] [Save and Recompute]
+
+If the count is 0, no dialog — save and recompute fire directly. The settings save returns synchronously; the recompute runs in the background.
+
+A **"Recompute review state now"** button appears below the criteria groups. Triggers the recompute job without changing any settings. Same confirmation dialog when overrides exist > 0.
+
+## Background recompute job
+
+New job type: `recompute_review`. Payload:
+
+```go
+type RecomputeReviewPayload struct {
+  ClearOverrides bool `json:"clear_overrides"`
+}
+```
+
+Worker behavior:
+
+1. If `ClearOverrides`, run `UPDATE files SET review_override = NULL, review_overridden_at = NULL` across all main files.
+2. Walk all main files in batches (chunks of N — pick based on existing scan-job batch sizing). For each, recompute `reviewed`.
+3. Emit progress via the existing job-status SSE stream.
+4. On completion, invalidate book-list and book-retrieve query caches via the existing event mechanism.
+
+Job is queued by:
+- Migration (initial population — see [Migration](#migration)).
+- Settings save.
+- Manual "Recompute now" admin button.
+
+Permission to enqueue: `config:write` (settings change) and a new `jobs:write` is already required for the manual button via existing job-creation routes.
+
+## API surface
+
+### `PATCH /books/files/:id/review`
+
+```go
+type SetFileReviewPayload struct {
+  // null = clear override; "reviewed" or "unreviewed" otherwise
+  Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
+}
+```
+
+Permission: `books:write` + library access on the file's library. Sets `review_override`, updates `review_overridden_at`, recomputes `reviewed`. Returns the updated file.
+
+### `PATCH /books/:id/review` (book-level cascade)
+
+```go
+type SetBookReviewPayload struct {
+  Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
+}
+```
+
+Cascades to all main files of the book, identical to setting each file individually. Returns the updated book with files.
+
+### `POST /books/bulk/review` (multi-select cascade)
+
+```go
+type BulkSetReviewPayload struct {
+  BookIDs  []int   `json:"book_ids" validate:"required,min=1,max=500"`
+  Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
+}
+```
+
+Cascades to all main files of all listed books. Library-access check is enforced per book; books the user can't access are silently skipped (consistent with existing bulk patterns).
+
+### `GET /books?reviewed_filter=needs_review|reviewed|all`
+
+Add to existing book-list query parameters. `all` is the default and current behavior. `needs_review` and `reviewed` use the aggregation queries from [Book-level aggregation](#book-level-aggregation).
+
+### `GET /settings/review-criteria` and `PUT /settings/review-criteria`
+
+Standard admin settings endpoints. PUT triggers the recompute job; supports the `clear_overrides` query/body flag.
+
+### `POST /jobs` with `type: "recompute_review"`
+
+Manual trigger via the existing job-creation route, gated by `jobs:write`. Body matches the payload above.
+
+## UI
+
+### Library gallery (`Gallery` component) — book card
+
+- Add a small "Needs review" badge (matching existing badge styles, e.g., the `Badge` component with `variant="secondary"`) overlaid on the bottom-right corner of the cover or in the card metadata row. Visible only when the book aggregate is `needs_review`. Reviewed books show no badge — i.e., the absence of a badge means "good."
+- No "missing fields" hint on cards.
+
+### Library gallery — `FilterSheet`
+
+Add a new "Review state" section with three radio options:
+- All (default)
+- Needs review
+- Reviewed
+
+The current value participates in `ActiveFilterChips` like other filters.
+
+### Bulk-select toolbar (`SelectionToolbar.tsx`)
+
+The toolbar is already crowded (Add, Download, Merge, Delete, Clear, X). Add a single **"More" button (kebab/three-dots icon)** that opens a popover with:
+
+- "Mark reviewed"
+- "Mark needs review"
+
+Tap one → fires `POST /books/bulk/review` with the chosen override → exits selection mode → toast confirmation. Same disabled/enabled rules as Delete (requires `books:write` and library access).
+
+### Book detail page (`BookDetail.tsx`)
+
+Add a small "Review" panel near the top, below or beside the existing actions row. Contents:
+
+- **Toggle**: "Reviewed" — single binary control. Tri-state visual when the book's files are mixed (some reviewed, some not, none manually overridden in a uniform way) — render as indeterminate with a hover tooltip listing per-file states.
+- **State indicator** (small text below the toggle):
+  - "Auto" if no override is present on any file of the book.
+  - "Manually set on {date}" if all files share the same override (use the most recent `review_overridden_at`).
+  - "Manually set on multiple files" if overrides differ across files.
+- **Missing fields hint** (only when book aggregates to needs-review): "Missing: {fields}" — a comma-separated list aggregated across all main files. If the same field is missing on all files, list it once. If different files miss different fields, qualify with file type or filename — e.g., `Missing: cover (EPUB), narrators (M4B)`.
+
+Toggling the book-level control fires `PATCH /books/:id/review` and cascades.
+
+### File edit dialog (`FileEditDialog.tsx`)
+
+Add a "Review" subsection at the top, mirroring the book-level panel but scoped to the single file:
+
+- Toggle (Reviewed / Needs review).
+- State indicator (Auto / Manually set on {date}).
+- Missing fields hint (only when the file is currently incomplete).
+
+Toggling fires `PATCH /books/files/:id/review`.
+
+### Admin settings (`AdminSettings.tsx`)
+
+New "Review Criteria" section — see [Settings: review criteria](#settings-review-criteria).
+
+## Migration
+
+New migration: `pkg/migrations/<timestamp>_add_file_review_fields.go`.
+
+1. Add columns to `files`: `review_override`, `review_overridden_at`, `reviewed` (all nullable). No initial population — `reviewed` stays NULL until the recompute job runs.
+2. Add `idx_files_book_reviewed`.
+3. Add CHECK constraint on `review_override`.
+4. Seed the `review_criteria` settings keys with the defaults from [Schema → app_settings](#schema).
+5. Enqueue a `recompute_review` job (with `clear_overrides = false`) so all files settle into the correct state asynchronously after the worker picks it up.
+
+NULL semantics during the gap between migration and job completion: queries treat `reviewed IS NULL` for main files as "not yet computed" and include them in the **needs-review** filter (the conservative bucket — better to surface them than to hide them). The reviewed filter excludes NULL. Once the job completes (typically seconds to minutes for libraries up to tens of thousands of files), every main file has a non-NULL `reviewed` and the gap closes.
+
+This keeps the migration trivially fast (column adds only) and uses the existing job mechanism for the actual computation.
+
+## Telemetry / observability
+
+- Recompute job emits standard job logs and progress.
+- `reviewed` transitions are not audit-logged in v1. If a user manually toggles, the `review_overridden_at` timestamp is the only trace. (Add audit logging later if it becomes a debugging need.)
+
+## Tests
+
+### Backend
+
+- `pkg/books/review_test.go` — completeness rule unit tests for every candidate field, with both book-level and file-level fields, with audio/non-audio books, with multi-file books, with mixed file types.
+- `pkg/books/service_test.go` (extend) — `RecomputeReviewedForFile` and `RecomputeReviewedForBook` happy paths + override interactions.
+- `pkg/worker/scan_unified_test.go` (extend) — file create, file update, plugin enrich each trigger recompute and produce the right state.
+- `pkg/books/handlers_test.go` (extend) — `PATCH /review` endpoints set state correctly, respect permissions and library access, and the `reviewed_filter` query param filters as specified.
+- `pkg/worker/recompute_review_test.go` (new) — job processes all main files, honors `clear_overrides`, ignores supplements.
+
+All new tests use `t.Parallel()` per project convention.
+
+### Frontend
+
+- `Gallery.test.tsx` (extend) — needs-review badge visibility based on book state.
+- `FilterSheet.test.tsx` (extend) — new review state filter renders and applies.
+- `BookDetail.test.tsx` (extend) — review panel renders all three states (auto / manual / mixed) and missing-fields hint formatting.
+- `FileEditDialog.test.tsx` (extend) — file-level review toggle.
+- `SelectionToolbar.test.tsx` (extend) — bulk mark popover items fire the right mutation.
+
+### E2E
+
+- `e2e/review-flag.spec.ts` (new) —
+  1. Import a book with missing fields → appears in needs-review filter.
+  2. Fill in the missing fields via edit dialog → auto-flips out of the filter.
+  3. Toggle manual unreviewed → reappears in the filter even though it's complete.
+  4. Toggle manual reviewed → drops out of the filter even when missing fields.
+  5. Bulk-select two books and "Mark reviewed" → both drop out.
+
+## Documentation
+
+- New page: `website/docs/review-state.md` — explains the concept, the auto-flip rules, manual override semantics, the "Review Criteria" admin setting, and how the gallery filter and badge work.
+- Update `website/docs/configuration.md` — only if any of these settings end up in the static config file (which they don't in this design — they live in runtime settings).
+- Update `website/docs/users-and-permissions.md` if new permission is added (none added — `books:write` covers manual toggles, `config:write` covers settings, `jobs:write` covers the recompute button).
+- Cross-link from `website/docs/metadata.md` and the gallery/library doc (whichever exists) to the new page.
+
+## Open questions / future work
+
+- Per-library criteria override (drop-in extension: add a `library_id`-keyed setting that overrides the server-level one).
+- Surfacing reviewed/unreviewed in OPDS as a category facet.
+- A "Review reason" annotation per book (free-text note on why a manual override was applied) — only worth doing if users ask for it.
+- Audit log entries for review-state transitions.

--- a/e2e/review-flag.spec.ts
+++ b/e2e/review-flag.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * E2E tests for the Review Flag feature.
+ *
+ * Covers:
+ * 1. A book missing reviewed status appears in the "Needs review" filter and
+ *    drops out when marked reviewed via API.
+ * 2. Manually toggling a complete book back to "needs review" keeps it in
+ *    the queue even though it was previously marked reviewed.
+ * 3. Bulk-mark-reviewed via multi-select cascades to all selected books.
+ *
+ * Running:
+ *   pnpm e2e:chromium e2e/review-flag.spec.ts   # Chromium only
+ *   mise test:e2e -- review-flag                 # Both browsers
+ */
+
+import type { Page } from "@playwright/test";
+
+import { expect, getApiBaseURL, request, test } from "./fixtures";
+
+interface TestData {
+  libraryId: number;
+}
+
+let testData: TestData;
+
+const USERNAME = "reviewtest";
+const PASSWORD = "password123";
+
+test.describe("Review flag", () => {
+  test.beforeAll(async ({ browser }) => {
+    const apiBaseURL = getApiBaseURL(browser.browserType().name());
+    const apiContext = await request.newContext({ baseURL: apiBaseURL });
+
+    // Clean slate
+    await apiContext.delete("/test/ereader");
+    await apiContext.delete("/test/users");
+
+    await apiContext.post("/test/users", {
+      data: { username: USERNAME, password: PASSWORD },
+    });
+
+    const libraryResp = await apiContext.post("/test/libraries", {
+      data: { name: "Review Flag Test Library" },
+    });
+    const library = (await libraryResp.json()) as { id: number };
+
+    testData = { libraryId: library.id };
+    await apiContext.dispose();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const apiBaseURL = getApiBaseURL(browser.browserType().name());
+    const apiContext = await request.newContext({ baseURL: apiBaseURL });
+    await apiContext.delete("/test/ereader");
+    await apiContext.delete("/test/users");
+    await apiContext.dispose();
+  });
+
+  // Helper: log in and navigate to the test library gallery.
+  async function loginAndOpenLibrary(page: Page) {
+    await page.goto("/login", { waitUntil: "domcontentloaded" });
+    await page.getByLabel("Username").fill(USERNAME);
+    await page.getByLabel("Password").fill(PASSWORD);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.waitForURL(/\/settings\/libraries|\/libraries\//);
+    await page.goto(`/libraries/${testData.libraryId}`, {
+      waitUntil: "domcontentloaded",
+    });
+    // Wait for the gallery to resolve.
+    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+  }
+
+  test("book with unreviewed file shows in Needs review filter and drops out when marked reviewed", async ({
+    page,
+    apiContext,
+  }) => {
+    // Seed a book — new books have reviewed=null (needs review).
+    const bookResp = await apiContext.post("/test/books", {
+      data: {
+        libraryId: testData.libraryId,
+        title: "Unreviewed Book",
+        fileType: "epub",
+      },
+    });
+    const book = (await bookResp.json()) as { id: number; fileId: number };
+
+    await loginAndOpenLibrary(page);
+
+    // Navigate to the library with needs_review filter via URL (the filter is
+    // URL-driven, so direct navigation is more reliable than UI interaction).
+    await page.goto(
+      `/libraries/${testData.libraryId}?reviewed_filter=needs_review`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+
+    // The unreviewed book should appear in the filtered view.
+    await expect(page.getByText("Unreviewed Book")).toBeVisible();
+
+    // Mark the book's file as reviewed via the authenticated browser API.
+    // page.request uses the logged-in session cookies.
+    const patchResp = await page.request.patch(
+      `/api/books/files/${book.fileId}/review`,
+      { data: { override: "reviewed" } },
+    );
+    expect(patchResp.status()).toBe(200);
+
+    // Reload the filtered view — the book should no longer appear.
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+    await expect(page.getByText("Unreviewed Book")).not.toBeVisible();
+  });
+
+  test("manually toggling a reviewed book back to needs review keeps it in the queue", async ({
+    page,
+    apiContext,
+  }) => {
+    // Seed a book and immediately mark it reviewed.
+    const bookResp = await apiContext.post("/test/books", {
+      data: {
+        libraryId: testData.libraryId,
+        title: "Toggle Back Book",
+        fileType: "epub",
+      },
+    });
+    const book = (await bookResp.json()) as { id: number; fileId: number };
+
+    await loginAndOpenLibrary(page);
+
+    // Mark reviewed via authenticated session.
+    let patchResp = await page.request.patch(
+      `/api/books/files/${book.fileId}/review`,
+      { data: { override: "reviewed" } },
+    );
+    expect(patchResp.status()).toBe(200);
+
+    // Verify it does NOT appear in the needs_review filter.
+    await page.goto(
+      `/libraries/${testData.libraryId}?reviewed_filter=needs_review`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+    await expect(page.getByText("Toggle Back Book")).not.toBeVisible();
+
+    // Toggle back to unreviewed.
+    patchResp = await page.request.patch(
+      `/api/books/files/${book.fileId}/review`,
+      { data: { override: "unreviewed" } },
+    );
+    expect(patchResp.status()).toBe(200);
+
+    // Reload — the book should now appear in the needs_review filter.
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+    await expect(page.getByText("Toggle Back Book")).toBeVisible();
+  });
+
+  test("bulk mark reviewed via multi-select removes all selected books from the needs review queue", async ({
+    page,
+    apiContext,
+  }) => {
+    // Seed two unreviewed books.
+    await apiContext.post("/test/books", {
+      data: {
+        libraryId: testData.libraryId,
+        title: "Bulk Book Alpha",
+        fileType: "epub",
+      },
+    });
+    await apiContext.post("/test/books", {
+      data: {
+        libraryId: testData.libraryId,
+        title: "Bulk Book Beta",
+        fileType: "epub",
+      },
+    });
+
+    await loginAndOpenLibrary(page);
+
+    // Navigate to the filtered view so only unreviewed books are visible.
+    await page.goto(
+      `/libraries/${testData.libraryId}?reviewed_filter=needs_review`,
+      { waitUntil: "domcontentloaded" },
+    );
+    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+
+    // Both books should appear.
+    await expect(page.getByText("Bulk Book Alpha")).toBeVisible();
+    await expect(page.getByText("Bulk Book Beta")).toBeVisible();
+
+    // Enter selection mode.
+    await page.getByRole("button", { name: "Select" }).click();
+
+    // Click both book cards to select them. In selection mode the card wrapper
+    // has the click handler; pointer events on inner elements (title, link)
+    // bubble up to it. Use the cover placeholder area (the first child of the
+    // Link) to reliably target the card rather than the tooltip-wrapped title.
+    // Using force:true tells Playwright to dispatch the event directly even
+    // though a parent element intercepts it — the event bubbles to the card
+    // wrapper which holds the selection handler.
+    await page
+      .locator(".group\\/card")
+      .filter({ hasText: "Bulk Book Alpha" })
+      .click({ force: true });
+    await page
+      .locator(".group\\/card")
+      .filter({ hasText: "Bulk Book Beta" })
+      .click({ force: true });
+
+    // The selection toolbar should appear showing 2 selected.
+    await expect(page.getByText(/2 selected/)).toBeVisible();
+
+    // Open the "More" popover and click "Mark reviewed".
+    await page.getByRole("button", { name: /^More$/ }).click();
+    await page.getByText("Mark reviewed").click();
+
+    // Wait for the toolbar to dismiss (selection mode exits after bulk action).
+    await expect(page.getByText(/2 selected/)).not.toBeVisible();
+
+    // The filtered view should now show neither book (they were marked reviewed).
+    await expect(page.getByText("Bulk Book Alpha")).not.toBeVisible();
+    await expect(page.getByText("Bulk Book Beta")).not.toBeVisible();
+  });
+});

--- a/pkg/appsettings/service.go
+++ b/pkg/appsettings/service.go
@@ -1,0 +1,50 @@
+package appsettings
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/uptrace/bun"
+)
+
+type Service struct {
+	db *bun.DB
+}
+
+func NewService(db *bun.DB) *Service {
+	return &Service{db: db}
+}
+
+// GetJSON loads the JSON-encoded value for key into out. Returns (false, nil) if no row exists.
+func (svc *Service) GetJSON(ctx context.Context, key string, out interface{}) (bool, error) {
+	row := &models.AppSetting{}
+	err := svc.db.NewSelect().Model(row).Where("key = ?", key).Scan(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, errors.WithStack(err)
+	}
+	if err := json.Unmarshal([]byte(row.Value), out); err != nil {
+		return false, errors.WithStack(err)
+	}
+	return true, nil
+}
+
+// SetJSON stores the JSON-encoded value at key. Upserts on conflict.
+func (svc *Service) SetJSON(ctx context.Context, key string, value interface{}) error {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	row := &models.AppSetting{Key: key, Value: string(encoded)}
+	_, err = svc.db.NewInsert().
+		Model(row).
+		On("CONFLICT (key) DO UPDATE").
+		Set("value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP").
+		Exec(ctx)
+	return errors.WithStack(err)
+}

--- a/pkg/appsettings/service_test.go
+++ b/pkg/appsettings/service_test.go
@@ -1,0 +1,89 @@
+package appsettings
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+type sampleConfig struct {
+	BookFields  []string `json:"book_fields"`
+	AudioFields []string `json:"audio_fields"`
+}
+
+func newTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	// Enable foreign keys to match production behavior
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func TestGetSetJSON_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := newTestDB(t)
+	svc := NewService(db)
+
+	want := sampleConfig{
+		BookFields:  []string{"authors", "description"},
+		AudioFields: []string{"narrators"},
+	}
+	require.NoError(t, svc.SetJSON(ctx, "review_criteria", want))
+
+	var got sampleConfig
+	ok, err := svc.GetJSON(ctx, "review_criteria", &got)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, want, got)
+}
+
+func TestGetJSON_Missing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := newTestDB(t)
+	svc := NewService(db)
+
+	var got sampleConfig
+	ok, err := svc.GetJSON(ctx, "missing_key", &got)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestSetJSON_Overwrite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := newTestDB(t)
+	svc := NewService(db)
+
+	require.NoError(t, svc.SetJSON(ctx, "k", sampleConfig{BookFields: []string{"a"}}))
+	require.NoError(t, svc.SetJSON(ctx, "k", sampleConfig{BookFields: []string{"b"}}))
+
+	var got sampleConfig
+	_, err := svc.GetJSON(ctx, "k", &got)
+	require.NoError(t, err)
+	require.Equal(t, []string{"b"}, got.BookFields)
+}

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -678,6 +678,11 @@ func (h *handler) update(c echo.Context) error {
 		}
 	}
 
+	// Recompute reviewed for the book — covers the cases where relations
+	// changed but no source column did (e.g. series-only edits don't touch
+	// any *_source column, so UpdateBook short-circuits its own recompute).
+	h.bookService.RecomputeReviewedForBook(ctx, book.ID)
+
 	return errors.WithStack(c.JSON(http.StatusOK, book))
 }
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/cbzpages"
 	"github.com/shishobooks/shisho/pkg/config"
 	"github.com/shishobooks/shisho/pkg/downloadcache"
@@ -65,22 +66,23 @@ type Scanner interface {
 }
 
 type handler struct {
-	config           *config.Config
-	bookService      *Service
-	libraryService   *libraries.Service
-	personService    *people.Service
-	searchService    *search.Service
-	genreService     *genres.Service
-	tagService       *tags.Service
-	publisherService *publishers.Service
-	imprintService   *imprints.Service
-	listsService     *lists.Service
-	settingsService  *settings.Service
-	downloadCache    *downloadcache.Cache
-	pageCache        *cbzpages.Cache
-	pdfPageCache     *pdfpages.Cache
-	scanner          Scanner
-	pluginManager    pluginManager
+	config             *config.Config
+	bookService        *Service
+	libraryService     *libraries.Service
+	personService      *people.Service
+	searchService      *search.Service
+	genreService       *genres.Service
+	tagService         *tags.Service
+	publisherService   *publishers.Service
+	imprintService     *imprints.Service
+	listsService       *lists.Service
+	settingsService    *settings.Service
+	appSettingsService *appsettings.Service
+	downloadCache      *downloadcache.Cache
+	pageCache          *cbzpages.Cache
+	pdfPageCache       *pdfpages.Cache
+	scanner            Scanner
+	pluginManager      pluginManager
 }
 
 // pluginManager defines the interface for plugin operations needed by the books handler.

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -147,17 +147,23 @@ func (h *handler) list(c echo.Context) error {
 		explicitSort = parsed
 	}
 
+	reviewedFilter := params.ReviewedFilter
+	if reviewedFilter == "all" {
+		reviewedFilter = ""
+	}
+
 	opts := ListBooksOptions{
-		Limit:     &params.Limit,
-		Offset:    &params.Offset,
-		LibraryID: params.LibraryID,
-		SeriesID:  params.SeriesID,
-		Search:    params.Search,
-		FileTypes: params.FileTypes,
-		GenreIDs:  params.GenreIDs,
-		TagIDs:    params.TagIDs,
-		Language:  languageFilter,
-		IDs:       params.IDs,
+		Limit:          &params.Limit,
+		Offset:         &params.Offset,
+		LibraryID:      params.LibraryID,
+		SeriesID:       params.SeriesID,
+		Search:         params.Search,
+		FileTypes:      params.FileTypes,
+		GenreIDs:       params.GenreIDs,
+		TagIDs:         params.TagIDs,
+		Language:       languageFilter,
+		IDs:            params.IDs,
+		ReviewedFilter: reviewedFilter,
 	}
 
 	// Filter by user's library access if user is in context.

--- a/pkg/books/handlers_review.go
+++ b/pkg/books/handlers_review.go
@@ -1,6 +1,7 @@
 package books
 
 import (
+	"net/http"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
@@ -42,6 +43,11 @@ func (h *handler) setFileReview(c echo.Context) error {
 			return errcodes.Forbidden("You don't have access to this library")
 		}
 	}
+	// Supplements never participate in review state — reject overrides
+	// rather than silently persisting orphan rows.
+	if file.FileRole != models.FileRoleMain {
+		return errcodes.BadRequest("Cannot set review state on a supplement file")
+	}
 
 	criteria, err := review.Load(ctx, h.appSettingsService)
 	if err != nil {
@@ -55,7 +61,7 @@ func (h *handler) setFileReview(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.JSON(200, updated)
+	return c.JSON(http.StatusOK, updated)
 }
 
 // setBookReview cascades a review override to all main files of a book.
@@ -98,7 +104,7 @@ func (h *handler) setBookReview(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.JSON(200, updated)
+	return c.JSON(http.StatusOK, updated)
 }
 
 // bulkSetReview applies a review override to all main files across multiple books.
@@ -134,5 +140,5 @@ func (h *handler) bulkSetReview(c echo.Context) error {
 			}
 		}
 	}
-	return c.NoContent(204)
+	return c.NoContent(http.StatusNoContent)
 }

--- a/pkg/books/handlers_review.go
+++ b/pkg/books/handlers_review.go
@@ -1,0 +1,53 @@
+package books
+
+import (
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// SetReviewPayload is the request body for PATCH /books/files/:id/review.
+type SetReviewPayload struct {
+	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
+}
+
+// setFileReview sets or clears the review override for a single file.
+func (h *handler) setFileReview(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.BadRequest("Invalid file id")
+	}
+
+	var payload SetReviewPayload
+	if err := c.Bind(&payload); err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context()
+	file, err := h.bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &id})
+	if err != nil {
+		return err
+	}
+	if user, ok := c.Get("user").(*models.User); ok {
+		if !user.HasLibraryAccess(file.LibraryID) {
+			return errcodes.Forbidden("You don't have access to this library")
+		}
+	}
+
+	criteria, err := review.Load(ctx, h.appSettingsService)
+	if err != nil {
+		return err
+	}
+	if err := review.SetOverride(ctx, h.bookService.DB(), id, payload.Override, criteria); err != nil {
+		return err
+	}
+
+	updated, err := h.bookService.RetrieveFile(ctx, RetrieveFileOptions{ID: &id})
+	if err != nil {
+		return err
+	}
+	return c.JSON(200, updated)
+}

--- a/pkg/books/handlers_review.go
+++ b/pkg/books/handlers_review.go
@@ -14,6 +14,12 @@ type SetReviewPayload struct {
 	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
 }
 
+// BulkSetReviewPayload is the request body for POST /books/bulk/review.
+type BulkSetReviewPayload struct {
+	BookIDs  []int   `json:"book_ids" validate:"required,min=1,max=500"`
+	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
+}
+
 // setFileReview sets or clears the review override for a single file.
 func (h *handler) setFileReview(c echo.Context) error {
 	id, err := strconv.Atoi(c.Param("id"))
@@ -50,4 +56,83 @@ func (h *handler) setFileReview(c echo.Context) error {
 		return err
 	}
 	return c.JSON(200, updated)
+}
+
+// setBookReview cascades a review override to all main files of a book.
+func (h *handler) setBookReview(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.BadRequest("Invalid book id")
+	}
+
+	var payload SetReviewPayload
+	if err := c.Bind(&payload); err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context()
+	book, err := h.bookService.RetrieveBook(ctx, RetrieveBookOptions{ID: &id})
+	if err != nil {
+		return err
+	}
+	if user, ok := c.Get("user").(*models.User); ok {
+		if !user.HasLibraryAccess(book.LibraryID) {
+			return errcodes.Forbidden("You don't have access to this library")
+		}
+	}
+
+	criteria, err := review.Load(ctx, h.appSettingsService)
+	if err != nil {
+		return err
+	}
+	for _, f := range book.Files {
+		if f.FileRole != models.FileRoleMain {
+			continue
+		}
+		if err := review.SetOverride(ctx, h.bookService.DB(), f.ID, payload.Override, criteria); err != nil {
+			return err
+		}
+	}
+
+	updated, err := h.bookService.RetrieveBook(ctx, RetrieveBookOptions{ID: &id})
+	if err != nil {
+		return err
+	}
+	return c.JSON(200, updated)
+}
+
+// bulkSetReview applies a review override to all main files across multiple books.
+func (h *handler) bulkSetReview(c echo.Context) error {
+	var payload BulkSetReviewPayload
+	if err := c.Bind(&payload); err != nil {
+		return err
+	}
+
+	ctx := c.Request().Context()
+	user, _ := c.Get("user").(*models.User)
+
+	criteria, err := review.Load(ctx, h.appSettingsService)
+	if err != nil {
+		return err
+	}
+
+	for _, bookID := range payload.BookIDs {
+		id := bookID
+		book, err := h.bookService.RetrieveBook(ctx, RetrieveBookOptions{ID: &id})
+		if err != nil {
+			continue // silently skip missing books
+		}
+		if user != nil && !user.HasLibraryAccess(book.LibraryID) {
+			continue
+		}
+		for _, f := range book.Files {
+			if f.FileRole != models.FileRoleMain {
+				continue
+			}
+			if err := review.SetOverride(ctx, h.bookService.DB(), f.ID, payload.Override, criteria); err != nil {
+				return err
+			}
+		}
+	}
+	return c.NoContent(204)
 }

--- a/pkg/books/handlers_review_test.go
+++ b/pkg/books/handlers_review_test.go
@@ -174,6 +174,71 @@ func TestSetFileReview_ClearsOverride(t *testing.T) {
 	assert.Nil(t, updated.ReviewOverriddenAt)
 }
 
+func TestSetFileReview_RejectsSupplement(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		Filepath:        "/tmp",
+		TitleSource:     "file",
+		SortTitle:       "T",
+		SortTitleSource: "file",
+		AuthorSource:    "file",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	supplement := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypePDF,
+		FileRole:      models.FileRoleSupplement,
+		Filepath:      "/tmp/extra.pdf",
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(supplement).Exec(ctx)
+	require.NoError(t, err)
+
+	svc := NewService(db).WithAppSettings(appsettings.NewService(db))
+	h := &handler{
+		bookService:        svc,
+		appSettingsService: appsettings.NewService(db),
+	}
+
+	e := newTestEchoBooks(t)
+	body := []byte(`{"override":"reviewed"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(supplement.ID))
+
+	user := setupTestUser(t, db, library.ID, true)
+	c.Set("user", user)
+
+	err = h.setFileReview(c)
+	require.Error(t, err, "expected supplement override to be rejected")
+
+	// Verify nothing persisted to the supplement row.
+	var unchanged models.File
+	require.NoError(t, db.NewSelect().Model(&unchanged).Where("f.id = ?", supplement.ID).Scan(ctx))
+	assert.Nil(t, unchanged.ReviewOverride)
+	assert.Nil(t, unchanged.ReviewOverriddenAt)
+}
+
 func TestSetBookReview_CascadesToAllFiles(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/books/handlers_review_test.go
+++ b/pkg/books/handlers_review_test.go
@@ -1,0 +1,171 @@
+package books
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetFileReview_SetsOverride(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Seed library, book, and file
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		Filepath:        "/tmp",
+		TitleSource:     "file",
+		SortTitle:       "T",
+		SortTitleSource: "file",
+		AuthorSource:    "file",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/test.epub",
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Build handler
+	svc := NewService(db).WithAppSettings(appsettings.NewService(db))
+	h := &handler{
+		bookService:        svc,
+		appSettingsService: appsettings.NewService(db),
+	}
+
+	// Build Echo context with PATCH body {"override":"reviewed"}
+	e := newTestEchoBooks(t)
+	payload := map[string]string{"override": models.ReviewOverrideReviewed}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(file.ID))
+
+	// Create user with library access
+	user := setupTestUser(t, db, library.ID, true)
+	c.Set("user", user)
+
+	err = h.setFileReview(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify the file's review_override and review_overridden_at are set
+	var updated models.File
+	err = db.NewSelect().Model(&updated).Where("f.id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, updated.ReviewOverride)
+	assert.Equal(t, models.ReviewOverrideReviewed, *updated.ReviewOverride)
+	assert.NotNil(t, updated.ReviewOverriddenAt)
+}
+
+func TestSetFileReview_ClearsOverride(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Seed library, book, and file
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		Filepath:        "/tmp",
+		TitleSource:     "file",
+		SortTitle:       "T",
+		SortTitleSource: "file",
+		AuthorSource:    "file",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/test.epub",
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Seed an existing override so we can verify it gets cleared
+	overrideVal := models.ReviewOverrideReviewed
+	_, err = db.NewUpdate().
+		Model((*models.File)(nil)).
+		Set("review_override = ?", overrideVal).
+		Where("id = ?", file.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	// Build handler
+	svc := NewService(db).WithAppSettings(appsettings.NewService(db))
+	h := &handler{
+		bookService:        svc,
+		appSettingsService: appsettings.NewService(db),
+	}
+
+	// Build Echo context with PATCH body {"override":null}
+	e := newTestEchoBooks(t)
+	body := []byte(`{"override":null}`)
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(file.ID))
+
+	// Create user with library access
+	user := setupTestUser(t, db, library.ID, true)
+	c.Set("user", user)
+
+	err = h.setFileReview(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify the file's review_override and review_overridden_at are cleared
+	var updated models.File
+	err = db.NewSelect().Model(&updated).Where("f.id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, updated.ReviewOverride)
+	assert.Nil(t, updated.ReviewOverriddenAt)
+}

--- a/pkg/books/handlers_review_test.go
+++ b/pkg/books/handlers_review_test.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -305,4 +308,99 @@ func TestBulkSetReview_AppliesToAllSpecifiedBooks(t *testing.T) {
 		require.NotNil(t, f.ReviewOverride)
 		assert.Equal(t, "reviewed", *f.ReviewOverride)
 	}
+}
+
+// TestUpdateBook_AddingGenre_FlipsReviewedToTrue is a regression test for the
+// case where a book was unreviewed solely because it lacked a required genre.
+// Adding a genre via the book update handler should fire the recompute and
+// flip files.reviewed to TRUE.
+//
+// The bug this guards against: pkg/books/routes.go was instantiating the books
+// service without WithAppSettings(...), so RecomputeReviewedForBook silently
+// no-op'd — the toggle never auto-flipped after edits even though the data
+// became complete.
+func TestUpdateBook_AddingGenre_FlipsReviewedToTrue(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	// Seed a book that satisfies the default review criteria EXCEPT genres:
+	// authors present, description present, cover present, narrators not
+	// required (epub). After the update adds a genre, completeness should
+	// flip to TRUE.
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	desc := "A complete description"
+	bookDir := t.TempDir()
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceManual,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+		Description:     &desc,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	// Author so completeness has authors covered.
+	person := &models.Person{Name: "Author One", LibraryID: library.ID}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+	author := &models.Author{BookID: book.ID, PersonID: person.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+
+	// Main file with a cover so file-level cover requirement is satisfied.
+	coverFilename := "test.epub.cover.jpg"
+	coverMime := "image/jpeg"
+	filePath := filepath.Join(bookDir, "test.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("epub content"), 0644))
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filePath,
+		FilesizeBytes:      1,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &coverMime,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Pre-condition: no genres → file should evaluate to NOT reviewed.
+	// Run a recompute manually so files.reviewed reflects current state
+	// (mirrors what the migration job would do for existing books).
+	svc := NewService(db).WithAppSettings(appsettings.NewService(db))
+	svc.RecomputeReviewedForBook(ctx, book.ID)
+
+	var preFile models.File
+	require.NoError(t, db.NewSelect().Model(&preFile).Where("f.id = ?", file.ID).Scan(ctx))
+	require.NotNil(t, preFile.Reviewed)
+	require.False(t, *preFile.Reviewed, "file should not be reviewed when genres are missing")
+
+	// Now PATCH the book to add a genre, going through the full HTTP handler.
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+	e := setupTestServer(t, db)
+	body := `{"genres": ["Fiction"]}`
+	req := httptest.NewRequest(http.MethodPost, "/books/"+strconv.Itoa(book.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	// Post-condition: file should now be reviewed=TRUE.
+	var postFile models.File
+	require.NoError(t, db.NewSelect().Model(&postFile).Where("f.id = ?", file.ID).Scan(ctx))
+	require.NotNil(t, postFile.Reviewed)
+	assert.True(t, *postFile.Reviewed, "file should auto-flip to reviewed after adding the missing genre")
 }

--- a/pkg/books/handlers_review_test.go
+++ b/pkg/books/handlers_review_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
 )
 
 func TestSetFileReview_SetsOverride(t *testing.T) {
@@ -168,4 +169,140 @@ func TestSetFileReview_ClearsOverride(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, updated.ReviewOverride)
 	assert.Nil(t, updated.ReviewOverriddenAt)
+}
+
+func TestSetBookReview_CascadesToAllFiles(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		Filepath:        "/tmp",
+		TitleSource:     "file",
+		SortTitle:       "T",
+		SortTitleSource: "file",
+		AuthorSource:    "file",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	for _, ft := range []string{models.FileTypeEPUB, models.FileTypeM4B} {
+		f := &models.File{
+			LibraryID:     library.ID,
+			BookID:        book.ID,
+			Filepath:      "/tmp/" + ft,
+			FileType:      ft,
+			FileRole:      models.FileRoleMain,
+			FilesizeBytes: 1,
+		}
+		_, err = db.NewInsert().Model(f).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	svc := NewService(db).WithAppSettings(appsettings.NewService(db))
+	h := &handler{
+		bookService:        svc,
+		appSettingsService: appsettings.NewService(db),
+	}
+
+	body := []byte(`{"override":"reviewed"}`)
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e := newTestEchoBooks(t)
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(book.ID))
+
+	user := setupTestUser(t, db, library.ID, true)
+	c.Set("user", user)
+
+	require.NoError(t, h.setBookReview(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var rows []*models.File
+	require.NoError(t, db.NewSelect().Model(&rows).Where("f.book_id = ?", book.ID).Scan(ctx))
+	for _, f := range rows {
+		require.NotNil(t, f.ReviewOverride)
+		assert.Equal(t, "reviewed", *f.ReviewOverride)
+	}
+}
+
+func TestBulkSetReview_AppliesToAllSpecifiedBooks(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	bookIDs := make([]int, 0, 2)
+	for i := 0; i < 2; i++ {
+		book := &models.Book{
+			LibraryID:       library.ID,
+			Title:           "T" + strconv.Itoa(i),
+			Filepath:        "/tmp/book" + strconv.Itoa(i),
+			TitleSource:     "file",
+			SortTitle:       "T",
+			SortTitleSource: "file",
+			AuthorSource:    "file",
+		}
+		_, err = db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+		bookIDs = append(bookIDs, book.ID)
+
+		f := &models.File{
+			LibraryID:     library.ID,
+			BookID:        book.ID,
+			Filepath:      "/tmp/book" + strconv.Itoa(i) + "/file.epub",
+			FileType:      models.FileTypeEPUB,
+			FileRole:      models.FileRoleMain,
+			FilesizeBytes: 1,
+		}
+		_, err = db.NewInsert().Model(f).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	svc := NewService(db).WithAppSettings(appsettings.NewService(db))
+	h := &handler{
+		bookService:        svc,
+		appSettingsService: appsettings.NewService(db),
+	}
+
+	bodyStr := `{"book_ids":[` + strconv.Itoa(bookIDs[0]) + `,` + strconv.Itoa(bookIDs[1]) + `],"override":"reviewed"}`
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader([]byte(bodyStr)))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e := newTestEchoBooks(t)
+	c := e.NewContext(req, rec)
+
+	user := setupTestUser(t, db, library.ID, true)
+	c.Set("user", user)
+
+	require.NoError(t, h.bulkSetReview(c))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	var files []*models.File
+	require.NoError(t, db.NewSelect().Model(&files).Where("f.book_id IN (?)", bun.List(bookIDs)).Scan(ctx))
+	for _, f := range files {
+		require.NotNil(t, f.ReviewOverride)
+		assert.Equal(t, "reviewed", *f.ReviewOverride)
+	}
 }

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/binder"
 	"github.com/shishobooks/shisho/pkg/config"
@@ -235,9 +236,11 @@ func setupTestServer(t *testing.T, db *bun.DB) *echo.Echo {
 	authService := auth.NewService(db, cfg.JWTSecret, cfg.SessionDuration())
 	authMiddleware := auth.NewMiddleware(authService)
 
-	// Register routes (pass nil for plugin manager and nil for appSettingsSvc in tests)
+	// Register routes (pass nil for plugin manager). appSettingsSvc must be a
+	// real instance so RecomputeReviewedFor{File,Book} actually runs after
+	// mutations — otherwise reviewed flag tests give false greens.
 	g := e.Group("/books")
-	RegisterRoutesWithGroup(g, db, cfg, authMiddleware, &mockScanner{}, nil, nil, nil)
+	RegisterRoutesWithGroup(g, db, cfg, authMiddleware, &mockScanner{}, nil, nil, appsettings.NewService(db))
 
 	return e
 }

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -235,9 +235,9 @@ func setupTestServer(t *testing.T, db *bun.DB) *echo.Echo {
 	authService := auth.NewService(db, cfg.JWTSecret, cfg.SessionDuration())
 	authMiddleware := auth.NewMiddleware(authService)
 
-	// Register routes (pass nil for plugin manager in tests)
+	// Register routes (pass nil for plugin manager and nil for appSettingsSvc in tests)
 	g := e.Group("/books")
-	RegisterRoutesWithGroup(g, db, cfg, authMiddleware, &mockScanner{}, nil, nil)
+	RegisterRoutesWithGroup(g, db, cfg, authMiddleware, &mockScanner{}, nil, nil, nil)
 
 	return e
 }

--- a/pkg/books/merge.go
+++ b/pkg/books/merge.go
@@ -466,6 +466,13 @@ func (svc *Service) MoveFilesToBook(ctx context.Context, opts MoveFilesOptions) 
 		}
 	}
 
+	// Recompute reviewed state for all affected books — files moved between books
+	// may change completeness because the new book has different relations.
+	for sourceBookID := range sourceBookPaths {
+		svc.RecomputeReviewedForBook(ctx, sourceBookID)
+	}
+	svc.RecomputeReviewedForBook(ctx, targetBook.ID)
+
 	// Reload target book with all relations
 	result.TargetBook, err = svc.RetrieveBook(ctx, RetrieveBookOptions{
 		ID: &targetBook.ID,

--- a/pkg/books/merge_test.go
+++ b/pkg/books/merge_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/books/review"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -612,4 +614,69 @@ func TestMoveFilesToBook_SetsPrimaryOnNewlyCreatedBook(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, updatedSourceBook.PrimaryFileID)
 	assert.Equal(t, sourceFile1.ID, *updatedSourceBook.PrimaryFileID)
+}
+
+// TestMoveFilesToBook_RecomputesReviewedForBothBooks verifies that after files
+// are moved, files.reviewed is recomputed for both the source and target books.
+func TestMoveFilesToBook_RecomputesReviewedForBothBooks(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := setupTestDB(t)
+
+	// Configure criteria: only "authors" required so we have a clear signal
+	appSettingsSvc := appsettings.NewService(db)
+	err := review.Save(ctx, appSettingsSvc, review.Criteria{
+		BookFields:  []string{review.FieldAuthors},
+		AudioFields: []string{},
+	})
+	require.NoError(t, err)
+
+	library := setupTestLibrary(t, db)
+
+	// Source book has an author → its file will be reviewed=true after move
+	sourceBook, sourceFile := setupTestBookWithFile(t, db, library, "Source Book")
+	person := &models.Person{Name: "Author One", LibraryID: library.ID}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+	author := &models.Author{
+		BookID:    sourceBook.ID,
+		PersonID:  person.ID,
+		SortOrder: 1,
+		Role:      nil,
+	}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+
+	// Target book has no authors → its file will be reviewed=false after move
+	targetBook, targetFile := setupTestBookWithFile(t, db, library, "Target Book")
+
+	// Seed reviewed=true on sourceFile (simulate it was complete before the move)
+	reviewed := true
+	_, err = db.NewUpdate().Model((*models.File)(nil)).
+		Set("reviewed = ?", reviewed).
+		Where("id = ?", sourceFile.ID).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	// Move the source file to the target book
+	svc := NewService(db).WithAppSettings(appSettingsSvc)
+	_, err = svc.MoveFilesToBook(ctx, MoveFilesOptions{
+		FileIDs:      []int{sourceFile.ID},
+		TargetBookID: &targetBook.ID,
+		LibraryID:    library.ID,
+	})
+	require.NoError(t, err)
+
+	// After move: sourceFile is now on targetBook (no authors) → reviewed=false
+	var movedFile models.File
+	require.NoError(t, db.NewSelect().Model(&movedFile).Where("f.id = ?", sourceFile.ID).Scan(ctx))
+	require.NotNil(t, movedFile.Reviewed, "reviewed must be set after recompute for moved file")
+	assert.False(t, *movedFile.Reviewed, "moved file should be reviewed=false because target book has no authors")
+
+	// targetFile (original file of targetBook) also recomputed: no authors → false
+	var targetFileAfter models.File
+	require.NoError(t, db.NewSelect().Model(&targetFileAfter).Where("f.id = ?", targetFile.ID).Scan(ctx))
+	require.NotNil(t, targetFileAfter.Reviewed, "reviewed must be set for target book's original file after recompute")
+	assert.False(t, *targetFileAfter.Reviewed, "target book's original file should be reviewed=false because target book has no authors")
 }

--- a/pkg/books/review/completeness.go
+++ b/pkg/books/review/completeness.go
@@ -1,0 +1,75 @@
+package review
+
+import (
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// MissingFields returns the list of required-field names that are not satisfied
+// for a single main file. The book and file must have all relations loaded.
+//
+// For supplements, returns nil.
+//
+// The criteria's BookFields apply to every file; AudioFields apply when the
+// file is m4b.
+func MissingFields(book *models.Book, file *models.File, criteria Criteria) []string {
+	if file.FileRole == models.FileRoleSupplement {
+		return nil
+	}
+	missing := make([]string, 0)
+	for _, f := range criteria.BookFields {
+		if !isPresent(book, file, f) {
+			missing = append(missing, f)
+		}
+	}
+	if file.FileType == models.FileTypeM4B {
+		for _, f := range criteria.AudioFields {
+			if !isPresent(book, file, f) {
+				missing = append(missing, f)
+			}
+		}
+	}
+	return missing
+}
+
+// IsComplete returns true iff MissingFields returns an empty slice for a main file.
+func IsComplete(book *models.Book, file *models.File, criteria Criteria) bool {
+	return len(MissingFields(book, file, criteria)) == 0
+}
+
+func isPresent(book *models.Book, file *models.File, field string) bool {
+	switch field {
+	case FieldAuthors:
+		return len(book.Authors) > 0
+	case FieldDescription:
+		return book.Description != nil && *book.Description != ""
+	case FieldGenres:
+		return len(book.BookGenres) > 0
+	case FieldTags:
+		return len(book.BookTags) > 0
+	case FieldSeries:
+		return len(book.BookSeries) > 0
+	case FieldSubtitle:
+		return book.Subtitle != nil && *book.Subtitle != ""
+	case FieldCover:
+		return file.CoverImageFilename != nil && *file.CoverImageFilename != ""
+	case FieldPublisher:
+		return file.PublisherID != nil
+	case FieldImprint:
+		return file.ImprintID != nil
+	case FieldIdentifiers:
+		return len(file.Identifiers) > 0
+	case FieldReleaseDate:
+		return file.ReleaseDate != nil
+	case FieldLanguage:
+		return file.Language != nil && *file.Language != ""
+	case FieldURL:
+		return file.URL != nil && *file.URL != ""
+	case FieldNarrators:
+		return len(file.Narrators) > 0
+	case FieldChapters:
+		return len(file.Chapters) > 0
+	case FieldAbridged:
+		return file.Abridged != nil
+	}
+	return false
+}

--- a/pkg/books/review/completeness_test.go
+++ b/pkg/books/review/completeness_test.go
@@ -1,0 +1,144 @@
+package review
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func ptrStr(s string) *string        { return &s }
+func ptrInt(i int) *int              { return &i }
+func ptrBool(b bool) *bool           { return &b }
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func TestMissingFields_Supplement_NoCheck(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{}
+	file := &models.File{FileRole: models.FileRoleSupplement}
+	require.Nil(t, MissingFields(book, file, Default()))
+}
+
+func TestMissingFields_EpubMissingAll_Default(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{}
+	file := &models.File{FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain}
+	missing := MissingFields(book, file, Default())
+	require.ElementsMatch(t, []string{"authors", "description", "cover", "genres"}, missing)
+}
+
+func TestMissingFields_EpubComplete(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		Description: ptrStr("desc"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("cover.jpg"),
+	}
+	require.Empty(t, MissingFields(book, file, Default()))
+}
+
+func TestMissingFields_M4BNeedsNarrators(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		Description: ptrStr("desc"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeM4B,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("cover.jpg"),
+	}
+	require.Contains(t, MissingFields(book, file, Default()), "narrators")
+}
+
+func TestMissingFields_M4BComplete(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		Description: ptrStr("desc"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeM4B,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("cover.jpg"),
+		Narrators:          []*models.Narrator{{}},
+	}
+	require.Empty(t, MissingFields(book, file, Default()))
+}
+
+func TestMissingFields_NonAudio_DoesNotCheckAudioFields(t *testing.T) {
+	t.Parallel()
+	criteria := Criteria{
+		BookFields:  []string{},
+		AudioFields: []string{"narrators"},
+	}
+	book := &models.Book{}
+	file := &models.File{FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain}
+	require.Empty(t, MissingFields(book, file, criteria))
+}
+
+func TestMissingFields_AllFields(t *testing.T) {
+	t.Parallel()
+	criteria := Criteria{
+		BookFields: []string{
+			FieldAuthors, FieldDescription, FieldCover, FieldGenres, FieldTags,
+			FieldSeries, FieldSubtitle, FieldPublisher, FieldImprint,
+			FieldIdentifiers, FieldReleaseDate, FieldLanguage, FieldURL,
+		},
+		AudioFields: []string{FieldNarrators, FieldChapters, FieldAbridged},
+	}
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		BookTags:    []*models.BookTag{{}},
+		BookSeries:  []*models.BookSeries{{}},
+		Description: ptrStr("desc"),
+		Subtitle:    ptrStr("sub"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeM4B,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("c.jpg"),
+		PublisherID:        ptrInt(1),
+		ImprintID:          ptrInt(1),
+		Identifiers:        []*models.FileIdentifier{{}},
+		ReleaseDate:        ptrTime(time.Now()),
+		Language:           ptrStr("en"),
+		URL:                ptrStr("https://example"),
+		Narrators:          []*models.Narrator{{}},
+		Chapters:           []*models.Chapter{{}},
+		Abridged:           ptrBool(false),
+	}
+	require.Empty(t, MissingFields(book, file, criteria))
+}
+
+func TestIsComplete_True(t *testing.T) {
+	t.Parallel()
+	book := &models.Book{
+		Authors:     []*models.Author{{}},
+		BookGenres:  []*models.BookGenre{{}},
+		Description: ptrStr("d"),
+	}
+	file := &models.File{
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		CoverImageFilename: ptrStr("c.jpg"),
+	}
+	require.True(t, IsComplete(book, file, Default()))
+}
+
+func TestIsComplete_False(t *testing.T) {
+	t.Parallel()
+	require.False(t, IsComplete(&models.Book{}, &models.File{
+		FileType: models.FileTypeEPUB,
+		FileRole: models.FileRoleMain,
+	}, Default()))
+}

--- a/pkg/books/review/criteria.go
+++ b/pkg/books/review/criteria.go
@@ -1,0 +1,102 @@
+package review
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/appsettings"
+)
+
+const SettingsKey = "review_criteria"
+
+// Field constants — every name must be in either UniversalCandidates or AudioCandidates.
+const (
+	FieldAuthors     = "authors"
+	FieldDescription = "description"
+	FieldCover       = "cover"
+	FieldGenres      = "genres"
+	FieldTags        = "tags"
+	FieldSeries      = "series"
+	FieldSubtitle    = "subtitle"
+	FieldPublisher   = "publisher"
+	FieldImprint     = "imprint"
+	FieldIdentifiers = "identifiers"
+	FieldReleaseDate = "release_date"
+	FieldLanguage    = "language"
+	FieldURL         = "url"
+	FieldNarrators   = "narrators"
+	FieldChapters    = "chapters"
+	FieldAbridged    = "abridged"
+)
+
+// UniversalCandidates is the set of fields that can be required for all books.
+var UniversalCandidates = []string{
+	FieldAuthors, FieldDescription, FieldCover, FieldGenres, FieldTags,
+	FieldSeries, FieldSubtitle, FieldPublisher, FieldImprint, FieldIdentifiers,
+	FieldReleaseDate, FieldLanguage, FieldURL,
+}
+
+// AudioCandidates is the set of fields that can be required only when the book has at least one audio file.
+var AudioCandidates = []string{FieldNarrators, FieldChapters, FieldAbridged}
+
+type Criteria struct {
+	BookFields  []string `json:"book_fields"`
+	AudioFields []string `json:"audio_fields"`
+}
+
+// Default returns the seeded review criteria.
+func Default() Criteria {
+	return Criteria{
+		BookFields:  []string{FieldAuthors, FieldDescription, FieldCover, FieldGenres},
+		AudioFields: []string{FieldNarrators},
+	}
+}
+
+// Load reads the criteria from app settings, falling back to Default if unset.
+func Load(ctx context.Context, settings *appsettings.Service) (Criteria, error) {
+	var c Criteria
+	ok, err := settings.GetJSON(ctx, SettingsKey, &c)
+	if err != nil {
+		return Criteria{}, errors.WithStack(err)
+	}
+	if !ok {
+		return Default(), nil
+	}
+	// Defensive: if either slice is nil from older serializations, use defaults for that side.
+	if c.BookFields == nil {
+		c.BookFields = Default().BookFields
+	}
+	if c.AudioFields == nil {
+		c.AudioFields = Default().AudioFields
+	}
+	return c, nil
+}
+
+// Save persists the criteria.
+func Save(ctx context.Context, settings *appsettings.Service, c Criteria) error {
+	return errors.WithStack(settings.SetJSON(ctx, SettingsKey, c))
+}
+
+// Validate returns an error if any field name in the criteria isn't a known candidate.
+func Validate(c Criteria) error {
+	if err := validateAgainst(c.BookFields, UniversalCandidates); err != nil {
+		return errors.Wrap(err, "book_fields")
+	}
+	if err := validateAgainst(c.AudioFields, AudioCandidates); err != nil {
+		return errors.Wrap(err, "audio_fields")
+	}
+	return nil
+}
+
+func validateAgainst(fields []string, allowed []string) error {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		allowedSet[a] = struct{}{}
+	}
+	for _, f := range fields {
+		if _, ok := allowedSet[f]; !ok {
+			return errors.Errorf("unknown field %q", f)
+		}
+	}
+	return nil
+}

--- a/pkg/books/review/criteria_test.go
+++ b/pkg/books/review/criteria_test.go
@@ -1,0 +1,87 @@
+package review
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func newTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	// Enable foreign keys to match production behavior
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func TestDefault_HasExpectedFields(t *testing.T) {
+	t.Parallel()
+	d := Default()
+	require.ElementsMatch(t, []string{"authors", "description", "cover", "genres"}, d.BookFields)
+	require.ElementsMatch(t, []string{"narrators"}, d.AudioFields)
+}
+
+func TestLoad_FallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := newTestDB(t)
+	svc := appsettings.NewService(db)
+
+	c, err := Load(ctx, svc)
+	require.NoError(t, err)
+	require.Equal(t, Default(), c)
+}
+
+func TestLoad_ReadsSavedValue(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := newTestDB(t)
+	svc := appsettings.NewService(db)
+
+	want := Criteria{BookFields: []string{"authors"}, AudioFields: []string{}}
+	require.NoError(t, Save(ctx, svc, want))
+
+	got, err := Load(ctx, svc)
+	require.NoError(t, err)
+	require.Equal(t, want.BookFields, got.BookFields)
+	require.Equal(t, want.AudioFields, got.AudioFields)
+}
+
+func TestValidate_RejectsUnknownField(t *testing.T) {
+	t.Parallel()
+	err := Validate(Criteria{BookFields: []string{"made_up_field"}})
+	require.Error(t, err)
+}
+
+func TestValidate_RejectsAudioFieldInUniversal(t *testing.T) {
+	t.Parallel()
+	err := Validate(Criteria{BookFields: []string{"narrators"}})
+	require.Error(t, err)
+}
+
+func TestValidate_AcceptsKnown(t *testing.T) {
+	t.Parallel()
+	err := Validate(Default())
+	require.NoError(t, err)
+}

--- a/pkg/books/review/recompute.go
+++ b/pkg/books/review/recompute.go
@@ -1,0 +1,114 @@
+package review
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/uptrace/bun"
+)
+
+// RecomputeForFile reloads the file (with relations needed by completeness),
+// computes its `reviewed` value, and persists. Override-set rows short-circuit.
+// Supplements get reviewed=NULL.
+func RecomputeForFile(ctx context.Context, db bun.IDB, fileID int, criteria Criteria) error {
+	file := &models.File{}
+	err := db.NewSelect().
+		Model(file).
+		Where("f.id = ?", fileID).
+		Relation("Narrators").
+		Relation("Identifiers").
+		Relation("Chapters").
+		Scan(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if file.FileRole == models.FileRoleSupplement {
+		_, err := db.NewUpdate().
+			Model((*models.File)(nil)).
+			Set("reviewed = NULL").
+			Where("id = ?", fileID).
+			Exec(ctx)
+		return errors.WithStack(err)
+	}
+
+	book := &models.Book{}
+	err = db.NewSelect().
+		Model(book).
+		Where("b.id = ?", file.BookID).
+		Relation("Authors").
+		Relation("BookSeries").
+		Relation("BookGenres").
+		Relation("BookTags").
+		Scan(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	reviewed := computeReviewedValue(book, file, criteria)
+	_, err = db.NewUpdate().
+		Model((*models.File)(nil)).
+		Set("reviewed = ?", reviewed).
+		Where("id = ?", fileID).
+		Exec(ctx)
+	return errors.WithStack(err)
+}
+
+// RecomputeForBook recomputes reviewed for every file belonging to the book.
+func RecomputeForBook(ctx context.Context, db bun.IDB, bookID int, criteria Criteria) error {
+	var fileIDs []int
+	err := db.NewSelect().
+		Model((*models.File)(nil)).
+		Column("id").
+		Where("book_id = ?", bookID).
+		Scan(ctx, &fileIDs)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, id := range fileIDs {
+		if err := RecomputeForFile(ctx, db, id, criteria); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetOverride writes an explicit override and the timestamp, then writes the
+// effective `reviewed` value. Pass override=nil to clear (then completeness
+// drives reviewed).
+func SetOverride(ctx context.Context, db bun.IDB, fileID int, override *string, criteria Criteria) error {
+	if override != nil && *override != models.ReviewOverrideReviewed && *override != models.ReviewOverrideUnreviewed {
+		return errors.Errorf("invalid override value: %q", *override)
+	}
+	now := time.Now().UTC()
+	q := db.NewUpdate().Model((*models.File)(nil)).Where("id = ?", fileID)
+	if override == nil {
+		q = q.Set("review_override = NULL").Set("review_overridden_at = NULL")
+	} else {
+		q = q.Set("review_override = ?", *override).Set("review_overridden_at = ?", now)
+	}
+	if _, err := q.Exec(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+	return RecomputeForFile(ctx, db, fileID, criteria)
+}
+
+// computeReviewedValue returns the effective reviewed value for a (book, main-file)
+// pair given the override and completeness. Returns nil for supplements (caller
+// is responsible for that branch).
+func computeReviewedValue(book *models.Book, file *models.File, criteria Criteria) *bool {
+	if file.ReviewOverride != nil {
+		switch *file.ReviewOverride {
+		case models.ReviewOverrideReviewed:
+			t := true
+			return &t
+		case models.ReviewOverrideUnreviewed:
+			f := false
+			return &f
+		}
+	}
+	v := IsComplete(book, file, criteria)
+	return &v
+}

--- a/pkg/books/review/recompute_test.go
+++ b/pkg/books/review/recompute_test.go
@@ -1,0 +1,147 @@
+package review
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecomputeForFile_Incomplete_SetsFalse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := newTestDB(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T", TitleSource: "filepath", Filepath: "/tmp", SortTitle: "T", SortTitleSource: "filepath", AuthorSource: "filepath"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		Filepath:      "/tmp/x.epub",
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, RecomputeForFile(ctx, db, file.ID, Default()))
+
+	var got bool
+	err = db.NewSelect().Table("files").Column("reviewed").Where("id = ?", file.ID).Scan(ctx, &got)
+	require.NoError(t, err)
+	require.False(t, got)
+}
+
+func TestRecomputeForFile_OverrideReviewed_ShortCircuits(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := newTestDB(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T", TitleSource: "filepath", Filepath: "/tmp", SortTitle: "T", SortTitleSource: "filepath", AuthorSource: "filepath"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	override := models.ReviewOverrideReviewed
+	file := &models.File{
+		LibraryID:      library.ID,
+		BookID:         book.ID,
+		Filepath:       "/tmp/x.epub",
+		FileType:       models.FileTypeEPUB,
+		FileRole:       models.FileRoleMain,
+		FilesizeBytes:  1,
+		ReviewOverride: &override,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// File has no metadata, but override should win
+	require.NoError(t, RecomputeForFile(ctx, db, file.ID, Default()))
+
+	var got bool
+	err = db.NewSelect().Table("files").Column("reviewed").Where("id = ?", file.ID).Scan(ctx, &got)
+	require.NoError(t, err)
+	require.True(t, got)
+}
+
+func TestRecomputeForFile_Supplement_SetsNull(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := newTestDB(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T", TitleSource: "filepath", Filepath: "/tmp", SortTitle: "T", SortTitleSource: "filepath", AuthorSource: "filepath"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		Filepath:      "/tmp/x.pdf",
+		FileType:      models.FileTypePDF,
+		FileRole:      models.FileRoleSupplement,
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, RecomputeForFile(ctx, db, file.ID, Default()))
+
+	var got *bool
+	err = db.NewSelect().Table("files").Column("reviewed").Where("id = ?", file.ID).Scan(ctx, &got)
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+func TestSetOverride_RoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := newTestDB(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{LibraryID: library.ID, Title: "T", TitleSource: "filepath", Filepath: "/tmp", SortTitle: "T", SortTitleSource: "filepath", AuthorSource: "filepath"}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		Filepath:      "/tmp/x.epub",
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	v := models.ReviewOverrideReviewed
+	require.NoError(t, SetOverride(ctx, db, file.ID, &v, Default()))
+
+	var got models.File
+	err = db.NewSelect().Model(&got).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, got.ReviewOverride)
+	require.Equal(t, "reviewed", *got.ReviewOverride)
+	require.NotNil(t, got.ReviewOverriddenAt)
+	require.NotNil(t, got.Reviewed)
+	require.True(t, *got.Reviewed)
+
+	// Clear
+	require.NoError(t, SetOverride(ctx, db, file.ID, nil, Default()))
+	got = models.File{}
+	err = db.NewSelect().Model(&got).Where("id = ?", file.ID).Scan(ctx)
+	require.NoError(t, err)
+	require.Nil(t, got.ReviewOverride)
+	require.Nil(t, got.ReviewOverriddenAt)
+	// Now driven by completeness — incomplete book → false
+	require.False(t, *got.Reviewed)
+}

--- a/pkg/books/routes.go
+++ b/pkg/books/routes.go
@@ -33,7 +33,7 @@ func RegisterLibraryRoutes(g *echo.Group, db *bun.DB, authMiddleware *auth.Middl
 
 // RegisterRoutesWithGroup registers book routes on a pre-configured group.
 func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, scanner Scanner, pm *plugins.Manager, dlCache *downloadcache.Cache, appSettingsSvc *appsettings.Service) {
-	bookService := NewService(db)
+	bookService := NewService(db).WithAppSettings(appSettingsSvc)
 	libraryService := libraries.NewService(db)
 	personService := people.NewService(db)
 	searchService := search.NewService(db)

--- a/pkg/books/routes.go
+++ b/pkg/books/routes.go
@@ -100,4 +100,6 @@ func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, auth
 	g.POST("/files/:id/resync", h.resyncFile, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
 	g.PATCH("/files/:id/review", h.setFileReview, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
 	g.DELETE("/files/:id", h.deleteFile, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
+	g.PATCH("/:id/review", h.setBookReview, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
+	g.POST("/bulk/review", h.bulkSetReview, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
 }

--- a/pkg/books/routes.go
+++ b/pkg/books/routes.go
@@ -2,6 +2,7 @@ package books
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/cbzpages"
 	"github.com/shishobooks/shisho/pkg/config"
@@ -31,7 +32,7 @@ func RegisterLibraryRoutes(g *echo.Group, db *bun.DB, authMiddleware *auth.Middl
 }
 
 // RegisterRoutesWithGroup registers book routes on a pre-configured group.
-func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, scanner Scanner, pm *plugins.Manager, dlCache *downloadcache.Cache) {
+func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, authMiddleware *auth.Middleware, scanner Scanner, pm *plugins.Manager, dlCache *downloadcache.Cache, appSettingsSvc *appsettings.Service) {
 	bookService := NewService(db)
 	libraryService := libraries.NewService(db)
 	personService := people.NewService(db)
@@ -46,21 +47,22 @@ func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, auth
 	pdfPageCache := pdfpages.NewCache(cfg.CacheDir, cfg.PDFRenderDPI, cfg.PDFRenderQuality)
 
 	h := &handler{
-		config:           cfg,
-		bookService:      bookService,
-		libraryService:   libraryService,
-		personService:    personService,
-		searchService:    searchService,
-		genreService:     genreService,
-		tagService:       tagService,
-		publisherService: publisherService,
-		imprintService:   imprintService,
-		listsService:     listsService,
-		settingsService:  settingsService,
-		downloadCache:    dlCache,
-		pageCache:        pageCache,
-		pdfPageCache:     pdfPageCache,
-		scanner:          scanner,
+		config:             cfg,
+		bookService:        bookService,
+		libraryService:     libraryService,
+		personService:      personService,
+		searchService:      searchService,
+		genreService:       genreService,
+		tagService:         tagService,
+		publisherService:   publisherService,
+		imprintService:     imprintService,
+		listsService:       listsService,
+		settingsService:    settingsService,
+		appSettingsService: appSettingsSvc,
+		downloadCache:      dlCache,
+		pageCache:          pageCache,
+		pdfPageCache:       pdfPageCache,
+		scanner:            scanner,
 	}
 	// Only set pluginManager if it's not nil to avoid interface holding nil pointer
 	if pm != nil {
@@ -96,5 +98,6 @@ func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, cfg *config.Config, auth
 	g.GET("/files/:id/page/:pageNum", h.getPage)
 	g.GET("/files/:id/stream", h.streamFile)
 	g.POST("/files/:id/resync", h.resyncFile, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
+	g.PATCH("/files/:id/review", h.setFileReview, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
 	g.DELETE("/files/:id", h.deleteFile, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
 }

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -30,18 +30,19 @@ type RetrieveBookOptions struct {
 }
 
 type ListBooksOptions struct {
-	Limit      *int
-	Offset     *int
-	LibraryID  *int
-	LibraryIDs []int // Filter by multiple library IDs (for access control)
-	SeriesID   *int
-	PersonID   *int     // Filter to books authored by this person (joins through authors)
-	FileTypes  []string // Filter by file types (e.g., ["epub", "cbz"])
-	GenreIDs   []int    // Filter by genre IDs
-	TagIDs     []int    // Filter by tag IDs
-	Language   *string  // Filter by language tag (matches exact tag and subtag variants, e.g. "en" matches "en-US")
-	IDs        []int    // Filter by specific book IDs
-	Search     *string  // Search query for title/author
+	Limit          *int
+	Offset         *int
+	LibraryID      *int
+	LibraryIDs     []int // Filter by multiple library IDs (for access control)
+	SeriesID       *int
+	PersonID       *int     // Filter to books authored by this person (joins through authors)
+	FileTypes      []string // Filter by file types (e.g., ["epub", "cbz"])
+	GenreIDs       []int    // Filter by genre IDs
+	TagIDs         []int    // Filter by tag IDs
+	Language       *string  // Filter by language tag (matches exact tag and subtag variants, e.g. "en" matches "en-US")
+	IDs            []int    // Filter by specific book IDs
+	Search         *string  // Search query for title/author
+	ReviewedFilter string   // "" (default = all), "needs_review", "reviewed"
 
 	// Sort overrides the default ordering. When nil and SeriesID is set,
 	// books are ordered by series_number ASC + sort_title ASC. When nil
@@ -452,6 +453,27 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 	// Filter by language (exact match + subtag variants, e.g., "en" matches "en-US", "en-GB")
 	if opts.Language != nil && *opts.Language != "" {
 		q = q.Where("b.id IN (SELECT DISTINCT book_id FROM files WHERE language = ? OR language LIKE ?)", *opts.Language, *opts.Language+"-%")
+	}
+
+	// Filter by reviewed state
+	switch opts.ReviewedFilter {
+	case "needs_review":
+		q = q.Where(`EXISTS (
+            SELECT 1 FROM files f_rev
+            WHERE f_rev.book_id = b.id
+              AND f_rev.file_role = 'main'
+              AND (f_rev.reviewed = FALSE OR f_rev.reviewed IS NULL)
+        )`)
+	case "reviewed":
+		q = q.Where(`NOT EXISTS (
+            SELECT 1 FROM files f_rev
+            WHERE f_rev.book_id = b.id
+              AND f_rev.file_role = 'main'
+              AND (f_rev.reviewed = FALSE OR f_rev.reviewed IS NULL)
+        )`).Where(`EXISTS (
+            SELECT 1 FROM files f_rev2
+            WHERE f_rev2.book_id = b.id AND f_rev2.file_role = 'main'
+        )`)
 	}
 
 	// Search using FTS5

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -92,6 +92,11 @@ func NewService(db *bun.DB) *Service {
 	return &Service{db: db}
 }
 
+// DB returns the underlying database connection. Used by review override APIs.
+func (svc *Service) DB() *bun.DB {
+	return svc.db
+}
+
 // WithAppSettings attaches an appsettings.Service so that mutation methods
 // automatically recompute files.reviewed after each successful write.
 func (svc *Service) WithAppSettings(s *appsettings.Service) *Service {

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/books/review"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/identifiers"
@@ -80,11 +82,58 @@ type UpdateFileOptions struct {
 }
 
 type Service struct {
-	db *bun.DB
+	db                 *bun.DB
+	appSettingsService *appsettings.Service
 }
 
+// NewService creates a book service without review-criteria support.
+// Pass the result to WithAppSettings to enable automatic reviewed recomputation.
 func NewService(db *bun.DB) *Service {
-	return &Service{db}
+	return &Service{db: db}
+}
+
+// WithAppSettings attaches an appsettings.Service so that mutation methods
+// automatically recompute files.reviewed after each successful write.
+func (svc *Service) WithAppSettings(s *appsettings.Service) *Service {
+	svc.appSettingsService = s
+	return svc
+}
+
+// RecomputeReviewedForFile loads the active criteria and refreshes
+// files.reviewed for the given file. Errors are logged but do not propagate
+// to the caller — review state is non-critical metadata.
+func (svc *Service) RecomputeReviewedForFile(ctx context.Context, fileID int) {
+	if svc.appSettingsService == nil {
+		return
+	}
+	criteria, err := review.Load(ctx, svc.appSettingsService)
+	if err != nil {
+		log := logger.FromContext(ctx)
+		log.Warn("review: load criteria failed", logger.Data{"err": err.Error()})
+		return
+	}
+	if err := review.RecomputeForFile(ctx, svc.db, fileID, criteria); err != nil {
+		log := logger.FromContext(ctx)
+		log.Warn("review: recompute for file failed", logger.Data{"err": err.Error(), "file_id": fileID})
+	}
+}
+
+// RecomputeReviewedForBook refreshes files.reviewed for every file of the book.
+// Errors are logged but do not propagate to the caller.
+func (svc *Service) RecomputeReviewedForBook(ctx context.Context, bookID int) {
+	if svc.appSettingsService == nil {
+		return
+	}
+	criteria, err := review.Load(ctx, svc.appSettingsService)
+	if err != nil {
+		log := logger.FromContext(ctx)
+		log.Warn("review: load criteria failed", logger.Data{"err": err.Error()})
+		return
+	}
+	if err := review.RecomputeForBook(ctx, svc.db, bookID, criteria); err != nil {
+		log := logger.FromContext(ctx)
+		log.Warn("review: recompute for book failed", logger.Data{"err": err.Error(), "book_id": bookID})
+	}
 }
 
 func (svc *Service) CreateBook(ctx context.Context, book *models.Book) error {
@@ -484,6 +533,11 @@ func (svc *Service) UpdateBook(ctx context.Context, book *models.Book, opts Upda
 		}
 	}
 
+	// Recompute reviewed state for all files in the book after any successful mutation.
+	if hasDBWork {
+		svc.RecomputeReviewedForBook(ctx, book.ID)
+	}
+
 	return nil
 }
 
@@ -528,13 +582,19 @@ func (svc *Service) CreateFile(ctx context.Context, file *models.File) error {
 
 	// Note: FileNarrators are created separately via CreateFileNarrator after person creation
 
+	svc.RecomputeReviewedForFile(ctx, file.ID)
+
 	return nil
 }
 
 // DeleteFileIdentifiers deletes all identifiers for a file.
 func (svc *Service) DeleteFileIdentifiers(ctx context.Context, fileID int) error {
 	_, err := svc.db.NewDelete().Model((*models.FileIdentifier)(nil)).Where("file_id = ?", fileID).Exec(ctx)
-	return errors.WithStack(err)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	svc.RecomputeReviewedForFile(ctx, fileID)
+	return nil
 }
 
 // escapeLikePattern escapes the SQLite LIKE wildcards (%, _) and the escape
@@ -695,6 +755,8 @@ func (svc *Service) UpdateFile(ctx context.Context, file *models.File, opts Upda
 		}
 		return errors.WithStack(err)
 	}
+
+	svc.RecomputeReviewedForFile(ctx, file.ID)
 
 	return nil
 }
@@ -1432,7 +1494,19 @@ func (svc *Service) BulkCreateFileIdentifiers(ctx context.Context, fileIdentifie
 		return nil
 	}
 	_, err := svc.db.NewInsert().Model(&deduped).Exec(ctx)
-	return errors.WithStack(err)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	// Recompute review state for every file whose identifiers changed.
+	seenFiles := make(map[int]struct{}, len(deduped))
+	for _, fi := range deduped {
+		if _, ok := seenFiles[fi.FileID]; ok {
+			continue
+		}
+		seenFiles[fi.FileID] = struct{}{}
+		svc.RecomputeReviewedForFile(ctx, fi.FileID)
+	}
+	return nil
 }
 
 // DeleteNarratorsForFile deletes all narrators for a file.

--- a/pkg/books/service_filter_test.go
+++ b/pkg/books/service_filter_test.go
@@ -2,6 +2,7 @@ package books
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -115,4 +116,68 @@ func TestListBooks_PersonIDFilter_ScopesToLibrary(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, got, 1, "LibraryID restricts to libA only")
 	assert.Equal(t, bookInA.ID, got[0].ID)
+}
+
+// TestListBooks_ReviewedFilter confirms that:
+//   - "needs_review" returns books where any main file has reviewed=FALSE or NULL
+//   - "reviewed" returns books where all main files have reviewed=TRUE
+//   - NULL is treated as "needs review" (migration gap state)
+func TestListBooks_ReviewedFilter(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	db := setupBooksTestDB(t)
+	svc := NewService(db)
+	lib := seedLibrary(t, db, "L")
+
+	bookCounter := 0
+	mkBook := func(reviewed *bool) int {
+		bookCounter++
+		book := seedBook(t, db, lib, "T"+strconv.Itoa(bookCounter), "T"+strconv.Itoa(bookCounter), time.Now())
+		f := &models.File{
+			LibraryID:     lib.ID,
+			BookID:        book.ID,
+			Filepath:      "/tmp/" + strconv.Itoa(book.ID),
+			FileType:      models.FileTypeEPUB,
+			FileRole:      models.FileRoleMain,
+			FilesizeBytes: 1,
+			Reviewed:      reviewed,
+		}
+		_, err := db.NewInsert().Model(f).Exec(ctx)
+		require.NoError(t, err)
+		return book.ID
+	}
+
+	tru := true
+	fal := false
+	_ = mkBook(&tru)          // reviewed=TRUE  → should NOT appear in needs_review
+	bookFalse := mkBook(&fal) // reviewed=FALSE → needs_review
+	bookNull := mkBook(nil)   // reviewed=NULL  → needs_review (migration gap)
+
+	// needs_review: FALSE + NULL should appear; TRUE should not
+	books, _, err := svc.ListBooksWithTotal(ctx, ListBooksOptions{
+		LibraryID:      &lib.ID,
+		ReviewedFilter: "needs_review",
+	})
+	require.NoError(t, err)
+	gotIDs := make([]int, 0, len(books))
+	for _, b := range books {
+		gotIDs = append(gotIDs, b.ID)
+	}
+	require.ElementsMatch(t, []int{bookFalse, bookNull}, gotIDs, "needs_review: FALSE and NULL books only")
+
+	// reviewed: only TRUE should appear
+	books, _, err = svc.ListBooksWithTotal(ctx, ListBooksOptions{
+		LibraryID:      &lib.ID,
+		ReviewedFilter: "reviewed",
+	})
+	require.NoError(t, err)
+	gotIDs = make([]int, 0, len(books))
+	for _, b := range books {
+		gotIDs = append(gotIDs, b.ID)
+	}
+	// Only the TRUE book should appear; FALSE and NULL are excluded
+	require.Len(t, gotIDs, 1, "reviewed: only the TRUE book")
+	assert.NotContains(t, gotIDs, bookFalse)
+	assert.NotContains(t, gotIDs, bookNull)
 }

--- a/pkg/books/validators.go
+++ b/pkg/books/validators.go
@@ -3,17 +3,18 @@ package books
 import "github.com/shishobooks/shisho/pkg/models"
 
 type ListBooksQuery struct {
-	Limit     int      `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
-	Offset    int      `query:"offset" json:"offset,omitempty" validate:"min=0"`
-	LibraryID *int     `query:"library_id" json:"library_id,omitempty" validate:"omitempty,min=1" tstype:"number"`
-	SeriesID  *int     `query:"series_id" json:"series_id,omitempty" validate:"omitempty,min=1" tstype:"number"`
-	Search    *string  `query:"search" json:"search,omitempty" validate:"omitempty,max=100" tstype:"string"`
-	FileTypes []string `query:"file_types" json:"file_types,omitempty"`                                         // Filter by file types (e.g., ["epub", "m4b"])
-	GenreIDs  []int    `query:"genre_ids" json:"genre_ids,omitempty"`                                           // Filter by genre IDs
-	TagIDs    []int    `query:"tag_ids" json:"tag_ids,omitempty"`                                               // Filter by tag IDs
-	Language  *string  `query:"language" json:"language,omitempty" validate:"omitempty,max=35" tstype:"string"` // Filter by language tag
-	IDs       []int    `query:"ids" json:"ids,omitempty"`                                                       // Filter by specific book IDs
-	Sort      string   `query:"sort" json:"sort,omitempty" validate:"omitempty,max=200"`
+	Limit          int      `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
+	Offset         int      `query:"offset" json:"offset,omitempty" validate:"min=0"`
+	LibraryID      *int     `query:"library_id" json:"library_id,omitempty" validate:"omitempty,min=1" tstype:"number"`
+	SeriesID       *int     `query:"series_id" json:"series_id,omitempty" validate:"omitempty,min=1" tstype:"number"`
+	Search         *string  `query:"search" json:"search,omitempty" validate:"omitempty,max=100" tstype:"string"`
+	FileTypes      []string `query:"file_types" json:"file_types,omitempty"`                                         // Filter by file types (e.g., ["epub", "m4b"])
+	GenreIDs       []int    `query:"genre_ids" json:"genre_ids,omitempty"`                                           // Filter by genre IDs
+	TagIDs         []int    `query:"tag_ids" json:"tag_ids,omitempty"`                                               // Filter by tag IDs
+	Language       *string  `query:"language" json:"language,omitempty" validate:"omitempty,max=35" tstype:"string"` // Filter by language tag
+	IDs            []int    `query:"ids" json:"ids,omitempty"`                                                       // Filter by specific book IDs
+	Sort           string   `query:"sort" json:"sort,omitempty" validate:"omitempty,max=200"`
+	ReviewedFilter string   `query:"reviewed_filter" json:"reviewed_filter,omitempty" validate:"omitempty,oneof=all needs_review reviewed"` // "" or "all" = all books, "needs_review", "reviewed"
 }
 
 type UpdateBookPayload struct {

--- a/pkg/chapters/handlers.go
+++ b/pkg/chapters/handlers.go
@@ -87,6 +87,9 @@ func (h *handler) replace(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	// Recompute reviewed state — chapters are a configurable audio_field
+	h.bookService.RecomputeReviewedForFile(ctx, fileID)
+
 	// Return updated chapters
 	updatedChapters, err := h.chapterService.ListChapters(ctx, fileID)
 	if err != nil {

--- a/pkg/chapters/handlers_test.go
+++ b/pkg/chapters/handlers_test.go
@@ -1,0 +1,150 @@
+package chapters
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func newTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func newTestEcho(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	return e
+}
+
+// TestReplaceChapters_TriggersReviewRecompute verifies that a successful PUT
+// chapters request calls RecomputeReviewedForFile so that files.reviewed is
+// refreshed when "chapters" is in the active audio_fields criteria.
+func TestReplaceChapters_TriggersReviewRecompute(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := newTestDB(t)
+
+	// Seed library, book, and an M4B file (chapters only apply to audio_fields)
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Audiobook",
+		Filepath:        t.TempDir(),
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Audiobook",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeM4B,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/test.m4b",
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Configure criteria: only "chapters" required so adding one chapter makes the file complete
+	appSettingsSvc := appsettings.NewService(db)
+	err = review.Save(ctx, appSettingsSvc, review.Criteria{
+		BookFields:  []string{},
+		AudioFields: []string{review.FieldChapters},
+	})
+	require.NoError(t, err)
+
+	// Build handler with appSettings wired so recompute is active
+	bookSvc := books.NewService(db).WithAppSettings(appSettingsSvc)
+	h := &handler{
+		chapterService: NewService(db),
+		bookService:    bookSvc,
+	}
+
+	// Build PUT request with one chapter
+	dur := int64(0)
+	payload := ReplaceChaptersPayload{
+		Chapters: []ChapterInput{
+			{Title: "Chapter 1", StartTimestampMs: &dur},
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e := newTestEcho(t)
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(file.ID))
+
+	// Inject a user with library access
+	user := &models.User{
+		Username:      "testuser",
+		PasswordHash:  "hash",
+		RoleID:        1,
+		IsActive:      true,
+		LibraryAccess: []*models.UserLibraryAccess{{UserID: 0, LibraryID: &library.ID}},
+	}
+	c.Set("user", user)
+
+	require.NoError(t, h.replace(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify reviewed was recomputed to true (chapters criterion is now satisfied)
+	var after models.File
+	require.NoError(t, db.NewSelect().Model(&after).Where("f.id = ?", file.ID).Scan(ctx))
+	require.NotNil(t, after.Reviewed, "reviewed should not be nil after recompute")
+	assert.True(t, *after.Reviewed, "file should be reviewed=true after chapters added with chapters-only criteria")
+}

--- a/pkg/chapters/routes.go
+++ b/pkg/chapters/routes.go
@@ -2,6 +2,7 @@ package chapters
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -9,9 +10,10 @@ import (
 )
 
 func RegisterRoutes(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware) {
+	appSettingsSvc := appsettings.NewService(db)
 	h := &handler{
 		chapterService: NewService(db),
-		bookService:    books.NewService(db),
+		bookService:    books.NewService(db).WithAppSettings(appSettingsSvc),
 	}
 
 	g.GET("/files/:id/chapters", h.list)

--- a/pkg/jobs/recompute_review_handler_test.go
+++ b/pkg/jobs/recompute_review_handler_test.go
@@ -1,0 +1,84 @@
+package jobs
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newValidator returns a validator instance that mirrors the one used by the
+// binder (same tag-name function so field names in errors use JSON names).
+func newValidator() *validator.Validate {
+	v := validator.New()
+	v.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+		if name == "-" {
+			return ""
+		}
+		return name
+	})
+	return v
+}
+
+// TestCreateJob_RecomputeReview verifies that the service layer accepts a
+// recompute_review job and persists it with the correct type and status.
+func TestCreateJob_RecomputeReview(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	svc := NewService(db)
+	ctx := context.Background()
+
+	job := &models.Job{
+		Type:       models.JobTypeRecomputeReview,
+		Status:     models.JobStatusPending,
+		DataParsed: &models.JobRecomputeReviewData{ClearOverrides: true},
+	}
+	err := svc.CreateJob(ctx, job)
+	require.NoError(t, err)
+	assert.Positive(t, job.ID)
+
+	// Retrieve and verify the persisted job.
+	retrieved, err := svc.RetrieveJob(ctx, RetrieveJobOptions{ID: &job.ID})
+	require.NoError(t, err)
+	assert.Equal(t, models.JobTypeRecomputeReview, retrieved.Type)
+	assert.Equal(t, models.JobStatusPending, retrieved.Status)
+	data, ok := retrieved.DataParsed.(*models.JobRecomputeReviewData)
+	require.True(t, ok, "expected DataParsed to be *models.JobRecomputeReviewData")
+	assert.True(t, data.ClearOverrides)
+}
+
+// TestCreateJobPayload_RecomputeReview_Valid verifies that the CreateJobPayload
+// validation (the oneof= tag on the Type field) accepts "recompute_review".
+func TestCreateJobPayload_RecomputeReview_Valid(t *testing.T) {
+	t.Parallel()
+	v := newValidator()
+
+	payload := CreateJobPayload{
+		Type: models.JobTypeRecomputeReview,
+		Data: &models.JobRecomputeReviewData{ClearOverrides: false},
+	}
+	err := v.Struct(payload)
+	assert.NoError(t, err, "recompute_review should be a valid job type in CreateJobPayload")
+}
+
+// TestListJobsQuery_RecomputeReview_Valid verifies that the ListJobsQuery
+// validation accepts "recompute_review" as a filter type.
+func TestListJobsQuery_RecomputeReview_Valid(t *testing.T) {
+	t.Parallel()
+	v := newValidator()
+
+	jobType := models.JobTypeRecomputeReview
+	query := ListJobsQuery{
+		Limit:  10,
+		Offset: 0,
+		Type:   &jobType,
+	}
+	err := v.Struct(query)
+	assert.NoError(t, err, "recompute_review should be a valid type in ListJobsQuery")
+}

--- a/pkg/jobs/service_test.go
+++ b/pkg/jobs/service_test.go
@@ -346,20 +346,23 @@ func TestListJobs_FilterByLibraryIDOrGlobal(t *testing.T) {
 	err = svc.CreateJob(ctx, lib2Job)
 	require.NoError(t, err)
 
-	// Filter for library 1 or global - should get global and lib1 jobs
+	// Filter for library 1 or global - should get global and lib1 jobs (but not lib2)
 	jobs, err := svc.ListJobs(ctx, ListJobsOptions{LibraryIDOrGlobal: &libraryID1})
 	require.NoError(t, err)
-	assert.Len(t, jobs, 2)
 
-	// Verify we got the right jobs
-	var foundGlobal, foundLib1 bool
+	// Verify we got the right jobs (use booleans rather than Len, since
+	// migrations may seed additional global jobs that also appear here).
+	var foundGlobal, foundLib1, foundLib2 bool
 	for _, j := range jobs {
 		if j.LibraryID == nil {
 			foundGlobal = true
 		} else if *j.LibraryID == libraryID1 {
 			foundLib1 = true
+		} else if *j.LibraryID == libraryID2 {
+			foundLib2 = true
 		}
 	}
 	assert.True(t, foundGlobal, "should include global job")
 	assert.True(t, foundLib1, "should include library 1 job")
+	assert.False(t, foundLib2, "should not include library 2 job")
 }

--- a/pkg/jobs/validators.go
+++ b/pkg/jobs/validators.go
@@ -1,8 +1,8 @@
 package jobs
 
 type CreateJobPayload struct {
-	Type      string      `json:"type" validate:"required,oneof=export scan bulk_download"`
-	Data      interface{} `json:"data" validate:"required" tstype:"JobExportData | JobScanData | JobBulkDownloadData"`
+	Type      string      `json:"type" validate:"required,oneof=export scan bulk_download recompute_review"`
+	Data      interface{} `json:"data" validate:"required" tstype:"JobExportData | JobScanData | JobBulkDownloadData | JobRecomputeReviewData"`
 	LibraryID *int        `json:"library_id,omitempty"`
 }
 
@@ -10,6 +10,6 @@ type ListJobsQuery struct {
 	Limit             int      `query:"limit" json:"limit,omitempty" default:"10" validate:"min=1,max=100"`
 	Offset            int      `query:"offset" json:"offset,omitempty" validate:"min=0"`
 	Status            []string `query:"status" json:"status,omitempty" validate:"dive,oneof=pending in_progress completed failed"`
-	Type              *string  `query:"type" json:"type,omitempty" validate:"omitempty,oneof=export scan bulk_download"`
+	Type              *string  `query:"type" json:"type,omitempty" validate:"omitempty,oneof=export scan bulk_download recompute_review"`
 	LibraryIDOrGlobal *int     `query:"library_id_or_global" json:"library_id_or_global,omitempty"`
 }

--- a/pkg/migrations/20260425100000_add_app_settings.go
+++ b/pkg/migrations/20260425100000_add_app_settings.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		_, err := db.ExecContext(ctx, `
+			CREATE TABLE app_settings (
+				key TEXT PRIMARY KEY NOT NULL,
+				value TEXT NOT NULL,
+				updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+			)
+		`)
+		return errors.WithStack(err)
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		_, err := db.ExecContext(ctx, `DROP TABLE app_settings`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/migrations/20260425100100_add_file_review_fields.go
+++ b/pkg/migrations/20260425100100_add_file_review_fields.go
@@ -1,0 +1,45 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		stmts := []string{
+			`ALTER TABLE files ADD COLUMN review_override TEXT
+				CHECK (review_override IS NULL OR review_override IN ('reviewed','unreviewed'))`,
+			`ALTER TABLE files ADD COLUMN review_overridden_at TIMESTAMP`,
+			`ALTER TABLE files ADD COLUMN reviewed BOOLEAN`,
+			`CREATE INDEX idx_files_book_reviewed
+				ON files(book_id, reviewed)
+				WHERE file_role = 'main'`,
+		}
+		for _, s := range stmts {
+			if _, err := db.ExecContext(ctx, s); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		stmts := []string{
+			`DROP INDEX IF EXISTS idx_files_book_reviewed`,
+			`ALTER TABLE files DROP COLUMN reviewed`,
+			`ALTER TABLE files DROP COLUMN review_overridden_at`,
+			`ALTER TABLE files DROP COLUMN review_override`,
+		}
+		for _, s := range stmts {
+			if _, err := db.ExecContext(ctx, s); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/migrations/20260425100200_seed_review_criteria_and_enqueue_recompute.go
+++ b/pkg/migrations/20260425100200_seed_review_criteria_and_enqueue_recompute.go
@@ -1,0 +1,59 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(ctx context.Context, db *bun.DB) error {
+		// Seed default review criteria.
+		defaultJSON, err := json.Marshal(map[string]interface{}{
+			"book_fields":  []string{"authors", "description", "cover", "genres"},
+			"audio_fields": []string{"narrators"},
+		})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO app_settings (key, value, updated_at)
+			VALUES ('review_criteria', ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(key) DO NOTHING
+		`, string(defaultJSON)); err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Enqueue a recompute job so the worker fills in files.reviewed
+		// asynchronously after migrations finish. Until then, files.reviewed
+		// is NULL and the books/list query treats NULL as needs-review.
+		jobData, err := json.Marshal(map[string]interface{}{"clear_overrides": false})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.ExecContext(ctx, `
+			INSERT INTO jobs (type, status, data, progress, created_at, updated_at)
+			VALUES ('recompute_review', 'pending', ?, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+		`, string(jobData)); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
+	}
+
+	down := func(ctx context.Context, db *bun.DB) error {
+		stmts := []string{
+			`DELETE FROM jobs WHERE type = 'recompute_review'`,
+			`DELETE FROM app_settings WHERE key = 'review_criteria'`,
+		}
+		for _, s := range stmts {
+			if _, err := db.ExecContext(ctx, s); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		return nil
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/app-setting.go
+++ b/pkg/models/app-setting.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type AppSetting struct {
+	bun.BaseModel `bun:"table:app_settings,alias:as" tstype:"-"`
+
+	Key       string    `bun:",pk,nullzero" json:"key"`
+	Value     string    `bun:",notnull" json:"value"`
+	UpdatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"updated_at"`
+}

--- a/pkg/models/file.go
+++ b/pkg/models/file.go
@@ -20,6 +20,12 @@ const (
 	FileRoleSupplement = "supplement"
 )
 
+const (
+	//tygo:emit export type ReviewOverride = typeof ReviewOverrideReviewed | typeof ReviewOverrideUnreviewed;
+	ReviewOverrideReviewed   = "reviewed"
+	ReviewOverrideUnreviewed = "unreviewed"
+)
+
 type File struct {
 	bun.BaseModel `bun:"table:files,alias:f" tstype:"-"`
 
@@ -64,6 +70,9 @@ type File struct {
 	LanguageSource           *string           `json:"language_source" tstype:"DataSource"`
 	Abridged                 *bool             `json:"abridged"`
 	AbridgedSource           *string           `json:"abridged_source" tstype:"DataSource"`
+	ReviewOverride           *string           `json:"review_override" tstype:"ReviewOverride"`
+	ReviewOverriddenAt       *time.Time        `json:"review_overridden_at"`
+	Reviewed                 *bool             `json:"reviewed"`
 }
 
 func (f *File) CoverExtension() string {

--- a/pkg/models/job.go
+++ b/pkg/models/job.go
@@ -17,11 +17,12 @@ const (
 )
 
 const (
-	//tygo:emit export type JobType = typeof JobTypeExport | typeof JobTypeScan | typeof JobTypeBulkDownload | typeof JobTypeHashGeneration;
-	JobTypeExport         = "export"
-	JobTypeScan           = "scan"
-	JobTypeBulkDownload   = "bulk_download"
-	JobTypeHashGeneration = "hash_generation"
+	//tygo:emit export type JobType = typeof JobTypeExport | typeof JobTypeScan | typeof JobTypeBulkDownload | typeof JobTypeHashGeneration | typeof JobTypeRecomputeReview;
+	JobTypeExport          = "export"
+	JobTypeScan            = "scan"
+	JobTypeBulkDownload    = "bulk_download"
+	JobTypeHashGeneration  = "hash_generation"
+	JobTypeRecomputeReview = "recompute_review"
 )
 
 type Job struct {
@@ -33,7 +34,7 @@ type Job struct {
 	Type       string      `bun:",nullzero" json:"type" tstype:"JobType"`
 	Status     string      `bun:",nullzero" json:"status" tstype:"JobStatus"`
 	Data       string      `bun:",nullzero" json:"-"`
-	DataParsed interface{} `bun:"-" json:"data" tstype:"JobExportData | JobScanData | JobBulkDownloadData | JobHashGenerationData"`
+	DataParsed interface{} `bun:"-" json:"data" tstype:"JobExportData | JobScanData | JobBulkDownloadData | JobHashGenerationData | JobRecomputeReviewData"`
 	Progress   int         `json:"progress"`
 	ProcessID  *string     `json:"process_id,omitempty"`
 	LibraryID  *int        `json:"library_id,omitempty"`
@@ -49,6 +50,8 @@ func (job *Job) UnmarshalData() error {
 		job.DataParsed = &JobBulkDownloadData{}
 	case JobTypeHashGeneration:
 		job.DataParsed = &JobHashGenerationData{}
+	case JobTypeRecomputeReview:
+		job.DataParsed = &JobRecomputeReviewData{}
 	}
 
 	err := json.Unmarshal([]byte(job.Data), job.DataParsed)
@@ -68,6 +71,12 @@ type JobScanData struct{}
 // a sha256 fingerprint in file_fingerprints.
 type JobHashGenerationData struct {
 	LibraryID int `json:"library_id"`
+}
+
+type JobRecomputeReviewData struct {
+	// ClearOverrides, when true, sets review_override and review_overridden_at to NULL
+	// for every main file before recomputing reviewed.
+	ClearOverrides bool `json:"clear_overrides"`
 }
 
 type JobBulkDownloadData struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/robinjoseph08/golib/echo/v4/middleware/logger"
 	"github.com/robinjoseph08/golib/echo/v4/middleware/recovery"
 	"github.com/shishobooks/shisho/pkg/apikeys"
+	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/audnexus"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/binder"
@@ -217,7 +218,8 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 
 	// Plugin identify routes (editors can search/apply metadata)
 	pluginService := plugins.NewService(db)
-	bookSvc := books.NewService(db)
+	appSettingsSvc := appsettings.NewService(db)
+	bookSvc := books.NewService(db).WithAppSettings(appSettingsSvc)
 	bookAdapter := &bookUpdaterAdapter{svc: bookSvc}
 	pageExtractor := books.NewPluginPageExtractor(cbzCache, pdfCache)
 	enrichDeps := &plugins.EnrichDeps{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -148,7 +148,7 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 	booksGroup := e.Group("/books")
 	booksGroup.Use(authMiddleware.Authenticate)
 	booksGroup.Use(authMiddleware.RequirePermission(models.ResourceBooks, models.OperationRead))
-	books.RegisterRoutesWithGroup(booksGroup, db, cfg, authMiddleware, w, pm, dlCache)
+	books.RegisterRoutesWithGroup(booksGroup, db, cfg, authMiddleware, w, pm, dlCache, appsettings.NewService(db))
 	chapters.RegisterRoutes(booksGroup, db, authMiddleware)
 
 	// Libraries routes

--- a/pkg/settings/review_criteria_handlers.go
+++ b/pkg/settings/review_criteria_handlers.go
@@ -1,0 +1,103 @@
+package settings
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/uptrace/bun"
+)
+
+// reviewCriteriaHandler handles the review-criteria settings endpoints.
+type reviewCriteriaHandler struct {
+	db                 *bun.DB
+	appSettingsService *appsettings.Service
+}
+
+type reviewCriteriaResponse struct {
+	BookFields          []string `json:"book_fields"`
+	AudioFields         []string `json:"audio_fields"`
+	UniversalCandidates []string `json:"universal_candidates"`
+	AudioCandidates     []string `json:"audio_candidates"`
+	OverrideCount       int      `json:"override_count"`
+	MainFileCount       int      `json:"main_file_count"`
+}
+
+type putReviewCriteriaPayload struct {
+	BookFields     []string `json:"book_fields" validate:"required"`
+	AudioFields    []string `json:"audio_fields" validate:"required"`
+	ClearOverrides bool     `json:"clear_overrides"`
+}
+
+func (h *reviewCriteriaHandler) getReviewCriteria(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	criteria, err := review.Load(ctx, h.appSettingsService)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	resp := reviewCriteriaResponse{
+		BookFields:          criteria.BookFields,
+		AudioFields:         criteria.AudioFields,
+		UniversalCandidates: review.UniversalCandidates,
+		AudioCandidates:     review.AudioCandidates,
+	}
+
+	if err := h.db.NewSelect().
+		TableExpr("files").
+		ColumnExpr("count(*)").
+		Where("file_role = 'main' AND review_override IS NOT NULL").
+		Scan(ctx, &resp.OverrideCount); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err := h.db.NewSelect().
+		TableExpr("files").
+		ColumnExpr("count(*)").
+		Where("file_role = 'main'").
+		Scan(ctx, &resp.MainFileCount); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (h *reviewCriteriaHandler) putReviewCriteria(c echo.Context) error {
+	var payload putReviewCriteriaPayload
+	if err := c.Bind(&payload); err != nil {
+		return errors.WithStack(err)
+	}
+
+	criteria := review.Criteria{BookFields: payload.BookFields, AudioFields: payload.AudioFields}
+	if err := review.Validate(criteria); err != nil {
+		return errcodes.BadRequest(err.Error())
+	}
+
+	ctx := c.Request().Context()
+
+	if err := review.Save(ctx, h.appSettingsService, criteria); err != nil {
+		return errors.WithStack(err)
+	}
+
+	jobData, err := json.Marshal(models.JobRecomputeReviewData{ClearOverrides: payload.ClearOverrides})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	job := &models.Job{
+		Type:   models.JobTypeRecomputeReview,
+		Status: models.JobStatusPending,
+		Data:   string(jobData),
+	}
+	if _, err := h.db.NewInsert().Model(job).Exec(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return c.NoContent(http.StatusOK)
+}

--- a/pkg/settings/review_criteria_handlers_test.go
+++ b/pkg/settings/review_criteria_handlers_test.go
@@ -1,0 +1,126 @@
+package settings
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func buildReviewCriteriaGetRequest(t *testing.T, e *echo.Echo) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/settings/review-criteria", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	return c, rec
+}
+
+func buildReviewCriteriaPutRequest(t *testing.T, e *echo.Echo, body string) (echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/settings/review-criteria", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	return c, rec
+}
+
+func newReviewCriteriaHandler(t *testing.T, db *bun.DB) *reviewCriteriaHandler {
+	t.Helper()
+	return &reviewCriteriaHandler{
+		db:                 db,
+		appSettingsService: appsettings.NewService(db),
+	}
+}
+
+func TestGetReviewCriteria_ReturnsDefault(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	h := newReviewCriteriaHandler(t, db)
+
+	e := newTestEcho(t)
+	c, rec := buildReviewCriteriaGetRequest(t, e)
+
+	require.NoError(t, h.getReviewCriteria(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var body reviewCriteriaResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	// Default criteria seeded by review.Default()
+	defaults := review.Default()
+	assert.Equal(t, defaults.BookFields, body.BookFields)
+	assert.Equal(t, defaults.AudioFields, body.AudioFields)
+
+	// Candidate slices are always present
+	assert.Equal(t, review.UniversalCandidates, body.UniversalCandidates)
+	assert.Equal(t, review.AudioCandidates, body.AudioCandidates)
+
+	// No files in the test DB yet
+	assert.Equal(t, 0, body.OverrideCount)
+	assert.Equal(t, 0, body.MainFileCount)
+}
+
+func TestPutReviewCriteria_PersistsAndEnqueuesJob(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	h := newReviewCriteriaHandler(t, db)
+
+	body := `{"book_fields":["authors","cover"],"audio_fields":["narrators"],"clear_overrides":true}`
+
+	e := newTestEcho(t)
+	c, rec := buildReviewCriteriaPutRequest(t, e, body)
+
+	require.NoError(t, h.putReviewCriteria(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify criteria persisted in app_settings
+	criteria, err := review.Load(context.Background(), appsettings.NewService(db))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"authors", "cover"}, criteria.BookFields)
+	assert.Equal(t, []string{"narrators"}, criteria.AudioFields)
+
+	// Verify a recompute_review job was inserted
+	var job models.Job
+	err = db.NewSelect().
+		Model(&job).
+		Where("type = ?", models.JobTypeRecomputeReview).
+		OrderExpr("id DESC").
+		Limit(1).
+		Scan(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, models.JobStatusPending, job.Status)
+
+	require.NoError(t, job.UnmarshalData())
+	data, ok := job.DataParsed.(*models.JobRecomputeReviewData)
+	require.True(t, ok)
+	assert.True(t, data.ClearOverrides)
+}
+
+func TestPutReviewCriteria_RejectsInvalidField(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	h := newReviewCriteriaHandler(t, db)
+
+	// "narrators" is an audio-only field, not valid in book_fields
+	body := `{"book_fields":["narrators"],"audio_fields":[]}`
+
+	e := newTestEcho(t)
+	c, _ := buildReviewCriteriaPutRequest(t, e, body)
+
+	err := h.putReviewCriteria(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+}

--- a/pkg/settings/routes.go
+++ b/pkg/settings/routes.go
@@ -27,6 +27,9 @@ func RegisterRoutes(e *echo.Echo, db *bun.DB, authMiddleware *auth.Middleware) {
 	g.GET("/libraries/:library_id", libraryH.getLibrarySettings)
 	g.PUT("/libraries/:library_id", libraryH.updateLibrarySettings)
 
-	g.GET("/review-criteria", reviewCriteriaH.getReviewCriteria, authMiddleware.RequirePermission(models.ResourceConfig, models.OperationRead))
+	// GET is books:read so the ReviewPanel can render the missing-fields hint
+	// for any user who can view books (editors and viewers, not just admins).
+	// PUT remains admin-only via config:write.
+	g.GET("/review-criteria", reviewCriteriaH.getReviewCriteria, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationRead))
 	g.PUT("/review-criteria", reviewCriteriaH.putReviewCriteria, authMiddleware.RequirePermission(models.ResourceConfig, models.OperationWrite))
 }

--- a/pkg/settings/routes.go
+++ b/pkg/settings/routes.go
@@ -2,7 +2,9 @@ package settings
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
 )
 
@@ -11,6 +13,10 @@ func RegisterRoutes(e *echo.Echo, db *bun.DB, authMiddleware *auth.Middleware) {
 
 	userH := &handler{settingsService: svc}
 	libraryH := &libraryHandler{settingsService: svc}
+	reviewCriteriaH := &reviewCriteriaHandler{
+		db:                 db,
+		appSettingsService: appsettings.NewService(db),
+	}
 
 	g := e.Group("/settings")
 	g.Use(authMiddleware.Authenticate)
@@ -20,4 +26,7 @@ func RegisterRoutes(e *echo.Echo, db *bun.DB, authMiddleware *auth.Middleware) {
 
 	g.GET("/libraries/:library_id", libraryH.getLibrarySettings)
 	g.PUT("/libraries/:library_id", libraryH.updateLibrarySettings)
+
+	g.GET("/review-criteria", reviewCriteriaH.getReviewCriteria, authMiddleware.RequirePermission(models.ResourceConfig, models.OperationRead))
+	g.PUT("/review-criteria", reviewCriteriaH.putReviewCriteria, authMiddleware.RequirePermission(models.ResourceConfig, models.OperationWrite))
 }

--- a/pkg/worker/recompute_review.go
+++ b/pkg/worker/recompute_review.go
@@ -26,6 +26,12 @@ func (w *Worker) ProcessRecomputeReviewJob(ctx context.Context, job *models.Job,
 			return errors.WithStack(err)
 		}
 	}
+	// Bail out cleanly between stages if shutdown was requested. Each bulk
+	// statement above already respects ctx via Exec(ctx); these checks just
+	// avoid starting the next stage when cancellation is already in flight.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
 	// Reset reviewed for supplements in a single statement; supplements never
 	// participate in the per-file iteration below.
@@ -35,6 +41,9 @@ func (w *Worker) ProcessRecomputeReviewJob(ctx context.Context, job *models.Job,
 		Where("file_role = ?", models.FileRoleSupplement).
 		Exec(ctx); err != nil {
 		return errors.WithStack(err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	criteria, err := review.Load(ctx, w.appSettingsService)
@@ -51,6 +60,9 @@ func (w *Worker) ProcessRecomputeReviewJob(ctx context.Context, job *models.Job,
 		Order("id ASC").
 		Scan(ctx, &fileIDs); err != nil {
 		return errors.WithStack(err)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	total := len(fileIDs)

--- a/pkg/worker/recompute_review.go
+++ b/pkg/worker/recompute_review.go
@@ -1,0 +1,64 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/segmentio/encoding/json"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/joblogs"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+func (w *Worker) ProcessRecomputeReviewJob(ctx context.Context, job *models.Job, _ *joblogs.JobLogger) error {
+	var data models.JobRecomputeReviewData
+	if err := json.Unmarshal([]byte(job.Data), &data); err != nil {
+		return errors.WithStack(err)
+	}
+
+	if data.ClearOverrides {
+		if _, err := w.db.NewUpdate().
+			Model((*models.File)(nil)).
+			Set("review_override = NULL").
+			Set("review_overridden_at = NULL").
+			Where("file_role = ?", models.FileRoleMain).
+			Exec(ctx); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	criteria, err := review.Load(ctx, w.appSettingsService)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	var fileIDs []int
+	if err := w.db.NewSelect().
+		Model((*models.File)(nil)).
+		Column("id").
+		Order("id ASC").
+		Scan(ctx, &fileIDs); err != nil {
+		return errors.WithStack(err)
+	}
+
+	total := len(fileIDs)
+	for i, id := range fileIDs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := review.RecomputeForFile(ctx, w.db, id, criteria); err != nil {
+			return errors.WithStack(err)
+		}
+		if total > 0 {
+			pct := int(float64(i+1) / float64(total) * 100)
+			if _, err := w.db.NewUpdate().
+				Model((*models.Job)(nil)).
+				Set("progress = ?", pct).
+				Where("id = ?", job.ID).
+				Exec(ctx); err != nil {
+				return errors.WithStack(err)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/worker/recompute_review.go
+++ b/pkg/worker/recompute_review.go
@@ -27,15 +27,27 @@ func (w *Worker) ProcessRecomputeReviewJob(ctx context.Context, job *models.Job,
 		}
 	}
 
+	// Reset reviewed for supplements in a single statement; supplements never
+	// participate in the per-file iteration below.
+	if _, err := w.db.NewUpdate().
+		Model((*models.File)(nil)).
+		Set("reviewed = NULL").
+		Where("file_role = ?", models.FileRoleSupplement).
+		Exec(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+
 	criteria, err := review.Load(ctx, w.appSettingsService)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
+	// Iterate only main files. Order by id for stable progress %.
 	var fileIDs []int
 	if err := w.db.NewSelect().
 		Model((*models.File)(nil)).
 		Column("id").
+		Where("file_role = ?", models.FileRoleMain).
 		Order("id ASC").
 		Scan(ctx, &fileIDs); err != nil {
 		return errors.WithStack(err)

--- a/pkg/worker/recompute_review_test.go
+++ b/pkg/worker/recompute_review_test.go
@@ -1,0 +1,119 @@
+package worker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessRecomputeReviewJob_PopulatesReviewed(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tc := newTestContext(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := tc.db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "T",
+		TitleSource:     "filepath",
+		SortTitle:       "T",
+		SortTitleSource: "filepath",
+		AuthorSource:    "filepath",
+		Filepath:        "/tmp",
+	}
+	_, err = tc.db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	main := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		Filepath:      "/tmp/m.epub",
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		FilesizeBytes: 1,
+	}
+	_, err = tc.db.NewInsert().Model(main).Exec(ctx)
+	require.NoError(t, err)
+	supp := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		Filepath:      "/tmp/s.pdf",
+		FileType:      models.FileTypePDF,
+		FileRole:      models.FileRoleSupplement,
+		FilesizeBytes: 1,
+	}
+	_, err = tc.db.NewInsert().Model(supp).Exec(ctx)
+	require.NoError(t, err)
+
+	job := &models.Job{
+		Type:   models.JobTypeRecomputeReview,
+		Status: models.JobStatusPending,
+		Data:   `{"clear_overrides":false}`,
+	}
+	_, err = tc.db.NewInsert().Model(job).Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, tc.worker.ProcessRecomputeReviewJob(ctx, job, nil))
+
+	var mainReviewed *bool
+	require.NoError(t, tc.db.NewSelect().Table("files").Column("reviewed").Where("id = ?", main.ID).Scan(ctx, &mainReviewed))
+	require.NotNil(t, mainReviewed)
+	require.False(t, *mainReviewed)
+
+	var suppReviewed *bool
+	require.NoError(t, tc.db.NewSelect().Table("files").Column("reviewed").Where("id = ?", supp.ID).Scan(ctx, &suppReviewed))
+	require.Nil(t, suppReviewed)
+}
+
+func TestProcessRecomputeReviewJob_ClearOverrides(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tc := newTestContext(t)
+
+	library := &models.Library{Name: "L", CoverAspectRatio: "book"}
+	_, err := tc.db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "T",
+		TitleSource:     "filepath",
+		SortTitle:       "T",
+		SortTitleSource: "filepath",
+		AuthorSource:    "filepath",
+		Filepath:        "/tmp",
+	}
+	_, err = tc.db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+	override := models.ReviewOverrideReviewed
+	file := &models.File{
+		LibraryID:      library.ID,
+		BookID:         book.ID,
+		Filepath:       "/tmp/x.epub",
+		FileType:       models.FileTypeEPUB,
+		FileRole:       models.FileRoleMain,
+		FilesizeBytes:  1,
+		ReviewOverride: &override,
+	}
+	_, err = tc.db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	job := &models.Job{
+		Type:   models.JobTypeRecomputeReview,
+		Status: models.JobStatusPending,
+		Data:   `{"clear_overrides":true}`,
+	}
+	_, err = tc.db.NewInsert().Model(job).Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, tc.worker.ProcessRecomputeReviewJob(ctx, job, nil))
+
+	var got models.File
+	require.NoError(t, tc.db.NewSelect().Model(&got).Where("f.id = ?", file.ID).Scan(ctx))
+	require.Nil(t, got.ReviewOverride)
+	require.Nil(t, got.ReviewOverriddenAt)
+	require.NotNil(t, got.Reviewed)
+	require.False(t, *got.Reviewed)
+}

--- a/pkg/worker/scan_enricher_test.go
+++ b/pkg/worker/scan_enricher_test.go
@@ -1,11 +1,16 @@
 package worker
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/shishobooks/shisho/pkg/books/review"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/plugins"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -682,4 +687,183 @@ func TestCoverPageProtection_NoCoverPage_EnricherCoverPreserved(t *testing.T) {
 	assert.Equal(t, "image/png", enrichedMeta.CoverMimeType)
 	assert.Nil(t, enrichedMeta.CoverPage)
 	assert.Equal(t, enricherSource, enrichedMeta.FieldDataSources["cover"])
+}
+
+// TestScanEnricher_FullEnrichment_SetsReviewedTrue verifies that when an
+// enricher provides all fields required by the review criteria, the file's
+// reviewed column is set to TRUE after the scan.
+func TestScanEnricher_FullEnrichment_SetsReviewedTrue(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := t.TempDir()
+	tc := newTestContextWithPlugins(t, pluginDir)
+
+	// Set review criteria to require only authors and description (no cover/genres
+	// so we don't need real image files on disk).
+	appSvc := tc.worker.appSettingsService
+	require.NoError(t, review.Save(tc.ctx, appSvc, review.Criteria{
+		BookFields:  []string{review.FieldAuthors, review.FieldDescription},
+		AudioFields: []string{},
+	}))
+
+	// Install a file parser for ".revtest" files so the scanner recognises them.
+	parserManifest := `{
+  "manifestVersion": 1,
+  "id": "revtest-parser",
+  "name": "RevTest Parser",
+  "version": "1.0.0",
+  "capabilities": {
+    "fileParser": {
+      "description": "Parses revtest files",
+      "types": ["revtest"]
+    }
+  }
+}`
+	parserJS := `var plugin = (function() {
+  return {
+    fileParser: {
+      parse: function(ctx) {
+        return { title: "Rev Book" };
+      }
+    }
+  };
+})();`
+	installTestPlugin(t, tc, pluginDir, "revtest-parser", parserManifest, parserJS)
+
+	// Install an enricher that returns BOTH required fields (authors + description).
+	enricherManifest := `{
+  "manifestVersion": 1,
+  "id": "full-enricher",
+  "name": "Full Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "description": "Provides authors and description",
+      "fileTypes": ["revtest"],
+      "fields": ["authors", "description"]
+    }
+  }
+}`
+	enricherJS := `var plugin = (function() {
+  return {
+    metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{
+          authors: [{ name: "Enriched Author", role: "" }],
+          description: "Enriched description"
+        }] };
+      }
+    }
+  };
+})();`
+	installTestPlugin(t, tc, pluginDir, "full-enricher", enricherManifest, enricherJS)
+
+	pluginService := plugins.NewService(tc.db)
+	require.NoError(t, pluginService.AppendToOrder(context.Background(), models.PluginHookMetadataEnricher, "test", "full-enricher"))
+	require.NoError(t, tc.worker.pluginManager.LoadAll(context.Background()))
+
+	libraryPath := t.TempDir()
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := filepath.Join(libraryPath, "Rev Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(bookDir, "book.revtest"), []byte("content"), 0644))
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+
+	var reviewed *bool
+	require.NoError(t, tc.db.NewSelect().Table("files").Column("reviewed").Where("id = ?", files[0].ID).Scan(tc.ctx, &reviewed))
+	require.NotNil(t, reviewed, "reviewed should not be NULL for a main file")
+	assert.True(t, *reviewed, "file with all required fields provided by enricher should be reviewed=TRUE")
+}
+
+// TestScanEnricher_PartialEnrichment_SetsReviewedFalse verifies that when an
+// enricher provides only some required fields (leaving others missing), the
+// file's reviewed column is set to FALSE after the scan.
+func TestScanEnricher_PartialEnrichment_SetsReviewedFalse(t *testing.T) {
+	t.Parallel()
+
+	pluginDir := t.TempDir()
+	tc := newTestContextWithPlugins(t, pluginDir)
+
+	// Require both authors and description; enricher will only supply authors.
+	appSvc := tc.worker.appSettingsService
+	require.NoError(t, review.Save(tc.ctx, appSvc, review.Criteria{
+		BookFields:  []string{review.FieldAuthors, review.FieldDescription},
+		AudioFields: []string{},
+	}))
+
+	parserManifest := `{
+  "manifestVersion": 1,
+  "id": "revtest2-parser",
+  "name": "RevTest2 Parser",
+  "version": "1.0.0",
+  "capabilities": {
+    "fileParser": {
+      "description": "Parses revtest2 files",
+      "types": ["revtest2"]
+    }
+  }
+}`
+	parserJS := `var plugin = (function() {
+  return {
+    fileParser: {
+      parse: function(ctx) {
+        return { title: "Partial Book" };
+      }
+    }
+  };
+})();`
+	installTestPlugin(t, tc, pluginDir, "revtest2-parser", parserManifest, parserJS)
+
+	// This enricher only returns authors — description is still missing.
+	enricherManifest := `{
+  "manifestVersion": 1,
+  "id": "partial-enricher",
+  "name": "Partial Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "description": "Provides authors only",
+      "fileTypes": ["revtest2"],
+      "fields": ["authors"]
+    }
+  }
+}`
+	enricherJS := `var plugin = (function() {
+  return {
+    metadataEnricher: {
+      search: function(ctx) {
+        return { results: [{
+          authors: [{ name: "Partial Author", role: "" }]
+        }] };
+      }
+    }
+  };
+})();`
+	installTestPlugin(t, tc, pluginDir, "partial-enricher", enricherManifest, enricherJS)
+
+	pluginService := plugins.NewService(tc.db)
+	require.NoError(t, pluginService.AppendToOrder(context.Background(), models.PluginHookMetadataEnricher, "test", "partial-enricher"))
+	require.NoError(t, tc.worker.pluginManager.LoadAll(context.Background()))
+
+	libraryPath := t.TempDir()
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := filepath.Join(libraryPath, "Partial Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(bookDir, "book.revtest2"), []byte("content"), 0644))
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+
+	var reviewed *bool
+	require.NoError(t, tc.db.NewSelect().Table("files").Column("reviewed").Where("id = ?", files[0].ID).Scan(tc.ctx, &reviewed))
+	require.NotNil(t, reviewed, "reviewed should not be NULL for a main file")
+	assert.False(t, *reviewed, "file missing required description field should be reviewed=FALSE")
 }

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2227,6 +2227,20 @@ func (w *Worker) scanFileCore(
 		}
 	}
 
+	// ==========================================================================
+	// Safety-net recompute of reviewed state
+	// ==========================================================================
+	//
+	// Relationship rows (narrators, authors, genres, tags, series, identifiers)
+	// are bulk-inserted via UpdateBookRelationships *after* the per-relationship
+	// source-column UpdateFile/UpdateBook calls that trigger recompute. Those
+	// earlier triggers fire while the old rows are still in place, so the final
+	// reviewed value can be stale. A single recompute here, after all mutations
+	// are complete, ensures the flag is accurate. Non-fatal: a missed recompute
+	// is self-healing (the recompute_review background job or the next file
+	// mutation will correct it).
+	w.bookService.RecomputeReviewedForFile(ctx, file.ID)
+
 	return &ScanResult{File: file, Book: book, FileCreated: false}, nil
 }
 

--- a/pkg/worker/scheduler_test.go
+++ b/pkg/worker/scheduler_test.go
@@ -21,10 +21,16 @@ func TestScheduler_SkipsWhenNoLibraries(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, hasActive)
 
-	// List jobs - should be empty
+	// List scan jobs - should be empty (migrations may seed non-scan jobs like recompute_review)
 	allJobs, err := tc.jobService.ListJobs(tc.ctx, jobs.ListJobsOptions{})
 	require.NoError(t, err)
-	assert.Empty(t, allJobs)
+	scanJobs := make([]*models.Job, 0)
+	for _, j := range allJobs {
+		if j.Type == models.JobTypeScan {
+			scanJobs = append(scanJobs, j)
+		}
+	}
+	assert.Empty(t, scanJobs)
 }
 
 func TestScheduler_SkipsWhenScanJobPending(t *testing.T) {

--- a/pkg/worker/testhelpers_test.go
+++ b/pkg/worker/testhelpers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/chapters"
 	"github.com/shishobooks/shisho/pkg/config"
@@ -92,6 +93,7 @@ func newTestContext(t *testing.T) *testContext {
 	publisherService := publishers.NewService(db)
 	imprintService := imprints.NewService(db)
 	fingerprintService := fingerprints.NewService(db)
+	appSettingsService := appsettings.NewService(db)
 
 	// Create worker
 	cfg := &config.Config{
@@ -114,6 +116,7 @@ func newTestContext(t *testing.T) *testContext {
 		publisherService:   publisherService,
 		imprintService:     imprintService,
 		fingerprintService: fingerprintService,
+		appSettingsService: appSettingsService,
 	}
 
 	// Create context with logger
@@ -304,6 +307,7 @@ func newTestContextWithSearchService(t *testing.T) *testContext {
 	publisherService := publishers.NewService(db)
 	imprintService := imprints.NewService(db)
 	fingerprintService := fingerprints.NewService(db)
+	appSettingsService := appsettings.NewService(db)
 
 	// Create worker with search service
 	cfg := &config.Config{
@@ -327,6 +331,7 @@ func newTestContextWithSearchService(t *testing.T) *testContext {
 		publisherService:   publisherService,
 		imprintService:     imprintService,
 		fingerprintService: fingerprintService,
+		appSettingsService: appSettingsService,
 	}
 
 	// Create context with logger

--- a/pkg/worker/testhelpers_test.go
+++ b/pkg/worker/testhelpers_test.go
@@ -81,7 +81,8 @@ func newTestContext(t *testing.T) *testContext {
 	}
 
 	// Create services
-	bookService := books.NewService(db)
+	appSettingsService := appsettings.NewService(db)
+	bookService := books.NewService(db).WithAppSettings(appSettingsService)
 	chapterService := chapters.NewService(db)
 	libraryService := libraries.NewService(db)
 	jobService := jobs.NewService(db)
@@ -93,7 +94,6 @@ func newTestContext(t *testing.T) *testContext {
 	publisherService := publishers.NewService(db)
 	imprintService := imprints.NewService(db)
 	fingerprintService := fingerprints.NewService(db)
-	appSettingsService := appsettings.NewService(db)
 
 	// Create worker
 	cfg := &config.Config{
@@ -294,7 +294,8 @@ func newTestContextWithSearchService(t *testing.T) *testContext {
 	}
 
 	// Create services
-	bookService := books.NewService(db)
+	appSettingsService := appsettings.NewService(db)
+	bookService := books.NewService(db).WithAppSettings(appSettingsService)
 	chapterService := chapters.NewService(db)
 	libraryService := libraries.NewService(db)
 	jobService := jobs.NewService(db)
@@ -307,7 +308,6 @@ func newTestContextWithSearchService(t *testing.T) *testContext {
 	publisherService := publishers.NewService(db)
 	imprintService := imprints.NewService(db)
 	fingerprintService := fingerprints.NewService(db)
-	appSettingsService := appsettings.NewService(db)
 
 	// Create worker with search service
 	cfg := &config.Config{

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -90,7 +90,8 @@ type Worker struct {
 }
 
 func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) *Worker {
-	bookService := books.NewService(db)
+	appSettingsService := appsettings.NewService(db)
+	bookService := books.NewService(db).WithAppSettings(appSettingsService)
 	chapterService := chapters.NewService(db)
 	genreService := genres.NewService(db)
 	imprintService := imprints.NewService(db)
@@ -104,7 +105,6 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 	tagService := tags.NewService(db)
 	pluginService := plugins.NewService(db)
 	fingerprintService := fingerprints.NewService(db)
-	appSettingsService := appsettings.NewService(db)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/chapters"
 	"github.com/shishobooks/shisho/pkg/downloadcache"
@@ -58,6 +59,8 @@ type Worker struct {
 	tagService         *tags.Service
 	fingerprintService *fingerprints.Service
 
+	appSettingsService *appsettings.Service
+
 	pluginService *plugins.Service
 	pluginManager *plugins.Manager
 
@@ -101,6 +104,7 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 	tagService := tags.NewService(db)
 	pluginService := plugins.NewService(db)
 	fingerprintService := fingerprints.NewService(db)
+	appSettingsService := appsettings.NewService(db)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -112,6 +116,7 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 		ctx:    ctx,
 		cancel: cancel,
 
+		appSettingsService: appSettingsService,
 		bookService:        bookService,
 		chapterService:     chapterService,
 		genreService:       genreService,
@@ -140,9 +145,10 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 	}
 
 	w.processFuncs = map[string]func(ctx context.Context, job *models.Job, jobLog *joblogs.JobLogger) error{
-		models.JobTypeScan:           w.ProcessScanJob,
-		models.JobTypeBulkDownload:   w.ProcessBulkDownloadJob,
-		models.JobTypeHashGeneration: w.ProcessHashGenerationJob,
+		models.JobTypeScan:            w.ProcessScanJob,
+		models.JobTypeBulkDownload:    w.ProcessBulkDownloadJob,
+		models.JobTypeHashGeneration:  w.ProcessHashGenerationJob,
+		models.JobTypeRecomputeReview: w.ProcessRecomputeReviewJob,
 	}
 
 	if dlCache != nil {

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -15,7 +15,7 @@ packages:
   - path: "github.com/shishobooks/shisho/pkg/jobs"
     output_path: "app/types/generated/jobs.ts"
     frontmatter: |
-      import { JobBulkDownloadData, JobExportData, JobScanData } from "@/types";
+      import { JobBulkDownloadData, JobExportData, JobRecomputeReviewData, JobScanData } from "@/types";
     include_files:
       - validators.go
   - path: "github.com/shishobooks/shisho/pkg/joblogs"

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -6,6 +6,8 @@ sidebar_position: 50
 
 Shisho extracts metadata from your book files and organizes it into a structured set of resources. You can edit metadata through the web interface, and Shisho tracks the source of each field so your manual edits are never overwritten by automated scans.
 
+> See also: [Review State](./review-state.md) for how field completeness drives the "Needs review" queue.
+
 ## Resources
 
 ### Books

--- a/website/docs/review-state.md
+++ b/website/docs/review-state.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 60
+---
+
+# Review State
+
+Each book and file in your library has a **Reviewed** state that helps you track which books still need your attention. The library gallery offers a "Needs review" filter so you can work through books one at a time without losing track.
+
+## Auto-flip
+
+Files automatically flip to **Reviewed** when they have all the metadata fields you've marked as required. The defaults are:
+
+- **All books:** authors, description, cover, genres
+- **Audiobooks (additional):** narrators
+
+If a file is missing any of these, it stays in your "Needs review" queue.
+
+When you fill in a missing field — through the edit dialog, a plugin enrichment, or the identify dialog — the flag flips automatically. If you delete a field, the file returns to the queue (unless you've manually marked it).
+
+## Manual Override
+
+If you want to keep a book in the queue regardless of completeness, or sign off on a book that will never have certain fields, use the toggle on the book or file edit page. Manual choices are sticky in both directions and persist until you change them again.
+
+## Filter and Badge
+
+The library gallery shows a small **Needs review** badge on books that have at least one main file outstanding. Open the **Filter** sheet to switch between "All", "Needs review", and "Reviewed".
+
+## Bulk Actions
+
+When multi-selecting books in the gallery, use the **More** menu in the action bar to mark all selected books as reviewed (or needs review) at once.
+
+## Configuring Required Fields
+
+Admins can change the required-field set in **Server Settings → Review Criteria**. Saving updated criteria triggers a background recompute of every main file. If you have manual overrides, you'll see a prompt asking whether to clear them — pick what fits your situation.
+
+## Cross-reference
+
+- [Metadata](./metadata.md) — what each field means.
+- [Plugins](./plugins/overview.md) — plugins fill in metadata that drives review state.

--- a/website/docs/review-state.md
+++ b/website/docs/review-state.md
@@ -31,7 +31,7 @@ When multi-selecting books in the gallery, use the **More** menu in the action b
 
 ## Configuring Required Fields
 
-Admins can change the required-field set in **Server Settings → Review Criteria**. Saving updated criteria triggers a background recompute of every main file. If you have manual overrides, you'll see a prompt asking whether to clear them — pick what fits your situation.
+Admins can change the required-field set on the **Settings → Review Criteria** page. Saving updated criteria triggers a background recompute of every main file. If you have manual overrides, you'll see a prompt asking whether to clear them — pick what fits your situation.
 
 ## Cross-reference
 


### PR DESCRIPTION
## Summary
- Adds a per-file Reviewed state driven by an admin-configurable set of required metadata fields. Files auto-flip reviewed when they have everything; manual overrides are sticky in both directions.
- Surfaces a "Needs review" filter, a card badge in the gallery, a per-book/file Review Panel in the detail page and edit dialogs, and bulk mark/unmark in the multi-select toolbar.
- Adds a dedicated `Settings → Review Criteria` admin page with checkboxes for required fields, a confirmation dialog when overrides exist, and a manual "Recompute now" action backed by a new `recompute_review` background job.

## Test plan
- `mise check:quiet` passes (Go tests, JS unit tests, E2E Chromium + Firefox, lint, types).
- New backend coverage: completeness rule, override + recompute helpers, worker job (populate + clear-overrides), PATCH/POST review endpoints, `reviewed_filter` query param, settings GET/PUT, regression test for adding a genre auto-flipping reviewed.
- New frontend coverage: ReviewPanel (states, tooltip, missing-fields hint, controlled mode), Needs-review badge, FilterSheet entry + active chip, SelectionToolbar More popover, Review Criteria settings page.
- New E2E spec covers needs-review filter, manual override sticky, bulk-mark cascade.
- Manual smoke: drop a Goodreads-only book into a library, verify badge + queue; fill in missing fields, verify auto-flip; toggle manual unreviewed and confirm the book reappears; bulk-mark two books and confirm both drop out of the queue.