### PR TITLE
[Fix] Serve OPDS cover images from the OPDS group

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -128,6 +128,7 @@ Used to determine which metadata to keep when conflicts occur. During scans, enr
 
 - OPDS v1.2 server hosted in the application
 - As new functionality is added, keep the OPDS server up-to-date with the new features
+- **Cover URLs in feeds must point at `/opds/v1/books/:id/cover`**, not the books API. Reasons mirror eReader: OPDS uses Basic Auth (the books group requires session auth), and in production the Caddy `/opds/*` handler proxies to the backend while bare `/books/*` falls through to the SPA. The cover endpoint lives in `pkg/opds/handlers.go` (`bookCover`) and is built off `apiBase + "/opds/v1"` in `bookToEntryWithKepub` so an `X-Forwarded-Prefix` (e.g. `/api` in dev) is preserved.
 
 ### eReader Browser UI (`pkg/ereader/`)
 

--- a/pkg/opds/handlers.go
+++ b/pkg/opds/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
 	"github.com/shishobooks/shisho/pkg/httputil"
+	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/settings"
 	"github.com/shishobooks/shisho/pkg/sortspec"
@@ -29,6 +30,7 @@ const (
 type handler struct {
 	opdsService     *Service
 	bookService     *books.Service
+	libraryService  *libraries.Service
 	downloadCache   *downloadcache.Cache
 	settingsService *settings.Service
 }
@@ -822,6 +824,46 @@ func (h *handler) downloadKepub(c echo.Context) error {
 	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
 
 	return c.File(cachedPath)
+}
+
+// bookCover serves a book's cover image. Mirrors the books bookCover
+// handler but lives under the OPDS group so it accepts Basic Auth and
+// is reachable through the production /opds/* Caddy route.
+func (h *handler) bookCover(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.NotFound("Book")
+	}
+
+	book, err := h.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &id})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if err := checkLibraryAccess(c, book.LibraryID); err != nil {
+		return err
+	}
+
+	library, err := h.libraryService.RetrieveLibrary(ctx, libraries.RetrieveLibraryOptions{
+		ID: &book.LibraryID,
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	coverFile := selectCoverFile(book.Files, library.CoverAspectRatio)
+	if coverFile == nil || coverFile.CoverImageFilename == nil || *coverFile.CoverImageFilename == "" {
+		return errcodes.NotFound("Cover")
+	}
+
+	// Resolve the cover via the file's parent dir — book.Filepath may be
+	// a synthetic organized-folder path that never exists on disk for
+	// root-level files. The cover always lives alongside the file.
+	coverPath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	return errors.WithStack(c.File(coverPath))
 }
 
 // respondXML sends an XML response with the correct content type.

--- a/pkg/opds/handlers.go
+++ b/pkg/opds/handlers.go
@@ -826,9 +826,9 @@ func (h *handler) downloadKepub(c echo.Context) error {
 	return c.File(cachedPath)
 }
 
-// bookCover serves a book's cover image. Mirrors the books bookCover
-// handler but lives under the OPDS group so it accepts Basic Auth and
-// is reachable through the production /opds/* Caddy route.
+// bookCover serves a book's cover image. Mirrors `pkg/books/handlers.go`
+// `bookCover` but lives under the OPDS group so it accepts Basic Auth
+// and is reachable through the production /opds/* Caddy route.
 func (h *handler) bookCover(c echo.Context) error {
 	ctx := c.Request().Context()
 

--- a/pkg/opds/handlers_cover_test.go
+++ b/pkg/opds/handlers_cover_test.go
@@ -1,0 +1,198 @@
+package opds
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/libraries"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupCoverTest builds a fully wired handler against a real in-memory
+// DB and seeds one library, one book, and one file with a cover image
+// on disk. Returns the handler, library ID, book ID, cover bytes.
+func setupCoverTest(t *testing.T) (*handler, int, int, []byte) {
+	t.Helper()
+
+	db := setupOPDSDB(t)
+
+	dir := t.TempDir()
+	bookPath := filepath.Join(dir, "book.epub")
+	require.NoError(t, os.WriteFile(bookPath, []byte("epub"), 0o644))
+
+	coverFilename := "book.epub.cover.jpg"
+	coverBytes := []byte("\xff\xd8\xff\xe0fakejpeg")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, coverFilename), coverBytes, 0o644))
+
+	ctx := context.Background()
+	lib := &models.Library{
+		Name:                     "Lib",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Test",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        dir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:          lib.ID,
+		BookID:             book.ID,
+		Filepath:           bookPath,
+		FileType:           models.FileTypeEPUB,
+		FilesizeBytes:      4,
+		CoverImageFilename: &coverFilename,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		bookService:    books.NewService(db),
+		libraryService: libraries.NewService(db),
+	}
+	return h, lib.ID, book.ID, coverBytes
+}
+
+func newCoverRequest(t *testing.T, h *handler, bookID int, user *models.User) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/opds/v1/books/"+strconv.Itoa(bookID)+"/cover", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/opds/v1/books/:id/cover")
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(bookID))
+	if user != nil {
+		c.Set("user", user)
+	}
+	return rec, h.bookCover(c)
+}
+
+// TestBookCover_ServesImageWhenAuthorized confirms the happy path:
+// authenticated user with library access gets the cover bytes back
+// with the no-cache header that prevents stale clients from serving
+// an outdated image after a re-cover.
+func TestBookCover_ServesImageWhenAuthorized(t *testing.T) {
+	t.Parallel()
+
+	h, libID, bookID, want := setupCoverTest(t)
+
+	user := &models.User{
+		ID:       1,
+		Username: "alice",
+		IsActive: true,
+		LibraryAccess: []*models.UserLibraryAccess{
+			{LibraryID: &libID},
+		},
+	}
+
+	rec, err := newCoverRequest(t, h, bookID, user)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, want, rec.Body.Bytes())
+	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+}
+
+// TestBookCover_ForbiddenWithoutLibraryAccess confirms the access-control
+// branch: a user with no entry for this library gets 403 even though
+// they're authenticated. This is the security-relevant branch — without
+// it the OPDS feed would leak covers across libraries.
+func TestBookCover_ForbiddenWithoutLibraryAccess(t *testing.T) {
+	t.Parallel()
+
+	h, _, bookID, _ := setupCoverTest(t)
+
+	otherLib := 999
+	user := &models.User{
+		ID:       2,
+		Username: "bob",
+		IsActive: true,
+		LibraryAccess: []*models.UserLibraryAccess{
+			{LibraryID: &otherLib},
+		},
+	}
+
+	_, err := newCoverRequest(t, h, bookID, user)
+	require.Error(t, err)
+	ec, ok := err.(*errcodes.Error)
+	require.True(t, ok, "expected *errcodes.Error, got %T: %v", err, err)
+	assert.Equal(t, http.StatusForbidden, ec.HTTPCode)
+}
+
+// TestBookCover_NotFoundWhenBookHasNoCover confirms the no-cover branch
+// returns 404 rather than serving an empty body or some default. A book
+// with files but no CoverImageFilename should be unambiguous to clients.
+func TestBookCover_NotFoundWhenBookHasNoCover(t *testing.T) {
+	t.Parallel()
+
+	db := setupOPDSDB(t)
+	ctx := context.Background()
+
+	lib := &models.Library{
+		Name:                     "Lib",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "No Cover",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "No Cover",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        "/tmp/nocover",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     lib.ID,
+		BookID:        book.ID,
+		Filepath:      "/tmp/nocover/book.epub",
+		FileType:      models.FileTypeEPUB,
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		bookService:    books.NewService(db),
+		libraryService: libraries.NewService(db),
+	}
+
+	user := &models.User{
+		ID:            3,
+		Username:      "carol",
+		IsActive:      true,
+		LibraryAccess: []*models.UserLibraryAccess{{LibraryID: &lib.ID}},
+	}
+
+	_, err = newCoverRequest(t, h, book.ID, user)
+	require.Error(t, err)
+	ec, ok := err.(*errcodes.Error)
+	require.True(t, ok, "expected *errcodes.Error, got %T: %v", err, err)
+	assert.Equal(t, http.StatusNotFound, ec.HTTPCode)
+}

