### PR TITLE
[Build] Coordinate concurrent mise check:quiet across worktrees

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -73,6 +73,10 @@ outputs = ["app/types/generated/**/*.ts"]
 
 [tasks.lint]
 description = "Run Go linting"
+# Per-worktree cache so concurrent worktrees don't trip golangci-lint's
+# "parallel golangci-lint is running" lock against each other. Cold cache
+# costs ~30s extra on the first run in a fresh worktree; warm cache is ~3s.
+env = { GOLANGCI_LINT_CACHE = "{{config_root}}/tmp/golangci-lint-cache" }
 run = "golangci-lint run"
 
 [tasks."lint:js"]
@@ -108,6 +112,10 @@ run = "go test -race ./pkg/... -coverprofile coverage.out"
 description = "Run all JS tests"
 depends = ["tygo", "test:unit", "test:e2e"]
 
+[tasks."test:js:fast"]
+description = "Run JS tests with chromium e2e only (firefox runs in CI)"
+depends = ["tygo", "test:unit", "e2e:chromium"]
+
 [tasks."test:unit"]
 description = "Run JS unit tests"
 run = "pnpm test:unit"
@@ -140,14 +148,14 @@ depends = ["tygo"]
 run = '''
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
-for step in lint test test:js lint:js; do
+for step in lint test test:js:fast lint:js; do
   echo 1 >"$tmpdir/$step.rc"
   touch "$tmpdir/$step.out"
   ( mise "$step" >"$tmpdir/$step.out" 2>&1; echo $? >"$tmpdir/$step.rc" ) &
 done
 wait
 failed=0
-for step in lint test test:js lint:js; do
+for step in lint test test:js:fast lint:js; do
   rc=$(cat "$tmpdir/$step.rc" 2>/dev/null || echo 1)
   if [ "$rc" -eq 0 ]; then
     printf '  \033[32mPASS\033[0m  %s\n' "$step"

--- a/.mise.toml
+++ b/.mise.toml
@@ -146,6 +146,20 @@ depends = ["lint", "lint:js", "test", "test:js"]
 description = "Run all checks, suppress output on success"
 depends = ["tygo"]
 run = '''
+# Serialize concurrent check:quiet runs from different worktrees on the
+# same host with flock — both runs together still finish faster than a
+# single run, but with much less CPU contention so the host stays
+# responsive. Falls through gracefully if flock isn't installed.
+lockfile="/tmp/shisho-check-quiet.lock"
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$lockfile"
+  if ! flock -n 9; then
+    echo "Another mise check:quiet is running on this host — waiting for it to finish..."
+    flock 9
+  fi
+else
+  echo "flock not found — running without host-wide lock (install with 'brew install flock' on macOS)"
+fi
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 for step in lint test test:js:fast lint:js; do

--- a/.mise.toml
+++ b/.mise.toml
@@ -160,6 +160,7 @@ if command -v flock >/dev/null 2>&1; then
 else
   echo "flock not found — running without host-wide lock (install with 'brew install flock' on macOS)"
 fi
+echo "Running checks..."
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 for step in lint test test:js:fast lint:js; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,12 +116,13 @@ file.CoverImageFilename = &filename
 - `mise lint` - Run Go linting with golangci-lint
 - `mise lint:js` - Run all JS/TS linting (ESLint, Prettier, TypeScript) in parallel
 - `mise check` - Run all validation checks in parallel (tests, Go lint, JS lint)
-- `mise check:quiet` - Same as check but quieter, skips Firefox e2e (runs in CI), and serializes concurrent runs across worktrees via `flock`. Prefer this over `mise check` locally.
+- `mise check:quiet` - Same as check but quieter, skips Firefox e2e (which still runs in CI), and serializes concurrent runs across worktrees via `flock`. Prefer this over `mise check` locally.
 
 ### Testing
 - `mise test` - Run all Go tests with coverage
 - `mise test:race` - Run all Go tests with race detection and coverage (local; CI runs the same `-race` tests but sharded across parallel jobs in `.github/workflows/ci.yml`)
 - `mise test:js` - Run all JS tests (unit + E2E) in parallel
