### PR TITLE
[Fix] Accept HEAD on OPDS download routes

### DIFF
--- a/pkg/opds/routes.go
+++ b/pkg/opds/routes.go
@@ -1,6 +1,7 @@
 package opds
 
 import (
+	"net/http"
 	"path/filepath"
 
 	"github.com/labstack/echo/v4"
@@ -59,8 +60,11 @@ func RegisterRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authMiddleware
 	v1Kepub.GET("/:types/libraries/:libraryID/search", h.librarySearchKepub)
 	v1Kepub.GET("/:types/libraries/:libraryID/opensearch.xml", h.libraryOpenSearchKepub)
 
-	// File downloads (version-agnostic, shared across OPDS versions)
-	// Also requires Basic Auth
-	e.GET("/opds/download/:id", h.download, authMiddleware.BasicAuth)
-	e.GET("/opds/download/:id/kepub", h.downloadKepub, authMiddleware.BasicAuth)
+	// File downloads (version-agnostic, shared across OPDS versions).
+	// Also requires Basic Auth. HEAD is registered alongside GET so OPDS
+	// clients (e.g., KOReader's "Use server filenames" mode) can read the
+	// Content-Disposition filename without fetching the body.
+	downloadMethods := []string{http.MethodGet, http.MethodHead}
+	e.Match(downloadMethods, "/opds/download/:id", h.download, authMiddleware.BasicAuth)
+	e.Match(downloadMethods, "/opds/download/:id/kepub", h.downloadKepub, authMiddleware.BasicAuth)
 }

--- a/pkg/opds/routes.go
+++ b/pkg/opds/routes.go
@@ -1,7 +1,6 @@
 package opds
 
 import (
-	"net/http"
 	"path/filepath"
 
 	"github.com/labstack/echo/v4"
@@ -64,7 +63,8 @@ func RegisterRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authMiddleware
 	// Also requires Basic Auth. HEAD is registered alongside GET so OPDS
 	// clients (e.g., KOReader's "Use server filenames" mode) can read the
 	// Content-Disposition filename without fetching the body.
-	downloadMethods := []string{http.MethodGet, http.MethodHead}
-	e.Match(downloadMethods, "/opds/download/:id", h.download, authMiddleware.BasicAuth)
-	e.Match(downloadMethods, "/opds/download/:id/kepub", h.downloadKepub, authMiddleware.BasicAuth)
+	e.GET("/opds/download/:id", h.download, authMiddleware.BasicAuth)
+	e.HEAD("/opds/download/:id", h.download, authMiddleware.BasicAuth)
+	e.GET("/opds/download/:id/kepub", h.downloadKepub, authMiddleware.BasicAuth)
+	e.HEAD("/opds/download/:id/kepub", h.downloadKepub, authMiddleware.BasicAuth)
 }

--- a/pkg/opds/routes_test.go
+++ b/pkg/opds/routes_test.go
@@ -1,0 +1,41 @@
+package opds
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/auth"
+	"github.com/shishobooks/shisho/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRegisterRoutes_DownloadAcceptsHEAD ensures the OPDS download routes
+// respond to HEAD as well as GET. KOReader's "Use server filenames" mode
+// issues a HEAD request to read Content-Disposition before downloading; if
+// the route is GET-only, Echo returns 405 and KOReader falls back to the
+// URL-derived filename (the file ID).
+func TestRegisterRoutes_DownloadAcceptsHEAD(t *testing.T) {
+	t.Parallel()
+
+	db := setupOPDSDB(t)
+	cfg := &config.Config{CacheDir: t.TempDir(), DownloadCacheMaxSizeGB: 1}
+	authMw := auth.NewMiddleware(auth.NewService(db, "test-secret", time.Hour))
+
+	e := echo.New()
+	RegisterRoutes(e, db, cfg, authMw)
+
+	methods := map[string]map[string]bool{}
+	for _, r := range e.Routes() {
+		if methods[r.Path] == nil {
+			methods[r.Path] = map[string]bool{}
+		}
+		methods[r.Path][r.Method] = true
+	}
+
+	for _, path := range []string{"/opds/download/:id", "/opds/download/:id/kepub"} {
+		assert.True(t, methods[path][http.MethodGet], "GET %s should be registered", path)
+		assert.True(t, methods[path][http.MethodHead], "HEAD %s should be registered (KOReader 'Use server filenames' relies on it)", path)
+	}
+}


### PR DESCRIPTION
## Summary
- KOReader's "Use server filenames" mode issues a `HEAD` request against the OPDS download URL to read the `Content-Disposition` filename before downloading. Echo doesn't auto-handle HEAD on GET-only routes, so the request returned 405 and KOReader fell back to the URL-derived filename (the numeric file ID).
- Switch `/opds/download/:id` and `/opds/download/:id/kepub` from `e.GET` to `e.Match([GET, HEAD], ...)`. `http.ServeFile` (via `c.File`) already strips the body for HEAD, so no handler change is needed.
- Add a regression test in `pkg/opds/routes_test.go` that calls `RegisterRoutes` and asserts both methods are registered for the two download paths.

## Test plan
- `go test ./pkg/opds/ -run TestRegisterRoutes_DownloadAcceptsHEAD -v` passes.
- Reverting `routes.go` makes the new test fail with the expected `HEAD ... should be registered` message (Red→Green confirmed).
- Manually: against a Shisho instance, `curl -I -u user:pass https://host/opds/download/<id>` should now return `200` with the `Content-Disposition: attachment; filename="..."` header instead of `405`.
- In KOReader: enable "Use server filenames" on the OPDS catalog and download an EPUB — the file should land with the server-provided filename rather than the file ID.