### PR TITLE
[Backend] Consolidate cover selection and serving into pkg/covers

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -104,7 +104,7 @@ file.CoverImageFilename = &newCoverPath
 
 **Always resolve cover paths via the file, not the book**, because `book.Filepath` can be a synthetic organized-folder path that never exists on disk (root-level books in libraries with `OrganizeFileStructure` disabled — see `scanFileCreateNew`). The cover lives alongside the file for both root-level and directory-backed books.
 
-- **Read-side (serving, fingerprinting, file generation):** use `filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)`. Pure-string, no stat, no synthetic-path trap. Examples: `fileCover`/`bookCover` in `pkg/books/handlers.go`, `pkg/series/handlers.go`, `pkg/ereader/handlers.go`, `pkg/kobo/handlers.go`, `pkg/filegen/*`, `pkg/downloadcache/fingerprint.go`, and `deleteFileFromDisk`.
+- **Read-side (serving, fingerprinting, file generation):** use `filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)`. Pure-string, no stat, no synthetic-path trap. Book-cover serving across the books, OPDS, and eReader handlers shares `pkg/covers.ServeBookCover`, which encapsulates this resolution; the series handler uses `pkg/covers.SelectFile` and resolves the path itself because it adds an ETag header. Other examples: `fileCover` in `pkg/books/handlers.go`, `pkg/kobo/handlers.go`, `pkg/filegen/*`, `pkg/downloadcache/fingerprint.go`, and `deleteFileFromDisk`.
 - **Write-side (scanner, pre-organize):** use `fileutils.ResolveCoverDirForWrite(bookFilepath, fileFilepath)` when `bookFilepath` may be a synthetic organized-folder path that hasn't been created on disk yet. Falls back to `filepath.Dir(fileFilepath)` when the book path doesn't resolve to a real directory.
 
 **Book sidecars** for root-level books are similarly anchored next to the file — `sidecar.WriteBookSidecarFromModel(book)` falls back via `book.Files[0].Filepath` when `book.Filepath` doesn't resolve to an existing directory. Reads use `sidecar.ReadBookSidecarFromModel(book, fileHint)` and pass the current file as a hint so resolution works before the book's Files relation is loaded.
@@ -158,7 +158,7 @@ Server-rendered HTML pages for stock eReader browsers (Kobo, Kindle) that can't 
 **Cover Images:**
 - eReader routes use API key auth, so covers need their own endpoint at `/ereader/key/:apiKey/cover/:bookId`
 - Cannot use `/api/books/{id}/cover` (requires session auth)
-- The `selectCoverFile()` function must fall back to any available cover type, not just the preferred aspect ratio
+- Selection goes through `pkg/covers.SelectFile` (shared with the books, series, and OPDS handlers), which always falls back to any available cover type when the preferred aspect ratio has no covers — important for eReaders since the user may have an audiobook-only book
 
 ### Authentication & Authorization
 

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -104,7 +104,7 @@ file.CoverImageFilename = &newCoverPath
 
 **Always resolve cover paths via the file, not the book**, because `book.Filepath` can be a synthetic organized-folder path that never exists on disk (root-level books in libraries with `OrganizeFileStructure` disabled — see `scanFileCreateNew`). The cover lives alongside the file for both root-level and directory-backed books.
 
-- **Read-side (serving, fingerprinting, file generation):** use `filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)`. Pure-string, no stat, no synthetic-path trap. Book-cover serving across the books, OPDS, and eReader handlers shares `pkg/covers.ServeBookCover`, which encapsulates this resolution; the series handler uses `pkg/covers.SelectFile` and resolves the path itself because it adds an ETag header. Other examples: `fileCover` in `pkg/books/handlers.go`, `pkg/kobo/handlers.go`, `pkg/filegen/*`, `pkg/downloadcache/fingerprint.go`, and `deleteFileFromDisk`.
+- **Read-side (serving, fingerprinting, file generation):** use `filepath.Join(filepath.Dir(file.Filepath), *file.CoverImageFilename)`. Pure-string, no stat, no synthetic-path trap. Book-cover serving across the books, OPDS, and eReader handlers shares `pkg/covers.ServeBookCover`, which encapsulates this resolution; the series handler uses `pkg/covers.SelectFile` and resolves the path itself because the *selected file* can change while the newly-selected cover's mtime stays put, so it has to bake the file ID into an ETag (see "Conditional-GET for cover endpoints" below). Other examples: `fileCover` in `pkg/books/handlers.go`, `pkg/kobo/handlers.go`, `pkg/filegen/*`, `pkg/downloadcache/fingerprint.go`, and `deleteFileFromDisk`.
 - **Write-side (scanner, pre-organize):** use `fileutils.ResolveCoverDirForWrite(bookFilepath, fileFilepath)` when `bookFilepath` may be a synthetic organized-folder path that hasn't been created on disk yet. Falls back to `filepath.Dir(fileFilepath)` when the book path doesn't resolve to a real directory.
 
 **Book sidecars** for root-level books are similarly anchored next to the file — `sidecar.WriteBookSidecarFromModel(book)` falls back via `book.Files[0].Filepath` when `book.Filepath` doesn't resolve to an existing directory. Reads use `sidecar.ReadBookSidecarFromModel(book, fileHint)` and pass the current file as a hint so resolution works before the book's Files relation is loaded.