+- `mise test:js:fast` - Run JS tests with chromium e2e only (Firefox runs in CI); used by `mise check:quiet`
 - `mise test:unit` - Run JS unit tests only
 - `mise test:e2e` - Run E2E tests (Chromium + Firefox) in parallel
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,8 +165,13 @@ For detailed architecture information, see:
 - Database is SQLite file at `tmp/data.sqlite`
 - Sample library files in `tmp/library/` for testing
 - All Go files are formatted with `goimports` so all changes should continue that formatting
-- Always run `mise check:quiet` before committing — it suppresses output on success and only shows output for failing steps, printing a one-line pass/fail summary. Use `mise check` only when you need full verbose output for debugging.
-- **Don't run checks multiple times** — `mise check:quiet` gives a clear pass/fail summary in ~6 lines. Run it once.
+- **While iterating, run only the targeted subset of checks relevant to what you changed.** Don't run the full `mise check:quiet` between iterations — it fans out 4 heavy parallel pipelines and pegs CPU; when several agents do this concurrently across worktrees the host becomes unusable. Subset cheat sheet:
+  - Go-only edits → `mise lint test`
+  - Frontend-only edits → `mise lint:js test:unit` (already runs `tygo`, eslint, prettier, tsc, and the SDK build)
+  - Both → run both
+  - Migrations → also `mise db:rollback && mise db:migrate`
+  - E2E flows → `mise e2e:chromium` only when you actually touched a flow (CI runs Firefox)
+- **Run the full `mise check:quiet` exactly once, as the final pre-commit / pre-push check, and only when no other in-flight work is mid-iteration on this host.** Before invoking it, look for a parallel `mise check:quiet`, `golangci-lint`, or heavy build running from another worktree or agent — `pgrep -fl 'golangci-lint|mise check'` is enough. If one is running, wait for it to finish before starting yours. The `lint` task uses a per-worktree golangci-lint cache (`tmp/golangci-lint-cache`) so two worktrees can lint without contention, but `mise check:quiet` itself is still CPU-heavy. Avoid plain `mise check` — its parallel verbose output is hard to follow and tempts you to re-run it.
 - **Keep docs up to date.** When making any user-facing change — new feature, changed behavior, new/changed config option, new API endpoint, modified UI — the corresponding page in `website/docs/` MUST be updated or created. **This applies to implementation plans too** — if a plan changes user-facing behavior, it MUST include a task for updating docs. If unsure which page, check the sidebar structure in `website/docs/`. This includes but is not limited to:
   - New or changed config options → `website/docs/configuration.md`
   - Plugin system changes → `website/docs/plugins/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ file.CoverImageFilename = &filename
 - `mise lint` - Run Go linting with golangci-lint
 - `mise lint:js` - Run all JS/TS linting (ESLint, Prettier, TypeScript) in parallel
 - `mise check` - Run all validation checks in parallel (tests, Go lint, JS lint)
-- `mise check:quiet` - Same as check but suppresses output on success, only shows failures
+- `mise check:quiet` - Same as check but quieter, skips Firefox e2e (runs in CI), and serializes concurrent runs across worktrees via `flock`. Prefer this over `mise check` locally.
 
 ### Testing
 - `mise test` - Run all Go tests with coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,13 +165,13 @@ For detailed architecture information, see:
 - Database is SQLite file at `tmp/data.sqlite`
 - Sample library files in `tmp/library/` for testing
 - All Go files are formatted with `goimports` so all changes should continue that formatting
-- **While iterating, run only the targeted subset of checks relevant to what you changed.** Don't run the full `mise check:quiet` between iterations — it fans out 4 heavy parallel pipelines and pegs CPU; when several agents do this concurrently across worktrees the host becomes unusable. Subset cheat sheet:
+- **While iterating, run only the targeted subset of checks relevant to what you changed.** `mise check:quiet` fans out four heavy parallel pipelines that peg CPU; running it between every iteration is wasteful when you only touched one stack. Subset cheat sheet:
   - Go-only edits → `mise lint test`
   - Frontend-only edits → `mise lint:js test:unit` (already runs `tygo`, eslint, prettier, tsc, and the SDK build)
   - Both → run both
   - Migrations → also `mise db:rollback && mise db:migrate`
   - E2E flows → `mise e2e:chromium` only when you actually touched a flow (CI runs Firefox)
-- **Run the full `mise check:quiet` exactly once, as the final pre-commit / pre-push check, and only when no other in-flight work is mid-iteration on this host.** Before invoking it, look for a parallel `mise check:quiet`, `golangci-lint`, or heavy build running from another worktree or agent — `pgrep -fl 'golangci-lint|mise check'` is enough. If one is running, wait for it to finish before starting yours. The `lint` task uses a per-worktree golangci-lint cache (`tmp/golangci-lint-cache`) so two worktrees can lint without contention, but `mise check:quiet` itself is still CPU-heavy. Avoid plain `mise check` — its parallel verbose output is hard to follow and tempts you to re-run it.
+- **Run the full `mise check:quiet` once when the feature/fix is done, before pushing or opening a PR.** Concurrent runs from different worktrees serialize automatically via `flock` (install with `brew install flock` on macOS; built in on Linux), so you don't need to coordinate with other agents — just kick it off and it'll wait its turn if another is in flight. Avoid plain `mise check` — its parallel verbose output is hard to follow and tempts you to re-run it.
 - **Keep docs up to date.** When making any user-facing change — new feature, changed behavior, new/changed config option, new API endpoint, modified UI — the corresponding page in `website/docs/` MUST be updated or created. **This applies to implementation plans too** — if a plan changes user-facing behavior, it MUST include a task for updating docs. If unsure which page, check the sidebar structure in `website/docs/`. This includes but is not limited to:
   - New or changed config options → `website/docs/configuration.md`
   - Plugin system changes → `website/docs/plugins/`

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -189,7 +189,7 @@ await expect(
 ).toBeVisible();
 ```
 
