### PR TITLE
[Frontend] Consolidate book actions into the ... menu

### DIFF
--- a/app/components/library/AddToListPopover.tsx
+++ b/app/components/library/AddToListPopover.tsx
@@ -121,8 +121,12 @@ const AddToListPopover = ({
       <PopoverContent
         align="end"
         className="w-56 p-0"
-        onFocusOutside={(e) => e.preventDefault()}
-        onOpenAutoFocus={(e) => e.preventDefault()}
+        // When opened from a closing dropdown menu, Radix's onItemLeave fires a
+        // focus event the popover would otherwise read as outside-focus and
+        // dismiss on. Suppress that only in the controlled (dropdown handoff)
+        // case so the standalone trigger keeps its normal focus semantics.
+        onFocusOutside={isControlled ? (e) => e.preventDefault() : undefined}
+        onOpenAutoFocus={isControlled ? (e) => e.preventDefault() : undefined}
       >
         <p className="text-xs font-medium text-muted-foreground px-3 py-2">
           Add to List

--- a/app/components/library/AddToListPopover.tsx
+++ b/app/components/library/AddToListPopover.tsx
@@ -24,10 +24,23 @@ import type { CreateListPayload } from "@/types";
 interface AddToListPopoverProps {
   bookId: number;
   trigger?: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-const AddToListPopover = ({ bookId, trigger }: AddToListPopoverProps) => {
-  const [open, setOpen] = useState(false);
+const AddToListPopover = ({
+  bookId,
+  trigger,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+}: AddToListPopoverProps) => {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = (value: boolean) => {
+    if (!isControlled) setInternalOpen(value);
+    controlledOnOpenChange?.(value);
+  };
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [manageDialogOpen, setManageDialogOpen] = useState(false);
   const [mutatingListId, setMutatingListId] = useState<number | null>(null);
@@ -105,7 +118,12 @@ const AddToListPopover = ({ bookId, trigger }: AddToListPopoverProps) => {
           </Button>
         )}
       </PopoverTrigger>
-      <PopoverContent align="end" className="w-56 p-0">
+      <PopoverContent
+        align="end"
+        className="w-56 p-0"
+        onFocusOutside={(e) => e.preventDefault()}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
         <p className="text-xs font-medium text-muted-foreground px-3 py-2">
           Add to List
         </p>

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1127,73 +1127,77 @@ const BookDetail = () => {
               <h1 className="text-2xl md:text-3xl font-semibold">
                 {book.title}
               </h1>
-              <div className="flex items-center gap-2 shrink-0">
-                <div className="relative">
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button size="sm" variant="outline">
-                        <MoreVertical className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      align="end"
-                      onCloseAutoFocus={(e) => e.preventDefault()}
+              {/*
+                The relative wrapper exists so AddToListPopover can be opened
+                from the dropdown menu's "Add to list" item: its trigger is an
+                invisible absolute span that anchors the popover to the same
+                rectangle as the dropdown's "..." button.
+              */}
+              <div className="relative shrink-0">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button size="sm" variant="outline">
+                      <MoreVertical className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="end"
+                    onCloseAutoFocus={(e) => e.preventDefault()}
+                  >
+                    <DropdownMenuItem onClick={() => setEditDialogOpen(true)}>
+                      <Edit className="h-4 w-4 mr-2" />
+                      Edit
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onSelect={() => {
+                        setTimeout(() => setAddToListOpen(true), 0);
+                      }}
                     >
-                      <DropdownMenuItem onClick={() => setEditDialogOpen(true)}>
-                        <Edit className="h-4 w-4 mr-2" />
-                        Edit
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onSelect={() => {
-                          setTimeout(() => setAddToListOpen(true), 0);
-                        }}
-                      >
-                        <List className="h-4 w-4 mr-2" />
-                        Add to list
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        disabled={resyncBookMutation.isPending}
-                        onClick={() => setShowBookRescanDialog(true)}
-                      >
-                        <RefreshCw className="h-4 w-4 mr-2" />
-                        Rescan book
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => setShowIdentifyDialog(true)}
-                      >
-                        <Search className="h-4 w-4 mr-2" />
-                        Identify book
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onClick={() => setShowMergeIntoDialog(true)}
-                      >
-                        <GitMerge className="h-4 w-4 mr-2" />
-                        Merge into another book
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        className="text-destructive focus:text-destructive"
-                        onClick={() => setShowDeleteDialog(true)}
-                      >
-                        <Trash2 className="h-4 w-4 mr-2 text-destructive" />
-                        Delete book
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                  <AddToListPopover
-                    bookId={book.id}
-                    onOpenChange={setAddToListOpen}
-                    open={addToListOpen}
-                    trigger={
-                      <span
-                        aria-hidden
-                        className="absolute inset-0 pointer-events-none"
-                      />
-                    }
-                  />
-                </div>
+                      <List className="h-4 w-4 mr-2" />
+                      Add to list
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      disabled={resyncBookMutation.isPending}
+                      onClick={() => setShowBookRescanDialog(true)}
+                    >
+                      <RefreshCw className="h-4 w-4 mr-2" />
+                      Rescan book
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => setShowIdentifyDialog(true)}
+                    >
+                      <Search className="h-4 w-4 mr-2" />
+                      Identify book
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={() => setShowMergeIntoDialog(true)}
+                    >
+                      <GitMerge className="h-4 w-4 mr-2" />
+                      Merge into another book
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onClick={() => setShowDeleteDialog(true)}
+                    >
+                      <Trash2 className="h-4 w-4 mr-2 text-destructive" />
+                      Delete book
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <AddToListPopover
+                  bookId={book.id}
+                  onOpenChange={setAddToListOpen}
+                  open={addToListOpen}
+                  trigger={
+                    <span
+                      aria-hidden
+                      className="absolute inset-0 pointer-events-none"
+                    />
+                  }
+                />
               </div>
             </div>
             {book.sort_title && book.sort_title !== book.title && (

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -425,7 +425,6 @@ const FileRow = ({
                     </DropdownMenuItem>
                   </>
                 )}
-                <DropdownMenuSeparator />
                 <DropdownMenuItem
                   className="text-destructive focus:text-destructive"
                   disabled={isDeletingFile}
@@ -574,7 +573,6 @@ const FileRow = ({
                   </DropdownMenuItem>
                 </>
               )}
-              <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="text-destructive focus:text-destructive"
                 disabled={isDeletingFile}
@@ -740,6 +738,7 @@ const BookDetail = () => {
   const setPrimaryFileMutation = useSetPrimaryFile();
   const setBookReviewMutation = useSetBookReview();
   const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [addToListOpen, setAddToListOpen] = useState(false);
   const [showBookRescanDialog, setShowBookRescanDialog] = useState(false);
   const [rescanFileId, setRescanFileId] = useState<number | null>(null);
   const [showMergeIntoDialog, setShowMergeIntoDialog] = useState(false);
@@ -1129,63 +1128,72 @@ const BookDetail = () => {
                 {book.title}
               </h1>
               <div className="flex items-center gap-2 shrink-0">
-                <AddToListPopover
-                  bookId={book.id}
-                  trigger={
-                    <Button size="sm" title="Add to list" variant="outline">
-                      <List className="h-4 w-4 sm:mr-2" />
-                      <span className="hidden sm:inline">Add to list</span>
-                    </Button>
-                  }
-                />
-                <Button
-                  onClick={() => setEditDialogOpen(true)}
-                  size="sm"
-                  variant="outline"
-                >
-                  <Edit className="h-4 w-4 sm:mr-2" />
-                  <span className="hidden sm:inline">Edit</span>
-                </Button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button size="sm" variant="outline">
-                      <MoreVertical className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    align="end"
-                    onCloseAutoFocus={(e) => e.preventDefault()}
-                  >
-                    <DropdownMenuItem
-                      disabled={resyncBookMutation.isPending}
-                      onClick={() => setShowBookRescanDialog(true)}
+                <div className="relative">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button size="sm" variant="outline">
+                        <MoreVertical className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="end"
+                      onCloseAutoFocus={(e) => e.preventDefault()}
                     >
-                      <RefreshCw className="h-4 w-4 mr-2" />
-                      Rescan book
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => setShowIdentifyDialog(true)}
-                    >
-                      <Search className="h-4 w-4 mr-2" />
-                      Identify book
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onClick={() => setShowMergeIntoDialog(true)}
-                    >
-                      <GitMerge className="h-4 w-4 mr-2" />
-                      Merge into another book
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      className="text-destructive focus:text-destructive"
-                      onClick={() => setShowDeleteDialog(true)}
-                    >
-                      <Trash2 className="h-4 w-4 mr-2 text-destructive" />
-                      Delete book
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                      <DropdownMenuItem onClick={() => setEditDialogOpen(true)}>
+                        <Edit className="h-4 w-4 mr-2" />
+                        Edit
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onSelect={() => {
+                          setTimeout(() => setAddToListOpen(true), 0);
+                        }}
+                      >
+                        <List className="h-4 w-4 mr-2" />
+                        Add to list
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        disabled={resyncBookMutation.isPending}
+                        onClick={() => setShowBookRescanDialog(true)}
+                      >
+                        <RefreshCw className="h-4 w-4 mr-2" />
+                        Rescan book
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => setShowIdentifyDialog(true)}
+                      >
+                        <Search className="h-4 w-4 mr-2" />
+                        Identify book
+                      </DropdownMenuItem>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={() => setShowMergeIntoDialog(true)}
+                      >
+                        <GitMerge className="h-4 w-4 mr-2" />
+                        Merge into another book
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="text-destructive focus:text-destructive"
+                        onClick={() => setShowDeleteDialog(true)}
+                      >
+                        <Trash2 className="h-4 w-4 mr-2 text-destructive" />
+                        Delete book
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                  <AddToListPopover
+                    bookId={book.id}
+                    onOpenChange={setAddToListOpen}
+                    open={addToListOpen}
+                    trigger={
+                      <span
+                        aria-hidden
+                        className="absolute inset-0 pointer-events-none"
+                      />
+                    }
+                  />
+                </div>
               </div>
             </div>
             {book.sort_title && book.sort_title !== book.title && (


### PR DESCRIPTION
## Summary
- Move the standalone Edit and Add to list buttons on the book detail page into the ... dropdown so the book menu mirrors the file menu (Edit at the top, then Add to list, Rescan + Identify, Merge + Delete).
- Drop the separator before Delete in both the book and file dropdowns so destructive actions sit flush with the prior group.
- Make AddToListPopover support controlled open/onOpenChange so it can be triggered from the dropdown menu, and add onFocusOutside/onOpenAutoFocus preventDefault on its content to keep a stray focus event from the closing dropdown from immediately dismissing the popover.

## Test plan
- Open a book detail page, click the ... button, and confirm the menu items are: Edit / (sep) / Add to list / (sep) / Rescan book / Identify book / (sep) / Merge into another book / Delete book — with no separator between Merge and Delete.
- Click Edit and confirm the edit dialog opens.
- Click Add to list and confirm the lists popover opens (with "No lists yet" + Create New List, or your lists if any exist) and that selecting/dismissing it works.
- Click Rescan book, Identify book, Merge into another book, and Delete book and confirm each opens its existing dialog.
- Open the file row ... menu (desktop and mobile widths) and confirm Delete file no longer has a separator above it.