@@ -158,7 +158,7 @@ Server-rendered HTML pages for stock eReader browsers (Kobo, Kindle) that can't 
 **Cover Images:**
 - eReader routes use API key auth, so covers need their own endpoint at `/ereader/key/:apiKey/cover/:bookId`
 - Cannot use `/api/books/{id}/cover` (requires session auth)
-- Selection goes through `pkg/covers.SelectFile` (shared with the books, series, and OPDS handlers), which always falls back to any available cover type when the preferred aspect ratio has no covers — important for eReaders since the user may have an audiobook-only book
+- Selection goes through `pkg/covers.SelectFile`, shared with the books, series, and OPDS handlers. The shared selector must continue to fall back to any available cover type when the preferred aspect ratio has no covers — eReaders showing an audiobook-only book still need to get a cover
 
 ### Authentication & Authorization
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/cbzpages"
 	"github.com/shishobooks/shisho/pkg/config"
+	"github.com/shishobooks/shisho/pkg/covers"
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
@@ -1717,53 +1718,7 @@ func (h *handler) bookCover(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Select the appropriate file based on the library's cover aspect ratio setting
-	coverFile := selectCoverFile(book.Files, library.CoverAspectRatio)
-	if coverFile == nil || coverFile.CoverImageFilename == nil || *coverFile.CoverImageFilename == "" {
-		return errcodes.NotFound("Cover")
-	}
-
-	// Resolve the cover via the file's parent dir rather than book.Filepath —
-	// see fileCover for the rationale (synthetic organized-folder paths for
-	// root-level files break book.Filepath-based resolution).
-	coverPath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
-	c.Response().Header().Set("Cache-Control", "private, no-cache")
-	return errors.WithStack(c.File(coverPath))
-}
-
-// selectCoverFile selects the appropriate file for cover display based on the library's
-// cover aspect ratio setting.
-func selectCoverFile(files []*models.File, coverAspectRatio string) *models.File {
-	var bookFiles, audiobookFiles []*models.File
-	for _, f := range files {
-		if f.CoverImageFilename == nil || *f.CoverImageFilename == "" {
-			continue
-		}
-		switch f.FileType {
-		case models.FileTypeEPUB, models.FileTypeCBZ, models.FileTypePDF:
-			bookFiles = append(bookFiles, f)
-		case models.FileTypeM4B:
-			audiobookFiles = append(audiobookFiles, f)
-		}
-	}
-
-	switch coverAspectRatio {
-	case "audiobook", "audiobook_fallback_book":
-		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
-		}
-		if len(bookFiles) > 0 {
-			return bookFiles[0]
-		}
-	default: // "book", "book_fallback_audiobook"
-		if len(bookFiles) > 0 {
-			return bookFiles[0]
-		}
-		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
-		}
-	}
-	return nil
+	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio)
 }
 
 // downloadFile handles downloading a file with generated metadata embedded.

