### PR TITLE
[Backend] Hard-delete series + close FTS leak in orphan cleanup

### DIFF
--- a/app/hooks/queries/books.ts
+++ b/app/hooks/queries/books.ts
@@ -96,6 +96,11 @@ export const useUpdateBook = () => {
       queryClient.invalidateQueries({ queryKey: [SeriesQueryKey.ListSeries] });
       queryClient.invalidateQueries({ queryKey: [GenresQueryKey.ListGenres] });
       queryClient.invalidateQueries({ queryKey: [TagsQueryKey.ListTags] });
+      // Title, subtitle, authors, and series_names all feed books_fts —
+      // invalidate global search results.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
+      });
     },
   });
 };
@@ -129,6 +134,10 @@ export const useUpdateFile = () => {
       });
       queryClient.invalidateQueries({
         queryKey: [ImprintsQueryKey.ListImprints],
+      });
+      // Filenames and narrators both feed books_fts — invalidate search.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
       });
     },
   });
@@ -230,6 +239,10 @@ export const useMergeBooks = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.RetrieveBook] });
+      // Source book disappears, target book absorbs files — books_fts changes.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
+      });
     },
   });
 };

--- a/app/hooks/queries/books.ts
+++ b/app/hooks/queries/books.ts
@@ -217,6 +217,11 @@ export const useMoveFiles = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [QueryKey.RetrieveBook] });
+      // Filenames and narrators on both source and target books shift —
+      // books_fts changes for both.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
+      });
     },
   });
 };

--- a/app/hooks/queries/people.ts
+++ b/app/hooks/queries/people.ts
@@ -10,6 +10,7 @@ import type { Book, File, Person } from "@/types";
 import type { UpdatePersonPayload } from "@/types/generated/people";
 
 import { QueryKey as BooksQueryKey } from "./books";
+import { QueryKey as SearchQueryKey } from "./search";
 
 export enum QueryKey {
   ListPeople = "ListPeople",
@@ -142,6 +143,10 @@ export const useUpdatePerson = () => {
       // Invalidate book queries since they display author/narrator info
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+      // Person name shows up in search — invalidate global search results.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
+      });
     },
   });
 };
@@ -169,6 +174,10 @@ export const useMergePerson = () => {
       // Invalidate book queries since they display author/narrator info
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+      // Person name shows up in search — invalidate global search results.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
+      });
     },
   });
 };
@@ -185,6 +194,10 @@ export const useDeletePerson = () => {
       // Invalidate book queries since they display author/narrator info
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+      // Person name shows up in search — invalidate global search results.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
+      });
     },
   });
 };

--- a/app/hooks/queries/series.ts
+++ b/app/hooks/queries/series.ts
@@ -13,6 +13,7 @@ import type {
 } from "@/types/generated/series";
 
 import { QueryKey as BooksQueryKey } from "./books";
+import { QueryKey as SearchQueryKey } from "./search";
 
 export enum QueryKey {
   ListSeries = "ListSeries",
@@ -114,6 +115,10 @@ export const useUpdateSeries = () => {
       // Invalidate book queries since they display series info
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+      // Series name shows up in search — invalidate global search results.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
+      });
     },
   });
 };
@@ -145,6 +150,10 @@ export const useMergeSeries = () => {
       // Invalidate book queries since they display series info
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+      // Series name shows up in search — invalidate global search results.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
+      });
     },
   });
 };
@@ -161,6 +170,10 @@ export const useDeleteSeries = () => {
       // Invalidate book queries since they display series info
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });
+      // Series name shows up in search — invalidate global search results.
+      queryClient.invalidateQueries({
+        queryKey: [SearchQueryKey.GlobalSearch],
+      });
     },
   });
 };