-For more flexibility (e.g., "starts with X" or a specific casing), pass a regex instead: `name: /^Select$/`.
+For more flexibility (e.g., "starts with X" or a specific casing), pass a regex instead: `name: /^Select /` to allow any "Select …" name, or `name: /select/i` for explicit case-insensitive matching.
 
 This is especially insidious because the test passes until someone adds an unrelated button whose name happens to contain the same substring — the failure shows up in CI on a PR that didn't touch the test.
 

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -189,6 +189,8 @@ await expect(
 ).toBeVisible();
 ```
 
+For more flexibility (e.g., "starts with X" or a specific casing), pass a regex instead: `name: /^Select$/`.
+
 This is especially insidious because the test passes until someone adds an unrelated button whose name happens to contain the same substring — the failure shows up in CI on a PR that didn't touch the test.
 
 ## Test File Structure

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -173,6 +173,24 @@ await page.goto("/setup", { waitUntil: "domcontentloaded" });
 await expect(page.getByRole("heading", { name: "Welcome!" })).toBeVisible();
 ```
 
+### 5. `getByRole(role, { name })` Matches Names as Substrings
+
+**Problem:** `getByRole(role, { name })` performs a case-insensitive substring match by default. If two elements with the same role have names where one is a prefix/substring of the other (e.g., a "Select" toolbar button and a "Select Library" dropdown trigger on the same page), the locator resolves to multiple elements and Playwright's strict mode fails it with `strict mode violation`.
+
+**Solution:** Pass `exact: true` whenever the visible name is — or could plausibly become — a substring of another element's name on the same page:
+
+```typescript
+// ❌ BAD: also matches "Select Library", "Select All", etc.
+await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+
+// ✅ GOOD: matches only the exact "Select" button
+await expect(
+  page.getByRole("button", { name: "Select", exact: true }),
+).toBeVisible();
+```
+
+This is especially insidious because the test passes until someone adds an unrelated button whose name happens to contain the same substring — the failure shows up in CI on a PR that didn't touch the test.
+
 ## Test File Structure
 
 ```typescript

--- a/e2e/review-flag.spec.ts
+++ b/e2e/review-flag.spec.ts
@@ -67,7 +67,9 @@ test.describe("Review flag", () => {
       waitUntil: "domcontentloaded",
     });
     // Wait for the gallery to resolve.
-    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Select", exact: true }),
+    ).toBeVisible();
   }
 
   test("book with unreviewed file shows in Needs review filter and drops out when marked reviewed", async ({
@@ -92,7 +94,9 @@ test.describe("Review flag", () => {
       `/libraries/${testData.libraryId}?reviewed_filter=needs_review`,
       { waitUntil: "domcontentloaded" },
     );
-    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Select", exact: true }),
+    ).toBeVisible();
 
     // The unreviewed book should appear in the filtered view.
     await expect(page.getByText("Unreviewed Book")).toBeVisible();
@@ -107,7 +111,9 @@ test.describe("Review flag", () => {
 
     // Reload the filtered view — the book should no longer appear.
     await page.reload({ waitUntil: "domcontentloaded" });
-    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Select", exact: true }),
+    ).toBeVisible();
     await expect(page.getByText("Unreviewed Book")).not.toBeVisible();
   });
 
@@ -139,7 +145,9 @@ test.describe("Review flag", () => {
       `/libraries/${testData.libraryId}?reviewed_filter=needs_review`,
       { waitUntil: "domcontentloaded" },
     );
-    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Select", exact: true }),
+    ).toBeVisible();
     await expect(page.getByText("Toggle Back Book")).not.toBeVisible();
 
     // Toggle back to unreviewed.
@@ -151,7 +159,9 @@ test.describe("Review flag", () => {
 
     // Reload — the book should now appear in the needs_review filter.
     await page.reload({ waitUntil: "domcontentloaded" });
-    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Select", exact: true }),
+    ).toBeVisible();
     await expect(page.getByText("Toggle Back Book")).toBeVisible();
   });
 
@@ -182,14 +192,16 @@ test.describe("Review flag", () => {
       `/libraries/${testData.libraryId}?reviewed_filter=needs_review`,
       { waitUntil: "domcontentloaded" },
     );
-    await expect(page.getByRole("button", { name: "Select" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Select", exact: true }),
+    ).toBeVisible();
 
     // Both books should appear.
     await expect(page.getByText("Bulk Book Alpha")).toBeVisible();
     await expect(page.getByText("Bulk Book Beta")).toBeVisible();
 
     // Enter selection mode.
-    await page.getByRole("button", { name: "Select" }).click();
+    await page.getByRole("button", { name: "Select", exact: true }).click();
 
     // Click both book cards to select them. In selection mode the card wrapper
     // has the click handler; pointer events on inner elements (title, link)


### PR DESCRIPTION
## Summary
- Wrap `mise check:quiet` in `flock` (`/tmp/shisho-check-quiet.lock`) so concurrent runs from different worktrees serialize instead of pegging the host. In testing, two unflocked runs both finish in ~1m25s but drive fans hard; two flocked runs total ~2m without making the laptop laggy. Falls back gracefully when `flock` isn't installed (with a hint to `brew install flock` on macOS).
- Pin `GOLANGCI_LINT_CACHE` to `tmp/golangci-lint-cache` under each worktree. Previously every worktree shared the user-level golangci-lint cache and one of any pair of concurrent lints would abort with `parallel golangci-lint is running`. Cold cache costs ~30s on the first lint per worktree; warm ~3s.
- `mise check:quiet` now runs the Chromium e2e suite only (via a new `test:js:fast` task) — Firefox still runs in CI, so coverage is preserved while local feedback is faster.
- Soften the root `CLAUDE.md` guidance: run targeted subsets while iterating; run the full `mise check:quiet` once when the feature/fix is done; concurrent runs serialize automatically via flock so no manual coordination is needed.
- Fix a strict-mode E2E flake in `e2e/review-flag.spec.ts` — `getByRole("button", { name: "Select" })` was matching both the gallery's "Select" toolbar button and a "Select Library" dropdown trigger. All occurrences now use `exact: true`. Pitfall documented in `e2e/CLAUDE.md` so the next test author doesn't repeat it.

## Test plan
- Run `mise check:quiet` in two worktrees concurrently and confirm the second prints `Another mise check:quiet is running on this host — waiting for it to finish...`, blocks until the first finishes, then prints `Running checks...` and proceeds.
- Run `mise lint` and confirm `tmp/golangci-lint-cache/` is created under the current worktree (and that `tmp/` remains gitignored).
- Run `mise check:quiet` and confirm `test:js:fast` runs (i.e., only `e2e:chromium`, no `e2e:firefox`).
- Run `pnpm e2e:chromium e2e/review-flag.spec.ts` locally and confirm all three tests pass.
- Confirm CI on this PR is green (CI still runs both Chromium and Firefox e2e via existing per-browser jobs).