--- a/pkg/covers/covers.go
+++ b/pkg/covers/covers.go
@@ -3,6 +3,7 @@
 package covers
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/labstack/echo/v4"
@@ -52,7 +53,7 @@ func SelectFile(files []*models.File, coverAspectRatio string) *models.File {
 // ServeBookCover selects the cover file from `files` using the library's
 // preferred aspect ratio and serves it via c.File. Callers must perform any
 // auth and library-access checks before calling. Returns errcodes.NotFound
-// when no suitable cover exists.
+// when no suitable cover exists or the cover image is missing on disk.
 //
 // The cover is resolved via the file's parent directory rather than the book's
 // filepath because book.Filepath can be a synthetic organized-folder path that
@@ -64,6 +65,16 @@ func ServeBookCover(c echo.Context, files []*models.File, coverAspectRatio strin
 	}
 
 	coverPath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
+	// Stat first so a cover file deleted from disk surfaces as a typed 404
+	// (matching the no-filename branch above) instead of bubbling up as
+	// echo.HTTPError's generic "Not Found" from c.File.
+	if _, err := os.Stat(coverPath); err != nil {
+		if os.IsNotExist(err) {
+			return errcodes.NotFound("Cover")
+		}
+		return errors.WithStack(err)
+	}
+
 	c.Response().Header().Set("Cache-Control", "private, no-cache")
 	return errors.WithStack(c.File(coverPath))
 }

