### PR TITLE
[Fix] Clean up book_series rows when soft-deleting a series

### DIFF
--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -374,7 +374,7 @@ func (h *handler) merge(c echo.Context) error {
 	}
 
 	// Merge source series into target (this) series
-	err = h.seriesService.MergeSeries(ctx, id, params.SourceID)
+	movedBookIDs, err := h.seriesService.MergeSeries(ctx, id, params.SourceID)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -384,6 +384,20 @@ func (h *handler) merge(c echo.Context) error {
 	// Remove the merged (source) series from FTS index
 	if err := h.searchService.DeleteFromSeriesIndex(ctx, params.SourceID); err != nil {
 		log.Warn("failed to remove merged series from search index", logger.Data{"series_id": params.SourceID, "error": err.Error()})
+	}
+
+	// Books that moved from source to target carry the source series name in
+	// their books_fts row; re-index them so the target series name is what
+	// shows up in search.
+	for _, bookID := range movedBookIDs {
+		book, err := h.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
+		if err != nil {
+			log.Warn("failed to retrieve book for FTS reindex after series merge", logger.Data{"book_id": bookID, "error": err.Error()})
+			continue
+		}
+		if err := h.searchService.IndexBook(ctx, book); err != nil {
+			log.Warn("failed to update book search index after series merge", logger.Data{"book_id": bookID, "error": err.Error()})
+		}
 	}
 
 	// Re-index the target series since it now has more books
@@ -426,15 +440,26 @@ func (h *handler) deleteSeries(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	log := logger.FromContext(ctx)
+
 	// Removing the join rows can flip the books' Reviewed completeness state
-	// (e.g. when `series` is a required field) so each affected book needs a
-	// fresh recompute.
+	// (e.g. when `series` is a required field) and stales their books_fts
+	// rows, which still reference the deleted series name. Recompute review
+	// state and re-index each affected book.
 	for _, bookID := range affectedBookIDs {
 		h.bookService.RecomputeReviewedForBook(ctx, bookID)
+
+		book, err := h.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
+		if err != nil {
+			log.Warn("failed to retrieve book for FTS reindex after series delete", logger.Data{"book_id": bookID, "error": err.Error()})
+			continue
+		}
+		if err := h.searchService.IndexBook(ctx, book); err != nil {
+			log.Warn("failed to update book search index after series delete", logger.Data{"book_id": bookID, "error": err.Error()})
+		}
 	}
 
-	// Remove from FTS index
-	log := logger.FromContext(ctx)
+	// Remove the deleted series itself from the series FTS index.
 	if err := h.searchService.DeleteFromSeriesIndex(ctx, id); err != nil {
 		log.Warn("failed to remove series from search index", logger.Data{"series_id": id, "error": err.Error()})
 	}

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -421,9 +421,16 @@ func (h *handler) deleteSeries(c echo.Context) error {
 		}
 	}
 
-	err = h.seriesService.DeleteSeries(ctx, id)
+	affectedBookIDs, err := h.seriesService.DeleteSeries(ctx, id)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	// Removing the join rows can flip the books' Reviewed completeness state
+	// (e.g. when `series` is a required field) so each affected book needs a
+	// fresh recompute.
+	for _, bookID := range affectedBookIDs {
+		h.bookService.RecomputeReviewedForBook(ctx, bookID)
 	}
 
 	// Remove from FTS index

--- a/pkg/series/routes.go
+++ b/pkg/series/routes.go
@@ -2,6 +2,7 @@ package series
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/libraries"
@@ -11,9 +12,9 @@ import (
 )
 
 // RegisterRoutesWithGroup registers series routes on a pre-configured group.
-func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware) {
+func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware, appSettingsSvc *appsettings.Service) {
 	seriesService := NewService(db)
-	bookService := books.NewService(db)
+	bookService := books.NewService(db).WithAppSettings(appSettingsSvc)
 	libraryService := libraries.NewService(db)
 	searchService := search.NewService(db)
 

--- a/pkg/series/service.go
+++ b/pkg/series/service.go
@@ -280,11 +280,23 @@ func (svc *Service) RestoreSeries(ctx context.Context, seriesID int) error {
 	return nil
 }
 
-// MergeSeries merges sourceSeries into targetSeries (moves all books, soft-deletes source).
-func (svc *Service) MergeSeries(ctx context.Context, targetID, sourceID int) error {
-	return svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
+// MergeSeries merges sourceSeries into targetSeries (moves all books,
+// soft-deletes source). Returns the IDs of books whose join rows moved so
+// the caller can recompute search indexes that bake in the series name.
+func (svc *Service) MergeSeries(ctx context.Context, targetID, sourceID int) ([]int, error) {
+	var movedBookIDs []int
+	err := svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
+		err := tx.NewSelect().
+			Model((*models.BookSeries)(nil)).
+			ColumnExpr("DISTINCT bs.book_id").
+			Where("bs.series_id = ?", sourceID).
+			Scan(ctx, &movedBookIDs)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
 		// Update all book_series entries from source series to target series
-		_, err := tx.NewUpdate().
+		_, err = tx.NewUpdate().
 			Model((*models.BookSeries)(nil)).
 			Set("series_id = ?", targetID).
 			Where("series_id = ?", sourceID).
@@ -300,6 +312,10 @@ func (svc *Service) MergeSeries(ctx context.Context, targetID, sourceID int) err
 			Exec(ctx)
 		return errors.WithStack(err)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return movedBookIDs, nil
 }
 
 // CleanupOrphanedSeries soft-deletes series with no books.

--- a/pkg/series/service.go
+++ b/pkg/series/service.go
@@ -229,17 +229,40 @@ func (svc *Service) UpdateSeries(ctx context.Context, series *models.Series, opt
 	return nil
 }
 
-// DeleteSeries soft-deletes a series.
-func (svc *Service) DeleteSeries(ctx context.Context, seriesID int) error {
-	_, err := svc.db.
-		NewDelete().
-		Model((*models.Series)(nil)).
-		Where("id = ?", seriesID).
-		Exec(ctx)
-	if err != nil {
+// DeleteSeries soft-deletes a series and hard-deletes its book_series join
+// rows so they don't masquerade as live series associations on the affected
+// books. Returns the IDs of books that had a join row removed; callers should
+// use these to recompute review state.
+func (svc *Service) DeleteSeries(ctx context.Context, seriesID int) ([]int, error) {
+	var affectedBookIDs []int
+	err := svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
+		err := tx.NewSelect().
+			Model((*models.BookSeries)(nil)).
+			ColumnExpr("DISTINCT bs.book_id").
+			Where("bs.series_id = ?", seriesID).
+			Scan(ctx, &affectedBookIDs)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = tx.NewDelete().
+			Model((*models.BookSeries)(nil)).
+			Where("series_id = ?", seriesID).
+			Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = tx.NewDelete().
+			Model((*models.Series)(nil)).
+			Where("id = ?", seriesID).
+			Exec(ctx)
 		return errors.WithStack(err)
+	})
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	return affectedBookIDs, nil
 }
 
 // RestoreSeries restores a soft-deleted series.

--- a/pkg/series/service_test.go
+++ b/pkg/series/service_test.go
@@ -1,0 +1,134 @@
+package series
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/appsettings"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/books/review"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func setupTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+// TestDeleteSeries_RemovesBookSeriesAndFlipsReviewed is a regression test for
+// the bug where soft-deleting a series left orphan book_series rows behind,
+// so the Reviewed-flag completeness check (len(book.BookSeries) > 0) would
+// still consider the book to have a series even though no UI surfaces it.
+//
+// After deletion the join rows must be gone and a reviewed-recompute must
+// flip the file back to reviewed=false when `series` is a required field.
+func TestDeleteSeries_RemovesBookSeriesAndFlipsReviewed(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceManual,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/test.epub",
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	s := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Test Series",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Test Series",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(s).Exec(ctx)
+	require.NoError(t, err)
+
+	bs := &models.BookSeries{BookID: book.ID, SeriesID: s.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(bs).Exec(ctx)
+	require.NoError(t, err)
+
+	// Configure review criteria so that `series` is the only thing keeping the
+	// file reviewed=true. Then recompute and confirm reviewed=true.
+	settings := appsettings.NewService(db)
+	require.NoError(t, review.Save(ctx, settings, review.Criteria{
+		BookFields:  []string{review.FieldSeries},
+		AudioFields: nil,
+	}))
+
+	bookSvc := books.NewService(db).WithAppSettings(settings)
+	bookSvc.RecomputeReviewedForBook(ctx, book.ID)
+
+	var pre models.File
+	require.NoError(t, db.NewSelect().Model(&pre).Where("f.id = ?", file.ID).Scan(ctx))
+	require.NotNil(t, pre.Reviewed)
+	require.True(t, *pre.Reviewed, "file should be reviewed when its only required field (series) is satisfied")
+
+	// Delete the series. DeleteSeries should hard-delete the join rows and
+	// return the affected book IDs so the caller can recompute.
+	svc := NewService(db)
+	affected, err := svc.DeleteSeries(ctx, s.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int{book.ID}, affected)
+
+	// book_series rows for this series must be gone.
+	count, err := db.NewSelect().Model((*models.BookSeries)(nil)).Where("series_id = ?", s.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "book_series rows pointing at the deleted series must be removed")
+
+	// Recompute (mirrors what the handler will do for each affected book).
+	bookSvc.RecomputeReviewedForBook(ctx, book.ID)
+
+	var post models.File
+	require.NoError(t, db.NewSelect().Model(&post).Where("f.id = ?", file.ID).Scan(ctx))
+	require.NotNil(t, post.Reviewed)
+	assert.False(t, *post.Reviewed, "file should flip back to unreviewed once the series is gone")
+}

--- a/pkg/series/service_test.go
+++ b/pkg/series/service_test.go
@@ -2,40 +2,43 @@ package series
 
 import (
 	"context"
-	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/books/review"
-	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/dialect/sqlitedialect"
-	"github.com/uptrace/bun/driver/sqliteshim"
 )
 
-func setupTestDB(t *testing.T) *bun.DB {
+// indexBookFTS retrieves a book with the relations IndexBook reads and writes
+// the books_fts row for it. Used in tests to seed the FTS state for a book
+// before exercising mutations that should refresh the row.
+func indexBookFTS(ctx context.Context, t *testing.T, bookSvc *books.Service, searchSvc *search.Service, bookID int) {
 	t.Helper()
-
-	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	b, err := bookSvc.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
 	require.NoError(t, err)
+	require.NoError(t, searchSvc.IndexBook(ctx, b))
+}
 
-	db := bun.NewDB(sqldb, sqlitedialect.New())
-
-	_, err = db.Exec("PRAGMA foreign_keys = ON")
+// readBooksFTSSeriesNames returns the books_fts.series_names column for a book.
+// books_fts is a virtual FTS5 table, so we use a raw query.
+func readBooksFTSSeriesNames(ctx context.Context, t *testing.T, db *bun.DB, bookID int) string {
+	t.Helper()
+	var seriesNames string
+	err := db.NewRaw("SELECT series_names FROM books_fts WHERE book_id = ?", bookID).
+		Scan(ctx, &seriesNames)
 	require.NoError(t, err)
-
-	_, err = migrations.BringUpToDate(context.Background(), db)
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		db.Close()
-	})
-
-	return db
+	return seriesNames
 }
 
 // TestDeleteSeries_RemovesBookSeriesAndFlipsReviewed is a regression test for
@@ -48,7 +51,7 @@ func setupTestDB(t *testing.T) *bun.DB {
 func TestDeleteSeries_RemovesBookSeriesAndFlipsReviewed(t *testing.T) {
 	t.Parallel()
 
-	db := setupTestDB(t)
+	db := setupSeriesTestDB(t)
 	ctx := context.Background()
 
 	library := &models.Library{
@@ -131,4 +134,182 @@ func TestDeleteSeries_RemovesBookSeriesAndFlipsReviewed(t *testing.T) {
 	require.NoError(t, db.NewSelect().Model(&post).Where("f.id = ?", file.ID).Scan(ctx))
 	require.NotNil(t, post.Reviewed)
 	assert.False(t, *post.Reviewed, "file should flip back to unreviewed once the series is gone")
+}
+
+// TestDeleteSeriesHandler_ReindexesAffectedBooks asserts that going through
+// the deleteSeries HTTP handler refreshes the books_fts row for any book that
+// was associated with the deleted series, so search results no longer surface
+// the gone-series name as a token on those books.
+func TestDeleteSeriesHandler_ReindexesAffectedBooks(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceManual,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/test.epub",
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	s := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Distinctive Series Name",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Distinctive Series Name",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(s).Exec(ctx)
+	require.NoError(t, err)
+
+	bs := &models.BookSeries{BookID: book.ID, SeriesID: s.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(bs).Exec(ctx)
+	require.NoError(t, err)
+
+	bookSvc := books.NewService(db).WithAppSettings(appsettings.NewService(db))
+	searchSvc := search.NewService(db)
+
+	// Seed the FTS state: index the book while the series association is alive.
+	indexBookFTS(ctx, t, bookSvc, searchSvc, book.ID)
+	require.Equal(t, "Distinctive Series Name", readBooksFTSSeriesNames(ctx, t, db, book.ID),
+		"FTS row should contain the series name before deletion")
+
+	// Build the handler and invoke deleteSeries. No user is set on the context,
+	// so the library access check is skipped.
+	h := &handler{
+		seriesService:  NewService(db),
+		bookService:    bookSvc,
+		libraryService: libraries.NewService(db),
+		searchService:  searchSvc,
+	}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodDelete, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(s.ID))
+	require.NoError(t, h.deleteSeries(c))
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	assert.Empty(t, readBooksFTSSeriesNames(ctx, t, db, book.ID),
+		"books_fts.series_names must not retain the deleted series name after deleteSeries")
+}
+
+// TestMergeSeriesHandler_ReindexesAffectedBooks asserts that merging a source
+// series into a target updates the books_fts row of every book that moved, so
+// the source series name is no longer a search token on those books and the
+// target series name is.
+func TestMergeSeriesHandler_ReindexesAffectedBooks(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceManual,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/test.epub",
+		FilesizeBytes: 1,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	source := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Old Source Name",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Old Source Name",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(source).Exec(ctx)
+	require.NoError(t, err)
+
+	target := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "New Target Name",
+		NameSource:     models.DataSourceManual,
+		SortName:       "New Target Name",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(target).Exec(ctx)
+	require.NoError(t, err)
+
+	bs := &models.BookSeries{BookID: book.ID, SeriesID: source.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(bs).Exec(ctx)
+	require.NoError(t, err)
+
+	bookSvc := books.NewService(db).WithAppSettings(appsettings.NewService(db))
+	searchSvc := search.NewService(db)
+
+	// Seed FTS while the book is on the source series.
+	indexBookFTS(ctx, t, bookSvc, searchSvc, book.ID)
+	require.Equal(t, "Old Source Name", readBooksFTSSeriesNames(ctx, t, db, book.ID))
+
+	// Merge source into target via the HTTP handler.
+	h := &handler{
+		seriesService:  NewService(db),
+		bookService:    bookSvc,
+		libraryService: libraries.NewService(db),
+		searchService:  searchSvc,
+	}
+	e := echo.New()
+	body := `{"source_id":` + strconv.Itoa(source.ID) + `}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(target.ID))
+	require.NoError(t, h.merge(c))
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	assert.Equal(t, "New Target Name", readBooksFTSSeriesNames(ctx, t, db, book.ID),
+		"books_fts.series_names must reflect the target series name after a merge")
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -179,7 +179,7 @@ func registerProtectedRoutes(e *echo.Echo, db *bun.DB, cfg *config.Config, authM
 	seriesGroup := e.Group("/series")
 	seriesGroup.Use(authMiddleware.Authenticate)
 	seriesGroup.Use(authMiddleware.RequirePermission(models.ResourceSeries, models.OperationRead))
-	series.RegisterRoutesWithGroup(seriesGroup, db, authMiddleware)
+	series.RegisterRoutesWithGroup(seriesGroup, db, authMiddleware, appsettings.NewService(db))
 
 	// Lists routes
 	listsGroup := e.Group("/lists")


### PR DESCRIPTION
## Summary
- `DeleteSeries` left orphan `book_series` join rows pointing at the soft-deleted series, so the Reviewed-flag completeness check (`len(book.BookSeries) > 0`) could keep `files.reviewed = true` even though no UI surfaces the series. Now hard-deletes the join rows in the same transaction and returns the affected book IDs.
- The series delete handler fans out `RecomputeReviewedForBook` for each affected book, so review state flips correctly when `series` is a required field.
- Wired `appsettings.Service` into `series.RegisterRoutesWithGroup` so the books service has `WithAppSettings` applied — without this, `RecomputeReviewedForBook` silently no-ops (same gotcha guarded by `TestUpdateBook_AddingGenre_FlipsReviewedToTrue`).
- Added regression test `TestDeleteSeries_RemovesBookSeriesAndFlipsReviewed` (Red-Green TDD) that locks in both the row cleanup and the reviewed flip-back.

## Test plan
- `go test ./pkg/series/ ./pkg/books/... ./pkg/server/...` — all pass.
- `golangci-lint run ./...` — 0 issues.
- Manual: in dev, attach a book to a series, set review criteria to require `series`, confirm book becomes reviewed; delete the series; confirm `book_series` rows gone and the book flips back to needs-review.