--- a/pkg/opds/routes.go
+++ b/pkg/opds/routes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/config"
 	"github.com/shishobooks/shisho/pkg/downloadcache"
+	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/settings"
 	"github.com/uptrace/bun"
 )
@@ -21,6 +22,7 @@ func RegisterRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authMiddleware
 	h := &handler{
 		opdsService:     opdsService,
 		bookService:     bookService,
+		libraryService:  libraries.NewService(db),
 		downloadCache:   cache,
 		settingsService: settings.NewService(db),
 	}
@@ -44,6 +46,11 @@ func RegisterRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authMiddleware
 	// Search within library
 	v1.GET("/:types/libraries/:libraryID/search", h.librarySearch)
 	v1.GET("/:types/libraries/:libraryID/opensearch.xml", h.libraryOpenSearch)
+
+	// Book cover (lives under /opds so it accepts Basic Auth and so the
+	// production /opds/* Caddy handler proxies it to the backend instead
+	// of returning the SPA shell).
+	v1.GET("/books/:id/cover", h.bookCover)
 
 	// KePub routes - same structure but downloads as KePub format
 	// These routes generate feeds with KePub download links for EPUB and CBZ files

--- a/pkg/opds/service.go
+++ b/pkg/opds/service.go
@@ -770,12 +770,18 @@ func (svc *Service) bookToEntryWithKepub(baseURL string, book *models.Book, cove
 	apiBase := strings.TrimSuffix(baseURL, "/opds/v1/kepub")
 	apiBase = strings.TrimSuffix(apiBase, "/opds/v1")
 
+	// OPDS-mounted base. Cover URLs must live inside /opds/v1 so they
+	// authenticate via Basic Auth (the books API uses session cookies)
+	// and so the production Caddy /opds/* handler proxies them to the
+	// backend instead of returning the SPA shell.
+	opdsBase := apiBase + "/opds/v1"
+
 	// Cover image link - select appropriate file based on cover aspect ratio
 	coverFile := selectCoverFile(book.Files, coverAspectRatio)
 	if coverFile != nil && coverFile.CoverImageFilename != nil && *coverFile.CoverImageFilename != "" {
 		ext := filepath.Ext(*coverFile.CoverImageFilename)
 		mimeType := CoverMimeType(ext)
-		coverURL := fmt.Sprintf("%s/books/%d/cover", apiBase, book.ID)
+		coverURL := fmt.Sprintf("%s/books/%d/cover", opdsBase, book.ID)
 		entry.AddImageLink(coverURL, mimeType)
 		entry.AddThumbnailLink(coverURL, mimeType)
 	}

--- a/pkg/opds/service.go
+++ b/pkg/opds/service.go
@@ -770,11 +770,13 @@ func (svc *Service) bookToEntryWithKepub(baseURL string, book *models.Book, cove
 	apiBase := strings.TrimSuffix(baseURL, "/opds/v1/kepub")
 	apiBase = strings.TrimSuffix(apiBase, "/opds/v1")
 
-	// OPDS-mounted base. Cover URLs must live inside /opds/v1 so they
-	// authenticate via Basic Auth (the books API uses session cookies)
-	// and so the production Caddy /opds/* handler proxies them to the
-	// backend instead of returning the SPA shell.
-	opdsBase := apiBase + "/opds/v1"
+	// OPDS-mounted base for cover links. Covers must live inside /opds/v1
+	// so they authenticate via Basic Auth (the books API uses session
+	// cookies) and so the production Caddy /opds/* handler proxies them
+	// to the backend instead of returning the SPA shell. For non-kepub
+	// feeds this is just baseURL; for kepub feeds we drop the /kepub
+	// suffix so covers point at the canonical (format-agnostic) endpoint.
+	opdsBase := strings.TrimSuffix(baseURL, "/kepub")
 
 	// Cover image link - select appropriate file based on cover aspect ratio
 	coverFile := selectCoverFile(book.Files, coverAspectRatio)

--- a/pkg/opds/service_test.go
+++ b/pkg/opds/service_test.go
@@ -113,3 +113,78 @@ func TestBookToEntry_LanguageAndPublisher(t *testing.T) {
 func intPtr(i int) *int {
 	return &i
 }
+
+// TestBookToEntry_CoverLinkUsesOPDSPath verifies that the cover image link
+// in an OPDS entry stays inside the /opds/v1 path. The cover endpoint must
+// live under the OPDS group so it can authenticate via Basic Auth and so
+// the Caddy /opds/* handler proxies it to the backend in production —
+// linking to /books/:id/cover (the React route) returns the SPA shell to
+// OPDS clients.
+func TestBookToEntry_CoverLinkUsesOPDSPath(t *testing.T) {
+	t.Parallel()
+
+	coverFilename := "book.cover.jpg"
+	book := &models.Book{
+		ID:    42,
+		Title: "Test Book",
+		Files: []*models.File{
+			{
+				ID:                 1,
+				FileType:           models.FileTypeEPUB,
+				CoverImageFilename: &coverFilename,
+			},
+		},
+	}
+
+	svc := &Service{}
+	baseURL := "http://example.com/opds/v1"
+	entry := svc.bookToEntryWithKepub(baseURL, book, "book", nil, false)
+
+	wantHref := "http://example.com/opds/v1/books/42/cover"
+	var imageHref, thumbHref string
+	for _, link := range entry.Links {
+		switch link.Rel {
+		case "http://opds-spec.org/image":
+			imageHref = link.Href
+		case "http://opds-spec.org/image/thumbnail":
+			thumbHref = link.Href
+		}
+	}
+	assert.Equal(t, wantHref, imageHref, "image link must point at the OPDS cover endpoint")
+	assert.Equal(t, wantHref, thumbHref, "thumbnail link must point at the OPDS cover endpoint")
+}
+
+// TestBookToEntry_CoverLinkRespectsForwardedPrefix verifies that when the
+// baseURL carries a reverse-proxy prefix (e.g. Caddy adds X-Forwarded-Prefix
+// /api in dev), the cover URL keeps the prefix so it round-trips through
+// the same proxy. Stripping /opds/v1 and reattaching to a bare host would
+// drop the prefix and route the cover to a different handler.
+func TestBookToEntry_CoverLinkRespectsForwardedPrefix(t *testing.T) {
+	t.Parallel()
+
+	coverFilename := "book.cover.jpg"
+	book := &models.Book{
+		ID:    42,
+		Title: "Test Book",
+		Files: []*models.File{
+			{
+				ID:                 1,
+				FileType:           models.FileTypeEPUB,
+				CoverImageFilename: &coverFilename,
+			},
+		},
+	}
+
+	svc := &Service{}
+	baseURL := "https://example.com/api/opds/v1"
+	entry := svc.bookToEntryWithKepub(baseURL, book, "book", nil, false)
+
+	wantHref := "https://example.com/api/opds/v1/books/42/cover"
+	for _, link := range entry.Links {
+		if link.Rel == "http://opds-spec.org/image" {
+			assert.Equal(t, wantHref, link.Href)
+			return
+		}
+	}
+	t.Fatalf("expected an image link with rel http://opds-spec.org/image, got %+v", entry.Links)
+}


### PR DESCRIPTION
## Summary
- OPDS feeds were emitting cover URLs at `/books/:id/cover`. That path is session-auth only and, in production, Caddy's catch-all serves it from the SPA — so OPDS clients (KOReader, Thorium, etc.) got the React shell back instead of an image and rendered no cover.
- Move the cover link under `/opds/v1/books/:id/cover` (Basic Auth, proxied by Caddy's `/opds/*` handler) and add a matching handler in `pkg/opds`. The URL is now built off `apiBase + "/opds/v1"` so an `X-Forwarded-Prefix` (e.g. `/api` in dev) is preserved.
- Documented the constraint in `pkg/CLAUDE.md` next to the equivalent eReader note.

## Test plan
- `go test ./pkg/opds/...` — two new unit tests assert the cover link format with and without a forwarded prefix.
- Manually open an OPDS client (e.g. KOReader, Thorium) against a Shisho instance and confirm covers render in the catalog.
- Hit `https://<host>/opds/v1/books/<id>/cover` with Basic Auth → returns the cover image bytes.
- Hit the same URL without credentials → 401, not the SPA shell.