--- a/pkg/covers/covers.go
+++ b/pkg/covers/covers.go
@@ -1,0 +1,69 @@
+// Package covers centralizes cover-file selection and serving so that the
+// books, series, ereader, and OPDS handlers don't drift independently.
+package covers
+
+import (
+	"path/filepath"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+// SelectFile picks the file whose cover should represent a book based on the
+// library's preferred cover aspect ratio. It always falls back across types
+// when the preferred kind has no covers — a book-only library still gets a
+// cover for an audiobook-only book, and vice versa.
+func SelectFile(files []*models.File, coverAspectRatio string) *models.File {
+	var bookFiles, audiobookFiles []*models.File
+	for _, f := range files {
+		if f.CoverImageFilename == nil || *f.CoverImageFilename == "" {
+			continue
+		}
+		switch f.FileType {
+		case models.FileTypeEPUB, models.FileTypeCBZ, models.FileTypePDF:
+			bookFiles = append(bookFiles, f)
+		case models.FileTypeM4B:
+			audiobookFiles = append(audiobookFiles, f)
+		}
+	}
+
+	switch coverAspectRatio {
+	case "audiobook", "audiobook_fallback_book":
+		if len(audiobookFiles) > 0 {
+			return audiobookFiles[0]
+		}
+		if len(bookFiles) > 0 {
+			return bookFiles[0]
+		}
+	default: // "book", "book_fallback_audiobook", or any other value
+		if len(bookFiles) > 0 {
+			return bookFiles[0]
+		}
+		if len(audiobookFiles) > 0 {
+			return audiobookFiles[0]
+		}
+	}
+	return nil
+}
+
+// ServeBookCover selects the cover file from `files` using the library's
+// preferred aspect ratio and serves it via c.File. Callers must perform any
+// auth and library-access checks before calling. Returns errcodes.NotFound
+// when no suitable cover exists.
+//
+// The cover is resolved via the file's parent directory rather than the book's
+// filepath because book.Filepath can be a synthetic organized-folder path that
+// never exists on disk for root-level books.
+func ServeBookCover(c echo.Context, files []*models.File, coverAspectRatio string) error {
+	coverFile := SelectFile(files, coverAspectRatio)
+	if coverFile == nil || coverFile.CoverImageFilename == nil || *coverFile.CoverImageFilename == "" {
+		return errcodes.NotFound("Cover")
+	}
+
+	coverPath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	return errors.WithStack(c.File(coverPath))
+}

--- a/pkg/covers/covers_test.go
+++ b/pkg/covers/covers_test.go
@@ -1,0 +1,121 @@
+package covers
+
+import (
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectFile(t *testing.T) {
+	t.Parallel()
+
+	withCover := func(id int, fileType, cover string) *models.File {
+		var ptr *string
+		if cover != "" {
+			ptr = &cover
+		}
+		return &models.File{ID: id, FileType: fileType, CoverImageFilename: ptr}
+	}
+
+	epub := withCover(1, models.FileTypeEPUB, "epub.cover.jpg")
+	cbz := withCover(2, models.FileTypeCBZ, "cbz.cover.jpg")
+	pdf := withCover(3, models.FileTypePDF, "pdf.cover.jpg")
+	m4b := withCover(4, models.FileTypeM4B, "m4b.cover.jpg")
+	bookNoCover := withCover(5, models.FileTypeEPUB, "")
+	audioNoCover := withCover(6, models.FileTypeM4B, "")
+
+	tests := []struct {
+		name           string
+		files          []*models.File
+		aspectRatio    string
+		expectedFileID int // 0 means nil
+	}{
+		{
+			name:           "prefers book file in default mode",
+			files:          []*models.File{m4b, epub},
+			aspectRatio:    "book",
+			expectedFileID: epub.ID,
+		},
+		{
+			name:           "falls back to audiobook in default mode",
+			files:          []*models.File{m4b},
+			aspectRatio:    "book",
+			expectedFileID: m4b.ID,
+		},
+		{
+			name:           "prefers audiobook file in audiobook mode",
+			files:          []*models.File{epub, m4b},
+			aspectRatio:    "audiobook",
+			expectedFileID: m4b.ID,
+		},
+		{
+			name:           "falls back to book file in audiobook mode",
+			files:          []*models.File{epub},
+			aspectRatio:    "audiobook",
+			expectedFileID: epub.ID,
+		},
+		{
+			name:           "audiobook_fallback_book behaves like audiobook",
+			files:          []*models.File{epub, m4b},
+			aspectRatio:    "audiobook_fallback_book",
+			expectedFileID: m4b.ID,
+		},
+		{
+			name:           "book_fallback_audiobook behaves like default",
+			files:          []*models.File{m4b, epub},
+			aspectRatio:    "book_fallback_audiobook",
+			expectedFileID: epub.ID,
+		},
+		{
+			name:           "skips files with no cover",
+			files:          []*models.File{bookNoCover, m4b},
+			aspectRatio:    "book",
+			expectedFileID: m4b.ID,
+		},
+		{
+			name:           "returns nil when no covers exist",
+			files:          []*models.File{bookNoCover, audioNoCover},
+			aspectRatio:    "book",
+			expectedFileID: 0,
+		},
+		{
+			name:           "treats CBZ as a book file",
+			files:          []*models.File{cbz},
+			aspectRatio:    "book",
+			expectedFileID: cbz.ID,
+		},
+		{
+			name:           "treats PDF as a book file",
+			files:          []*models.File{pdf},
+			aspectRatio:    "book",
+			expectedFileID: pdf.ID,
+		},
+		{
+			name:           "returns nil for empty files",
+			files:          nil,
+			aspectRatio:    "book",
+			expectedFileID: 0,
+		},
+		{
+			name:           "unknown aspect ratio falls through to default",
+			files:          []*models.File{m4b, epub},
+			aspectRatio:    "weird",
+			expectedFileID: epub.ID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := SelectFile(tt.files, tt.aspectRatio)
+			if tt.expectedFileID == 0 {
+				assert.Nil(t, got)
+				return
+			}
+			if assert.NotNil(t, got) {
+				assert.Equal(t, tt.expectedFileID, got.ID)
+			}
+		})
+	}
+}

--- a/pkg/covers/covers_test.go
+++ b/pkg/covers/covers_test.go
@@ -1,10 +1,17 @@
 package covers
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSelectFile(t *testing.T) {
@@ -118,4 +125,48 @@ func TestSelectFile(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServeBookCover_NotFoundWhenNoCover(t *testing.T) {
+	t.Parallel()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	files := []*models.File{
+		{ID: 1, FileType: models.FileTypeEPUB, CoverImageFilename: nil},
+	}
+
+	err := ServeBookCover(c, files, "book")
+	require.Error(t, err)
+	var ecErr *errcodes.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, http.StatusNotFound, ecErr.HTTPCode)
+}
+
+func TestServeBookCover_ServesCoverFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bookPath := filepath.Join(dir, "book.epub")
+	require.NoError(t, os.WriteFile(bookPath, []byte("epub-bytes"), 0o644))
+	coverName := "book.epub.cover.jpg"
+	coverBytes := []byte("\xff\xd8\xff\xe0jpeg-bytes")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, coverName), coverBytes, 0o644))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	files := []*models.File{
+		{ID: 1, FileType: models.FileTypeEPUB, Filepath: bookPath, CoverImageFilename: &coverName},
+	}
+
+	require.NoError(t, ServeBookCover(c, files, "book"))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, coverBytes, rec.Body.Bytes())
 }

--- a/pkg/covers/covers_test.go
+++ b/pkg/covers/covers_test.go
@@ -170,3 +170,29 @@ func TestServeBookCover_ServesCoverFile(t *testing.T) {
 	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
 	assert.Equal(t, coverBytes, rec.Body.Bytes())
 }
