### PR TITLE
[Frontend] Add Filter label to filter button

### DIFF
--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -346,16 +346,14 @@ const FilterButton = forwardRef<
     "hasActiveFilters"
   >
 >(({ hasActiveFilters, ...props }, ref) => (
-  <Button
-    aria-label="Filters"
-    ref={ref}
-    size="icon"
-    variant="outline"
-    {...props}
-  >
-    <ListFilter className={cn("h-4 w-4", hasActiveFilters && "text-primary")} />
+  <Button ref={ref} size="sm" variant="outline" {...props}>
+    <ListFilter className="h-4 w-4" />
+    Filter
     {hasActiveFilters && (
-      <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background" />
+      <span
+        aria-label="Filters are active"
+        className="absolute top-1 right-1 h-2 w-2 rounded-full bg-primary ring-2 ring-background"
+      />
     )}
   </Button>
 ));


### PR DESCRIPTION
## Summary
- Switch the library filter trigger from an icon-only button to a `size="sm"` button with a "Filter" text label next to the `ListFilter` icon, matching the existing Sort and Size buttons.
- Indicate active filters with the corner dot only; the icon no longer recolors to primary, mirroring how Sort/Size show their dirty state.
- Replace the redundant `aria-label="Filters"` on the trigger with an `aria-label="Filters are active"` on the indicator dot, since the button now has a visible text label.

## Test plan
- Visit the library home page and confirm the Filter button sits alongside Sort and Size with matching size, padding, and label styling.
- Apply a filter (e.g. file type or genre) and confirm the corner dot appears on the Filter button, the sheet still opens, and "Clear all" still works.
- Resize to mobile width and confirm the Drawer variant of the trigger still renders the new label and dot.