--- a/docs/superpowers/plans/2026-04-26-series-hard-delete.md
+++ b/docs/superpowers/plans/2026-04-26-series-hard-delete.md
@@ -1,0 +1,662 @@
+# Series Hard-Delete Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert `models.Series` from soft-delete to hard-delete by dropping the `deleted_at` column, the `bun:",soft_delete"` tag, the unused `RestoreSeries` function, and the surrounding hand-written `deleted_at IS NULL` filters.
+
+**Architecture:** Single SQLite migration drops the column and rebuilds the unique index unconditional. Removing the `bun:",soft_delete"` tag from `models.Series` flips every existing `NewDelete()` call from a soft-delete UPDATE to a real DELETE — Bun's behavior is entirely controlled by that tag, so call sites do not change. Pre-existing soft-deleted rows are hard-deleted by the migration; CASCADE on `book_series.series_id` (set in `20260406100000_add_fk_cascades.go`) cleans their join rows. A regression test pins the new behavior.
+
+**Tech Stack:** Go 1.23, Bun ORM, SQLite, mise for task running, testify for assertions.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-series-hard-delete-design.md`
+
+---
+
+## File Structure
+
+**Created:**
+- `pkg/migrations/20260426000000_drop_series_deleted_at.go` — migration that hard-deletes soft-deleted rows, drops the column, and rebuilds the unique index.
+
+**Modified:**
+- `pkg/models/series.go` — remove `DeletedAt` field (drops the soft-delete tag).
+- `pkg/series/service.go` — simplify `DeleteSeries`, delete `RestoreSeries`, fix doc comments on `MergeSeries` and `CleanupOrphanedSeries`.
+- `pkg/series/service_test.go` — add `TestDeleteSeries_HardDeletesRowAndFTS` regression test.
+- `pkg/books/service.go` — fix doc comment on duplicate `CleanupOrphanedSeries`.
+- `pkg/search/service.go` — drop `s.deleted_at IS NULL` filters from books-FTS and series-FTS rebuild SQL.
+
+---
+
+## Task 1: Add the migration
+
+**Files:**
+- Create: `pkg/migrations/20260426000000_drop_series_deleted_at.go`
+
+- [ ] **Step 1: Create the migration file**
+
+Create `pkg/migrations/20260426000000_drop_series_deleted_at.go` with this exact content:
+
+```go
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		// Hard-delete any soft-deleted series. CASCADE on book_series.series_id
+		// (set in 20260406100000_add_fk_cascades.go) cleans up join rows.
+		// Done before the schema change so the unconditional unique index in
+		// the final step can't collide on a name shared between a soft-deleted
+		// and a live row in the same library.
+		if _, err := db.Exec(`DELETE FROM series WHERE deleted_at IS NOT NULL`); err != nil {
+			return errors.WithStack(err)
+		}
+		// Defensive: purge any series_fts rows whose series_id is gone.
+		// Handlers already call DeleteFromSeriesIndex on soft-delete today,
+		// so this should be a no-op in practice.
+		if _, err := db.Exec(`DELETE FROM series_fts WHERE series_id NOT IN (SELECT id FROM series)`); err != nil {
+			return errors.WithStack(err)
+		}
+		// The partial unique index references deleted_at; drop before the column.
+		if _, err := db.Exec(`DROP INDEX ux_series_name_library_id`); err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.Exec(`ALTER TABLE series DROP COLUMN deleted_at`); err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.Exec(`CREATE UNIQUE INDEX ux_series_name_library_id ON series (name COLLATE NOCASE, library_id)`); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		// Lossy: does not restore deleted rows. Matches the precedent set by
+		// 20260423000000_drop_libraries_deleted_at.go.
+		if _, err := db.Exec(`DROP INDEX ux_series_name_library_id`); err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.Exec(`ALTER TABLE series ADD COLUMN deleted_at TIMESTAMPTZ`); err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.Exec(`CREATE UNIQUE INDEX ux_series_name_library_id ON series (name COLLATE NOCASE, library_id) WHERE deleted_at IS NULL`); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
+	}
+
+	Migrations.MustRegister(up, down)
+}
+```
+
+- [ ] **Step 2: Run the migration up**
+
+Run: `mise db:migrate`
+
+Expected: completes without error. The dev DB at `tmp/data.sqlite` now lacks the `deleted_at` column on `series`.
+
+- [ ] **Step 3: Verify the down migration works**
+
+Run: `mise db:rollback`
+
+Expected: completes without error. The `deleted_at` column is back, partial unique index restored.
+
+- [ ] **Step 4: Run the migration up again**
+
+Run: `mise db:migrate`
+
+Expected: completes without error. Leaves the DB in the up state for the rest of the work.
+
+- [ ] **Step 5: Commit the migration on its own**
+
+```bash
+git add pkg/migrations/20260426000000_drop_series_deleted_at.go
+git commit -m "[Backend] Add migration to drop series.deleted_at"
+```
+
+---
+
+## Task 2: Write the failing regression test (Red)
+
+**Files:**
+- Modify: `pkg/series/service_test.go` — add new test function.
+
+- [ ] **Step 1: Add the regression test**
+
+Append this function at the end of `pkg/series/service_test.go`. It re-uses the `setupSeriesTestDB` helper in `pkg/series/handlers_cover_cache_test.go:29` (same package, no import change needed).
+
+```go
+// TestDeleteSeries_HardDeletesRowAndFTS pins the post-soft-delete behavior:
+// after DeleteSeries the row is gone from `series` (not just flagged with
+// deleted_at), the join rows are gone, and DeleteFromSeriesIndex purges the
+// FTS row. Catches accidental reintroduction of the soft_delete tag.
+func TestDeleteSeries_HardDeletesRowAndFTS(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceManual,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	s := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Test Series",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Test Series",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(s).Exec(ctx)
+	require.NoError(t, err)
+
+	bs := &models.BookSeries{BookID: book.ID, SeriesID: s.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(bs).Exec(ctx)
+	require.NoError(t, err)
+
+	// Index the series in FTS so we can assert it's purged after deletion.
+	searchSvc := search.NewService(db)
+	require.NoError(t, searchSvc.IndexSeries(ctx, s))
+
+	// Sanity: FTS row exists before deletion. series_fts is a virtual FTS5
+	// table, so use a raw query (Bun model queries don't work against it).
+	var pre int
+	require.NoError(t, db.NewRaw("SELECT count(*) FROM series_fts WHERE series_id = ?", s.ID).
+		Scan(ctx, &pre))
+	require.Equal(t, 1, pre, "series_fts should have a row before deletion")
+
+	// Delete via the service. The service does NOT touch FTS — the handler
+	// does. We invoke DeleteFromSeriesIndex explicitly to mirror the handler.
+	svc := NewService(db)
+	_, err = svc.DeleteSeries(ctx, s.ID)
+	require.NoError(t, err)
+	require.NoError(t, searchSvc.DeleteFromSeriesIndex(ctx, s.ID))
+
+	// 1. The row is gone from `series` (not just flagged). This is the
+	//    assertion that fails on the pre-change tree.
+	count, err := db.NewSelect().Model((*models.Series)(nil)).
+		Where("id = ?", s.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "series row must be hard-deleted, not soft-deleted")
+
+	// 2. book_series rows for the deleted series are gone (CASCADE).
+	bsCount, err := db.NewSelect().Model((*models.BookSeries)(nil)).
+		Where("series_id = ?", s.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, bsCount, "book_series rows must be removed")
+
+	// 3. FTS row is gone.
+	var post int
+	require.NoError(t, db.NewRaw("SELECT count(*) FROM series_fts WHERE series_id = ?", s.ID).
+		Scan(ctx, &post))
+	assert.Equal(t, 0, post, "series_fts row must be removed after DeleteFromSeriesIndex")
+}
+```
+
+- [ ] **Step 2: Run the test to verify it FAILS**
+
+Run: `go test ./pkg/series/ -run TestDeleteSeries_HardDeletesRowAndFTS -v`
+
+Expected: FAIL on the assertion `series row must be hard-deleted, not soft-deleted` (count == 1, expected 0). This proves the test is wired correctly and the soft-delete tag is still in effect.
+
+If the test passes here, something is wrong — stop and investigate before proceeding.
+
+---
+
+## Task 3: Drop the `soft_delete` tag from the model (Green)
+
+**Files:**
+- Modify: `pkg/models/series.go:21`
+
+- [ ] **Step 1: Remove the `DeletedAt` field**
+
+Open `pkg/models/series.go`. The struct around line 15-32 looks like this:
+
+```go
+type Series struct {
+	bun.BaseModel `bun:"table:series,alias:s" tstype:"-"`
+
+	ID                 int           `bun:",pk,nullzero" json:"id"`
+	CreatedAt          time.Time     `json:"created_at"`
+	UpdatedAt          time.Time     `json:"updated_at"`
+	DeletedAt          *time.Time    `bun:",soft_delete" json:"-"`
+	LibraryID          int           `bun:",nullzero" json:"library_id"`
+	...
+}
+```
+
+Delete the `DeletedAt` line entirely. The struct should now have `UpdatedAt` followed directly by `LibraryID`.
+
+- [ ] **Step 2: Run the regression test to verify it PASSES**
+
+Run: `go test ./pkg/series/ -run TestDeleteSeries_HardDeletesRowAndFTS -v`
+
+Expected: PASS. The `NewDelete()` call inside `DeleteSeries` now translates to a real `DELETE` statement; the row is gone, CASCADE cleans the join, the explicit FTS delete removes the FTS row.
+
+- [ ] **Step 3: Run all series-package tests**
+
+Run: `go test ./pkg/series/ -v`
+
+Expected: all pass, including `TestDeleteSeries_RemovesBookSeriesAndFlipsReviewed` (still passes — its assertions are outside-observable hard-delete behavior).
+
+---
+
+## Task 4: Simplify `DeleteSeries`
+
+**Files:**
+- Modify: `pkg/series/service.go:232-266`
+
+The inner `tx.NewDelete().Model((*models.BookSeries)(nil))` is now redundant — `book_series.series_id` already CASCADEs (set in `20260406100000_add_fk_cascades.go:150`). Drop the redundant delete and the surrounding transaction.
+
+- [ ] **Step 1: Replace the function body**
+
+Find this function in `pkg/series/service.go`:
+
+```go
+// DeleteSeries soft-deletes a series and hard-deletes its book_series join
+// rows so they don't masquerade as live series associations on the affected
+// books. Returns the IDs of books that had a join row removed; callers should
+// use these to recompute review state.
+func (svc *Service) DeleteSeries(ctx context.Context, seriesID int) ([]int, error) {
+	var affectedBookIDs []int
+	err := svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
+		err := tx.NewSelect().
+			Model((*models.BookSeries)(nil)).
+			ColumnExpr("DISTINCT bs.book_id").
+			Where("bs.series_id = ?", seriesID).
+			Scan(ctx, &affectedBookIDs)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = tx.NewDelete().
+			Model((*models.BookSeries)(nil)).
+			Where("series_id = ?", seriesID).
+			Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = tx.NewDelete().
+			Model((*models.Series)(nil)).
+			Where("id = ?", seriesID).
+			Exec(ctx)
+		return errors.WithStack(err)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return affectedBookIDs, nil
+}
+```
+
+Replace it with:
+
+```go
+// DeleteSeries deletes a series. CASCADE on book_series.series_id removes
+// the join rows. Returns the IDs of books that had a join row removed;
+// callers should use these to recompute review state.
+func (svc *Service) DeleteSeries(ctx context.Context, seriesID int) ([]int, error) {
+	var affectedBookIDs []int
+	err := svc.db.NewSelect().
+		Model((*models.BookSeries)(nil)).
+		ColumnExpr("DISTINCT bs.book_id").
+		Where("bs.series_id = ?", seriesID).
+		Scan(ctx, &affectedBookIDs)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	_, err = svc.db.NewDelete().
+		Model((*models.Series)(nil)).
+		Where("id = ?", seriesID).
+		Exec(ctx)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return affectedBookIDs, nil
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `go build ./pkg/series/`
+
+Expected: builds cleanly. If `database/sql` or `bun` becomes an unused import after the function shrinks, the compiler will tell you — drop the unused import. (`bun.Tx` was the only `bun` reference inside the function, but the file uses `bun.DB` elsewhere, so the import stays.)
+
+- [ ] **Step 3: Run series-package tests**
+
+Run: `go test ./pkg/series/ -v`
+
+Expected: all pass, including `TestDeleteSeries_RemovesBookSeriesAndFlipsReviewed` (CASCADE replaces the explicit delete) and the new regression test.
+
+---
+
+## Task 5: Remove `RestoreSeries`
+
+**Files:**
+- Modify: `pkg/series/service.go:268-281`
+
+`RestoreSeries` has zero callers and is the only consumer of `WhereAllWithDeleted()`. Delete it.
+
+- [ ] **Step 1: Delete the function**
+
+Find this function in `pkg/series/service.go`:
+
+```go
+// RestoreSeries restores a soft-deleted series.
+func (svc *Service) RestoreSeries(ctx context.Context, seriesID int) error {
+	_, err := svc.db.
+		NewUpdate().
+		Model((*models.Series)(nil)).
+		Set("deleted_at = NULL").
+		Where("id = ?", seriesID).
+		WhereAllWithDeleted().
+		Exec(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+```
+
+Delete it entirely (including the doc comment).
+
+- [ ] **Step 2: Verify the package still builds and there are no callers anywhere**
+
+Run: `go build ./...`
+
+Expected: builds cleanly. If anything in another package was calling `RestoreSeries`, it would surface here. (Exploration confirmed there are none, but this catches any miss.)
+
+- [ ] **Step 3: Run all backend tests**
+
+Run: `go test ./pkg/series/ ./pkg/books/ ./pkg/search/ -v`
+
+Expected: all pass.
+
+---
+
+## Task 6: Drop `deleted_at` filters from FTS rebuild SQL
+
+**Files:**
+- Modify: `pkg/search/service.go:578` and `:596`
+
+`s.deleted_at IS NULL` in the rebuild SQL stops working after the column is dropped. Drop both filters.
+
+- [ ] **Step 1: Edit line 578 (books-FTS rebuild)**
+
+In `pkg/search/service.go`, find this line inside the books-FTS rebuild SQL:
+
+```sql
+COALESCE((SELECT GROUP_CONCAT(s.name, ' ') FROM book_series bs JOIN series s ON bs.series_id = s.id WHERE bs.book_id = b.id AND s.deleted_at IS NULL), '')
+```
+
+Change to:
+
+```sql
+COALESCE((SELECT GROUP_CONCAT(s.name, ' ') FROM book_series bs JOIN series s ON bs.series_id = s.id WHERE bs.book_id = b.id), '')
+```
+
+(Drop the trailing `AND s.deleted_at IS NULL`.)
+
+- [ ] **Step 2: Edit lines 595-596 (series-FTS rebuild)**
+
+A few lines below, find:
+
+```sql
+FROM series s
+WHERE s.deleted_at IS NULL
+```
+
+Change to:
+
+```sql
+FROM series s
+```
+
+(Drop the `WHERE s.deleted_at IS NULL` line entirely.)
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `go build ./pkg/search/`
+
+Expected: builds cleanly.
+
+- [ ] **Step 4: Run search-package tests**
+
+Run: `go test ./pkg/search/ -v`
+
+Expected: all pass. The rebuild path is exercised by tests that call `RebuildAllIndexes`; they will fail at runtime against the post-migration schema if the `s.deleted_at IS NULL` references aren't removed.
+
+---
+
+## Task 7: Update doc comments
+
+**Files:**
+- Modify: `pkg/series/service.go` — comments on `MergeSeries` and `CleanupOrphanedSeries`.
+- Modify: `pkg/books/service.go:1363` — comment on duplicate `CleanupOrphanedSeries`.
+
+Comments still say "soft-deletes" but the behavior is now hard delete. Per the user-feedback memory `feedback_update_comments_scope.md`, comments must reflect current scope.
+
+- [ ] **Step 1: Update `MergeSeries` comment in `pkg/series/service.go:283-285`**
+
+Find:
+
+```go
+// MergeSeries merges sourceSeries into targetSeries (moves all books,
+// soft-deletes source). Returns the IDs of books whose join rows moved so
+// the caller can recompute search indexes that bake in the series name.
+```
+
+Change "soft-deletes source" to "deletes source":
+
+```go
+// MergeSeries merges sourceSeries into targetSeries (moves all books,
+// deletes source). Returns the IDs of books whose join rows moved so
+// the caller can recompute search indexes that bake in the series name.
+```
+
+- [ ] **Step 2: Update inline comment in `MergeSeries`**
+
+Inside the same function (around line 308), find:
+
+```go
+		// Soft-delete the source series
+		_, err = tx.NewDelete().
+```
+
+Change to:
+
+```go
+		// Delete the source series
+		_, err = tx.NewDelete().
+```
+
+- [ ] **Step 3: Update `CleanupOrphanedSeries` comment in `pkg/series/service.go:321`**
+
+Find:
+
+```go
+// CleanupOrphanedSeries soft-deletes series with no books.
+```
+
+Change to:
+
+```go
+// CleanupOrphanedSeries deletes series with no books.
+```
+
+- [ ] **Step 4: Update duplicate `CleanupOrphanedSeries` comment in `pkg/books/service.go:1363`**
+
+Find:
+
+```go
+// CleanupOrphanedSeries soft-deletes series with no books.
+// This is duplicated from series service to avoid import cycles.
+```
+
+Change to:
+
+```go
+// CleanupOrphanedSeries deletes series with no books.
+// This is duplicated from series service to avoid import cycles.
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `go build ./...`
+
+Expected: builds cleanly.
+
+---
+
+## Task 8: Run targeted lint and tests
+
+- [ ] **Step 1: Run Go lint and tests**
+
+Run: `mise lint test`
+
+Expected: all pass. This is the targeted-subset run for a Go-only change per `CLAUDE.md`.
+
+If anything fails, do not proceed — investigate the failure and re-run.
+
+---
+
+## Task 9: Commit the code changes together
+
+Tasks 2–7 together form one logical change: "switch series to hard-delete".
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add pkg/models/series.go pkg/series/service.go pkg/series/service_test.go pkg/books/service.go pkg/search/service.go
+git commit -m "$(cat <<'EOF'
+[Backend] Hard-delete series, drop soft-delete plumbing
+
+models.Series was the only model using bun's soft_delete tag. RestoreSeries
+had zero callers and every read path filtered deleted_at IS NULL, so the
+recovery mechanism was unreachable. Drop the tag, simplify DeleteSeries
+(book_series.series_id already CASCADEs since 20260406100000), remove the
+unused RestoreSeries, and drop the s.deleted_at IS NULL filters from the
+FTS rebuild SQL.
+
+Adds TestDeleteSeries_HardDeletesRowAndFTS as a regression pin.
+EOF
+)"
+```
+
+- [ ] **Step 2: Verify the commit looks right**
+
+Run: `git log -1 --stat`
+
+Expected: shows the 5 files modified — `pkg/models/series.go`, `pkg/series/service.go`, `pkg/series/service_test.go`, `pkg/books/service.go`, `pkg/search/service.go`.
+
+---
+
+## Task 10: Manual smoke test
+
+Per `CLAUDE.md`, UI/feature changes warrant a quick manual check even when tests pass.
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `mise start`
+
+Expected: API + Vite frontend come up. Watch the API logs to confirm migration `20260426000000_drop_series_deleted_at` runs once with no error on first startup against your dev DB.
+
+- [ ] **Step 2: Log in and exercise series delete**
+
+Open http://localhost:5173, log in with `robin / password123`.
+
+- Navigate to a library that has at least one series. If none, edit a book and add a series first.
+- Open the series detail page and delete the series via the UI.
+- Confirm the series disappears from the series list.
+- Open global search and search for the deleted series name. Confirm zero series hits.
+
+Expected: series gone from list and search.
+
+- [ ] **Step 3: Exercise series merge**
+
+- Create two series in the same library (or pick two existing ones).
+- Merge one into the other via the UI.
+- Confirm the source disappears, the target keeps all books.
+
+Expected: source gone, target intact.
+
+- [ ] **Step 4: Stop the dev server**
+
+Hit Ctrl-C in the `mise start` terminal.
+
+---
+
+## Task 11: Final pre-PR check
+
+- [ ] **Step 1: Run the full validation suite**
+
+Run: `mise check:quiet`
+
+Expected: passes. This is the once-before-PR gate per `CLAUDE.md`. Concurrent runs from other worktrees serialize via `flock`, so just kick it off and wait.
+
+- [ ] **Step 2: Push the branch**
+
+Run: `git push -u origin task/soft-delete`
+
+Expected: pushes cleanly.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "[Backend] Hard-delete series, remove soft-delete plumbing" --body "$(cat <<'EOF'
+## Summary
+
+- `models.Series` was the only model in the codebase using Bun's `soft_delete` tag, with `RestoreSeries` having zero callers — the recovery mechanism was unreachable.
+- Drop the `deleted_at` column, the partial unique index `WHERE deleted_at IS NULL`, the unused `RestoreSeries` function, and the hand-written `s.deleted_at IS NULL` filters in FTS rebuild SQL.
+- Simplify `DeleteSeries`: `book_series.series_id` already CASCADEs (set in `20260406100000_add_fk_cascades.go`), so the explicit join-row delete and surrounding transaction are now redundant.
+- Migration hard-deletes any rows currently in the soft-deleted state and rebuilds the unique index unconditional. **Down migration is lossy** — does not restore deleted rows. Same precedent as `20260423000000_drop_libraries_deleted_at.go` two days ago.
+
+## Test plan
+
+- [x] `mise db:rollback && mise db:migrate` round-trip
+- [x] New regression test `TestDeleteSeries_HardDeletesRowAndFTS` fails on master, passes on this branch
+- [x] `mise lint test`
+- [x] `mise check:quiet`
+- [x] Manual: delete a series via UI; confirm it's gone from the list and global search
+- [x] Manual: merge two series; confirm source is gone, target intact
+
+Spec: `docs/superpowers/specs/2026-04-26-series-hard-delete-design.md`
+EOF
+)"
+```
+
+Expected: PR opens. Return the URL to the user.
+
+---
+
+## Notes for the implementing engineer
+
+- **Don't skip the Red step (Task 2 Step 2).** Watching the test fail before changing the implementation is the only proof that the test actually catches the bug. Per `CLAUDE.md`, this is a hard requirement.
+- **Don't add `Restore*` back.** If a future task needs deleted-series recovery, it should be designed deliberately with a UI surface, not by reintroducing a soft-delete tag.
+- **`CleanupOrphanedSeries` is duplicated on purpose.** `pkg/series/service.go:321` and `pkg/books/service.go:1363` both exist to break an import cycle. Don't try to deduplicate as part of this PR — it's noted as out-of-scope in the spec.
+- **The `users.is_active` "deactivation" pattern is unrelated.** It's a different mechanism, actively used, and explicitly out of scope.
+- **No frontend, OPDS, eReader, plugin SDK, sidecar, or website docs to touch.** Exploration confirmed none of these reference soft-delete on series. Don't go looking for changes there.

--- a/docs/superpowers/specs/2026-04-26-series-hard-delete-design.md
+++ b/docs/superpowers/specs/2026-04-26-series-hard-delete-design.md
@@ -1,0 +1,113 @@
+# Series Hard-Delete — Design
+
+## Problem
+
+`models.Series` is the only model in the codebase using Bun's `soft_delete` tag. The infrastructure built around it — a `deleted_at` column, a partial unique index `WHERE deleted_at IS NULL`, hand-written `s.deleted_at IS NULL` filters in FTS rebuild SQL, a `RestoreSeries` function, manual `book_series` cleanup in `DeleteSeries` — exists for one model and leaks complexity across the search, books, and series packages.
+
+The soft-delete behavior is also write-only: `RestoreSeries` has zero callers (no HTTP handler, no frontend, no CLI, no test), and the only `WhereAllWithDeleted()` call sits inside `RestoreSeries` itself. Once a series is "soft-deleted", every read path — listing, search, FTS rebuild, Bun relation walks — filters it out, with no path back. We're paying for a recovery mechanism nobody can invoke.
+
+A precedent for ripping out unused soft-delete plumbing already exists: `20260423000000_drop_libraries_deleted_at.go` removed the equivalent column from `libraries` two days ago.
+
+## Goals
+
+- Convert `models.Series` from soft-delete to hard-delete.
+- Remove the `deleted_at` column, the partial unique index, the `WhereAllWithDeleted()` call, the `s.deleted_at IS NULL` filters in FTS rebuild SQL, and the unused `RestoreSeries` function.
+- Recreate the unique index on `(name COLLATE NOCASE, library_id)` without the partial WHERE clause so it enforces uniqueness over the whole table.
+- Hard-delete any rows currently in the soft-deleted state as part of the migration. CASCADE on `book_series.series_id` (set in `20260406100000_add_fk_cascades.go`) cleans their join rows; a defensive purge handles any orphaned `series_fts` rows.
+- Pin the new behavior with a regression test that fails on the pre-change tree.
+- No user-visible behavior change. Soft-deleted series are already filtered everywhere; making them actually gone has no observable effect on the UI, OPDS, eReader, Kobo sync, plugins, or sidecars.
+
+## Non-Goals
+
+- Touching the `users.is_active` "deactivation" toggle in `pkg/users/service.go`. That's a different mechanism (a boolean flag, not a `deleted_at` timestamp), it's actively used, and removing it would require user-facing UX changes.
+- Deduplicating the two copies of `CleanupOrphanedSeries` (`pkg/series/service.go:321` and `pkg/books/service.go:1363`). The duplication exists to avoid an import cycle; resolving it is a separate refactor.
+- Adding any new restore mechanism. There was no working one before; we're not building one.
+- Frontend, OPDS, eReader, plugin SDK, sidecar, or `website/docs/` changes. Verified during exploration that none of these reference soft-delete.
+
+## Architecture
+
+### Migration
+
+New file: `pkg/migrations/20260426000000_drop_series_deleted_at.go`. Modeled on `20260423000000_drop_libraries_deleted_at.go`.
+
+Up direction, in order:
+
+1. `DELETE FROM series WHERE deleted_at IS NOT NULL` — hard-deletes all currently-soft-deleted rows. CASCADE on `book_series.series_id` removes their join rows automatically. Done before the schema change so the unconditional unique index in step 5 can't collide on a name shared between a soft-deleted and a live row in the same library.
+2. `DELETE FROM series_fts WHERE series_id NOT IN (SELECT id FROM series)` — defensive purge. Handlers already call `DeleteFromSeriesIndex` on soft-delete today, so this should be a no-op in practice; included so the migration is self-healing if any orphans crept in.
+3. `DROP INDEX ux_series_name_library_id` — the partial index references `deleted_at` and would block step 4.
+4. `ALTER TABLE series DROP COLUMN deleted_at` — SQLite ≥ 3.35 (March 2021) supports this; the project is well above that version.
+5. `CREATE UNIQUE INDEX ux_series_name_library_id ON series (name COLLATE NOCASE, library_id)` — recreate without the partial WHERE clause.
+
+FK enforcement (`PRAGMA foreign_keys=ON`) stays on throughout. That's what makes step 1 cascade to `book_series` cleanly.
+
+Down direction is lossy (does not restore deleted rows), matching the precedent set by `20260423000000_drop_libraries_deleted_at.go`:
+
+1. `DROP INDEX ux_series_name_library_id`
+2. `ALTER TABLE series ADD COLUMN deleted_at TIMESTAMPTZ`
+3. `CREATE UNIQUE INDEX ux_series_name_library_id ON series (name COLLATE NOCASE, library_id) WHERE deleted_at IS NULL`
+
+### Code changes
+
+**`pkg/models/series.go:21`** — delete the `DeletedAt` field carrying the `bun:",soft_delete"` tag:
+
+```go
+DeletedAt *time.Time `bun:",soft_delete" json:"-"`
+```
+
+This single tag removal flips every `NewDelete().Model((*models.Series)(nil))` in the codebase from a soft-delete UPDATE to an actual SQL DELETE. No call site needs to change behavior; Bun translates the same builder call to different SQL based on the tag.
+
+**`pkg/series/service.go`:**
+
+- `DeleteSeries` (lines 232–266): the inner `tx.NewDelete().Model((*models.BookSeries)(nil))` is now redundant — `book_series.series_id` already CASCADEs. Simplify to: SELECT distinct affected book IDs, then DELETE the series; CASCADE removes the join rows. Drop the transaction wrapper (one SELECT + one DELETE doesn't need it). Update the doc comment from "soft-deletes a series and hard-deletes its book_series join rows" to "deletes a series; book_series join rows cascade".
+- `RestoreSeries` (lines 268–281): delete the entire function. This removes the only `WhereAllWithDeleted()` call in the codebase.
+- `MergeSeries` (lines 283–319): unchanged behavior. Update the comment from "moves all books, soft-deletes source" to "moves all books, deletes source".
+- `CleanupOrphanedSeries` (lines 321–332): unchanged behavior. Update the comment from "soft-deletes series with no books" to "deletes series with no books".
+
+**`pkg/books/service.go:1363`** — same `CleanupOrphanedSeries` comment fix on the duplicate copy.
+
+**`pkg/search/service.go`:**
+
+- Line 578: drop `AND s.deleted_at IS NULL` from the books-FTS rebuild subquery's join.
+- Line 596: drop `WHERE s.deleted_at IS NULL` from the series-FTS rebuild query.
+
+### Tests
+
+Existing tests in `pkg/series/service_test.go` continue to pass without modification. They assert outside-observable hard-delete semantics (book_series rows go away, search index gets reindexed) which are unchanged by the move from soft to hard delete.
+
+New regression test: `TestDeleteSeries_HardDeletesRowAndFTS` in `pkg/series/service_test.go`. Asserts:
+
+1. After `DeleteSeries(id)`, `SELECT count(*) FROM series WHERE id = ?` returns 0. (Proves a hard delete; would fail on the pre-change tree because soft-delete leaves the row in place.)
+2. After the handler-level call (which invokes `DeleteFromSeriesIndex`), `SELECT count(*) FROM series_fts WHERE series_id = ?` returns 0.
+3. `book_series` rows for the deleted series are gone (already covered by `TestDeleteSeries_RemovesBookSeriesAndFlipsReviewed`; re-asserting here for completeness in the new pinning test).
+
+Follows the Red-Green-Refactor rule from `CLAUDE.md`: write the test first, run on a tree that still has the soft-delete tag (and the migration applied) to confirm assertion 1 fails, then drop the tag + dead code and confirm green.
+
+### CleanupOrphanedSeries — unchanged
+
+`CleanupOrphanedSeries` has 5 callers (4 in `pkg/books/handlers.go` and 1 in `pkg/worker/worker.go`) and is still useful after this change. Deleting a book CASCADEs to remove `book_series` rows but does not remove the series itself; `CleanupOrphanedSeries` exists to clear empty series after their last book leaves. Behavior change is from a soft-delete UPDATE to a real DELETE — same end-state observable to users (the series disappears from listings).
+
+## Verification
+
+Local, in order:
+
+1. `mise db:rollback && mise db:migrate` — exercises the up migration.
+2. `mise db:rollback` — exercises the down migration (restores the column + partial index).
+3. `mise db:migrate` — re-up.
+4. **Red:** run `TestDeleteSeries_HardDeletesRowAndFTS` against a tree with the migration applied but the model tag still present. Assertion 1 must fail.
+5. **Green:** drop the model tag + dead code, re-run the test, confirm pass.
+6. `mise lint test` — Go-only edit, per the targeted-subset guidance in `CLAUDE.md`.
+7. Final pre-PR: `mise check:quiet`.
+
+Manual smoke (under five minutes):
+
+- `mise start`, log in as `robin:password123`.
+- Delete a series from the series list. Confirm it disappears from the list and from global search.
+- Merge two series. Confirm the source disappears and the target keeps all books.
+
+## Rollout
+
+- Single PR on the existing `task/soft-delete` branch.
+- Migration runs at application startup; no replicas, no concurrent writers, bounded by however many soft-deleted series exist (cheap).
+- No feature flag required — soft-deleted series were already filtered everywhere, so the behavior change is invisible to users.
+- PR description should call out the lossy-down migration explicitly so a reviewer doesn't assume the down direction is non-destructive.
+- No follow-up cleanup PR — this is a one-shot ship with no flag to remove later.

--- a/docs/superpowers/specs/2026-04-26-series-hard-delete-design.md
+++ b/docs/superpowers/specs/2026-04-26-series-hard-delete-design.md
@@ -15,12 +15,14 @@ A precedent for ripping out unused soft-delete plumbing already exists: `2026042
 - Recreate the unique index on `(name COLLATE NOCASE, library_id)` without the partial WHERE clause so it enforces uniqueness over the whole table.
 - Hard-delete any rows currently in the soft-deleted state as part of the migration. CASCADE on `book_series.series_id` (set in `20260406100000_add_fk_cascades.go`) cleans their join rows; a defensive purge handles any orphaned `series_fts` rows.
 - Pin the new behavior with a regression test that fails on the pre-change tree.
-- No user-visible behavior change. Soft-deleted series are already filtered everywhere; making them actually gone has no observable effect on the UI, OPDS, eReader, Kobo sync, plugins, or sidecars.
+- Fix a pre-existing latent bug exposed by smoke testing: `CleanupOrphanedSeries` deletes orphan rows from `series` but never purges the corresponding `series_fts` rows, leaving the search index pointing at non-existent series. The fix changes `CleanupOrphanedSeries` to return the deleted IDs (atomically via `RETURNING id`) and updates all five callers (4 in `pkg/books/handlers.go`, 1 in `pkg/worker/worker.go`) to pair the call with `searchService.DeleteFromSeriesIndex` — same shape as the existing `people` cleanup pattern.
+- No user-visible behavior change for the soft-delete removal itself. Soft-deleted series are already filtered everywhere; making them actually gone has no observable effect on the UI, OPDS, eReader, Kobo sync, plugins, or sidecars. The `CleanupOrphanedSeries` fix corrects an observable bug (stale search results pointing at deleted series).
 
 ## Non-Goals
 
 - Touching the `users.is_active` "deactivation" toggle in `pkg/users/service.go`. That's a different mechanism (a boolean flag, not a `deleted_at` timestamp), it's actively used, and removing it would require user-facing UX changes.
-- Deduplicating the two copies of `CleanupOrphanedSeries` (`pkg/series/service.go:321` and `pkg/books/service.go:1363`). The duplication exists to avoid an import cycle; resolving it is a separate refactor.
+- Deduplicating the two copies of `CleanupOrphanedSeries` (`pkg/series/service.go` and `pkg/books/service.go`). The duplication exists to avoid an import cycle; resolving it is a separate refactor.
+- Fixing the analogous "FTS not cleaned up" bug for genres, tags, or other entities with their own FTS indexes. The same problem may exist there (`CleanupOrphanedGenres` / `CleanupOrphanedTags` are called without paired FTS purges in `pkg/books/handlers.go`). Out of scope for this branch; worth a follow-up.
 - Adding any new restore mechanism. There was no working one before; we're not building one.
 - Frontend, OPDS, eReader, plugin SDK, sidecar, or `website/docs/` changes. Verified during exploration that none of these reference soft-delete.
 
@@ -82,9 +84,19 @@ New regression test: `TestDeleteSeries_HardDeletesRowAndFTS` in `pkg/series/serv
 
 Follows the Red-Green-Refactor rule from `CLAUDE.md`: write the test first, run on a tree that still has the soft-delete tag (and the migration applied) to confirm assertion 1 fails, then drop the tag + dead code and confirm green.
 
-### CleanupOrphanedSeries — unchanged
+### CleanupOrphanedSeries — signature change + caller updates
 
-`CleanupOrphanedSeries` has 5 callers (4 in `pkg/books/handlers.go` and 1 in `pkg/worker/worker.go`) and is still useful after this change. Deleting a book CASCADEs to remove `book_series` rows but does not remove the series itself; `CleanupOrphanedSeries` exists to clear empty series after their last book leaves. Behavior change is from a soft-delete UPDATE to a real DELETE — same end-state observable to users (the series disappears from listings).
+`CleanupOrphanedSeries` has 5 callers (4 in `pkg/books/handlers.go` and 1 in `pkg/worker/worker.go`) and is still useful after this change — deleting a book CASCADEs to remove `book_series` rows but does not remove the series itself, so `CleanupOrphanedSeries` clears empty series after their last book leaves.
+
+However, smoke testing surfaced a pre-existing bug: `CleanupOrphanedSeries` only deletes from the `series` table, leaving stale rows in `series_fts`. The series search path (`searchSeriesInternal` in `pkg/search/service.go`) queries `series_fts` directly with no JOIN to `series`, so deleted-via-cleanup series remain in search results forever. This was masked under soft-delete (the listings filtered on `deleted_at`, but search still showed them), and is more visible under hard-delete (clicking a stale search result 404s rather than showing a hidden "deleted" page).
+
+Fix:
+
+- Change both copies of `CleanupOrphanedSeries` (`pkg/series/service.go` and `pkg/books/service.go`) to return `([]int, error)` — the IDs of deleted series — using `NewDelete().Returning("id").Scan(ctx, &ids)`. SQLite's `RETURNING` clause makes this atomic, so the IDs returned are exactly the rows the same statement deleted (no race between a SELECT and a DELETE).
+- Update all 5 callers to iterate the returned IDs and call `searchService.DeleteFromSeriesIndex` for each. This mirrors the existing `people` cleanup pattern at `pkg/books/handlers.go:680-689`.
+- The worker's `cleanupOrphanedEntities` previously logged a count from `result.RowsAffected()`; switch to `len(deletedIDs)`.
+
+A new test `TestCleanupOrphanedSeries_ReturnsDeletedIDs` in `pkg/series/service_test.go` pins the signature and behavior.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-04-26-series-hard-delete-design.md
+++ b/docs/superpowers/specs/2026-04-26-series-hard-delete-design.md
@@ -22,7 +22,8 @@ A precedent for ripping out unused soft-delete plumbing already exists: `2026042
 
 - Touching the `users.is_active` "deactivation" toggle in `pkg/users/service.go`. That's a different mechanism (a boolean flag, not a `deleted_at` timestamp), it's actively used, and removing it would require user-facing UX changes.
 - Deduplicating the two copies of `CleanupOrphanedSeries` (`pkg/series/service.go` and `pkg/books/service.go`). The duplication exists to avoid an import cycle; resolving it is a separate refactor.
-- Fixing the analogous "FTS not cleaned up" bug for genres, tags, or other entities with their own FTS indexes. The same problem may exist there (`CleanupOrphanedGenres` / `CleanupOrphanedTags` are called without paired FTS purges in `pkg/books/handlers.go`). Out of scope for this branch; worth a follow-up.
+- Frontend `GlobalSearch` cache invalidation on entity mutations was added in this same branch (in scope after smoke testing surfaced "deleted series still in search until refresh"). Series, person, and book mutation hooks now invalidate `[GlobalSearch]` so search results refresh without a manual reload.
+- The analogous backend "FTS not cleaned up" bug exists for genres and tags. Pulled into scope alongside series after the smoke test exposed the pattern: `CleanupOrphanedGenres` and `CleanupOrphanedTags` now also return deleted IDs, and all callers in `pkg/books/handlers.go` and `pkg/worker/worker.go` pair the call with the corresponding `searchService.DeleteFromGenreIndex` / `DeleteFromTagIndex`.
 - Adding any new restore mechanism. There was no working one before; we're not building one.
 - Frontend, OPDS, eReader, plugin SDK, sidecar, or `website/docs/` changes. Verified during exploration that none of these reference soft-delete.
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -690,8 +690,14 @@ func (h *handler) update(c echo.Context) error {
 		}
 	}
 	if seriesChanged {
-		if _, err := h.bookService.CleanupOrphanedSeries(ctx); err != nil {
+		orphanedSeriesIDs, err := h.bookService.CleanupOrphanedSeries(ctx)
+		if err != nil {
 			log.Warn("failed to cleanup orphaned series", logger.Data{"error": err.Error()})
+		}
+		for _, seriesID := range orphanedSeriesIDs {
+			if err := h.searchService.DeleteFromSeriesIndex(ctx, seriesID); err != nil {
+				log.Warn("failed to remove orphaned series from search index", logger.Data{"series_id": seriesID, "error": err.Error()})
+			}
 		}
 	}
 
@@ -2502,8 +2508,14 @@ func (h *handler) deleteBook(c echo.Context) error {
 	if _, err := h.personService.CleanupOrphanedPeople(ctx); err != nil {
 		log.Warn("failed to cleanup orphaned people", logger.Data{"error": err.Error()})
 	}
-	if _, err := h.bookService.CleanupOrphanedSeries(ctx); err != nil {
+	orphanedSeriesIDs, err := h.bookService.CleanupOrphanedSeries(ctx)
+	if err != nil {
 		log.Warn("failed to cleanup orphaned series", logger.Data{"error": err.Error()})
+	}
+	for _, seriesID := range orphanedSeriesIDs {
+		if err := h.searchService.DeleteFromSeriesIndex(ctx, seriesID); err != nil {
+			log.Warn("failed to remove orphaned series from search index", logger.Data{"series_id": seriesID, "error": err.Error()})
+		}
 	}
 	if _, err := h.genreService.CleanupOrphanedGenres(ctx); err != nil {
 		log.Warn("failed to cleanup orphaned genres", logger.Data{"error": err.Error()})
@@ -2573,8 +2585,14 @@ func (h *handler) deleteFile(c echo.Context) error {
 		if _, err := h.personService.CleanupOrphanedPeople(ctx); err != nil {
 			log.Warn("failed to cleanup orphaned people", logger.Data{"error": err})
 		}
-		if _, err := h.bookService.CleanupOrphanedSeries(ctx); err != nil {
+		orphanedSeriesIDs, err := h.bookService.CleanupOrphanedSeries(ctx)
+		if err != nil {
 			log.Warn("failed to cleanup orphaned series", logger.Data{"error": err})
+		}
+		for _, seriesID := range orphanedSeriesIDs {
+			if err := h.searchService.DeleteFromSeriesIndex(ctx, seriesID); err != nil {
+				log.Warn("failed to remove orphaned series from search index", logger.Data{"series_id": seriesID, "error": err})
+			}
 		}
 		if _, err := h.genreService.CleanupOrphanedGenres(ctx); err != nil {
 			log.Warn("failed to cleanup orphaned genres", logger.Data{"error": err})
@@ -2660,8 +2678,14 @@ func (h *handler) deleteBooks(c echo.Context) error {
 	if _, err := h.personService.CleanupOrphanedPeople(ctx); err != nil {
 		log.Warn("failed to cleanup orphaned people", logger.Data{"error": err.Error()})
 	}
-	if _, err := h.bookService.CleanupOrphanedSeries(ctx); err != nil {
+	orphanedSeriesIDs, err := h.bookService.CleanupOrphanedSeries(ctx)
+	if err != nil {
 		log.Warn("failed to cleanup orphaned series", logger.Data{"error": err.Error()})
+	}
+	for _, seriesID := range orphanedSeriesIDs {
+		if err := h.searchService.DeleteFromSeriesIndex(ctx, seriesID); err != nil {
+			log.Warn("failed to remove orphaned series from search index", logger.Data{"series_id": seriesID, "error": err.Error()})
+		}
 	}
 	if _, err := h.genreService.CleanupOrphanedGenres(ctx); err != nil {
 		log.Warn("failed to cleanup orphaned genres", logger.Data{"error": err.Error()})

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -482,9 +482,15 @@ func (h *handler) update(c echo.Context) error {
 		book.GenreSource = &genreSource
 		opts.Columns = append(opts.Columns, "genre_source")
 
-		// Cleanup orphaned genres after deletion
-		if _, err := h.genreService.CleanupOrphanedGenres(ctx); err != nil {
+		// Cleanup orphaned genres after deletion and purge their FTS rows.
+		orphanedGenreIDs, err := h.genreService.CleanupOrphanedGenres(ctx)
+		if err != nil {
 			log.Warn("failed to cleanup orphaned genres", logger.Data{"error": err.Error()})
+		}
+		for _, id := range orphanedGenreIDs {
+			if err := h.searchService.DeleteFromGenreIndex(ctx, id); err != nil {
+				log.Warn("failed to remove orphaned genre from search index", logger.Data{"genre_id": id, "error": err.Error()})
+			}
 		}
 
 		// Re-index old genres (some may have been deleted/orphaned)
@@ -550,9 +556,15 @@ func (h *handler) update(c echo.Context) error {
 		book.TagSource = &tagSource
 		opts.Columns = append(opts.Columns, "tag_source")
 
-		// Cleanup orphaned tags after deletion
-		if _, err := h.tagService.CleanupOrphanedTags(ctx); err != nil {
+		// Cleanup orphaned tags after deletion and purge their FTS rows.
+		orphanedTagIDs, err := h.tagService.CleanupOrphanedTags(ctx)
+		if err != nil {
 			log.Warn("failed to cleanup orphaned tags", logger.Data{"error": err.Error()})
+		}
+		for _, id := range orphanedTagIDs {
+			if err := h.searchService.DeleteFromTagIndex(ctx, id); err != nil {
+				log.Warn("failed to remove orphaned tag from search index", logger.Data{"tag_id": id, "error": err.Error()})
+			}
 		}
 
 		// Re-index old tags (some may have been deleted/orphaned)
@@ -2517,11 +2529,23 @@ func (h *handler) deleteBook(c echo.Context) error {
 			log.Warn("failed to remove orphaned series from search index", logger.Data{"series_id": seriesID, "error": err.Error()})
 		}
 	}
-	if _, err := h.genreService.CleanupOrphanedGenres(ctx); err != nil {
+	orphanedGenreIDs, err := h.genreService.CleanupOrphanedGenres(ctx)
+	if err != nil {
 		log.Warn("failed to cleanup orphaned genres", logger.Data{"error": err.Error()})
 	}
-	if _, err := h.tagService.CleanupOrphanedTags(ctx); err != nil {
+	for _, genreID := range orphanedGenreIDs {
+		if err := h.searchService.DeleteFromGenreIndex(ctx, genreID); err != nil {
+			log.Warn("failed to remove orphaned genre from search index", logger.Data{"genre_id": genreID, "error": err.Error()})
+		}
+	}
+	orphanedTagIDs, err := h.tagService.CleanupOrphanedTags(ctx)
+	if err != nil {
 		log.Warn("failed to cleanup orphaned tags", logger.Data{"error": err.Error()})
+	}
+	for _, tagID := range orphanedTagIDs {
+		if err := h.searchService.DeleteFromTagIndex(ctx, tagID); err != nil {
+			log.Warn("failed to remove orphaned tag from search index", logger.Data{"tag_id": tagID, "error": err.Error()})
+		}
 	}
 
 	return c.JSON(http.StatusOK, DeleteBookResponse{
@@ -2594,11 +2618,23 @@ func (h *handler) deleteFile(c echo.Context) error {
 				log.Warn("failed to remove orphaned series from search index", logger.Data{"series_id": seriesID, "error": err})
 			}
 		}
-		if _, err := h.genreService.CleanupOrphanedGenres(ctx); err != nil {
+		orphanedGenreIDs, err := h.genreService.CleanupOrphanedGenres(ctx)
+		if err != nil {
 			log.Warn("failed to cleanup orphaned genres", logger.Data{"error": err})
 		}
-		if _, err := h.tagService.CleanupOrphanedTags(ctx); err != nil {
+		for _, genreID := range orphanedGenreIDs {
+			if err := h.searchService.DeleteFromGenreIndex(ctx, genreID); err != nil {
+				log.Warn("failed to remove orphaned genre from search index", logger.Data{"genre_id": genreID, "error": err})
+			}
+		}
+		orphanedTagIDs, err := h.tagService.CleanupOrphanedTags(ctx)
+		if err != nil {
 			log.Warn("failed to cleanup orphaned tags", logger.Data{"error": err})
+		}
+		for _, tagID := range orphanedTagIDs {
+			if err := h.searchService.DeleteFromTagIndex(ctx, tagID); err != nil {
+				log.Warn("failed to remove orphaned tag from search index", logger.Data{"tag_id": tagID, "error": err})
+			}
 		}
 	}
 
@@ -2687,11 +2723,23 @@ func (h *handler) deleteBooks(c echo.Context) error {
 			log.Warn("failed to remove orphaned series from search index", logger.Data{"series_id": seriesID, "error": err.Error()})
 		}
 	}
-	if _, err := h.genreService.CleanupOrphanedGenres(ctx); err != nil {
+	orphanedGenreIDs, err := h.genreService.CleanupOrphanedGenres(ctx)
+	if err != nil {
 		log.Warn("failed to cleanup orphaned genres", logger.Data{"error": err.Error()})
 	}
-	if _, err := h.tagService.CleanupOrphanedTags(ctx); err != nil {
+	for _, genreID := range orphanedGenreIDs {
+		if err := h.searchService.DeleteFromGenreIndex(ctx, genreID); err != nil {
+			log.Warn("failed to remove orphaned genre from search index", logger.Data{"genre_id": genreID, "error": err.Error()})
+		}
+	}
+	orphanedTagIDs, err := h.tagService.CleanupOrphanedTags(ctx)
+	if err != nil {
 		log.Warn("failed to cleanup orphaned tags", logger.Data{"error": err.Error()})
+	}
+	for _, tagID := range orphanedTagIDs {
+		if err := h.searchService.DeleteFromTagIndex(ctx, tagID); err != nil {
+			log.Warn("failed to remove orphaned tag from search index", logger.Data{"tag_id": tagID, "error": err.Error()})
+		}
 	}
 
 	return c.JSON(http.StatusOK, DeleteBooksResponse{

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -241,12 +241,6 @@ func (h *handler) update(c echo.Context) error {
 		oldSeriesIDs = append(oldSeriesIDs, bs.SeriesID)
 	}
 
-	// Track old author person IDs for FTS re-indexing
-	oldPersonIDs := make([]int, 0)
-	for _, author := range book.Authors {
-		oldPersonIDs = append(oldPersonIDs, author.PersonID)
-	}
-
 	// Update title
 	if params.Title != nil && *params.Title != book.Title {
 		oldTitle := book.Title
@@ -674,27 +668,10 @@ func (h *handler) update(c echo.Context) error {
 
 	// Cleanup orphaned records
 	if authorsChanged {
-		// Get list of orphaned people before deleting them (for FTS cleanup)
-		orphanedPersonIDs := make([]int, 0)
-		for _, personID := range oldPersonIDs {
-			// Check if this old person is still associated with any books
-			isOrphaned := true
-			for _, author := range book.Authors {
-				if author.PersonID == personID {
-					isOrphaned = false
-					break
-				}
-			}
-			if isOrphaned {
-				orphanedPersonIDs = append(orphanedPersonIDs, personID)
-			}
-		}
-
-		if _, err := h.personService.CleanupOrphanedPeople(ctx); err != nil {
+		orphanedPersonIDs, err := h.personService.CleanupOrphanedPeople(ctx)
+		if err != nil {
 			log.Warn("failed to cleanup orphaned people", logger.Data{"error": err.Error()})
 		}
-
-		// Remove orphaned people from FTS index
 		for _, personID := range orphanedPersonIDs {
 			if err := h.searchService.DeleteFromPersonIndex(ctx, personID); err != nil {
 				log.Warn("failed to remove orphaned person from search index", logger.Data{"person_id": personID, "error": err.Error()})
@@ -927,12 +904,6 @@ func (h *handler) updateFile(c echo.Context) error {
 
 		file.FileRole = newRole
 		opts.Columns = append(opts.Columns, "file_role")
-	}
-
-	// Track old narrator person IDs for FTS re-indexing
-	oldNarratorPersonIDs := make([]int, 0)
-	for _, narrator := range file.Narrators {
-		oldNarratorPersonIDs = append(oldNarratorPersonIDs, narrator.PersonID)
 	}
 
 	// narratorNames tracks the authoritative narrator list for this file —
@@ -1256,27 +1227,10 @@ func (h *handler) updateFile(c echo.Context) error {
 
 	// Cleanup orphaned people
 	if narratorsChanged {
-		// Get list of orphaned people before deleting them (for FTS cleanup)
-		orphanedPersonIDs := make([]int, 0)
-		for _, personID := range oldNarratorPersonIDs {
-			// Check if this old person is still associated with any files as narrator
-			isOrphaned := true
-			for _, narrator := range file.Narrators {
-				if narrator.PersonID == personID {
-					isOrphaned = false
-					break
-				}
-			}
-			if isOrphaned {
-				orphanedPersonIDs = append(orphanedPersonIDs, personID)
-			}
-		}
-
-		if _, err := h.personService.CleanupOrphanedPeople(ctx); err != nil {
+		orphanedPersonIDs, err := h.personService.CleanupOrphanedPeople(ctx)
+		if err != nil {
 			log.Warn("failed to cleanup orphaned people", logger.Data{"error": err.Error()})
 		}
-
-		// Remove orphaned people from FTS index
 		for _, personID := range orphanedPersonIDs {
 			if err := h.searchService.DeleteFromPersonIndex(ctx, personID); err != nil {
 				log.Warn("failed to remove orphaned person from search index", logger.Data{"person_id": personID, "error": err.Error()})
@@ -2517,8 +2471,14 @@ func (h *handler) deleteBook(c echo.Context) error {
 	}
 
 	// Clean up orphaned entities
-	if _, err := h.personService.CleanupOrphanedPeople(ctx); err != nil {
+	orphanedPersonIDs, err := h.personService.CleanupOrphanedPeople(ctx)
+	if err != nil {
 		log.Warn("failed to cleanup orphaned people", logger.Data{"error": err.Error()})
+	}
+	for _, personID := range orphanedPersonIDs {
+		if err := h.searchService.DeleteFromPersonIndex(ctx, personID); err != nil {
+			log.Warn("failed to remove orphaned person from search index", logger.Data{"person_id": personID, "error": err.Error()})
+		}
 	}
 	orphanedSeriesIDs, err := h.bookService.CleanupOrphanedSeries(ctx)
 	if err != nil {
@@ -2606,8 +2566,14 @@ func (h *handler) deleteFile(c echo.Context) error {
 		if err := h.searchService.DeleteFromBookIndex(ctx, result.BookID); err != nil {
 			log.Warn("failed to remove book from search index", logger.Data{"error": err, "bookID": result.BookID})
 		}
-		if _, err := h.personService.CleanupOrphanedPeople(ctx); err != nil {
+		orphanedPersonIDs, err := h.personService.CleanupOrphanedPeople(ctx)
+		if err != nil {
 			log.Warn("failed to cleanup orphaned people", logger.Data{"error": err})
+		}
+		for _, personID := range orphanedPersonIDs {
+			if err := h.searchService.DeleteFromPersonIndex(ctx, personID); err != nil {
+				log.Warn("failed to remove orphaned person from search index", logger.Data{"person_id": personID, "error": err})
+			}
 		}
 		orphanedSeriesIDs, err := h.bookService.CleanupOrphanedSeries(ctx)
 		if err != nil {
@@ -2711,8 +2677,14 @@ func (h *handler) deleteBooks(c echo.Context) error {
 			log.Warn("failed to remove book from search index", logger.Data{"error": err.Error(), "book_id": bookID})
 		}
 	}
-	if _, err := h.personService.CleanupOrphanedPeople(ctx); err != nil {
+	orphanedPersonIDs, err := h.personService.CleanupOrphanedPeople(ctx)
+	if err != nil {
 		log.Warn("failed to cleanup orphaned people", logger.Data{"error": err.Error()})
+	}
+	for _, personID := range orphanedPersonIDs {
+		if err := h.searchService.DeleteFromPersonIndex(ctx, personID); err != nil {
+			log.Warn("failed to remove orphaned person from search index", logger.Data{"person_id": personID, "error": err.Error()})
+		}
 	}
 	orphanedSeriesIDs, err := h.bookService.CleanupOrphanedSeries(ctx)
 	if err != nil {

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1360,18 +1360,21 @@ func (svc *Service) FindOrCreateSeries(ctx context.Context, name string, library
 	return series, nil
 }
 
-// CleanupOrphanedSeries deletes series with no books.
+// CleanupOrphanedSeries deletes series with no books and returns the IDs of
+// deleted series. Callers must pass the returned IDs to
+// searchService.DeleteFromSeriesIndex to keep series_fts in sync.
 // This is duplicated from series service to avoid import cycles.
-func (svc *Service) CleanupOrphanedSeries(ctx context.Context) (int, error) {
-	result, err := svc.db.NewDelete().
+func (svc *Service) CleanupOrphanedSeries(ctx context.Context) ([]int, error) {
+	deletedIDs := []int{}
+	err := svc.db.NewDelete().
 		Model((*models.Series)(nil)).
 		Where("id NOT IN (SELECT DISTINCT series_id FROM book_series)").
-		Exec(ctx)
+		Returning("id").
+		Scan(ctx, &deletedIDs)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	n, _ := result.RowsAffected()
-	return int(n), nil
+	return deletedIDs, nil
 }
 
 // RetrieveSeriesByID retrieves a series by its ID.

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1360,7 +1360,7 @@ func (svc *Service) FindOrCreateSeries(ctx context.Context, name string, library
 	return series, nil
 }
 
-// CleanupOrphanedSeries soft-deletes series with no books.
+// CleanupOrphanedSeries deletes series with no books.
 // This is duplicated from series service to avoid import cycles.
 func (svc *Service) CleanupOrphanedSeries(ctx context.Context) (int, error) {
 	result, err := svc.db.NewDelete().

--- a/pkg/genres/service.go
+++ b/pkg/genres/service.go
@@ -276,17 +276,22 @@ func (svc *Service) MergeGenres(ctx context.Context, targetID, sourceID int) err
 	})
 }
 
-// CleanupOrphanedGenres deletes genres with no book associations.
-func (svc *Service) CleanupOrphanedGenres(ctx context.Context) (int, error) {
-	result, err := svc.db.NewDelete().
+// CleanupOrphanedGenres deletes genres with no book associations and returns
+// the IDs of deleted genres. Callers must pass the returned IDs to
+// searchService.DeleteFromGenreIndex to keep genres_fts in sync — genres_fts
+// is a virtual FTS5 table not tied to genres via foreign keys, so it is not
+// cleaned up automatically.
+func (svc *Service) CleanupOrphanedGenres(ctx context.Context) ([]int, error) {
+	deletedIDs := []int{}
+	err := svc.db.NewDelete().
 		Model((*models.Genre)(nil)).
 		Where("id NOT IN (SELECT DISTINCT genre_id FROM book_genres)").
-		Exec(ctx)
+		Returning("id").
+		Scan(ctx, &deletedIDs)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	n, _ := result.RowsAffected()
-	return int(n), nil
+	return deletedIDs, nil
 }
 
 // buildFTSPrefixQuery builds an FTS5 query for prefix/typeahead search.

--- a/pkg/migrations/20260426000000_drop_series_deleted_at.go
+++ b/pkg/migrations/20260426000000_drop_series_deleted_at.go
@@ -1,0 +1,55 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		// Hard-delete any soft-deleted series. CASCADE on book_series.series_id
+		// (set in 20260406100000_add_fk_cascades.go) cleans up join rows.
+		// Done before the schema change so the unconditional unique index in
+		// the final step can't collide on a name shared between a soft-deleted
+		// and a live row in the same library.
+		if _, err := db.Exec(`DELETE FROM series WHERE deleted_at IS NOT NULL`); err != nil {
+			return errors.WithStack(err)
+		}
+		// Defensive: purge any series_fts rows whose series_id is gone.
+		// Handlers already call DeleteFromSeriesIndex on soft-delete today,
+		// so this should be a no-op in practice.
+		if _, err := db.Exec(`DELETE FROM series_fts WHERE series_id NOT IN (SELECT id FROM series)`); err != nil {
+			return errors.WithStack(err)
+		}
+		// The partial unique index references deleted_at; drop before the column.
+		if _, err := db.Exec(`DROP INDEX ux_series_name_library_id`); err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.Exec(`ALTER TABLE series DROP COLUMN deleted_at`); err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.Exec(`CREATE UNIQUE INDEX ux_series_name_library_id ON series (name COLLATE NOCASE, library_id)`); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		// Lossy: does not restore deleted rows. Matches the precedent set by
+		// 20260423000000_drop_libraries_deleted_at.go.
+		if _, err := db.Exec(`DROP INDEX ux_series_name_library_id`); err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.Exec(`ALTER TABLE series ADD COLUMN deleted_at TIMESTAMPTZ`); err != nil {
+			return errors.WithStack(err)
+		}
+		if _, err := db.Exec(`CREATE UNIQUE INDEX ux_series_name_library_id ON series (name COLLATE NOCASE, library_id) WHERE deleted_at IS NULL`); err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/migrations/20260426000000_drop_series_deleted_at.go
+++ b/pkg/migrations/20260426000000_drop_series_deleted_at.go
@@ -17,9 +17,11 @@ func init() {
 		if _, err := db.Exec(`DELETE FROM series WHERE deleted_at IS NOT NULL`); err != nil {
 			return errors.WithStack(err)
 		}
-		// Defensive: purge any series_fts rows whose series_id is gone.
-		// Handlers already call DeleteFromSeriesIndex on soft-delete today,
-		// so this should be a no-op in practice.
+		// Defensive: catches any series_fts orphans pointing at rows that no
+		// longer exist in `series`. The pre-existing CleanupOrphanedSeries
+		// path didn't purge FTS (fixed in this branch), so DBs that hit
+		// orphan-cleanup before this migration may have accumulated stale
+		// series_fts rows. Likely a no-op on most DBs; cheap insurance.
 		if _, err := db.Exec(`DELETE FROM series_fts WHERE series_id NOT IN (SELECT id FROM series)`); err != nil {
 			return errors.WithStack(err)
 		}

--- a/pkg/models/series.go
+++ b/pkg/models/series.go
@@ -18,7 +18,6 @@ type Series struct {
 	ID                 int           `bun:",pk,nullzero" json:"id"`
 	CreatedAt          time.Time     `json:"created_at"`
 	UpdatedAt          time.Time     `json:"updated_at"`
-	DeletedAt          *time.Time    `bun:",soft_delete" json:"-"`
 	LibraryID          int           `bun:",nullzero" json:"library_id"`
 	Library            *Library      `bun:"rel:belongs-to" json:"library,omitempty" tstype:"Library"`
 	Name               string        `bun:",nullzero" json:"name"`

--- a/pkg/people/service.go
+++ b/pkg/people/service.go
@@ -328,18 +328,23 @@ func (svc *Service) MergePeople(ctx context.Context, targetID, sourceID int) err
 	})
 }
 
-// CleanupOrphanedPeople deletes people with no authors or narrators.
-func (svc *Service) CleanupOrphanedPeople(ctx context.Context) (int, error) {
-	result, err := svc.db.NewDelete().
+// CleanupOrphanedPeople deletes people with no authors or narrators and
+// returns the IDs of deleted people. Callers must pass the returned IDs to
+// searchService.DeleteFromPersonIndex to keep persons_fts in sync —
+// persons_fts is a virtual FTS5 table not tied to persons via foreign keys,
+// so it is not cleaned up automatically.
+func (svc *Service) CleanupOrphanedPeople(ctx context.Context) ([]int, error) {
+	deletedIDs := []int{}
+	err := svc.db.NewDelete().
 		Model((*models.Person)(nil)).
 		Where("id NOT IN (SELECT DISTINCT person_id FROM authors)").
 		Where("id NOT IN (SELECT DISTINCT person_id FROM narrators)").
-		Exec(ctx)
+		Returning("id").
+		Scan(ctx, &deletedIDs)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	n, _ := result.RowsAffected()
-	return int(n), nil
+	return deletedIDs, nil
 }
 
 // buildFTSPrefixQuery builds an FTS5 query for prefix/typeahead search.

--- a/pkg/search/service.go
+++ b/pkg/search/service.go
@@ -575,7 +575,7 @@ func (svc *Service) RebuildAllIndexes(ctx context.Context) error {
 			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (SELECT DISTINCT p.name FROM authors a JOIN persons p ON a.person_id = p.id WHERE a.book_id = b.id)), ''),
 			COALESCE((SELECT GROUP_CONCAT(f.filepath, ' ') FROM files f WHERE f.book_id = b.id), ''),
 			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (SELECT DISTINCT p.name FROM files f JOIN narrators n ON n.file_id = f.id JOIN persons p ON n.person_id = p.id WHERE f.book_id = b.id)), ''),
-			COALESCE((SELECT GROUP_CONCAT(s.name, ' ') FROM book_series bs JOIN series s ON bs.series_id = s.id WHERE bs.book_id = b.id AND s.deleted_at IS NULL), '')
+			COALESCE((SELECT GROUP_CONCAT(s.name, ' ') FROM book_series bs JOIN series s ON bs.series_id = s.id WHERE bs.book_id = b.id), '')
 		FROM books b
 	`)
 	if err != nil {
@@ -593,7 +593,6 @@ func (svc *Service) RebuildAllIndexes(ctx context.Context) error {
 			COALESCE((SELECT GROUP_CONCAT(b.title, ' ') FROM book_series bs JOIN books b ON bs.book_id = b.id WHERE bs.series_id = s.id), ''),
 			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (SELECT DISTINCT p.name FROM book_series bs JOIN books b ON bs.book_id = b.id JOIN authors a ON a.book_id = b.id JOIN persons p ON a.person_id = p.id WHERE bs.series_id = s.id)), '')
 		FROM series s
-		WHERE s.deleted_at IS NULL
 	`)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/series/service.go
+++ b/pkg/series/service.go
@@ -231,24 +231,30 @@ func (svc *Service) UpdateSeries(ctx context.Context, series *models.Series, opt
 
 // DeleteSeries deletes a series. CASCADE on book_series.series_id removes
 // the join rows. Returns the IDs of books that had a join row removed;
-// callers should use these to recompute review state.
+// callers should use these to recompute review state. The SELECT and DELETE
+// run in a transaction so a concurrent insert into book_series cannot land
+// between them — that row would be CASCADE-deleted but its book_id would
+// be missing from the returned set.
 func (svc *Service) DeleteSeries(ctx context.Context, seriesID int) ([]int, error) {
 	var affectedBookIDs []int
-	err := svc.db.NewSelect().
-		Model((*models.BookSeries)(nil)).
-		ColumnExpr("DISTINCT bs.book_id").
-		Where("bs.series_id = ?", seriesID).
-		Scan(ctx, &affectedBookIDs)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
+	err := svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
+		err := tx.NewSelect().
+			Model((*models.BookSeries)(nil)).
+			ColumnExpr("DISTINCT bs.book_id").
+			Where("bs.series_id = ?", seriesID).
+			Scan(ctx, &affectedBookIDs)
+		if err != nil {
+			return errors.WithStack(err)
+		}
 
-	_, err = svc.db.NewDelete().
-		Model((*models.Series)(nil)).
-		Where("id = ?", seriesID).
-		Exec(ctx)
+		_, err = tx.NewDelete().
+			Model((*models.Series)(nil)).
+			Where("id = ?", seriesID).
+			Exec(ctx)
+		return errors.WithStack(err)
+	})
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return affectedBookIDs, nil
 }

--- a/pkg/series/service.go
+++ b/pkg/series/service.go
@@ -291,17 +291,22 @@ func (svc *Service) MergeSeries(ctx context.Context, targetID, sourceID int) ([]
 	return movedBookIDs, nil
 }
 
-// CleanupOrphanedSeries deletes series with no books.
-func (svc *Service) CleanupOrphanedSeries(ctx context.Context) (int, error) {
-	result, err := svc.db.NewDelete().
+// CleanupOrphanedSeries deletes series with no books and returns the IDs of
+// deleted series. Callers must pass the returned IDs to
+// searchService.DeleteFromSeriesIndex to keep series_fts in sync — series_fts
+// is a virtual table not tied to series via foreign keys, so it is not
+// cleaned up automatically.
+func (svc *Service) CleanupOrphanedSeries(ctx context.Context) ([]int, error) {
+	deletedIDs := []int{}
+	err := svc.db.NewDelete().
 		Model((*models.Series)(nil)).
 		Where("id NOT IN (SELECT DISTINCT series_id FROM book_series)").
-		Exec(ctx)
+		Returning("id").
+		Scan(ctx, &deletedIDs)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	n, _ := result.RowsAffected()
-	return int(n), nil
+	return deletedIDs, nil
 }
 
 // GetSeriesBookCount returns the number of books in a series.

--- a/pkg/series/service.go
+++ b/pkg/series/service.go
@@ -229,59 +229,32 @@ func (svc *Service) UpdateSeries(ctx context.Context, series *models.Series, opt
 	return nil
 }
 
-// DeleteSeries soft-deletes a series and hard-deletes its book_series join
-// rows so they don't masquerade as live series associations on the affected
-// books. Returns the IDs of books that had a join row removed; callers should
-// use these to recompute review state.
+// DeleteSeries deletes a series. CASCADE on book_series.series_id removes
+// the join rows. Returns the IDs of books that had a join row removed;
+// callers should use these to recompute review state.
 func (svc *Service) DeleteSeries(ctx context.Context, seriesID int) ([]int, error) {
 	var affectedBookIDs []int
-	err := svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {
-		err := tx.NewSelect().
-			Model((*models.BookSeries)(nil)).
-			ColumnExpr("DISTINCT bs.book_id").
-			Where("bs.series_id = ?", seriesID).
-			Scan(ctx, &affectedBookIDs)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		_, err = tx.NewDelete().
-			Model((*models.BookSeries)(nil)).
-			Where("series_id = ?", seriesID).
-			Exec(ctx)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-
-		_, err = tx.NewDelete().
-			Model((*models.Series)(nil)).
-			Where("id = ?", seriesID).
-			Exec(ctx)
-		return errors.WithStack(err)
-	})
+	err := svc.db.NewSelect().
+		Model((*models.BookSeries)(nil)).
+		ColumnExpr("DISTINCT bs.book_id").
+		Where("bs.series_id = ?", seriesID).
+		Scan(ctx, &affectedBookIDs)
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
+	}
+
+	_, err = svc.db.NewDelete().
+		Model((*models.Series)(nil)).
+		Where("id = ?", seriesID).
+		Exec(ctx)
+	if err != nil {
+		return nil, errors.WithStack(err)
 	}
 	return affectedBookIDs, nil
 }
 
-// RestoreSeries restores a soft-deleted series.
-func (svc *Service) RestoreSeries(ctx context.Context, seriesID int) error {
-	_, err := svc.db.
-		NewUpdate().
-		Model((*models.Series)(nil)).
-		Set("deleted_at = NULL").
-		Where("id = ?", seriesID).
-		WhereAllWithDeleted().
-		Exec(ctx)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-
 // MergeSeries merges sourceSeries into targetSeries (moves all books,
-// soft-deletes source). Returns the IDs of books whose join rows moved so
+// deletes source). Returns the IDs of books whose join rows moved so
 // the caller can recompute search indexes that bake in the series name.
 func (svc *Service) MergeSeries(ctx context.Context, targetID, sourceID int) ([]int, error) {
 	var movedBookIDs []int
@@ -305,7 +278,7 @@ func (svc *Service) MergeSeries(ctx context.Context, targetID, sourceID int) ([]
 			return errors.WithStack(err)
 		}
 
-		// Soft-delete the source series
+		// Delete the source series
 		_, err = tx.NewDelete().
 			Model((*models.Series)(nil)).
 			Where("id = ?", sourceID).
@@ -318,7 +291,7 @@ func (svc *Service) MergeSeries(ctx context.Context, targetID, sourceID int) ([]
 	return movedBookIDs, nil
 }
 
-// CleanupOrphanedSeries soft-deletes series with no books.
+// CleanupOrphanedSeries deletes series with no books.
 func (svc *Service) CleanupOrphanedSeries(ctx context.Context) (int, error) {
 	result, err := svc.db.NewDelete().
 		Model((*models.Series)(nil)).

--- a/pkg/series/service_test.go
+++ b/pkg/series/service_test.go
@@ -313,3 +313,87 @@ func TestMergeSeriesHandler_ReindexesAffectedBooks(t *testing.T) {
 	assert.Equal(t, "New Target Name", readBooksFTSSeriesNames(ctx, t, db, book.ID),
 		"books_fts.series_names must reflect the target series name after a merge")
 }
+
+// TestDeleteSeries_HardDeletesRowAndFTS pins the post-soft-delete behavior:
+// after DeleteSeries the row is gone from `series` (not just flagged with
+// deleted_at), the join rows are gone, and DeleteFromSeriesIndex purges the
+// FTS row. Catches accidental reintroduction of the soft_delete tag.
+func TestDeleteSeries_HardDeletesRowAndFTS(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceManual,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	s := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Test Series",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Test Series",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(s).Exec(ctx)
+	require.NoError(t, err)
+
+	bs := &models.BookSeries{BookID: book.ID, SeriesID: s.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(bs).Exec(ctx)
+	require.NoError(t, err)
+
+	// Index the series in FTS so we can assert it's purged after deletion.
+	searchSvc := search.NewService(db)
+	require.NoError(t, searchSvc.IndexSeries(ctx, s))
+
+	// Sanity: FTS row exists before deletion. series_fts is a virtual FTS5
+	// table, so use a raw query (Bun model queries don't work against it).
+	var pre int
+	require.NoError(t, db.NewRaw("SELECT count(*) FROM series_fts WHERE series_id = ?", s.ID).
+		Scan(ctx, &pre))
+	require.Equal(t, 1, pre, "series_fts should have a row before deletion")
+
+	// Delete via the service. The service does NOT touch FTS — the handler
+	// does. We invoke DeleteFromSeriesIndex explicitly to mirror the handler.
+	svc := NewService(db)
+	_, err = svc.DeleteSeries(ctx, s.ID)
+	require.NoError(t, err)
+	require.NoError(t, searchSvc.DeleteFromSeriesIndex(ctx, s.ID))
+
+	// 1. The row is gone from `series` (not just flagged). This is the
+	//    assertion that fails on the pre-change tree.
+	count, err := db.NewSelect().Model((*models.Series)(nil)).
+		Where("id = ?", s.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "series row must be hard-deleted, not soft-deleted")
+
+	// 2. book_series rows for the deleted series are gone (CASCADE).
+	bsCount, err := db.NewSelect().Model((*models.BookSeries)(nil)).
+		Where("series_id = ?", s.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, bsCount, "book_series rows must be removed")
+
+	// 3. FTS row is gone.
+	var post int
+	require.NoError(t, db.NewRaw("SELECT count(*) FROM series_fts WHERE series_id = ?", s.ID).
+		Scan(ctx, &post))
+	assert.Equal(t, 0, post, "series_fts row must be removed after DeleteFromSeriesIndex")
+}

--- a/pkg/series/service_test.go
+++ b/pkg/series/service_test.go
@@ -397,3 +397,79 @@ func TestDeleteSeries_HardDeletesRowAndFTS(t *testing.T) {
 		Scan(ctx, &post))
 	assert.Equal(t, 0, post, "series_fts row must be removed after DeleteFromSeriesIndex")
 }
+
+// TestCleanupOrphanedSeries_ReturnsDeletedIDs pins the requirement that
+// CleanupOrphanedSeries returns the IDs of deleted series so callers can keep
+// series_fts in sync. Without this, orphan-series cleanup silently leaves
+// stale FTS rows that surface in search results pointing at non-existent
+// series.
+func TestCleanupOrphanedSeries_ReturnsDeletedIDs(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	// Series with a book — must NOT be cleaned up.
+	keep := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Kept Series",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Kept Series",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(keep).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceManual,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	bs := &models.BookSeries{BookID: book.ID, SeriesID: keep.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(bs).Exec(ctx)
+	require.NoError(t, err)
+
+	// Orphan series with no book — must be cleaned up.
+	orphan := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Orphan Series",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Orphan Series",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(orphan).Exec(ctx)
+	require.NoError(t, err)
+
+	svc := NewService(db)
+	deletedIDs, err := svc.CleanupOrphanedSeries(ctx)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int{orphan.ID}, deletedIDs,
+		"CleanupOrphanedSeries must return the IDs of deleted series so callers can purge FTS")
+
+	// Orphan row is gone.
+	count, err := db.NewSelect().Model((*models.Series)(nil)).
+		Where("id = ?", orphan.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "orphan series row should be deleted")
+
+	// Kept series remains.
+	count, err = db.NewSelect().Model((*models.Series)(nil)).
+		Where("id = ?", keep.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "series with books must not be cleaned up")
+}

--- a/pkg/tags/service.go
+++ b/pkg/tags/service.go
@@ -276,17 +276,22 @@ func (svc *Service) MergeTags(ctx context.Context, targetID, sourceID int) error
 	})
 }
 
-// CleanupOrphanedTags deletes tags with no book associations.
-func (svc *Service) CleanupOrphanedTags(ctx context.Context) (int, error) {
-	result, err := svc.db.NewDelete().
+// CleanupOrphanedTags deletes tags with no book associations and returns the
+// IDs of deleted tags. Callers must pass the returned IDs to
+// searchService.DeleteFromTagIndex to keep tags_fts in sync — tags_fts is a
+// virtual FTS5 table not tied to tags via foreign keys, so it is not cleaned
+// up automatically.
+func (svc *Service) CleanupOrphanedTags(ctx context.Context) ([]int, error) {
+	deletedIDs := []int{}
+	err := svc.db.NewDelete().
 		Model((*models.Tag)(nil)).
 		Where("id NOT IN (SELECT DISTINCT tag_id FROM book_tags)").
-		Exec(ctx)
+		Returning("id").
+		Scan(ctx, &deletedIDs)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	n, _ := result.RowsAffected()
-	return int(n), nil
+	return deletedIDs, nil
 }
 
 // buildFTSPrefixQuery builds an FTS5 query for prefix/typeahead search.

--- a/pkg/worker/testhelpers_test.go
+++ b/pkg/worker/testhelpers_test.go
@@ -91,6 +91,7 @@ func newTestContext(t *testing.T) *testContext {
 	seriesService := series.NewService(db)
 	genreService := genres.NewService(db)
 	tagService := tags.NewService(db)
+	searchService := search.NewService(db)
 	publisherService := publishers.NewService(db)
 	imprintService := imprints.NewService(db)
 	fingerprintService := fingerprints.NewService(db)
@@ -113,6 +114,7 @@ func newTestContext(t *testing.T) *testContext {
 		seriesService:      seriesService,
 		genreService:       genreService,
 		tagService:         tagService,
+		searchService:      searchService,
 		publisherService:   publisherService,
 		imprintService:     imprintService,
 		fingerprintService: fingerprintService,
@@ -134,6 +136,7 @@ func newTestContext(t *testing.T) *testContext {
 		jobLogService:      jobLogService,
 		personService:      personService,
 		seriesService:      seriesService,
+		searchService:      searchService,
 		fingerprintService: fingerprintService,
 	}
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -446,10 +446,15 @@ func (w *Worker) checkPluginUpdates() {
 // cleanupOrphanedEntities removes series, people, genres, and tags
 // that are no longer referenced by any books.
 func (w *Worker) cleanupOrphanedEntities(ctx context.Context, log logger.Logger) {
-	if n, err := w.seriesService.CleanupOrphanedSeries(ctx); err != nil {
+	if deletedIDs, err := w.seriesService.CleanupOrphanedSeries(ctx); err != nil {
 		log.Err(err).Warn("failed to cleanup orphaned series")
-	} else if n > 0 {
-		log.Info("cleaned up orphaned series", logger.Data{"count": n})
+	} else if len(deletedIDs) > 0 {
+		for _, id := range deletedIDs {
+			if err := w.searchService.DeleteFromSeriesIndex(ctx, id); err != nil {
+				log.Err(err).Warn("failed to remove orphaned series from search index", logger.Data{"series_id": id})
+			}
+		}
+		log.Info("cleaned up orphaned series", logger.Data{"count": len(deletedIDs)})
 	}
 
 	if n, err := w.personService.CleanupOrphanedPeople(ctx); err != nil {

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -463,16 +463,26 @@ func (w *Worker) cleanupOrphanedEntities(ctx context.Context, log logger.Logger)
 		log.Info("cleaned up orphaned people", logger.Data{"count": n})
 	}
 
-	if n, err := w.genreService.CleanupOrphanedGenres(ctx); err != nil {
+	if deletedIDs, err := w.genreService.CleanupOrphanedGenres(ctx); err != nil {
 		log.Err(err).Warn("failed to cleanup orphaned genres")
-	} else if n > 0 {
-		log.Info("cleaned up orphaned genres", logger.Data{"count": n})
+	} else if len(deletedIDs) > 0 {
+		for _, id := range deletedIDs {
+			if err := w.searchService.DeleteFromGenreIndex(ctx, id); err != nil {
+				log.Err(err).Warn("failed to remove orphaned genre from search index", logger.Data{"genre_id": id})
+			}
+		}
+		log.Info("cleaned up orphaned genres", logger.Data{"count": len(deletedIDs)})
 	}
 
-	if n, err := w.tagService.CleanupOrphanedTags(ctx); err != nil {
+	if deletedIDs, err := w.tagService.CleanupOrphanedTags(ctx); err != nil {
 		log.Err(err).Warn("failed to cleanup orphaned tags")
-	} else if n > 0 {
-		log.Info("cleaned up orphaned tags", logger.Data{"count": n})
+	} else if len(deletedIDs) > 0 {
+		for _, id := range deletedIDs {
+			if err := w.searchService.DeleteFromTagIndex(ctx, id); err != nil {
+				log.Err(err).Warn("failed to remove orphaned tag from search index", logger.Data{"tag_id": id})
+			}
+		}
+		log.Info("cleaned up orphaned tags", logger.Data{"count": len(deletedIDs)})
 	}
 }
 

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -457,10 +457,15 @@ func (w *Worker) cleanupOrphanedEntities(ctx context.Context, log logger.Logger)
 		log.Info("cleaned up orphaned series", logger.Data{"count": len(deletedIDs)})
 	}
 
-	if n, err := w.personService.CleanupOrphanedPeople(ctx); err != nil {
+	if deletedIDs, err := w.personService.CleanupOrphanedPeople(ctx); err != nil {
 		log.Err(err).Warn("failed to cleanup orphaned people")
-	} else if n > 0 {
-		log.Info("cleaned up orphaned people", logger.Data{"count": n})
+	} else if len(deletedIDs) > 0 {
+		for _, id := range deletedIDs {
+			if err := w.searchService.DeleteFromPersonIndex(ctx, id); err != nil {
+				log.Err(err).Warn("failed to remove orphaned person from search index", logger.Data{"person_id": id})
+			}
+		}
+		log.Info("cleaned up orphaned people", logger.Data{"count": len(deletedIDs)})
 	}
 
 	if deletedIDs, err := w.genreService.CleanupOrphanedGenres(ctx); err != nil {


### PR DESCRIPTION
## Summary

- **Removes Bun's `soft_delete` plumbing from `models.Series`** — the only model in the codebase using it. `RestoreSeries` had zero callers and every read path filtered `deleted_at IS NULL`, so the recovery mechanism was unreachable. Drops the `deleted_at` column, the partial unique index, the `WhereAllWithDeleted()` call, and the `s.deleted_at IS NULL` filters in FTS rebuild SQL. `DeleteSeries` simplifies to one SELECT + one DELETE because `book_series.series_id` already CASCADEs (set in `20260406100000_add_fk_cascades.go`). Migration hard-deletes any rows currently in the soft-deleted state and rebuilds the unique index unconditional.
- **Fixes a latent FTS-index leak in orphan cleanup** for series, genres, and tags. `Cleanup*` functions deleted rows from the source table but never touched the corresponding `*_fts` virtual table. Search hits FTS directly with no JOIN to the source, so reaped entities stayed searchable forever and clicking a stale result 404'd. Latent under series soft-delete (listings filtered on `deleted_at`), exposed by switching to hard-delete. `CleanupOrphanedSeries`, `CleanupOrphanedGenres`, and `CleanupOrphanedTags` now return the IDs of deleted entities atomically (via `RETURNING id`); all 15 callers in `pkg/books/handlers.go` and `pkg/worker/worker.go` pair the call with the corresponding `searchService.DeleteFrom*Index`.
- **Adds frontend search-cache invalidation** for series, person, and book mutations (delete, merge, update). Surfaced in smoke testing as "deleted series still appear in search results until refresh" — Tanstack Query's `[GlobalSearch]` key wasn't invalidated by entity mutations, so the cached search response stayed visible until manual reload.
- **Down migration is lossy** (does not restore deleted rows) — same precedent as `20260423000000_drop_libraries_deleted_at.go`. Worth noting before any production rollback.

## Test plan

- New regression tests:
  - `TestDeleteSeries_HardDeletesRowAndFTS` — pins that DeleteSeries actually removes the row (not soft-deletes), and that the handler-level FTS cleanup runs.
  - `TestCleanupOrphanedSeries_ReturnsDeletedIDs` — pins the new signature so callers can wire FTS purges.
- `mise db:rollback && mise db:migrate` round-trip exercises the migration both directions.
- `mise check:quiet` green: lint, test, test:js:fast, lint:js.
- Manual smoke: delete a series via the UI; confirm it disappears from the series list and from global search **without a page refresh**. Merge two series; confirm source disappears, target keeps its books.

Spec: `docs/superpowers/specs/2026-04-26-series-hard-delete-design.md`
Plan: `docs/superpowers/plans/2026-04-26-series-hard-delete.md`