+
+func TestServeBookCover_NotFoundWhenCoverFileMissingOnDisk(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bookPath := filepath.Join(dir, "book.epub")
+	require.NoError(t, os.WriteFile(bookPath, []byte("epub-bytes"), 0o644))
+	// CoverImageFilename is set, but the cover file itself isn't on disk —
+	// e.g. it was deleted out from under the DB. Should 404, not 500.
+	coverName := "book.epub.cover.jpg"
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	files := []*models.File{
+		{ID: 1, FileType: models.FileTypeEPUB, Filepath: bookPath, CoverImageFilename: &coverName},
+	}
+
+	err := ServeBookCover(c, files, "book")
+	require.Error(t, err)
+	var ecErr *errcodes.Error
+	require.ErrorAs(t, err, &ecErr)
+	assert.Equal(t, http.StatusNotFound, ecErr.HTTPCode)
+}

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/apikeys"
 	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/covers"
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
@@ -730,17 +731,7 @@ func (h *handler) Cover(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Select the appropriate file based on the library's cover aspect ratio setting
-	coverFile := selectCoverFile(book.Files, library.CoverAspectRatio)
-	if coverFile == nil || coverFile.CoverImageFilename == nil || *coverFile.CoverImageFilename == "" {
-		return errcodes.NotFound("Cover")
-	}
-
-	// Resolve via the file's parent dir — book.Filepath may be a synthetic
-	// organized-folder path that doesn't exist on disk for root-level files.
-	coverPath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
-	c.Response().Header().Set("Cache-Control", "private, no-cache")
-	return errors.WithStack(c.File(coverPath))
+	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio)
 }
 
 // DownloadFile handles file downloads with API key authentication.
@@ -902,41 +893,6 @@ func (h *handler) DownloadFileKepub(c echo.Context) error {
 
 	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
 	return c.File(cachedPath)
-}
-
-// selectCoverFile selects the appropriate file for cover display.
-func selectCoverFile(files []*models.File, coverAspectRatio string) *models.File {
-	var bookFiles, audiobookFiles []*models.File
-	for _, f := range files {
-		if f.CoverImageFilename == nil || *f.CoverImageFilename == "" {
-			continue
-		}
-		switch f.FileType {
-		case models.FileTypeEPUB, models.FileTypeCBZ, models.FileTypePDF:
-			bookFiles = append(bookFiles, f)
-		case models.FileTypeM4B:
-			audiobookFiles = append(audiobookFiles, f)
-		}
-	}
-
-	switch coverAspectRatio {
-	case "audiobook", "audiobook_fallback_book":
-		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
-		}
-		if len(bookFiles) > 0 {
-			return bookFiles[0]
-		}
-	default: // "book", "book_fallback_audiobook", or any other value
-		if len(bookFiles) > 0 {
-			return bookFiles[0]
-		}
-		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
-		}
-	}
-
-	return nil
 }
 
 // Helper functions

--- a/pkg/opds/handlers.go
+++ b/pkg/opds/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/covers"
 	"github.com/shishobooks/shisho/pkg/downloadcache"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/filegen"
@@ -853,17 +854,7 @@ func (h *handler) bookCover(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	coverFile := selectCoverFile(book.Files, library.CoverAspectRatio)
-	if coverFile == nil || coverFile.CoverImageFilename == nil || *coverFile.CoverImageFilename == "" {
-		return errcodes.NotFound("Cover")
-	}
-
-	// Resolve the cover via the file's parent dir — book.Filepath may be
-	// a synthetic organized-folder path that never exists on disk for
-	// root-level files. The cover always lives alongside the file.
-	coverPath := filepath.Join(filepath.Dir(coverFile.Filepath), *coverFile.CoverImageFilename)
-	c.Response().Header().Set("Cache-Control", "private, no-cache")
-	return errors.WithStack(c.File(coverPath))
+	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio)
 }
 
 // respondXML sends an XML response with the correct content type.

--- a/pkg/opds/service.go
+++ b/pkg/opds/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/covers"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -779,7 +780,7 @@ func (svc *Service) bookToEntryWithKepub(baseURL string, book *models.Book, cove
 	opdsBase := strings.TrimSuffix(baseURL, "/kepub")
 
 	// Cover image link - select appropriate file based on cover aspect ratio
-	coverFile := selectCoverFile(book.Files, coverAspectRatio)
+	coverFile := covers.SelectFile(book.Files, coverAspectRatio)
 	if coverFile != nil && coverFile.CoverImageFilename != nil && *coverFile.CoverImageFilename != "" {
 		ext := filepath.Ext(*coverFile.CoverImageFilename)
 		mimeType := CoverMimeType(ext)
@@ -814,41 +815,6 @@ func (svc *Service) bookToEntryWithKepub(baseURL string, book *models.Book, cove
 // supportsKepub returns true if the file type can be converted to KePub.
 func supportsKepub(fileType string) bool {
 	return fileType == models.FileTypeEPUB || fileType == models.FileTypeCBZ
-}
-
-// selectCoverFile selects the appropriate file for cover display based on the library's
-// cover aspect ratio setting.
-func selectCoverFile(files []*models.File, coverAspectRatio string) *models.File {
-	var bookFiles, audiobookFiles []*models.File
-	for _, f := range files {
-		if f.CoverImageFilename == nil || *f.CoverImageFilename == "" {
-			continue
-		}
-		switch f.FileType {
-		case models.FileTypeEPUB, models.FileTypeCBZ, models.FileTypePDF:
-			bookFiles = append(bookFiles, f)
-		case models.FileTypeM4B:
-			audiobookFiles = append(audiobookFiles, f)
-		}
-	}
-
-	switch coverAspectRatio {
-	case "audiobook", "audiobook_fallback_book":
-		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
-		}
-		if len(bookFiles) > 0 {
-			return bookFiles[0]
-		}
-	default: // "book", "book_fallback_audiobook"
-		if len(bookFiles) > 0 {
-			return bookFiles[0]
-		}
-		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
-		}
-	}
-	return nil
 }
 
 // addPaginationLinks adds pagination links to a feed.

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/covers"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -268,7 +269,7 @@ func (h *handler) seriesCover(c echo.Context) error {
 	}
 
 	// Select the appropriate file based on the library's cover aspect ratio setting
-	coverFile := selectCoverFile(book.Files, library.CoverAspectRatio)
+	coverFile := covers.SelectFile(book.Files, library.CoverAspectRatio)
 	if coverFile == nil || coverFile.CoverImageFilename == nil || *coverFile.CoverImageFilename == "" {
 		return errcodes.NotFound("Series cover")
 	}
@@ -308,41 +309,6 @@ func (h *handler) seriesCover(c echo.Context) error {
 
 	// Zero modtime suppresses Last-Modified and IMS handling inside ServeContent.
 	http.ServeContent(c.Response(), c.Request(), filepath.Base(coverImagePath), time.Time{}, fh)
-	return nil
-}
-
-// selectCoverFile selects the appropriate file for cover display based on the library's
-// cover aspect ratio setting.
-func selectCoverFile(files []*models.File, coverAspectRatio string) *models.File {
-	var bookFiles, audiobookFiles []*models.File
-	for _, f := range files {
-		if f.CoverImageFilename == nil || *f.CoverImageFilename == "" {
-			continue
-		}
-		switch f.FileType {
-		case models.FileTypeEPUB, models.FileTypeCBZ, models.FileTypePDF:
-			bookFiles = append(bookFiles, f)
-		case models.FileTypeM4B:
-			audiobookFiles = append(audiobookFiles, f)
-		}
-	}
-
-	switch coverAspectRatio {
-	case "audiobook", "audiobook_fallback_book":
-		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
-		}
-		if len(bookFiles) > 0 {
-			return bookFiles[0]
-		}
-	default: // "book", "book_fallback_audiobook"
-		if len(bookFiles) > 0 {
-			return bookFiles[0]
-		}
-		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- New `pkg/covers` package exposes `SelectFile` (cover-file selection by aspect ratio) and `ServeBookCover` (selection + path resolution + `c.File` serving).
- Replaces four byte-identical `selectCoverFile` copies (books, series, opds service, opds handler, ereader) and collapses three duplicate `bookCover` handler bodies (books, opds, ereader) into one-line wrappers. Series keeps its custom ETag serving but uses `covers.SelectFile`.
- Adds table-driven unit tests for `SelectFile`; updates `pkg/CLAUDE.md` cross-references to point at the new package.

## Test plan
- `go test ./pkg/covers/... ./pkg/books/... ./pkg/series/... ./pkg/opds/... ./pkg/ereader/...` (existing handler tests cover the wrapper paths)
- `mise check:quiet` (lint + tests + js)
- Spot-check `/api/books/:id/cover`, `/series/:id/cover`, `/opds/v1/books/:id/cover`, and `/ereader/key/:apiKey/cover/:bookId` in dev to confirm the same headers/bytes come back as before