### PR TITLE
[Backend] Auto-classify supplement-named PDFs on scan

### DIFF
--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/types";
 import { isBookNeedsReview } from "@/utils/book";
 import { isCoverLoaded, markCoverLoaded } from "@/utils/coverCache";
+import { getCoverFileType, selectCoverFile } from "@/utils/coverSelection";
 import { getPrimaryFileType } from "@/utils/primaryFile";
 import { formatSeriesNumber } from "@/utils/seriesNumber";
 
@@ -64,70 +65,6 @@ interface BookItemProps {
   cacheKey?: number;
   gallerySize?: GallerySize;
 }
-
-// Selects the file that would be used for the cover based on cover_aspect_ratio setting
-// This mirrors the backend's selectCoverFile logic (requires cover_image_filename).
-// Supplements are excluded — they don't represent the book.
-const selectCoverFile = (
-  files: File[] | undefined,
-  coverAspectRatio: string,
-): File | null => {
-  if (!files) return null;
-
-  const bookFiles = files.filter(
-    (f) =>
-      f.file_role !== "supplement" &&
-      (f.file_type === "epub" || f.file_type === "cbz") &&
-      f.cover_image_filename,
-  );
-  const audiobookFiles = files.filter(
-    (f) =>
-      f.file_role !== "supplement" &&
-      f.file_type === "m4b" &&
-      f.cover_image_filename,
-  );
-
-  switch (coverAspectRatio) {
-    case "audiobook":
-    case "audiobook_fallback_book":
-      if (audiobookFiles.length > 0) return audiobookFiles[0];
-      if (bookFiles.length > 0) return bookFiles[0];
-      break;
-    default: // "book", "book_fallback_audiobook"
-      if (bookFiles.length > 0) return bookFiles[0];
-      if (audiobookFiles.length > 0) return audiobookFiles[0];
-  }
-  return null;
-};
-
-// Determines which file type would provide the cover based on library preference.
-// This mirrors the backend's selectCoverFile priority logic but doesn't require cover_image_filename.
-// Used for placeholder variant selection when there's no cover image.
-// Supplements are excluded — they don't represent the book.
-const getCoverFileType = (
-  files: File[] | undefined,
-  coverAspectRatio: string,
-): "book" | "audiobook" => {
-  if (!files || files.length === 0) return "book";
-
-  const mainFiles = files.filter((f) => f.file_role !== "supplement");
-  const hasBookFiles = mainFiles.some(
-    (f) => f.file_type === "epub" || f.file_type === "cbz",
-  );
-  const hasAudiobookFiles = mainFiles.some((f) => f.file_type === "m4b");
-
-  switch (coverAspectRatio) {
-    case "audiobook":
-    case "audiobook_fallback_book":
-      if (hasAudiobookFiles) return "audiobook";
-      if (hasBookFiles) return "book";
-      break;
-    default: // "book", "book_fallback_audiobook"
-      if (hasBookFiles) return "book";
-      if (hasAudiobookFiles) return "audiobook";
-  }
-  return "book";
-};
 
 const getAspectRatioClass = (
   coverAspectRatio: string,

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -66,7 +66,8 @@ interface BookItemProps {
 }
 
 // Selects the file that would be used for the cover based on cover_aspect_ratio setting
-// This mirrors the backend's selectCoverFile logic (requires cover_image_filename)
+// This mirrors the backend's selectCoverFile logic (requires cover_image_filename).
+// Supplements are excluded — they don't represent the book.
 const selectCoverFile = (
   files: File[] | undefined,
   coverAspectRatio: string,
@@ -75,11 +76,15 @@ const selectCoverFile = (
 
   const bookFiles = files.filter(
     (f) =>
+      f.file_role !== "supplement" &&
       (f.file_type === "epub" || f.file_type === "cbz") &&
       f.cover_image_filename,
   );
   const audiobookFiles = files.filter(
-    (f) => f.file_type === "m4b" && f.cover_image_filename,
+    (f) =>
+      f.file_role !== "supplement" &&
+      f.file_type === "m4b" &&
+      f.cover_image_filename,
   );
 
   switch (coverAspectRatio) {
@@ -98,16 +103,18 @@ const selectCoverFile = (
 // Determines which file type would provide the cover based on library preference.
 // This mirrors the backend's selectCoverFile priority logic but doesn't require cover_image_filename.
 // Used for placeholder variant selection when there's no cover image.
+// Supplements are excluded — they don't represent the book.
 const getCoverFileType = (
   files: File[] | undefined,
   coverAspectRatio: string,
 ): "book" | "audiobook" => {
   if (!files || files.length === 0) return "book";
 
-  const hasBookFiles = files.some(
+  const mainFiles = files.filter((f) => f.file_role !== "supplement");
+  const hasBookFiles = mainFiles.some(
     (f) => f.file_type === "epub" || f.file_type === "cbz",
   );
-  const hasAudiobookFiles = files.some((f) => f.file_type === "m4b");
+  const hasAudiobookFiles = mainFiles.some((f) => f.file_type === "m4b");
 
   switch (coverAspectRatio) {
     case "audiobook":

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -27,9 +27,11 @@ const ConfigRow = ({ description, label, value }: ConfigRowProps) => {
 
   return (
     <div className="flex flex-col py-3 border-b border-border last:border-b-0">
-      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-1 sm:gap-4">
-        <span className="text-sm font-medium text-foreground">{label}</span>
-        <span className="text-xs sm:text-sm text-muted-foreground font-mono break-all sm:break-normal sm:text-right">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 sm:gap-4">
+        <span className="text-sm font-medium text-foreground sm:whitespace-nowrap sm:shrink-0">
+          {label}
+        </span>
+        <span className="text-xs sm:text-sm text-muted-foreground font-mono break-all sm:break-words sm:text-right min-w-0">
           {displayValue}
         </span>
       </div>
@@ -191,6 +193,20 @@ const AdminSettings = () => {
               value={`${config.download_cache_max_size_gb} GB`}
             />
             <ConfigRow
+              description="File patterns excluded from supplement discovery"
+              label="Supplement Exclude Patterns"
+              value={config.supplement_exclude_patterns.join(", ")}
+            />
+          </div>
+        </div>
+
+        {/* PDF Settings */}
+        <div className="border border-border rounded-md p-4 md:p-6">
+          <h2 className="text-base md:text-lg font-semibold mb-3 md:mb-4">
+            PDF
+          </h2>
+          <div className="space-y-0">
+            <ConfigRow
               description="Resolution for rendering PDF pages in the viewer"
               label="PDF Render DPI"
               value={`${config.pdf_render_dpi} DPI`}
@@ -199,11 +215,6 @@ const AdminSettings = () => {
               description="JPEG quality for rendered PDF pages"
               label="PDF Render Quality"
               value={`${config.pdf_render_quality}`}
-            />
-            <ConfigRow
-              description="File patterns excluded from supplement discovery"
-              label="Supplement Exclude Patterns"
-              value={config.supplement_exclude_patterns.join(", ")}
             />
             <ConfigRow
               description="PDF basenames auto-classified as supplements when a sibling main file exists in the same directory"

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -35,7 +35,7 @@ const ConfigRow = ({ description, label, value }: ConfigRowProps) => {
           <p className="text-xs text-muted-foreground">{description}</p>
         )}
       </div>
-      <span className="text-xs sm:text-sm text-muted-foreground font-mono break-all sm:break-words sm:text-right min-w-0">
+      <span className="text-xs sm:text-sm text-muted-foreground font-mono break-words sm:text-right min-w-0">
         {displayValue}
       </span>
     </div>

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -205,6 +205,11 @@ const AdminSettings = () => {
               label="Supplement Exclude Patterns"
               value={config.supplement_exclude_patterns.join(", ")}
             />
+            <ConfigRow
+              description="PDF basenames auto-classified as supplements when a sibling main file exists in the same directory"
+              label="PDF Supplement Filenames"
+              value={config.pdf_supplement_filenames.join(", ")}
+            />
           </div>
         </div>
 

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -26,18 +26,18 @@ const ConfigRow = ({ description, label, value }: ConfigRowProps) => {
     typeof value === "boolean" ? (value ? "Yes" : "No") : String(value);
 
   return (
-    <div className="flex flex-col py-3 border-b border-border last:border-b-0">
-      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 sm:gap-4">
-        <span className="text-sm font-medium text-foreground sm:whitespace-nowrap sm:shrink-0">
+    <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-1 sm:gap-4 py-3 border-b border-border last:border-b-0">
+      <div className="flex flex-col gap-1 sm:shrink-0">
+        <span className="text-sm font-medium text-foreground sm:whitespace-nowrap">
           {label}
         </span>
-        <span className="text-xs sm:text-sm text-muted-foreground font-mono break-all sm:break-words sm:text-right min-w-0">
-          {displayValue}
-        </span>
+        {description && (
+          <p className="text-xs text-muted-foreground">{description}</p>
+        )}
       </div>
-      {description && (
-        <p className="text-xs text-muted-foreground mt-1">{description}</p>
-      )}
+      <span className="text-xs sm:text-sm text-muted-foreground font-mono break-all sm:break-words sm:text-right min-w-0">
+        {displayValue}
+      </span>
     </div>
   );
 };

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -84,6 +84,7 @@ import {
 } from "@/types";
 import { getAuthorRoleLabel } from "@/utils/authorRoles";
 import { isCoverLoaded, markCoverLoaded } from "@/utils/coverCache";
+import { getCoverFileType } from "@/utils/coverSelection";
 import {
   formatDate,
   formatDateTime,
@@ -95,36 +96,6 @@ import {
 import { getIdentifierUrl } from "@/utils/identifiers";
 import { getPrimaryFileType } from "@/utils/primaryFile";
 import { formatSeriesNumber } from "@/utils/seriesNumber";
-
-// Determines which file type would provide the cover based on library preference.
-// This mirrors the backend's selectCoverFile priority logic but doesn't require cover_image_filename.
-// Used for placeholder variant selection when there's no cover image.
-// Supplements are excluded — they don't represent the book.
-const getCoverFileType = (
-  files: File[] | undefined,
-  coverAspectRatio: string,
-): "book" | "audiobook" => {
-  if (!files || files.length === 0) return "book";
-
-  const mainFiles = files.filter((f) => f.file_role !== "supplement");
-  const hasBookFiles = mainFiles.some(
-    (f) =>
-      f.file_type === "epub" || f.file_type === "cbz" || f.file_type === "pdf",
-  );
-  const hasAudiobookFiles = mainFiles.some((f) => f.file_type === "m4b");
-
-  switch (coverAspectRatio) {
-    case "audiobook":
-    case "audiobook_fallback_book":
-      if (hasAudiobookFiles) return "audiobook";
-      if (hasBookFiles) return "book";
-      break;
-    default: // "book", "book_fallback_audiobook"
-      if (hasBookFiles) return "book";
-      if (hasAudiobookFiles) return "audiobook";
-  }
-  return "book";
-};
 
 interface DownloadError {
   fileId: number;

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -99,17 +99,19 @@ import { formatSeriesNumber } from "@/utils/seriesNumber";
 // Determines which file type would provide the cover based on library preference.
 // This mirrors the backend's selectCoverFile priority logic but doesn't require cover_image_filename.
 // Used for placeholder variant selection when there's no cover image.
+// Supplements are excluded — they don't represent the book.
 const getCoverFileType = (
   files: File[] | undefined,
   coverAspectRatio: string,
 ): "book" | "audiobook" => {
   if (!files || files.length === 0) return "book";
 
-  const hasBookFiles = files.some(
+  const mainFiles = files.filter((f) => f.file_role !== "supplement");
+  const hasBookFiles = mainFiles.some(
     (f) =>
       f.file_type === "epub" || f.file_type === "cbz" || f.file_type === "pdf",
   );
-  const hasAudiobookFiles = files.some((f) => f.file_type === "m4b");
+  const hasAudiobookFiles = mainFiles.some((f) => f.file_type === "m4b");
 
   switch (coverAspectRatio) {
     case "audiobook":

--- a/app/utils/coverSelection.test.ts
+++ b/app/utils/coverSelection.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import type { File } from "@/types";
+
+import { getCoverFileType, selectCoverFile } from "./coverSelection";
+
+const file = (overrides: Partial<File> & { id: number }): File =>
+  ({
+    book_id: 1,
+    library_id: 1,
+    filepath: "",
+    file_type: "epub",
+    file_role: "main",
+    filesize_bytes: 0,
+    ...overrides,
+  }) as File;
+
+const epubMain = file({
+  id: 1,
+  file_type: "epub",
+  cover_image_filename: "epub.cover.jpg",
+});
+const cbzMain = file({
+  id: 2,
+  file_type: "cbz",
+  cover_image_filename: "cbz.cover.jpg",
+});
+const pdfMain = file({
+  id: 3,
+  file_type: "pdf",
+  cover_image_filename: "pdf.cover.jpg",
+});
+const m4bMain = file({
+  id: 4,
+  file_type: "m4b",
+  cover_image_filename: "m4b.cover.jpg",
+});
+const epubMainNoCover = file({
+  id: 5,
+  file_type: "epub",
+  cover_image_filename: undefined,
+});
+const m4bMainNoCover = file({
+  id: 6,
+  file_type: "m4b",
+  cover_image_filename: undefined,
+});
+const pdfSupplement = file({
+  id: 7,
+  file_type: "pdf",
+  file_role: "supplement",
+  cover_image_filename: "supp.cover.jpg",
+});
+const epubSupplement = file({
+  id: 8,
+  file_type: "epub",
+  file_role: "supplement",
+  cover_image_filename: "supp.cover.jpg",
+});
+
+describe("selectCoverFile", () => {
+  it("prefers book file in default mode", () => {
+    expect(selectCoverFile([m4bMain, epubMain], "book")?.id).toBe(epubMain.id);
+  });
+
+  it("falls back to audiobook in default mode when no book file has a cover", () => {
+    expect(selectCoverFile([epubMainNoCover, m4bMain], "book")?.id).toBe(
+      m4bMain.id,
+    );
+  });
+
+  it("prefers audiobook in audiobook mode", () => {
+    expect(selectCoverFile([epubMain, m4bMain], "audiobook")?.id).toBe(
+      m4bMain.id,
+    );
+  });
+
+  it("falls back to book file in audiobook mode when no audiobook has a cover", () => {
+    expect(selectCoverFile([epubMain, m4bMainNoCover], "audiobook")?.id).toBe(
+      epubMain.id,
+    );
+  });
+
+  it("treats CBZ as a book file", () => {
+    expect(selectCoverFile([cbzMain], "book")?.id).toBe(cbzMain.id);
+  });
+
+  it("treats PDF as a book file", () => {
+    expect(selectCoverFile([pdfMain], "book")?.id).toBe(pdfMain.id);
+  });
+
+  it("returns null for empty files", () => {
+    expect(selectCoverFile([], "book")).toBeNull();
+    expect(selectCoverFile(undefined, "book")).toBeNull();
+  });
+
+  it("skips files with no cover", () => {
+    expect(selectCoverFile([epubMainNoCover, m4bMain], "book")?.id).toBe(
+      m4bMain.id,
+    );
+  });
+
+  it("skips PDF supplement when M4B main has cover", () => {
+    expect(selectCoverFile([pdfSupplement, m4bMain], "book")?.id).toBe(
+      m4bMain.id,
+    );
+  });
+
+  it("skips EPUB supplement when M4B main has cover", () => {
+    expect(selectCoverFile([epubSupplement, m4bMain], "book")?.id).toBe(
+      m4bMain.id,
+    );
+  });
+
+  it("returns null when only supplements have covers", () => {
+    expect(selectCoverFile([pdfSupplement, m4bMainNoCover], "book")).toBeNull();
+  });
+
+  it("audiobook_fallback_book behaves like audiobook mode", () => {
+    expect(
+      selectCoverFile([epubMain, m4bMain], "audiobook_fallback_book")?.id,
+    ).toBe(m4bMain.id);
+  });
+
+  it("unknown aspect ratio falls through to default", () => {
+    expect(selectCoverFile([m4bMain, epubMain], "weird")?.id).toBe(epubMain.id);
+  });
+});
+
+describe("getCoverFileType", () => {
+  it("returns book by default for empty files", () => {
+    expect(getCoverFileType(undefined, "book")).toBe("book");
+    expect(getCoverFileType([], "book")).toBe("book");
+  });
+
+  it("returns book when an epub main exists (default mode)", () => {
+    expect(getCoverFileType([epubMainNoCover], "book")).toBe("book");
+  });
+
+  it("returns audiobook when only an m4b main exists (default mode)", () => {
+    expect(getCoverFileType([m4bMainNoCover], "book")).toBe("audiobook");
+  });
+
+  it("returns book when only a pdf main exists (default mode)", () => {
+    expect(getCoverFileType([pdfMain], "book")).toBe("book");
+  });
+
+  it("returns audiobook when audiobook mode and m4b main exists", () => {
+    expect(
+      getCoverFileType([epubMainNoCover, m4bMainNoCover], "audiobook"),
+    ).toBe("audiobook");
+  });
+
+  it("ignores PDF supplement when picking variant for M4B-only main book", () => {
+    expect(getCoverFileType([m4bMainNoCover, pdfSupplement], "book")).toBe(
+      "audiobook",
+    );
+  });
+
+  it("ignores EPUB supplement when picking variant for M4B-only main book", () => {
+    expect(getCoverFileType([m4bMainNoCover, epubSupplement], "book")).toBe(
+      "audiobook",
+    );
+  });
+
+  it("returns book when no main file exists at all", () => {
+    expect(getCoverFileType([pdfSupplement], "book")).toBe("book");
+  });
+});

--- a/app/utils/coverSelection.ts
+++ b/app/utils/coverSelection.ts
@@ -1,0 +1,71 @@
+import type { File } from "@/types";
+
+const isMainFile = (f: File): boolean => f.file_role !== "supplement";
+
+const isBookFile = (f: File): boolean =>
+  f.file_type === "epub" || f.file_type === "cbz" || f.file_type === "pdf";
+
+const isAudiobookFile = (f: File): boolean => f.file_type === "m4b";
+
+const hasCover = (f: File): boolean => Boolean(f.cover_image_filename);
+
+/**
+ * Picks which file's cover should represent a book based on the library's
+ * preferred cover_aspect_ratio setting. Mirrors the backend's
+ * pkg/covers.SelectFile logic. Supplements are excluded — they don't
+ * represent the book.
+ */
+export const selectCoverFile = (
+  files: File[] | undefined,
+  coverAspectRatio: string,
+): File | null => {
+  if (!files) return null;
+
+  const candidates = files.filter(isMainFile);
+  const bookFiles = candidates.filter((f) => isBookFile(f) && hasCover(f));
+  const audiobookFiles = candidates.filter(
+    (f) => isAudiobookFile(f) && hasCover(f),
+  );
+
+  switch (coverAspectRatio) {
+    case "audiobook":
+    case "audiobook_fallback_book":
+      if (audiobookFiles.length > 0) return audiobookFiles[0];
+      if (bookFiles.length > 0) return bookFiles[0];
+      break;
+    default:
+      if (bookFiles.length > 0) return bookFiles[0];
+      if (audiobookFiles.length > 0) return audiobookFiles[0];
+  }
+  return null;
+};
+
+/**
+ * Determines which file type would provide the cover based on library
+ * preference. Used for placeholder variant selection and aspect-ratio frame
+ * sizing when no cover image is available. Mirrors selectCoverFile's
+ * priority logic but doesn't require cover_image_filename. Supplements are
+ * excluded.
+ */
+export const getCoverFileType = (
+  files: File[] | undefined,
+  coverAspectRatio: string,
+): "book" | "audiobook" => {
+  if (!files || files.length === 0) return "book";
+
+  const candidates = files.filter(isMainFile);
+  const hasBookFiles = candidates.some(isBookFile);
+  const hasAudiobookFiles = candidates.some(isAudiobookFile);
+
+  switch (coverAspectRatio) {
+    case "audiobook":
+    case "audiobook_fallback_book":
+      if (hasAudiobookFiles) return "audiobook";
+      if (hasBookFiles) return "book";
+      break;
+    default:
+      if (hasBookFiles) return "book";
+      if (hasAudiobookFiles) return "audiobook";
+  }
+  return "book";
+};

--- a/docs/superpowers/plans/2026-04-26-pdf-supplement-name-detection.md
+++ b/docs/superpowers/plans/2026-04-26-pdf-supplement-name-detection.md
@@ -1,0 +1,1093 @@
+# PDF Supplement Name Detection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-classify newly-discovered PDFs whose basename matches a configurable list of common supplement names (e.g. `Supplement.pdf`) as `FileRoleSupplement` instead of `FileRoleMain`, when a sibling main file exists in the same directory tree.
+
+**Architecture:** Add a `PDFSupplementFilenames []string` config field with a default list. In `pkg/worker/scan_unified.go::scanFileCreateNew`, before the file row is built, decide whether to set `FileRoleSupplement` based on (1) `fileType == "pdf"`, (2) basename match against the configured names, and (3) presence of a non-PDF main-eligible sibling on disk OR an existing book row at the same `bookPath`. The "first file in a directory" rule is preserved automatically: if no sibling exists, the PDF stays main. Add a stable-sort in `ProcessScanJob` to push supplement-named PDFs after non-supplement files (defensive optimization).
+
+**Tech Stack:** Go (Echo, Bun, koanf for config), `mise` for task running, testify for tests.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-pdf-supplement-name-detection-design.md`
+
+**Subagent reminder:** Check the project's root `CLAUDE.md` and `pkg/CLAUDE.md` for rules that apply to your work — these contain critical conventions (TDD red-green-refactor, docs update requirements, `t.Parallel()` requirement, naming rules, commit message format `[Category] description`). Violations are review failures.
+
+---
+
+## Task 1: Add `PDFSupplementFilenames` config field with default
+
+**Files:**
+- Modify: `pkg/config/config.go`
+
+The `Config` struct lives in `pkg/config/config.go`. The supplement-discovery section is already there (search for `// Supplement discovery settings`). Default values are set in `defaults()` and re-set in `NewForTest()`.
+
+- [ ] **Step 1: Add the field to the `Config` struct**
+
+Open `pkg/config/config.go` and find this block (currently around line 62-63):
+
+```go
+	// Supplement discovery settings
+	SupplementExcludePatterns []string `koanf:"supplement_exclude_patterns" json:"supplement_exclude_patterns"`
+```
+
+Replace it with:
+
+```go
+	// Supplement discovery settings
+	SupplementExcludePatterns []string `koanf:"supplement_exclude_patterns" json:"supplement_exclude_patterns"`
+	PDFSupplementFilenames    []string `koanf:"pdf_supplement_filenames" json:"pdf_supplement_filenames"`
+```
+
+- [ ] **Step 2: Set the default in `defaults()`**
+
+Find the `SupplementExcludePatterns:` line inside `defaults()` (currently around line 110):
+
+```go
+		SupplementExcludePatterns:     []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
+```
+
+Add this line right after it (keep the alignment the file uses — gofmt will handle column width):
+
+```go
+		PDFSupplementFilenames: []string{
+			"supplement", "supplemental", "bonus", "bonus material", "bonus content",
+			"companion", "notes", "liner notes", "errata", "booklet", "digital booklet",
+			"appendix", "map", "maps", "insert", "guide", "reference",
+			"cheat sheet", "cheatsheet", "cribsheet", "pamphlet", "extras",
+		},
+```
+
+- [ ] **Step 3: Mirror the default in `NewForTest()`**
+
+Find the `cfg.SupplementExcludePatterns = ...` line inside `NewForTest()` (currently around line 184). It's there because tests don't load the YAML, so they need the defaults set explicitly. Add right after it:
+
+```go
+	cfg.PDFSupplementFilenames = []string{
+		"supplement", "supplemental", "bonus", "bonus material", "bonus content",
+		"companion", "notes", "liner notes", "errata", "booklet", "digital booklet",
+		"appendix", "map", "maps", "insert", "guide", "reference",
+		"cheat sheet", "cheatsheet", "cribsheet", "pamphlet", "extras",
+	}
+```
+
+- [ ] **Step 4: Add the same default to the test worker config**
+
+Open `pkg/worker/testhelpers_test.go`. Find the `cfg := &config.Config{...}` block in `newTestContext()` (currently around line 100-103):
+
+```go
+	cfg := &config.Config{
+		WorkerProcesses:           1,
+		SupplementExcludePatterns: []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
+	}
+```
+
+Replace with:
+
+```go
+	cfg := &config.Config{
+		WorkerProcesses:           1,
+		SupplementExcludePatterns: []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
+		PDFSupplementFilenames: []string{
+			"supplement", "supplemental", "bonus", "bonus material", "bonus content",
+			"companion", "notes", "liner notes", "errata", "booklet", "digital booklet",
+			"appendix", "map", "maps", "insert", "guide", "reference",
+			"cheat sheet", "cheatsheet", "cribsheet", "pamphlet", "extras",
+		},
+	}
+```
+
+- [ ] **Step 5: Verify the package builds**
+
+Run: `mise lint`
+Expected: clean. (`mise lint` runs `golangci-lint run`; this is a Go-only change.)
+
+- [ ] **Step 6: Verify worker tests still compile and pass**
+
+Run: `go test ./pkg/config/... ./pkg/worker/...`
+Expected: all tests pass. (Existing tests don't reference the new field, so they should be unaffected.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/config/config.go pkg/worker/testhelpers_test.go
+git commit -m "[Backend] Add pdf_supplement_filenames config field"
+```
+
+---
+
+## Task 2: Add `looksLikePDFSupplement` helper with unit tests
+
+**Files:**
+- Modify: `pkg/worker/scan.go` (add helper)
+- Test: `pkg/worker/scan_helpers_test.go` (add test)
+
+The matcher is a pure function — no I/O, no DB, no plugin manager. Lives next to the existing `isMainFileExtension` and `isShishoSpecialFile` helpers in `pkg/worker/scan.go`.
+
+- [ ] **Step 1: Write the failing test**
+
+Open `pkg/worker/scan_helpers_test.go` and append:
+
+```go
+func TestLooksLikePDFSupplement(t *testing.T) {
+	t.Parallel()
+
+	defaultNames := []string{
+		"supplement", "supplemental", "bonus", "bonus material", "bonus content",
+		"companion", "notes", "liner notes", "errata", "booklet", "digital booklet",
+		"appendix", "map", "maps", "insert", "guide", "reference",
+		"cheat sheet", "cheatsheet", "cribsheet", "pamphlet", "extras",
+	}
+
+	tests := []struct {
+		name     string
+		filename string
+		names    []string
+		want     bool
+	}{
+		{name: "exact match lowercase", filename: "supplement.pdf", names: defaultNames, want: true},
+		{name: "exact match uppercase ext", filename: "Supplement.PDF", names: defaultNames, want: true},
+		{name: "all caps basename", filename: "BONUS MATERIAL.pdf", names: defaultNames, want: true},
+		{name: "trims surrounding whitespace", filename: "  supplement  .pdf", names: defaultNames, want: true},
+		{name: "multi-word entry matches", filename: "liner notes.pdf", names: defaultNames, want: true},
+		{name: "non-pdf extension does not match", filename: "supplement.txt", names: defaultNames, want: false},
+		{name: "substring does not match", filename: "my book - supplement.pdf", names: defaultNames, want: false},
+		{name: "unrelated name does not match", filename: "Companion Guide.pdf", names: defaultNames, want: false},
+		{name: "empty names list disables matching", filename: "supplement.pdf", names: []string{}, want: false},
+		{name: "nil names list disables matching", filename: "supplement.pdf", names: nil, want: false},
+		{name: "custom list overrides default", filename: "extra.pdf", names: []string{"extra"}, want: true},
+		{name: "no extension does not match", filename: "supplement", names: defaultNames, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := looksLikePDFSupplement(tt.filename, tt.names)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `go test ./pkg/worker/ -run TestLooksLikePDFSupplement -v`
+Expected: compile error — `undefined: looksLikePDFSupplement`. This is the "Red" step of TDD.
+
+- [ ] **Step 3: Implement `looksLikePDFSupplement` in `pkg/worker/scan.go`**
+
+Open `pkg/worker/scan.go`. Find the existing helper `isShishoSpecialFile` (currently around line 124) and add this function right after it:
+
+```go
+// looksLikePDFSupplement returns true if filename has a .pdf extension and its
+// basename (without extension, trimmed, lowercased) is an exact case-insensitive
+// match for any entry in names. Returns false when names is empty/nil.
+func looksLikePDFSupplement(filename string, names []string) bool {
+	if len(names) == 0 {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(filename))
+	if ext != ".pdf" {
+		return false
+	}
+	basename := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(filename, filepath.Ext(filename))))
+	if basename == "" {
+		return false
+	}
+	for _, name := range names {
+		if strings.ToLower(strings.TrimSpace(name)) == basename {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `go test ./pkg/worker/ -run TestLooksLikePDFSupplement -v`
+Expected: all 12 sub-tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/worker/scan.go pkg/worker/scan_helpers_test.go
+git commit -m "[Backend] Add looksLikePDFSupplement helper for filename matching"
+```
+
+---
+
+## Task 3: Add `hasNonPDFMainSibling` helper with unit tests
+
+**Files:**
+- Modify: `pkg/worker/scan.go` (add helper)
+- Test: `pkg/worker/scan_helpers_test.go` (add test)
+
+This walks a directory recursively looking for any non-PDF main-eligible file. Used to decide whether a candidate supplement PDF has a real sibling main file. The plugin-extension set comes from `w.pluginManager.RegisteredFileExtensions()` (extensions without leading dots) — pass it as a parameter so the helper stays pure.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/worker/scan_helpers_test.go`:
+
+```go
+func TestHasNonPDFMainSibling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("epub sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "book.epub"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("cbz sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "comic.cbz"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("m4b sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "audio.m4b"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("pdf-only directory has no sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "another.pdf"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("unrelated extension is not a sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "notes.txt"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("plugin-registered extension is a sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "book.azw3"))
+
+		// Plugin extensions are stored without leading dot, lowercase.
+		pluginExts := map[string]struct{}{"azw3": {}}
+		got, err := hasNonPDFMainSibling(dir, pluginExts)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("recursive sibling in subdirectory", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		sub := filepath.Join(dir, "extras")
+		require.NoError(t, os.MkdirAll(sub, 0o755))
+		writeFile(t, filepath.Join(sub, "book.epub"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("missing directory returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := hasNonPDFMainSibling(filepath.Join(t.TempDir(), "does-not-exist"), nil)
+		assert.Error(t, err)
+	})
+}
+
+// writeFile creates an empty file at path, failing the test on error.
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte{}, 0o644))
+}
+```
+
+You'll need to add new imports at the top of `scan_helpers_test.go`:
+
+```go
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/mediafile"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+```
+
+(Keep any existing imports the file already has — `mediafile` and `models` are already there. Add `os`, `path/filepath`, and `require`.)
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `go test ./pkg/worker/ -run TestHasNonPDFMainSibling -v`
+Expected: compile error — `undefined: hasNonPDFMainSibling`.
+
+- [ ] **Step 3: Implement `hasNonPDFMainSibling` in `pkg/worker/scan.go`**
+
+Add this function right after `looksLikePDFSupplement`:
+
+```go
+// hasNonPDFMainSibling returns true if dir (recursive) contains at least one
+// file with a non-PDF main-eligible extension. Main-eligible means EPUB / CBZ /
+// M4B or any extension in pluginExts (which comes from
+// pluginManager.RegisteredFileExtensions() — keys are extensions without the
+// leading dot, lowercase). pluginExts may be nil.
+func hasNonPDFMainSibling(dir string, pluginExts map[string]struct{}) (bool, error) {
+	found := false
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
+		if ext == "pdf" {
+			return nil
+		}
+		switch ext {
+		case models.FileTypeEPUB, models.FileTypeCBZ, models.FileTypeM4B:
+			found = true
+			return filepath.SkipAll
+		}
+		if pluginExts != nil {
+			if _, ok := pluginExts[ext]; ok {
+				found = true
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return found, nil
+}
+```
+
+`filepath.SkipAll` (Go 1.20+) bails out of the walk as soon as we find a hit, avoiding wasted I/O on large book directories.
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `go test ./pkg/worker/ -run TestHasNonPDFMainSibling -v`
+Expected: all sub-tests pass.
+
+- [ ] **Step 5: Run linter**
+
+Run: `mise lint`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/worker/scan.go pkg/worker/scan_helpers_test.go
+git commit -m "[Backend] Add hasNonPDFMainSibling helper for sibling check"
+```
+
+---
+
+## Task 4: Sort `filesToScan` to defer supplement-named PDFs
+
+**Files:**
+- Modify: `pkg/worker/scan.go` (`ProcessScanJob`)
+- Test: `pkg/worker/scan_helpers_test.go` (small unit test on the sort helper)
+
+Pull the sort logic into a tiny pure helper so we can test it without spinning up a worker.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pkg/worker/scan_helpers_test.go`:
+
+```go
+func TestPartitionSupplementPDFsLast(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"supplement", "bonus"}
+
+	// Mixed input — supplement-named PDFs interleaved with other files.
+	input := []string{
+		"/lib/[Author] Book/supplement.pdf",
+		"/lib/[Author] Book/book.epub",
+		"/lib/Other/bonus.pdf",
+		"/lib/Other/audio.m4b",
+		"/lib/Other/notes.txt",
+	}
+
+	got := partitionSupplementPDFsLast(input, names)
+
+	// Non-supplement files must come first, in their original order.
+	expected := []string{
+		"/lib/[Author] Book/book.epub",
+		"/lib/Other/audio.m4b",
+		"/lib/Other/notes.txt",
+		"/lib/[Author] Book/supplement.pdf",
+		"/lib/Other/bonus.pdf",
+	}
+	assert.Equal(t, expected, got)
+}
+
+func TestPartitionSupplementPDFsLast_StableForNoMatches(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"a.epub", "b.epub", "c.cbz"}
+	got := partitionSupplementPDFsLast(input, []string{"supplement"})
+	assert.Equal(t, input, got)
+}
+
+func TestPartitionSupplementPDFsLast_EmptyNames(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"supplement.pdf", "book.epub"}
+	got := partitionSupplementPDFsLast(input, nil)
+	assert.Equal(t, input, got)
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `go test ./pkg/worker/ -run TestPartitionSupplementPDFsLast -v`
+Expected: compile error — `undefined: partitionSupplementPDFsLast`.
+
+- [ ] **Step 3: Implement the partition helper**
+
+Add to `pkg/worker/scan.go` right after `hasNonPDFMainSibling`:
+
+```go
+// partitionSupplementPDFsLast returns paths reordered so that PDFs whose
+// basename matches the supplement name list appear after every other path.
+// Order within each partition is preserved (stable). The input slice is not
+// mutated. When names is empty/nil, the input is returned unchanged.
+func partitionSupplementPDFsLast(paths []string, names []string) []string {
+	if len(names) == 0 {
+		return paths
+	}
+	out := make([]string, 0, len(paths))
+	var deferred []string
+	for _, p := range paths {
+		if looksLikePDFSupplement(filepath.Base(p), names) {
+			deferred = append(deferred, p)
+			continue
+		}
+		out = append(out, p)
+	}
+	return append(out, deferred...)
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `go test ./pkg/worker/ -run TestPartitionSupplementPDFsLast -v`
+Expected: all 3 sub-tests pass.
+
+- [ ] **Step 5: Wire the partition into `ProcessScanJob`**
+
+Open `pkg/worker/scan.go`. Find the section right after the `filepath.WalkDir` loop completes and before `// Run input converters on discovered files` (currently around line 366-368):
+
+```go
+		// Run input converters on discovered files
+		if w.pluginManager != nil {
+			convertedFiles := w.runInputConverters(ctx, filesToScan, jobLog, library.ID)
+			filesToScan = append(filesToScan, convertedFiles...)
+		}
+```
+
+Add the partition call right before that block:
+
+```go
+		// Defer supplement-named PDFs so non-supplement files in the same
+		// directory get processed first by the parallel worker pool. This
+		// makes the supplement classification ordering-independent in the
+		// common case where a sibling main file exists, even though the
+		// on-disk sibling check in scanFileCreateNew is the actual
+		// correctness mechanism.
+		filesToScan = partitionSupplementPDFsLast(filesToScan, w.config.PDFSupplementFilenames)
+
+		// Run input converters on discovered files
+		if w.pluginManager != nil {
+			convertedFiles := w.runInputConverters(ctx, filesToScan, jobLog, library.ID)
+			filesToScan = append(filesToScan, convertedFiles...)
+		}
+```
+
+- [ ] **Step 6: Run the helper tests and the full worker test suite**
+
+Run: `go test ./pkg/worker/ -run TestPartitionSupplementPDFsLast -v && go test ./pkg/worker/...`
+Expected: all pass.
+
+- [ ] **Step 7: Lint**
+
+Run: `mise lint`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pkg/worker/scan.go pkg/worker/scan_helpers_test.go
+git commit -m "[Backend] Defer supplement-named PDFs in scan dispatch order"
+```
+
+---
+
+## Task 5: Apply supplement classification in `scanFileCreateNew`
+
+**Files:**
+- Modify: `pkg/worker/scan_unified.go` (`scanFileCreateNew`)
+- Test: `pkg/worker/supplement_test.go` (new integration tests)
+
+Wire the rule into the file-creation path. This is the correctness mechanism: regardless of the dispatch order, a PDF that meets the rule becomes a supplement.
+
+The rule (from the spec):
+- `fileType == "pdf"`, AND
+- `looksLikePDFSupplement(filepath.Base(path), w.config.PDFSupplementFilenames)`, AND
+- one of:
+  - `existingBook != nil` (a book row already exists at this path), OR
+  - `hasNonPDFMainSibling(bookPath, pluginExts)` returns true (an EPUB/CBZ/M4B/plugin-extension file is on disk in the directory tree).
+- AND `!isRootLevelFile` (root-level PDFs always stay main).
+
+When the rule fires, skip cover extraction (supplements don't get a cover during scan; matches the existing supplement create path at `scan_unified.go` ~L2554).
+
+- [ ] **Step 1: Write the first failing integration test (sibling-EPUB → supplement)**
+
+Open `pkg/worker/supplement_test.go` and append:
+
+```go
+// TestProcessScanJob_PDFNamedSupplementBecomesSupplement covers the core
+// scenario: a PDF named "Supplement.pdf" alongside a main EPUB in the same
+// directory must be classified as a supplement.
+func TestProcessScanJob_PDFNamedSupplementBecomesSupplement(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] My Book")
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{
+		Title:   "My Book",
+		Authors: []string{"Author"},
+	})
+	testgen.GeneratePDF(t, bookDir, "Supplement.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	booksList := tc.listBooks()
+	require.Len(t, booksList, 1, "EPUB and supplement PDF should belong to one book")
+
+	files := tc.listFiles()
+	require.Len(t, files, 2)
+
+	var mainCount, suppCount int
+	for _, f := range files {
+		switch f.FileRole {
+		case models.FileRoleMain:
+			mainCount++
+			assert.Equal(t, "epub", f.FileType, "main file should be the EPUB")
+		case models.FileRoleSupplement:
+			suppCount++
+			assert.Equal(t, "pdf", f.FileType, "supplement should be the PDF")
+			assert.Equal(t, "Supplement.pdf", filepath.Base(f.Filepath))
+		}
+	}
+	assert.Equal(t, 1, mainCount)
+	assert.Equal(t, 1, suppCount)
+}
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `go test ./pkg/worker/ -run TestProcessScanJob_PDFNamedSupplementBecomesSupplement -v`
+Expected: test fails — currently the PDF is classified as main, so we get 2 main files (or one main book per file). The exact failure mode may be `mainCount=2, suppCount=0` or `len(books)=2` depending on directory layout. The point is: it fails because the feature doesn't exist yet.
+
+- [ ] **Step 3: Implement the classification in `scanFileCreateNew`**
+
+Open `pkg/worker/scan_unified.go`. Find the section where `scanFileCreateNew` handles cover extraction and creates the file (currently around lines 2393-2434). The current code reads:
+
+```go
+	// Handle cover extraction. extractAndSaveCover also adopts a cover file
+	// that already sits next to the source file on disk, so we always call
+	// it — even when the parser returned no cover data for the source.
+	var coverImagePath *string
+	var coverMimeType *string
+	var coverSource *string
+	var coverPage *int
+
+	coverFilename, extractedMimeType, wasPreExisting, err := w.extractAndSaveCover(ctx, path, bookPath, isRootLevelFile, metadata, opts.JobLog)
+	if err != nil {
+		logWarn("failed to extract cover", logger.Data{"error": err.Error()})
+	} else if coverFilename != "" {
+		coverImagePath = &coverFilename
+		if extractedMimeType != "" {
+			coverMimeType = &extractedMimeType
+		}
+		if wasPreExisting {
+			existingCoverSource := models.DataSourceExistingCover
+			coverSource = &existingCoverSource
+		} else {
+			cs := metadata.SourceForField("cover")
+			coverSource = &cs
+		}
+	}
+	if metadata != nil && metadata.CoverPage != nil {
+		coverPage = metadata.CoverPage
+	}
+
+	// Create file record
+	logInfo("creating file", logger.Data{"path": path, "filesize": size})
+	file := &models.File{
+		LibraryID:          opts.LibraryID,
+		BookID:             book.ID,
+		Filepath:           path,
+		FileType:           fileType,
+		FilesizeBytes:      size,
+		FileModifiedAt:     &modTime,
+		CoverImageFilename: coverImagePath,
+		CoverMimeType:      coverMimeType,
+		CoverSource:        coverSource,
+		CoverPage:          coverPage,
+	}
+```
+
+Replace it with:
+
+```go
+	// Decide whether this new file should be a supplement based on filename
+	// pattern + on-disk siblings. Only applies to PDFs in directory-based
+	// books — root-level PDFs always stay main (root-level supplement linking
+	// uses basename-prefix matching, handled separately).
+	classifyAsSupplement := false
+	if fileType == models.FileTypePDF && !isRootLevelFile && looksLikePDFSupplement(filepath.Base(path), w.config.PDFSupplementFilenames) {
+		// Reuse-existing-book check: if a book row already lives at this
+		// bookPath, there's by definition another file (or there will be).
+		if existingBook != nil {
+			classifyAsSupplement = true
+		} else {
+			// On-disk sibling check: look for any non-PDF main-eligible file
+			// in the book directory. This is what makes the rule
+			// ordering-independent when both files arrive in the same scan.
+			var pluginExts map[string]struct{}
+			if w.pluginManager != nil {
+				pluginExts = w.pluginManager.RegisteredFileExtensions()
+			}
+			hasSibling, sibErr := hasNonPDFMainSibling(bookPath, pluginExts)
+			if sibErr != nil {
+				logWarn("failed to check for sibling main file", logger.Data{"error": sibErr.Error(), "dir": bookPath})
+			} else if hasSibling {
+				classifyAsSupplement = true
+			}
+		}
+	}
+
+	// Handle cover extraction. extractAndSaveCover also adopts a cover file
+	// that already sits next to the source file on disk, so we always call
+	// it — even when the parser returned no cover data for the source.
+	// Skipped for files we're about to create as supplements, matching the
+	// supplement-discovery code path further down (supplements don't get
+	// scanned-cover extraction).
+	var coverImagePath *string
+	var coverMimeType *string
+	var coverSource *string
+	var coverPage *int
+
+	if !classifyAsSupplement {
+		coverFilename, extractedMimeType, wasPreExisting, err := w.extractAndSaveCover(ctx, path, bookPath, isRootLevelFile, metadata, opts.JobLog)
+		if err != nil {
+			logWarn("failed to extract cover", logger.Data{"error": err.Error()})
+		} else if coverFilename != "" {
+			coverImagePath = &coverFilename
+			if extractedMimeType != "" {
+				coverMimeType = &extractedMimeType
+			}
+			if wasPreExisting {
+				existingCoverSource := models.DataSourceExistingCover
+				coverSource = &existingCoverSource
+			} else {
+				cs := metadata.SourceForField("cover")
+				coverSource = &cs
+			}
+		}
+		if metadata != nil && metadata.CoverPage != nil {
+			coverPage = metadata.CoverPage
+		}
+	}
+
+	// Create file record
+	logInfo("creating file", logger.Data{"path": path, "filesize": size, "supplement": classifyAsSupplement})
+	fileRole := models.FileRoleMain
+	if classifyAsSupplement {
+		fileRole = models.FileRoleSupplement
+	}
+	file := &models.File{
+		LibraryID:          opts.LibraryID,
+		BookID:             book.ID,
+		Filepath:           path,
+		FileType:           fileType,
+		FileRole:           fileRole,
+		FilesizeBytes:      size,
+		FileModifiedAt:     &modTime,
+		CoverImageFilename: coverImagePath,
+		CoverMimeType:      coverMimeType,
+		CoverSource:        coverSource,
+		CoverPage:          coverPage,
+	}
+```
+
+Note the additions:
+- `classifyAsSupplement` decision block before cover extraction.
+- Cover extraction guarded by `if !classifyAsSupplement { ... }`.
+- `FileRole: fileRole` added to the `models.File{}` literal.
+- `"supplement": classifyAsSupplement` added to the create-file log line.
+
+- [ ] **Step 4: Run the test and confirm it now passes**
+
+Run: `go test ./pkg/worker/ -run TestProcessScanJob_PDFNamedSupplementBecomesSupplement -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add the rest of the integration tests**
+
+Append to `pkg/worker/supplement_test.go`:
+
+```go
+// TestProcessScanJob_PDFAloneInDirStaysMain confirms the safety rule:
+// a directory containing only a supplement-named PDF must still import as
+// a main file so the book isn't silently dropped.
+func TestProcessScanJob_PDFAloneInDirStaysMain(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] PDF Only Book")
+	testgen.GeneratePDF(t, bookDir, "Supplement.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	require.Len(t, tc.listBooks(), 1)
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	assert.Equal(t, models.FileRoleMain, files[0].FileRole, "lone supplement-named PDF should be main")
+	assert.Equal(t, "pdf", files[0].FileType)
+}
+
+// TestProcessScanJob_PDFCaseInsensitiveMatch confirms basename matching
+// ignores case for both the filename and the configured names.
+func TestProcessScanJob_PDFCaseInsensitiveMatch(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Casing Test")
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{Title: "Casing Test"})
+	testgen.GeneratePDF(t, bookDir, "BONUS.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	require.Len(t, tc.listBooks(), 1)
+	files := tc.listFiles()
+	require.Len(t, files, 2)
+
+	for _, f := range files {
+		if f.FileType == "pdf" {
+			assert.Equal(t, models.FileRoleSupplement, f.FileRole)
+		}
+	}
+}
+
+// TestProcessScanJob_PDFSubstringDoesNotMatch confirms substring matches do
+// NOT trigger supplement classification — only exact basename matches.
+func TestProcessScanJob_PDFSubstringDoesNotMatch(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Substring Test")
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{Title: "Substring Test"})
+	testgen.GeneratePDF(t, bookDir, "My Book - Supplement.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	// PDF basename "My Book - Supplement" is NOT an exact match for any list
+	// entry, so it stays main. Two main files end up on the same book (the
+	// existing scan flow merges files with the same bookPath into one book).
+	require.Len(t, tc.listBooks(), 1)
+	files := tc.listFiles()
+	require.Len(t, files, 2)
+	for _, f := range files {
+		assert.Equal(t, models.FileRoleMain, f.FileRole, "substring match should not classify as supplement")
+	}
+}
+
+// TestProcessScanJob_PDFEmptyConfigDisablesFeature confirms setting
+// PDFSupplementFilenames to an empty slice disables the auto-classification.
+func TestProcessScanJob_PDFEmptyConfigDisablesFeature(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+	tc.worker.config.PDFSupplementFilenames = nil
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Disabled Test")
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{Title: "Disabled Test"})
+	testgen.GeneratePDF(t, bookDir, "Supplement.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 2)
+	for _, f := range files {
+		assert.Equal(t, models.FileRoleMain, f.FileRole, "feature should be disabled when config is empty")
+	}
+}
+
+// TestProcessScanJob_PDFExistingMainNotReclassified confirms an existing
+// PDF main file whose name happens to match the supplement list is NOT
+// reclassified on rescan. The rule only applies at file creation.
+func TestProcessScanJob_PDFExistingMainNotReclassified(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	// First scan: only the PDF exists, so it imports as main.
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Rescan Test")
+	testgen.GeneratePDF(t, bookDir, "Supplement.pdf", testgen.PDFOptions{})
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	require.Equal(t, models.FileRoleMain, files[0].FileRole)
+	mainID := files[0].ID
+
+	// Add an EPUB sibling and rescan.
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{Title: "Rescan Test"})
+	require.NoError(t, tc.runScan())
+
+	afterFiles := tc.listFiles()
+	require.Len(t, afterFiles, 2)
+
+	for _, f := range afterFiles {
+		if f.ID == mainID {
+			assert.Equal(t, models.FileRoleMain, f.FileRole, "existing main PDF must not be reclassified on rescan")
+		}
+	}
+}
+```
+
+- [ ] **Step 6: Run the new test suite**
+
+Run: `go test ./pkg/worker/ -run "TestProcessScanJob_PDF" -v`
+Expected: all 6 tests pass.
+
+- [ ] **Step 7: Run the full worker test suite to confirm nothing broke**
+
+Run: `go test ./pkg/worker/...`
+Expected: all pass. The pre-existing `TestProcessScanJob_ScannableSupplementNotRescannedAsMain` (which adds a PDF as a supplement directly via the DB) is the closest neighbor — it should keep passing.
+
+- [ ] **Step 8: Lint**
+
+Run: `mise lint`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pkg/worker/scan_unified.go pkg/worker/supplement_test.go
+git commit -m "[Backend] Auto-classify supplement-named PDFs on scan"
+```
+
+---
+
+## Task 6: Update example YAML
+
+**Files:**
+- Modify: `shisho.example.yaml`
+
+`shisho.example.yaml` is part of the project's "complete reference of all configurable fields" promise (see root `CLAUDE.md`). Anything added to `Config` must show up here.
+
+- [ ] **Step 1: Add the new field to the supplement section**
+
+Open `shisho.example.yaml`. Find the `supplement_exclude_patterns:` block (currently around line 156-168). Append after it:
+
+```yaml
+# PDF basenames (case-insensitive, no extension) that should be auto-classified
+# as supplements when discovered next to a main EPUB / CBZ / M4B file. A PDF
+# alone in a directory always imports as a main file regardless of name.
+# Set to [] to disable. Substring matches are NOT applied — exact basename only.
+# Env: PDF_SUPPLEMENT_FILENAMES (comma-separated)
+# Default: see list below
+pdf_supplement_filenames:
+  - "supplement"
+  - "supplemental"
+  - "bonus"
+  - "bonus material"
+  - "bonus content"
+  - "companion"
+  - "notes"
+  - "liner notes"
+  - "errata"
+  - "booklet"
+  - "digital booklet"
+  - "appendix"
+  - "map"
+  - "maps"
+  - "insert"
+  - "guide"
+  - "reference"
+  - "cheat sheet"
+  - "cheatsheet"
+  - "cribsheet"
+  - "pamphlet"
+  - "extras"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add shisho.example.yaml
+git commit -m "[Backend] Document pdf_supplement_filenames in example config"
+```
+
+---
+
+## Task 7: Update website docs
+
+**Files:**
+- Modify: `website/docs/configuration.md`
+- Modify: `website/docs/supplement-files.md`
+
+Per root `CLAUDE.md`: any user-facing change must update `website/docs/`. New config option goes in `configuration.md`; new supplement behavior goes in `supplement-files.md`.
+
+- [ ] **Step 1: Document the config field in `website/docs/configuration.md`**
+
+Open `website/docs/configuration.md` and find the section that documents `supplement_exclude_patterns` (search for `supplement_exclude_patterns`). Add a sibling entry for `pdf_supplement_filenames` immediately after it. Match the existing formatting (heading level, table structure, env-var notation) of `supplement_exclude_patterns` exactly — copy that section's pattern.
+
+The content should cover:
+- **Field name:** `pdf_supplement_filenames`
+- **Env var:** `PDF_SUPPLEMENT_FILENAMES` (comma-separated)
+- **Default:** the full default list (same 22 entries as in `pkg/config/config.go::defaults`)
+- **Behavior:** PDF basenames (case-insensitive, no extension) that get classified as supplements on scan when a sibling EPUB/CBZ/M4B exists in the same directory. Exact match only — substrings don't match. A PDF alone in a directory always imports as main.
+- **Disable:** set to `[]`.
+
+- [ ] **Step 2: Document the supplement behavior in `website/docs/supplement-files.md`**
+
+Open `website/docs/supplement-files.md`. Find the section "What Counts as a Supplement" and the existing exclude-patterns subsection. Add a new section titled "PDF Auto-Classification" between "Excluded Files" and the "Working with Supplements" section.
+
+Content to include:
+- A PDF whose basename exactly matches an entry in `pdf_supplement_filenames` is classified as a supplement when a sibling main file (EPUB / CBZ / M4B / plugin-registered file extension) exists in the same directory tree.
+- A directory-only PDF (no sibling main file) imports as a main file regardless of name.
+- The check runs only at file creation. PDFs already imported as main files are not retroactively reclassified.
+- Cross-link to `configuration.md#pdf_supplement_filenames` for the configurable list.
+- Show a small example tree like the existing examples in this doc:
+
+```
+[Author] My Book/
+├── My Book.epub          ← main file
+└── Supplement.pdf        ← classified as supplement (matches default list)
+```
+
+- [ ] **Step 3: Verify markdown renders**
+
+Run: `cd website && pnpm build`
+Expected: build completes without errors. (Docusaurus catches broken links and bad markdown.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add website/docs/configuration.md website/docs/supplement-files.md
+git commit -m "[Docs] Document pdf_supplement_filenames behavior"
+```
+
+---
+
+## Task 8: Update `pkg/CLAUDE.md` with the new gotcha
+
+**Files:**
+- Modify: `pkg/CLAUDE.md`
+
+Per root `CLAUDE.md`: when the work introduces a new convention or gotcha, update the relevant `CLAUDE.md`. The new convention here: `scanFileCreateNew` skips cover extraction when classifying as supplement. Future agents touching this code path could break that quietly.
+
+- [ ] **Step 1: Add a short note**
+
+Open `pkg/CLAUDE.md`. Find the section beginning `### scanInternal and File Organization`. Add a new sibling section right after the existing "Scan Cache Must Include Supplements" section:
+
+```markdown
+### Auto-Classification of Supplement-Named PDFs
+
+`scanFileCreateNew` (in `pkg/worker/scan_unified.go`) inspects new PDF files for the auto-supplement rule before creating the file row: when a PDF's basename matches `config.PDFSupplementFilenames` AND a sibling main file (EPUB / CBZ / M4B / plugin-registered extension) exists on disk OR a book row already exists at the same `bookPath`, it's created with `FileRole=Supplement` and **cover extraction is skipped** (matching the existing supplement-discovery path that creates supplements without covers).
+
+When editing the cover-extraction block in `scanFileCreateNew`, preserve the `if !classifyAsSupplement { ... }` guard. Rescans don't re-run this rule — existing main-file PDFs whose names match the list keep their role.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add pkg/CLAUDE.md
+git commit -m "[Docs] Note auto-supplement PDF rule in pkg/CLAUDE.md"
+```
+
+---
+
+## Task 9: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full check**
+
+Run: `mise check:quiet`
+Expected: clean. (This runs Go tests with `-race`, golangci-lint, Vitest, ESLint, Prettier, tsc, and chromium e2e.)
+
+If any failure appears, fix it inline before considering the plan complete. Common issues:
+- gofmt/goimports differences — run `mise lint` and apply suggestions.
+- `tygo` regenerated types — none expected here (no Go struct that's tygo'd was changed). If tygo runs and reports "skipping, outputs are up-to-date", that's normal per root CLAUDE.md.
+
+- [ ] **Step 2: Smoke-test in a running dev environment (manual)**
+
+This step is for the reviewer running interactively, not for an autonomous agent. Skip if running unattended; the integration tests in Task 5 cover correctness.
+
+If running interactively:
+1. Start `mise start`.
+2. Drop a `Book.epub` and `Supplement.pdf` into a watched library directory.
+3. Trigger a scan.
+4. Open the book detail page in the frontend; confirm the PDF appears under "Supplements" and the EPUB is the main file.
+
+- [ ] **Step 3: Confirm everything is committed**
+
+Run: `git status`
+Expected: working tree clean.
+
+Run: `git log --oneline master..HEAD`
+Expected: a sequence of commits matching the per-task messages above.

--- a/docs/superpowers/specs/2026-04-26-pdf-supplement-name-detection-design.md
+++ b/docs/superpowers/specs/2026-04-26-pdf-supplement-name-detection-design.md
@@ -1,0 +1,116 @@
+# PDF Supplement Name Detection
+
+## Problem
+
+Shisho currently treats every `.pdf` file the scanner encounters as a main file (see `pkg/worker/scan.go::extensionsToScan` and the discovery flow in `discoverSupplements`, which skips main-file extensions). When a user drops a companion PDF — e.g. `Supplement.pdf` next to `Book.epub` — into a book directory, the PDF becomes a separate main file (or a second main file on the same book) instead of a supplement attached to the EPUB.
+
+This means:
+- Companion PDFs pollute the library as standalone "books" or as redundant main files.
+- Users have to manually demote them to supplements every time.
+
+## Goal
+
+When the scanner discovers a PDF whose basename matches a configurable list of common supplement names, classify it as a supplement to the sibling main book, provided there's another file in the same directory tree that can serve as the main file. Never silently drop a book — a directory containing only a supplement-named PDF still imports as a main file.
+
+## Non-goals
+
+- Substring matching of supplement words inside arbitrary filenames (avoids false positives on real books with words like "Companion" in the title).
+- Reclassifying existing PDF main files on rescan. The check applies only when a brand-new file row is created.
+- Auto-linking root-level PDFs (e.g. `Book - Supplement.pdf` next to `Book.epub` at the library root) — root-level supplement linking is the existing basename-prefix flow in `discoverRootLevelSupplements` and is out of scope here.
+- Supplement classification for non-PDF main extensions (`.epub`, `.cbz`, `.m4b`, plugin-registered file parsers).
+
+## Design
+
+### Classification rule
+
+When `scanFileCreateNew` (in `pkg/worker/scan_unified.go`) is creating a new file row, after the `bookPath` and `existingBook` lookup but before the `models.File` is constructed:
+
+If **all** of the following are true, set `FileRole = models.FileRoleSupplement`:
+
+1. `fileType == "pdf"`.
+2. The basename (extension stripped, whitespace trimmed, lowercased) appears in the configured supplement-name list.
+3. **Either** `existingBook != nil` **or** the directory tree containing the PDF has at least one sibling file with a non-PDF main-eligible extension on disk.
+
+Otherwise, the file is created as `FileRoleMain` (current behavior).
+
+The "either / or" in (3) is what gives correct ordering-independent classification: the on-disk sibling check works even when the EPUB and the PDF are dropped together and `scanFileCreateNew` runs for them in unpredictable order under the parallel worker pool. The DB-existing-book check covers the case where a sibling main file was imported in a previous scan.
+
+### Scope of the sibling check
+
+- **Directory-based books:** walk the book directory recursively (`filepath.WalkDir` rooted at `bookPath`) looking for any non-PDF file with extension in the union of `models.FileTypeEPUB`, `models.FileTypeCBZ`, `models.FileTypeM4B`, and `pluginManager.RegisteredFileExtensions()`. First hit wins; bail early.
+- **Root-level files:** skip the sibling check and treat the PDF as main. Root-level files don't share a directory in the book sense, and root-level supplement linking is its own basename-matching flow.
+
+### Match style
+
+Case-insensitive exact match of the trimmed basename against the configured names list. Examples (with default list):
+- `Supplement.pdf` → matches `supplement` → supplement.
+- `BONUS MATERIAL.pdf` → matches `bonus material` → supplement.
+- `Companion Guide.pdf` → does not match any list entry → main.
+- `My Book - Supplement.pdf` → does not match → main (substring matching is non-goal).
+
+### Configuration
+
+New field on `pkg/config/config.go::Config`:
+
+```go
+PDFSupplementFilenames []string `mapstructure:"pdf_supplement_filenames"`
+```
+
+Default value (set in `defaultPDFSupplementFilenames` slice or via `viper.SetDefault`):
+
+```
+supplement, supplemental, bonus, bonus material, bonus content,
+companion, notes, liner notes, errata, booklet, digital booklet,
+appendix, map, maps, insert, guide, reference, cheat sheet,
+cheatsheet, cribsheet, pamphlet, extras
+```
+
+Setting the YAML key to `[]` (empty list) disables the feature. Omitting the key uses the default. Mirrored in `shisho.example.yaml` and documented in `website/docs/configuration.md`.
+
+### Touch points
+
+| File | Change |
+|------|--------|
+| `pkg/config/config.go` | Add `PDFSupplementFilenames []string` field with default. |
+| `shisho.example.yaml` | Add the field with the default list and a comment. |
+| `pkg/worker/scan.go` | Add `looksLikePDFSupplement(filename string, names []string) bool` helper. Add `hasNonPDFMainSibling(dir string, pluginExts map[string]struct{}) (bool, error)` helper. |
+| `pkg/worker/scan.go::ProcessScanJob` | After the walk fills `filesToScan`, stable-sort to push supplement-named PDFs to the end. Optimization for log readability and parallel-worker scheduling — not load-bearing for correctness. |
+| `pkg/worker/scan_unified.go::scanFileCreateNew` | Compute the FileRole using the rule above and set it on the `models.File` before `CreateFile`. Skip cover extraction (`extractAndSaveCover`) when classified as supplement, matching the existing supplement create path at L2554. |
+| `website/docs/configuration.md` | Document `pdf_supplement_filenames`. |
+| `website/docs/supplement-files.md` | New section "Supplement-named PDFs" explaining auto-classification and pointing at the config option. |
+
+### Edge cases
+
+| Scenario | Outcome |
+|----------|---------|
+| `Book.epub` and `Supplement.pdf` dropped together in same directory | EPUB and PDF processed in any order; PDF sees on-disk EPUB sibling → supplement. EPUB has no rule applied → main. |
+| Directory contains only `Supplement.pdf` | No existing book at `bookPath`, no non-PDF main sibling on disk → main. Book imports normally. |
+| `Supplement.pdf` added later to a directory that already has a book row | `existingBook != nil` → supplement. |
+| `Book.epub` deleted leaving only an existing main `Supplement.pdf` | Existing rescan path doesn't reclassify the PDF; orphan cleanup (`scan_orphans.go`) handles the EPUB removal independently. (No change from current behavior.) |
+| `Book.epub` deleted leaving an existing supplement `Supplement.pdf` | Existing orphan cleanup at `pkg/worker/scan_orphans.go:174-186` promotes the PDF to main via `PromoteSupplementToMain`. Book survives. (No change from current behavior.) |
+| User has manually named a real book "Companion.pdf" and is importing it for the first time | Matches the default list → classified as supplement if a sibling main file exists, or main if it's alone in its directory. If the user imports it next to another book they want, they can demote/promote manually, or remove `companion` from `pdf_supplement_filenames` in config. |
+| Plugin-registered file parser extension (e.g. `.azw3`) sits next to `Supplement.pdf` | Sibling check includes plugin-registered file extensions → PDF classified as supplement. |
+| Monitor (single-file rescan via `pkg/worker/monitor.go`) creates a new PDF row | Goes through the same `scanFileCreateNew` path; rule applies. |
+| Two supplement-named PDFs in a directory with no other main file (`Bonus.pdf` + `Notes.pdf`) | Sort puts both at the end; whichever the worker pool picks first sees no existing book and no sibling main → main. The second sees the first as an existing book → supplement. Deterministic by sort order, but the user effectively has a PDF-only book either way. |
+
+### Tests
+
+Extend `pkg/worker/supplement_test.go` and add cases covering:
+
+1. PDF named `Supplement.pdf` next to an EPUB in a directory → PDF created as `FileRoleSupplement`, EPUB as `FileRoleMain`, both attached to one book.
+2. Same as (1) but the PDF is processed before the EPUB (directly invoke `scanInternal` in PDF-then-EPUB order). Outcome must be identical, proving ordering-independence.
+3. PDF named `Supplement.pdf` alone in a directory → main. Book imports.
+4. PDF named `supplement.PDF` (mixed case) → matches case-insensitively → supplement when sibling exists.
+5. PDF named `Companion Guide.pdf` (does not exactly match any list entry) → main.
+6. PDF named `Bonus.pdf` next to `Notes.pdf` only → first one main, second one supplement (per sort + sibling rule).
+7. Existing main-file PDF whose name happens to match a list entry → unchanged on rescan (no reclassification).
+8. Plugin-registered file extension (`.azw3` registered as a parser) sitting next to `Supplement.pdf` → PDF classified as supplement (plugin extensions count as siblings).
+9. Empty `pdf_supplement_filenames` list in config → all PDFs classified as main (feature disabled).
+10. `ProcessScanJob` sort: supplement-named PDFs end up after non-supplement files in `filesToScan`.
+
+### Verification
+
+After implementation:
+- `mise lint test` for the Go-side changes (this is a Go-only change touching scan/config/docs).
+- Manually drop a `Supplement.pdf` and a `Book.epub` into a test library directory, trigger a scan, and confirm the PDF is attached as a supplement on the book detail page.
+- `mise check:quiet` once before pushing/PR.

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -52,6 +52,12 @@ Each domain (books, jobs, libraries, chapters) has:
 - Preload via `ListAllFilesForLibrary`, not `ListFilesForLibrary` (which is still main-only, used for orphan cleanup).
 - `scanFileByPath` early-returns with `&ScanResult{File: existing}` when the cached file has `FileRole == FileRoleSupplement` — supplements have no metadata to rescan.
 
+### Auto-Classification of Supplement-Named PDFs
+
+`scanFileCreateNew` (in `pkg/worker/scan_unified.go`) inspects new PDF files for the auto-supplement rule before creating the file row: when a PDF's basename matches `config.PDFSupplementFilenames` AND a sibling main file (EPUB / CBZ / M4B / plugin-registered extension) exists on disk OR a book row already exists at the same `bookPath`, it's created with `FileRole=Supplement` and **cover extraction is skipped** (matching the existing supplement-discovery path that creates supplements without covers).
+
+When editing the cover-extraction block in `scanFileCreateNew`, preserve the `if !classifyAsSupplement { ... }` guard. Rescans don't re-run this rule — existing main-file PDFs whose names match the list keep their role.
+
 ### File Types
 
 - To learn more about all the file types that we support, refer to:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 
 	// Supplement discovery settings
 	SupplementExcludePatterns []string `koanf:"supplement_exclude_patterns" json:"supplement_exclude_patterns"`
+	PDFSupplementFilenames    []string `koanf:"pdf_supplement_filenames" json:"pdf_supplement_filenames"`
 
 	// Authentication settings
 	JWTSecret           string `koanf:"jwt_secret" json:"-" validate:"required"` // Never expose in JSON
@@ -108,8 +109,14 @@ func defaults() *Config {
 		LibraryMonitorEnabled:         true,
 		LibraryMonitorDelaySeconds:    60,
 		SupplementExcludePatterns:     []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
-		SessionDurationDays:           30,
-		JWTSecret:                     "", // Must be set via config or env var
+		PDFSupplementFilenames: []string{
+			"supplement", "supplemental", "bonus", "bonus material", "bonus content",
+			"companion", "notes", "liner notes", "errata", "booklet", "digital booklet",
+			"appendix", "map", "maps", "insert", "guide", "reference",
+			"cheat sheet", "cheatsheet", "cribsheet", "pamphlet", "extras",
+		},
+		SessionDurationDays: 30,
+		JWTSecret:           "", // Must be set via config or env var
 	}
 }
 
@@ -182,6 +189,12 @@ func NewForTest() *Config {
 	cfg.CacheDir = "" // Must be set by test
 	cfg.DownloadCacheMaxSizeGB = 1
 	cfg.SupplementExcludePatterns = []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"}
+	cfg.PDFSupplementFilenames = []string{
+		"supplement", "supplemental", "bonus", "bonus material", "bonus content",
+		"companion", "notes", "liner notes", "errata", "booklet", "digital booklet",
+		"appendix", "map", "maps", "insert", "guide", "reference",
+		"cheat sheet", "cheatsheet", "cribsheet", "pamphlet", "extras",
+	}
 	cfg.JWTSecret = "test-secret-key-for-testing-only"
 	return cfg
 }

--- a/pkg/covers/covers.go
+++ b/pkg/covers/covers.go
@@ -19,10 +19,14 @@ import (
 // SelectFile picks the file whose cover should represent a book based on the
 // library's preferred cover aspect ratio. It always falls back across types
 // when the preferred kind has no covers — a book-only library still gets a
-// cover for an audiobook-only book, and vice versa.
+// cover for an audiobook-only book, and vice versa. Supplements are excluded
+// from selection regardless of cover state — they don't represent the book.
 func SelectFile(files []*models.File, coverAspectRatio string) *models.File {
 	var bookFiles, audiobookFiles []*models.File
 	for _, f := range files {
+		if f.FileRole == models.FileRoleSupplement {
+			continue
+		}
 		if f.CoverImageFilename == nil || *f.CoverImageFilename == "" {
 			continue
 		}

--- a/pkg/covers/covers_test.go
+++ b/pkg/covers/covers_test.go
@@ -27,6 +27,11 @@ func TestSelectFile(t *testing.T) {
 		}
 		return &models.File{ID: id, FileType: fileType, CoverImageFilename: ptr}
 	}
+	supplementWithCover := func(id int, fileType, cover string) *models.File {
+		f := withCover(id, fileType, cover)
+		f.FileRole = models.FileRoleSupplement
+		return f
+	}
 
 	epub := withCover(1, models.FileTypeEPUB, "epub.cover.jpg")
 	cbz := withCover(2, models.FileTypeCBZ, "cbz.cover.jpg")
@@ -34,6 +39,8 @@ func TestSelectFile(t *testing.T) {
 	m4b := withCover(4, models.FileTypeM4B, "m4b.cover.jpg")
 	bookNoCover := withCover(5, models.FileTypeEPUB, "")
 	audioNoCover := withCover(6, models.FileTypeM4B, "")
+	pdfSupplement := supplementWithCover(7, models.FileTypePDF, "supp.cover.jpg")
+	epubSupplement := supplementWithCover(8, models.FileTypeEPUB, "supp.cover.jpg")
 
 	tests := []struct {
 		name           string
@@ -112,6 +119,30 @@ func TestSelectFile(t *testing.T) {
 			files:          []*models.File{m4b, epub},
 			aspectRatio:    "weird",
 			expectedFileID: epub.ID,
+		},
+		{
+			name:           "skips PDF supplement when M4B main has cover",
+			files:          []*models.File{pdfSupplement, m4b},
+			aspectRatio:    "book",
+			expectedFileID: m4b.ID,
+		},
+		{
+			name:           "skips EPUB supplement when M4B main has cover",
+			files:          []*models.File{epubSupplement, m4b},
+			aspectRatio:    "book",
+			expectedFileID: m4b.ID,
+		},
+		{
+			name:           "skips supplement even when no main has cover",
+			files:          []*models.File{pdfSupplement, bookNoCover},
+			aspectRatio:    "book",
+			expectedFileID: 0,
+		},
+		{
+			name:           "supplement also skipped in audiobook mode",
+			files:          []*models.File{pdfSupplement, m4b},
+			aspectRatio:    "audiobook",
+			expectedFileID: m4b.ID,
 		},
 	}
 

--- a/pkg/opds/service.go
+++ b/pkg/opds/service.go
@@ -739,16 +739,22 @@ func (svc *Service) bookToEntryWithKepub(baseURL string, book *models.Book, cove
 	// are file-level in our model. Prefer the primary file (the book's
 	// canonical reading copy), falling back to the first file with a
 	// non-empty value for each field.
+	// Supplements don't represent the book — exclude them from the
+	// priority chain so a stray supplement-level Language or Publisher
+	// can't leak into the OPDS entry's book-level metadata.
 	filesInPriorityOrder := make([]*models.File, 0, len(book.Files))
 	if book.PrimaryFileID != nil {
 		for _, file := range book.Files {
-			if file.ID == *book.PrimaryFileID {
+			if file.ID == *book.PrimaryFileID && file.FileRole != models.FileRoleSupplement {
 				filesInPriorityOrder = append(filesInPriorityOrder, file)
 				break
 			}
 		}
 	}
 	for _, file := range book.Files {
+		if file.FileRole == models.FileRoleSupplement {
+			continue
+		}
 		if book.PrimaryFileID != nil && file.ID == *book.PrimaryFileID {
 			continue
 		}

--- a/pkg/opds/service_test.go
+++ b/pkg/opds/service_test.go
@@ -91,6 +91,25 @@ func TestBookToEntry_LanguageAndPublisher(t *testing.T) {
 			expectedLanguage:  "",
 			expectedPublisher: "",
 		},
+		{
+			// Supplements are not the book — their language/publisher
+			// shouldn't populate the OPDS entry. Practical case: a PDF
+			// supplement carries no Language/Publisher today, but a future
+			// parser path could leak supplement metadata into the book entry.
+			name: "ignores supplement files when filling book metadata",
+			files: []*models.File{
+				{ID: 1, FileType: models.FileTypeM4B}, // main, no metadata
+				{
+					ID:        2,
+					FileType:  models.FileTypePDF,
+					FileRole:  models.FileRoleSupplement,
+					Language:  &english,
+					Publisher: &models.Publisher{Name: "Supplement Co"},
+				},
+			},
+			expectedLanguage:  "",
+			expectedPublisher: "",
+		},
 	}
 
 	svc := &Service{}

--- a/pkg/plugins/handler_apply_metadata.go
+++ b/pkg/plugins/handler_apply_metadata.go
@@ -53,7 +53,10 @@ func (h *handler) applyMetadata(c echo.Context) error {
 		return errcodes.Forbidden("You don't have access to this library")
 	}
 
-	// Resolve target file
+	// Resolve target file. When the caller doesn't pin a specific FileID,
+	// fall back to the first MAIN file — supplements never represent the
+	// book, so applying enriched book-level metadata to a supplement
+	// (whose Name is e.g. "Supplement.pdf") would be wrong.
 	var targetFile *models.File
 	if payload.FileID != nil {
 		for i := range book.Files {
@@ -65,8 +68,13 @@ func (h *handler) applyMetadata(c echo.Context) error {
 		if targetFile == nil {
 			return errcodes.NotFound("File")
 		}
-	} else if len(book.Files) > 0 {
-		targetFile = book.Files[0]
+	} else {
+		for i := range book.Files {
+			if book.Files[i].FileRole == models.FileRoleMain {
+				targetFile = book.Files[i]
+				break
+			}
+		}
 	}
 
 	// Convert fields map to ParsedMetadata

--- a/pkg/plugins/handler_apply_metadata.go
+++ b/pkg/plugins/handler_apply_metadata.go
@@ -54,27 +54,12 @@ func (h *handler) applyMetadata(c echo.Context) error {
 	}
 
 	// Resolve target file. When the caller doesn't pin a specific FileID,
-	// fall back to the first MAIN file — supplements never represent the
-	// book, so applying enriched book-level metadata to a supplement
-	// (whose Name is e.g. "Supplement.pdf") would be wrong.
-	var targetFile *models.File
-	if payload.FileID != nil {
-		for i := range book.Files {
-			if book.Files[i].ID == *payload.FileID {
-				targetFile = book.Files[i]
-				break
-			}
-		}
-		if targetFile == nil {
-			return errcodes.NotFound("File")
-		}
-	} else {
-		for i := range book.Files {
-			if book.Files[i].FileRole == models.FileRoleMain {
-				targetFile = book.Files[i]
-				break
-			}
-		}
+	// resolveTargetFile falls back to the first FileRoleMain — supplements
+	// never represent the book, so applying enriched book-level metadata
+	// to a supplement (whose Name is e.g. "Supplement.pdf") would be wrong.
+	targetFile := resolveTargetFile(book.Files, payload.FileID)
+	if payload.FileID != nil && targetFile == nil {
+		return errcodes.NotFound("File")
 	}
 
 	// Convert fields map to ParsedMetadata

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -320,6 +320,49 @@ func TestApplyMetadata_DoesNotUpdateSupplementFileName(t *testing.T) {
 	assert.Equal(t, "Supplement.pdf", *file.Name, "supplement Name must not be overwritten with book title")
 }
 
+func TestApplyMetadata_FallbackTargetsMainFile_NotSupplement(t *testing.T) {
+	t.Parallel()
+
+	// Book with a supplement first in book.Files (the order callers might
+	// see post-classification when a supplement was scanned/created earlier
+	// in the slice). With no FileID in the payload, applyMetadata must
+	// target the main file, not the supplement.
+	book := newApplyTestBook(t, "Old Title")
+	supplement := &models.File{
+		ID:        7,
+		BookID:    book.ID,
+		LibraryID: book.LibraryID,
+		Filepath:  filepath.Join(book.Filepath, "Supplement.pdf"),
+		FileType:  models.FileTypePDF,
+		FileRole:  models.FileRoleSupplement,
+	}
+	main := &models.File{
+		ID:        8,
+		BookID:    book.ID,
+		LibraryID: book.LibraryID,
+		Filepath:  filepath.Join(book.Filepath, "main.epub"),
+		FileType:  models.FileTypeEPUB,
+		FileRole:  models.FileRoleMain,
+	}
+	book.Files = []*models.File{supplement, main}
+
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContext(t, map[string]any{"title": "New Title"})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	// The main file's Name should be set to the new title; the supplement's
+	// should remain untouched (persistMetadata also guards this, but only
+	// gets the chance because we picked the right targetFile).
+	require.NotNil(t, main.Name, "main file Name should be set when applyMetadata falls back to main")
+	assert.Equal(t, "New Title", *main.Name)
+	assert.Nil(t, supplement.Name, "supplement Name must not be touched when applyMetadata falls back to main")
+}
+
 func TestApplyMetadata_PreservesVolumeNotation_CBZ(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugins/handler_enrich.go
+++ b/pkg/plugins/handler_enrich.go
@@ -135,20 +135,13 @@ func (h *handler) searchMetadata(c echo.Context) error {
 		searchCtx["identifiers"] = ids
 	}
 
-	// Select the target file — use the explicitly requested file if provided,
-	// otherwise fall back to the first file on the book.
-	var targetFile *models.File
-	if payload.FileID != nil {
-		for _, f := range book.Files {
-			if f.ID == *payload.FileID {
-				targetFile = f
-				break
-			}
-		}
-	}
-	if targetFile == nil && len(book.Files) > 0 {
-		targetFile = book.Files[0]
-	}
+	// Select the target file. resolveTargetFile prefers an explicitly pinned
+	// FileID, otherwise falls back to the first FileRoleMain — supplements
+	// never represent the book, so feeding their hints to enrichers (or
+	// scoping the read-only sandbox to a supplement's path) would mislead
+	// enrichment for books like an M4B + supplement-PDF where the supplement
+	// could land first in book.Files.
+	targetFile := resolveTargetFile(book.Files, payload.FileID)
 
 	// Add file hints from the target file (non-modifiable context)
 	var fileType string

--- a/pkg/plugins/target_file.go
+++ b/pkg/plugins/target_file.go
@@ -1,0 +1,26 @@
+package plugins
+
+import "github.com/shishobooks/shisho/pkg/models"
+
+// resolveTargetFile picks the file a per-book plugin operation should target.
+// When fileID is non-nil, the matching file is returned (or nil if absent).
+// When fileID is nil, the first file with FileRoleMain is returned —
+// supplements never represent the book and must not be the implicit target
+// for book-level operations like enrichment search or apply-metadata.
+// Returns nil when nothing suitable is available.
+func resolveTargetFile(files []*models.File, fileID *int) *models.File {
+	if fileID != nil {
+		for _, f := range files {
+			if f.ID == *fileID {
+				return f
+			}
+		}
+		return nil
+	}
+	for _, f := range files {
+		if f.FileRole == models.FileRoleMain {
+			return f
+		}
+	}
+	return nil
+}

--- a/pkg/plugins/target_file_test.go
+++ b/pkg/plugins/target_file_test.go
@@ -1,0 +1,76 @@
+package plugins
+
+import (
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveTargetFile(t *testing.T) {
+	t.Parallel()
+
+	intPtr := func(i int) *int { return &i }
+	main := &models.File{ID: 1, FileRole: models.FileRoleMain}
+	supp := &models.File{ID: 2, FileRole: models.FileRoleSupplement}
+	main2 := &models.File{ID: 3, FileRole: models.FileRoleMain}
+
+	tests := []struct {
+		name    string
+		files   []*models.File
+		fileID  *int
+		wantID  int // 0 means nil
+		wantNil bool
+	}{
+		{
+			name:   "fileID hit returns that file",
+			files:  []*models.File{supp, main, main2},
+			fileID: intPtr(2),
+			wantID: 2, // supplement is returned when explicitly requested
+		},
+		{
+			name:    "fileID miss returns nil",
+			files:   []*models.File{main},
+			fileID:  intPtr(99),
+			wantNil: true,
+		},
+		{
+			name:   "no fileID picks first main, skipping leading supplement",
+			files:  []*models.File{supp, main, main2},
+			fileID: nil,
+			wantID: 1,
+		},
+		{
+			name:   "no fileID with single main picks it",
+			files:  []*models.File{main},
+			fileID: nil,
+			wantID: 1,
+		},
+		{
+			name:    "no fileID with only supplements returns nil",
+			files:   []*models.File{supp},
+			fileID:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "empty files returns nil",
+			files:   nil,
+			fileID:  nil,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveTargetFile(tt.files, tt.fileID)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			if assert.NotNil(t, got) {
+				assert.Equal(t, tt.wantID, got.ID)
+			}
+		})
+	}
+}

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -159,7 +159,9 @@ func looksLikePDFSupplement(filename string, names []string) bool {
 // file with a non-PDF main-eligible extension. Main-eligible means EPUB / CBZ /
 // M4B or any extension in pluginExts (which comes from
 // pluginManager.RegisteredFileExtensions() — keys are extensions without the
-// leading dot, lowercase). pluginExts may be nil.
+// leading dot, lowercase). pluginExts may be nil. Hidden subdirectories
+// (e.g. .git, .calibre, .stversions) are skipped so a stray ebook inside an
+// app-state directory doesn't accidentally qualify as a sibling.
 func hasNonPDFMainSibling(dir string, pluginExts map[string]struct{}) (bool, error) {
 	found := false
 	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
@@ -167,6 +169,13 @@ func hasNonPDFMainSibling(dir string, pluginExts map[string]struct{}) (bool, err
 			return walkErr
 		}
 		if d.IsDir() {
+			// Skip hidden directories so stray files inside app-state dirs
+			// (.git, .calibre, .stversions, etc.) don't qualify as siblings.
+			// The walk root itself may have a leading dot in odd setups, so
+			// only skip when we're not at the root.
+			if path != dir && strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -192,6 +192,26 @@ func hasNonPDFMainSibling(dir string, pluginExts map[string]struct{}) (bool, err
 	return found, nil
 }
 
+// partitionSupplementPDFsLast returns paths reordered so that PDFs whose
+// basename matches the supplement name list appear after every other path.
+// Order within each partition is preserved (stable). The input slice is not
+// mutated. When names is empty/nil, the input is returned unchanged.
+func partitionSupplementPDFsLast(paths []string, names []string) []string {
+	if len(names) == 0 {
+		return paths
+	}
+	out := make([]string, 0, len(paths))
+	var deferred []string
+	for _, p := range paths {
+		if looksLikePDFSupplement(filepath.Base(p), names) {
+			deferred = append(deferred, p)
+			continue
+		}
+		out = append(out, p)
+	}
+	return append(out, deferred...)
+}
+
 // matchesExcludePattern checks if filename matches any exclude pattern.
 func matchesExcludePattern(filename string, patterns []string) bool {
 	for _, pattern := range patterns {
@@ -425,6 +445,14 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 				return errors.WithStack(err)
 			}
 		}
+
+		// Defer supplement-named PDFs so non-supplement files in the same
+		// directory get processed first by the parallel worker pool. This
+		// makes the supplement classification ordering-independent in the
+		// common case where a sibling main file exists, even though the
+		// on-disk sibling check in scanFileCreateNew is the actual
+		// correctness mechanism.
+		filesToScan = partitionSupplementPDFsLast(filesToScan, w.config.PDFSupplementFilenames)
 
 		// Run input converters on discovered files
 		if w.pluginManager != nil {

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -170,7 +170,7 @@ func hasNonPDFMainSibling(dir string, pluginExts map[string]struct{}) (bool, err
 			return nil
 		}
 		ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
-		if ext == "pdf" {
+		if ext == models.FileTypePDF {
 			return nil
 		}
 		switch ext {

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -138,11 +138,12 @@ func looksLikePDFSupplement(filename string, names []string) bool {
 	if len(names) == 0 {
 		return false
 	}
-	ext := strings.ToLower(filepath.Ext(filename))
-	if ext != ".pdf" {
+	filename = filepath.Base(filename)
+	rawExt := filepath.Ext(filename)
+	if strings.ToLower(rawExt) != ".pdf" {
 		return false
 	}
-	basename := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(filename, filepath.Ext(filename))))
+	basename := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(filename, rawExt)))
 	if basename == "" {
 		return false
 	}

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -155,6 +155,43 @@ func looksLikePDFSupplement(filename string, names []string) bool {
 	return false
 }
 
+// hasNonPDFMainSibling returns true if dir (recursive) contains at least one
+// file with a non-PDF main-eligible extension. Main-eligible means EPUB / CBZ /
+// M4B or any extension in pluginExts (which comes from
+// pluginManager.RegisteredFileExtensions() — keys are extensions without the
+// leading dot, lowercase). pluginExts may be nil.
+func hasNonPDFMainSibling(dir string, pluginExts map[string]struct{}) (bool, error) {
+	found := false
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
+		if ext == "pdf" {
+			return nil
+		}
+		switch ext {
+		case models.FileTypeEPUB, models.FileTypeCBZ, models.FileTypeM4B:
+			found = true
+			return filepath.SkipAll
+		}
+		if pluginExts != nil {
+			if _, ok := pluginExts[ext]; ok {
+				found = true
+				return filepath.SkipAll
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+	return found, nil
+}
+
 // matchesExcludePattern checks if filename matches any exclude pattern.
 func matchesExcludePattern(filename string, patterns []string) bool {
 	for _, pattern := range patterns {

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -131,6 +131,29 @@ func isShishoSpecialFile(filename string) bool {
 	return false
 }
 
+// looksLikePDFSupplement returns true if filename has a .pdf extension and its
+// basename (without extension, trimmed, lowercased) is an exact case-insensitive
+// match for any entry in names. Returns false when names is empty/nil.
+func looksLikePDFSupplement(filename string, names []string) bool {
+	if len(names) == 0 {
+		return false
+	}
+	ext := strings.ToLower(filepath.Ext(filename))
+	if ext != ".pdf" {
+		return false
+	}
+	basename := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(filename, filepath.Ext(filename))))
+	if basename == "" {
+		return false
+	}
+	for _, name := range names {
+		if strings.ToLower(strings.TrimSpace(name)) == basename {
+			return true
+		}
+	}
+	return false
+}
+
 // matchesExcludePattern checks if filename matches any exclude pattern.
 func matchesExcludePattern(filename string, patterns []string) bool {
 	for _, pattern := range patterns {

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -881,3 +881,18 @@ func TestPartitionSupplementPDFsLast_EmptyNames(t *testing.T) {
 	got := partitionSupplementPDFsLast(input, nil)
 	assert.Equal(t, input, got)
 }
+
+func TestPartitionSupplementPDFsLast_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+
+	input := []string{
+		"/lib/[Author] Book/supplement.pdf",
+		"/lib/[Author] Book/book.epub",
+		"/lib/Other/bonus.pdf",
+	}
+	original := append([]string(nil), input...)
+
+	_ = partitionSupplementPDFsLast(input, []string{"supplement", "bonus"})
+
+	assert.Equal(t, original, input, "input slice must not be mutated by partition")
+}

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -831,6 +831,19 @@ func TestHasNonPDFMainSibling(t *testing.T) {
 		_, err := hasNonPDFMainSibling(filepath.Join(t.TempDir(), "does-not-exist"), nil)
 		assert.Error(t, err)
 	})
+
+	t.Run("ignores files in hidden subdirectories", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		hidden := filepath.Join(dir, ".calibre")
+		require.NoError(t, os.MkdirAll(hidden, 0o755))
+		writeFile(t, filepath.Join(hidden, "leftover.epub"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.False(t, got, "files inside hidden subdirectories must not count as siblings")
+	})
 }
 
 // writeFile creates an empty file at path, failing the test on error.

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -1,11 +1,14 @@
 package worker
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShouldUpdateScalar(t *testing.T) {
@@ -729,4 +732,101 @@ func TestIdentifierDiff_StableAcrossRescans(t *testing.T) {
 	newKeysWithAddition := parsedIdentifierKeys(parsedWithAddition)
 	got = shouldUpdateRelationship(newKeysWithAddition, existingKeys, models.DataSourceEPUBMetadata, models.DataSourceEPUBMetadata, false)
 	assert.True(t, got, "rescan must still detect a real addition even when the existing entries have cosmetic variants")
+}
+
+func TestHasNonPDFMainSibling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("epub sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "book.epub"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("cbz sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "comic.cbz"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("m4b sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "audio.m4b"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("pdf-only directory has no sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "another.pdf"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("unrelated extension is not a sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "notes.txt"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("plugin-registered extension is a sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		writeFile(t, filepath.Join(dir, "book.azw3"))
+
+		// Plugin extensions are stored without leading dot, lowercase.
+		pluginExts := map[string]struct{}{"azw3": {}}
+		got, err := hasNonPDFMainSibling(dir, pluginExts)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("recursive sibling in subdirectory", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "supplement.pdf"))
+		sub := filepath.Join(dir, "extras")
+		require.NoError(t, os.MkdirAll(sub, 0o755))
+		writeFile(t, filepath.Join(sub, "book.epub"))
+
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("missing directory returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := hasNonPDFMainSibling(filepath.Join(t.TempDir(), "does-not-exist"), nil)
+		assert.Error(t, err)
+	})
+}
+
+// writeFile creates an empty file at path, failing the test on error.
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte{}, 0o644))
 }

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -818,6 +818,14 @@ func TestHasNonPDFMainSibling(t *testing.T) {
 		assert.True(t, got)
 	})
 
+	t.Run("empty directory has no sibling", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		got, err := hasNonPDFMainSibling(dir, nil)
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
 	t.Run("missing directory returns error", func(t *testing.T) {
 		t.Parallel()
 		_, err := hasNonPDFMainSibling(filepath.Join(t.TempDir(), "does-not-exist"), nil)

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -838,3 +838,46 @@ func writeFile(t *testing.T, path string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, []byte{}, 0o644))
 }
+
+func TestPartitionSupplementPDFsLast(t *testing.T) {
+	t.Parallel()
+
+	names := []string{"supplement", "bonus"}
+
+	// Mixed input — supplement-named PDFs interleaved with other files.
+	input := []string{
+		"/lib/[Author] Book/supplement.pdf",
+		"/lib/[Author] Book/book.epub",
+		"/lib/Other/bonus.pdf",
+		"/lib/Other/audio.m4b",
+		"/lib/Other/notes.txt",
+	}
+
+	got := partitionSupplementPDFsLast(input, names)
+
+	// Non-supplement files must come first, in their original order.
+	expected := []string{
+		"/lib/[Author] Book/book.epub",
+		"/lib/Other/audio.m4b",
+		"/lib/Other/notes.txt",
+		"/lib/[Author] Book/supplement.pdf",
+		"/lib/Other/bonus.pdf",
+	}
+	assert.Equal(t, expected, got)
+}
+
+func TestPartitionSupplementPDFsLast_StableForNoMatches(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"a.epub", "b.epub", "c.cbz"}
+	got := partitionSupplementPDFsLast(input, []string{"supplement"})
+	assert.Equal(t, input, got)
+}
+
+func TestPartitionSupplementPDFsLast_EmptyNames(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"supplement.pdf", "book.epub"}
+	got := partitionSupplementPDFsLast(input, nil)
+	assert.Equal(t, input, got)
+}

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -673,6 +673,7 @@ func TestLooksLikePDFSupplement(t *testing.T) {
 		{name: "nil names list disables matching", filename: "supplement.pdf", names: nil, want: false},
 		{name: "custom list overrides default", filename: "extra.pdf", names: []string{"extra"}, want: true},
 		{name: "no extension does not match", filename: "supplement", names: defaultNames, want: false},
+		{name: "trims whitespace in names list entry", filename: "supplement.pdf", names: []string{"  supplement  "}, want: true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -645,6 +645,45 @@ func TestShouldApplySidecarRelationship(t *testing.T) {
 	}
 }
 
+func TestLooksLikePDFSupplement(t *testing.T) {
+	t.Parallel()
+
+	defaultNames := []string{
+		"supplement", "supplemental", "bonus", "bonus material", "bonus content",
+		"companion", "notes", "liner notes", "errata", "booklet", "digital booklet",
+		"appendix", "map", "maps", "insert", "guide", "reference",
+		"cheat sheet", "cheatsheet", "cribsheet", "pamphlet", "extras",
+	}
+
+	tests := []struct {
+		name     string
+		filename string
+		names    []string
+		want     bool
+	}{
+		{name: "exact match lowercase", filename: "supplement.pdf", names: defaultNames, want: true},
+		{name: "exact match uppercase ext", filename: "Supplement.PDF", names: defaultNames, want: true},
+		{name: "all caps basename", filename: "BONUS MATERIAL.pdf", names: defaultNames, want: true},
+		{name: "trims surrounding whitespace", filename: "  supplement  .pdf", names: defaultNames, want: true},
+		{name: "multi-word entry matches", filename: "liner notes.pdf", names: defaultNames, want: true},
+		{name: "non-pdf extension does not match", filename: "supplement.txt", names: defaultNames, want: false},
+		{name: "substring does not match", filename: "my book - supplement.pdf", names: defaultNames, want: false},
+		{name: "unrelated name does not match", filename: "Companion Guide.pdf", names: defaultNames, want: false},
+		{name: "empty names list disables matching", filename: "supplement.pdf", names: []string{}, want: false},
+		{name: "nil names list disables matching", filename: "supplement.pdf", names: nil, want: false},
+		{name: "custom list overrides default", filename: "extra.pdf", names: []string{"extra"}, want: true},
+		{name: "no extension does not match", filename: "supplement", names: defaultNames, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := looksLikePDFSupplement(tt.filename, tt.names)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // TestIdentifierDiff_StableAcrossRescans locks in the fix for a regression
 // where each rescan of a book with hyphenated/prefixed/mixed-case identifiers
 // would thrash delete+insert because the stored (normalized) value and the

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2392,8 +2392,9 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 
 	// Decide whether this new file should be a supplement based on filename
 	// pattern + on-disk siblings. Only applies to PDFs in directory-based
-	// books — root-level PDFs always stay main (root-level supplement linking
-	// uses basename-prefix matching, handled separately).
+	// books — root-level PDFs always stay main here. Root-level supplement
+	// linking is handled later in the function via discoverRootLevelSupplements
+	// (basename-prefix matching against the main file).
 	classifyAsSupplement := false
 	if fileType == models.FileTypePDF && !isRootLevelFile && looksLikePDFSupplement(filepath.Base(path), w.config.PDFSupplementFilenames) {
 		// Reuse-existing-book optimization: if a book row already lives at
@@ -2453,7 +2454,7 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 	}
 
 	// Create file record
-	logInfo("creating file", logger.Data{"path": path, "filesize": size, "supplement": classifyAsSupplement})
+	logInfo("creating file", logger.Data{"path": path, "filesize": size, "is_supplement": classifyAsSupplement})
 	fileRole := models.FileRoleMain
 	if classifyAsSupplement {
 		fileRole = models.FileRoleSupplement

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2390,41 +2390,78 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 		// by applyFilepathFallbacks above. scanFileCore will create the DB records.
 	}
 
+	// Decide whether this new file should be a supplement based on filename
+	// pattern + on-disk siblings. Only applies to PDFs in directory-based
+	// books — root-level PDFs always stay main (root-level supplement linking
+	// uses basename-prefix matching, handled separately).
+	classifyAsSupplement := false
+	if fileType == models.FileTypePDF && !isRootLevelFile && looksLikePDFSupplement(filepath.Base(path), w.config.PDFSupplementFilenames) {
+		// Reuse-existing-book check: if a book row already lives at this
+		// bookPath, there's by definition another file (or there will be).
+		if existingBook != nil {
+			classifyAsSupplement = true
+		} else {
+			// On-disk sibling check: look for any non-PDF main-eligible file
+			// in the book directory. This is what makes the rule
+			// ordering-independent when both files arrive in the same scan.
+			var pluginExts map[string]struct{}
+			if w.pluginManager != nil {
+				pluginExts = w.pluginManager.RegisteredFileExtensions()
+			}
+			hasSibling, sibErr := hasNonPDFMainSibling(bookPath, pluginExts)
+			if sibErr != nil {
+				logWarn("failed to check for sibling main file", logger.Data{"error": sibErr.Error(), "dir": bookPath})
+			} else if hasSibling {
+				classifyAsSupplement = true
+			}
+		}
+	}
+
 	// Handle cover extraction. extractAndSaveCover also adopts a cover file
 	// that already sits next to the source file on disk, so we always call
 	// it — even when the parser returned no cover data for the source.
+	// Skipped for files we're about to create as supplements, matching the
+	// supplement-discovery code path further down (supplements don't get
+	// scanned-cover extraction).
 	var coverImagePath *string
 	var coverMimeType *string
 	var coverSource *string
 	var coverPage *int
 
-	coverFilename, extractedMimeType, wasPreExisting, err := w.extractAndSaveCover(ctx, path, bookPath, isRootLevelFile, metadata, opts.JobLog)
-	if err != nil {
-		logWarn("failed to extract cover", logger.Data{"error": err.Error()})
-	} else if coverFilename != "" {
-		coverImagePath = &coverFilename
-		if extractedMimeType != "" {
-			coverMimeType = &extractedMimeType
+	if !classifyAsSupplement {
+		coverFilename, extractedMimeType, wasPreExisting, err := w.extractAndSaveCover(ctx, path, bookPath, isRootLevelFile, metadata, opts.JobLog)
+		if err != nil {
+			logWarn("failed to extract cover", logger.Data{"error": err.Error()})
+		} else if coverFilename != "" {
+			coverImagePath = &coverFilename
+			if extractedMimeType != "" {
+				coverMimeType = &extractedMimeType
+			}
+			if wasPreExisting {
+				existingCoverSource := models.DataSourceExistingCover
+				coverSource = &existingCoverSource
+			} else {
+				cs := metadata.SourceForField("cover")
+				coverSource = &cs
+			}
 		}
-		if wasPreExisting {
-			existingCoverSource := models.DataSourceExistingCover
-			coverSource = &existingCoverSource
-		} else {
-			cs := metadata.SourceForField("cover")
-			coverSource = &cs
+		if metadata != nil && metadata.CoverPage != nil {
+			coverPage = metadata.CoverPage
 		}
-	}
-	if metadata != nil && metadata.CoverPage != nil {
-		coverPage = metadata.CoverPage
 	}
 
 	// Create file record
-	logInfo("creating file", logger.Data{"path": path, "filesize": size})
+	logInfo("creating file", logger.Data{"path": path, "filesize": size, "supplement": classifyAsSupplement})
+	fileRole := models.FileRoleMain
+	if classifyAsSupplement {
+		fileRole = models.FileRoleSupplement
+	}
 	file := &models.File{
 		LibraryID:          opts.LibraryID,
 		BookID:             book.ID,
 		Filepath:           path,
 		FileType:           fileType,
+		FileRole:           fileRole,
 		FilesizeBytes:      size,
 		FileModifiedAt:     &modTime,
 		CoverImageFilename: coverImagePath,

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2396,8 +2396,10 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 	// uses basename-prefix matching, handled separately).
 	classifyAsSupplement := false
 	if fileType == models.FileTypePDF && !isRootLevelFile && looksLikePDFSupplement(filepath.Base(path), w.config.PDFSupplementFilenames) {
-		// Reuse-existing-book check: if a book row already lives at this
-		// bookPath, there's by definition another file (or there will be).
+		// Reuse-existing-book optimization: if a book row already lives at
+		// this bookPath, another file in this directory was already imported.
+		// scanFileCreateNew only runs for files not yet in the DB, so the
+		// existing book guarantees a sibling without re-walking the disk.
 		if existingBook != nil {
 			classifyAsSupplement = true
 		} else {

--- a/pkg/worker/supplement_test.go
+++ b/pkg/worker/supplement_test.go
@@ -285,3 +285,176 @@ func TestProcessScanJob_ScannableSupplementNotRescannedAsMain(t *testing.T) {
 	assert.True(t, os.IsNotExist(err),
 		"rescan should not extract a cover for an existing supplement PDF (cover file at %s)", coverPath)
 }
+
+// TestProcessScanJob_PDFNamedSupplementBecomesSupplement covers the core
+// scenario: a PDF named "Supplement.pdf" alongside a main EPUB in the same
+// directory must be classified as a supplement.
+func TestProcessScanJob_PDFNamedSupplementBecomesSupplement(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] My Book")
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{
+		Title:   "My Book",
+		Authors: []string{"Author"},
+	})
+	testgen.GeneratePDF(t, bookDir, "Supplement.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	booksList := tc.listBooks()
+	require.Len(t, booksList, 1, "EPUB and supplement PDF should belong to one book")
+
+	files := tc.listFiles()
+	require.Len(t, files, 2)
+
+	var mainCount, suppCount int
+	for _, f := range files {
+		switch f.FileRole {
+		case models.FileRoleMain:
+			mainCount++
+			assert.Equal(t, "epub", f.FileType, "main file should be the EPUB")
+		case models.FileRoleSupplement:
+			suppCount++
+			assert.Equal(t, "pdf", f.FileType, "supplement should be the PDF")
+			assert.Equal(t, "Supplement.pdf", filepath.Base(f.Filepath))
+		}
+	}
+	assert.Equal(t, 1, mainCount)
+	assert.Equal(t, 1, suppCount)
+}
+
+// TestProcessScanJob_PDFAloneInDirStaysMain confirms the safety rule:
+// a directory containing only a supplement-named PDF must still import as
+// a main file so the book isn't silently dropped.
+func TestProcessScanJob_PDFAloneInDirStaysMain(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] PDF Only Book")
+	testgen.GeneratePDF(t, bookDir, "Supplement.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	require.Len(t, tc.listBooks(), 1)
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	assert.Equal(t, models.FileRoleMain, files[0].FileRole, "lone supplement-named PDF should be main")
+	assert.Equal(t, "pdf", files[0].FileType)
+}
+
+// TestProcessScanJob_PDFCaseInsensitiveMatch confirms basename matching
+// ignores case for both the filename and the configured names.
+func TestProcessScanJob_PDFCaseInsensitiveMatch(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Casing Test")
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{Title: "Casing Test"})
+	testgen.GeneratePDF(t, bookDir, "BONUS.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	require.Len(t, tc.listBooks(), 1)
+	files := tc.listFiles()
+	require.Len(t, files, 2)
+
+	for _, f := range files {
+		if f.FileType == "pdf" {
+			assert.Equal(t, models.FileRoleSupplement, f.FileRole)
+		}
+	}
+}
+
+// TestProcessScanJob_PDFSubstringDoesNotMatch confirms substring matches do
+// NOT trigger supplement classification — only exact basename matches.
+func TestProcessScanJob_PDFSubstringDoesNotMatch(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Substring Test")
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{Title: "Substring Test"})
+	testgen.GeneratePDF(t, bookDir, "My Book - Supplement.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	// PDF basename "My Book - Supplement" is NOT an exact match for any list
+	// entry, so it stays main. Two main files end up on the same book (the
+	// existing scan flow merges files with the same bookPath into one book).
+	require.Len(t, tc.listBooks(), 1)
+	files := tc.listFiles()
+	require.Len(t, files, 2)
+	for _, f := range files {
+		assert.Equal(t, models.FileRoleMain, f.FileRole, "substring match should not classify as supplement")
+	}
+}
+
+// TestProcessScanJob_PDFEmptyConfigDisablesFeature confirms setting
+// PDFSupplementFilenames to an empty slice disables the auto-classification.
+func TestProcessScanJob_PDFEmptyConfigDisablesFeature(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+	tc.worker.config.PDFSupplementFilenames = nil
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Disabled Test")
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{Title: "Disabled Test"})
+	testgen.GeneratePDF(t, bookDir, "Supplement.pdf", testgen.PDFOptions{})
+
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 2)
+	for _, f := range files {
+		assert.Equal(t, models.FileRoleMain, f.FileRole, "feature should be disabled when config is empty")
+	}
+}
+
+// TestProcessScanJob_PDFExistingMainNotReclassified confirms an existing
+// PDF main file whose name happens to match the supplement list is NOT
+// reclassified on rescan. The rule only applies at file creation.
+func TestProcessScanJob_PDFExistingMainNotReclassified(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	// First scan: only the PDF exists, so it imports as main.
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Rescan Test")
+	testgen.GeneratePDF(t, bookDir, "Supplement.pdf", testgen.PDFOptions{})
+	require.NoError(t, tc.runScan())
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	require.Equal(t, models.FileRoleMain, files[0].FileRole)
+	mainID := files[0].ID
+
+	// Add an EPUB sibling and rescan.
+	testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{Title: "Rescan Test"})
+	require.NoError(t, tc.runScan())
+
+	afterFiles := tc.listFiles()
+	require.Len(t, afterFiles, 2)
+
+	for _, f := range afterFiles {
+		if f.ID == mainID {
+			assert.Equal(t, models.FileRoleMain, f.FileRole, "existing main PDF must not be reclassified on rescan")
+		}
+	}
+}

--- a/pkg/worker/testhelpers_test.go
+++ b/pkg/worker/testhelpers_test.go
@@ -100,6 +100,12 @@ func newTestContext(t *testing.T) *testContext {
 	cfg := &config.Config{
 		WorkerProcesses:           1,
 		SupplementExcludePatterns: []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
+		PDFSupplementFilenames: []string{
+			"supplement", "supplemental", "bonus", "bonus material", "bonus content",
+			"companion", "notes", "liner notes", "errata", "booklet", "digital booklet",
+			"appendix", "map", "maps", "insert", "guide", "reference",
+			"cheat sheet", "cheatsheet", "cribsheet", "pamphlet", "extras",
+		},
 	}
 	w := &Worker{
 		config:             cfg,
@@ -316,6 +322,12 @@ func newTestContextWithSearchService(t *testing.T) *testContext {
 	cfg := &config.Config{
 		WorkerProcesses:           1,
 		SupplementExcludePatterns: []string{".*", ".DS_Store", "Thumbs.db", "desktop.ini"},
+		PDFSupplementFilenames: []string{
+			"supplement", "supplemental", "bonus", "bonus material", "bonus content",
+			"companion", "notes", "liner notes", "errata", "booklet", "digital booklet",
+			"appendix", "map", "maps", "insert", "guide", "reference",
+			"cheat sheet", "cheatsheet", "cribsheet", "pamphlet", "extras",
+		},
 	}
 	w := &Worker{
 		config:             cfg,

--- a/shisho.example.yaml
+++ b/shisho.example.yaml
@@ -167,6 +167,36 @@ supplement_exclude_patterns:
   - "Thumbs.db"
   - "desktop.ini"
 
+# PDF basenames (case-insensitive, no extension) that should be auto-classified
+# as supplements when discovered next to a main EPUB / CBZ / M4B file. A PDF
+# alone in a directory always imports as a main file regardless of name.
+# Set to [] to disable. Substring matches are NOT applied — exact basename only.
+# Env: PDF_SUPPLEMENT_FILENAMES (comma-separated)
+# Default: see list below
+pdf_supplement_filenames:
+  - "supplement"
+  - "supplemental"
+  - "bonus"
+  - "bonus material"
+  - "bonus content"
+  - "companion"
+  - "notes"
+  - "liner notes"
+  - "errata"
+  - "booklet"
+  - "digital booklet"
+  - "appendix"
+  - "map"
+  - "maps"
+  - "insert"
+  - "guide"
+  - "reference"
+  - "cheat sheet"
+  - "cheatsheet"
+  - "cribsheet"
+  - "pamphlet"
+  - "extras"
+
 # =============================================================================
 # AUTHENTICATION SETTINGS
 # =============================================================================

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -95,6 +95,34 @@ See [Cache Management](./cache-management.md) for how to inspect and clear these
 | Setting | Env Variable | Default | Description |
 |---------|-------------|---------|-------------|
 | `supplement_exclude_patterns` | `SUPPLEMENT_EXCLUDE_PATTERNS` | `[".*", ".DS_Store", "Thumbs.db", "desktop.ini"]` | Glob patterns to exclude from [supplement file](./supplement-files) discovery. Env var accepts comma-separated values |
+| `pdf_supplement_filenames` | `PDF_SUPPLEMENT_FILENAMES` | See default list below | PDF basenames (case-insensitive, exact match, no extension) that get classified as [supplements](./supplement-files#pdf-auto-classification) on scan when a sibling EPUB/CBZ/M4B exists in the same directory. A PDF alone in a directory always imports as main. Substring matches are NOT applied. Set to `[]` to disable. Env var accepts comma-separated values |
+
+#### Default `pdf_supplement_filenames`
+
+```
+supplement
+supplemental
+bonus
+bonus material
+bonus content
+companion
+notes
+liner notes
+errata
+booklet
+digital booklet
+appendix
+map
+maps
+insert
+guide
+reference
+cheat sheet
+cheatsheet
+cribsheet
+pamphlet
+extras
+```
 
 ### Docker / Caddy
 

--- a/website/docs/supplement-files.md
+++ b/website/docs/supplement-files.md
@@ -67,6 +67,23 @@ supplement_exclude_patterns:
 
 The `.*` pattern matches all hidden files (files starting with a dot). You can add additional patterns using glob syntax (e.g., `*.tmp`, `backup-*`).
 
+## PDF Auto-Classification
+
+Companion PDFs that share a directory with a main book file are sometimes named generically (`Supplement.pdf`, `Bonus Material.pdf`, etc.). To avoid manually demoting these every scan, Shisho automatically classifies a PDF as a supplement when:
+
+1. Its basename matches an entry in `pdf_supplement_filenames` (case-insensitive, exact match — substrings do not match), AND
+2. A sibling main file (`.epub`, `.cbz`, `.m4b`, or a [plugin-registered](./plugins/overview) file extension) exists in the same directory tree.
+
+A PDF alone in its directory always imports as a main file regardless of name, so books are never silently dropped.
+
+```
+[Author] My Book/
+├── My Book.epub          ← main file
+└── Supplement.pdf        ← classified as supplement (matches default list)
+```
+
+The check runs only at file creation. Existing main-file PDFs whose names happen to match the list are not retroactively reclassified. To change which names trigger classification, see the [`pdf_supplement_filenames` setting](./configuration#supplement-discovery).
+
 ## Working with Supplements
 
 Supplements appear on the book detail page alongside the main files. You can:


### PR DESCRIPTION
## Summary
- Auto-classifies a PDF as a supplement during library scans when its basename matches a configurable list (e.g. `Supplement.pdf`, `Bonus Material.pdf`) **and** a sibling main file (EPUB / CBZ / M4B / plugin-registered file extension) exists in the same directory tree. A PDF alone in a directory always imports as main, so books are never silently dropped.
- Adds `pdf_supplement_filenames` config option (env: `PDF_SUPPLEMENT_FILENAMES`) with a 22-entry default list. Set to `[]` to disable. Substring matches are NOT applied — exact basename only. Documented in `shisho.example.yaml`, `website/docs/configuration.md`, `website/docs/supplement-files.md`, and `pkg/CLAUDE.md`.
- Classification runs only at file creation: existing main-file PDFs whose names match the list are not retroactively reclassified. Ordering-independent under the parallel scan workers via an on-disk sibling check; a defensive sort in `ProcessScanJob` defers supplement-named PDFs in dispatch order.

## Test plan
- Drop `Book.epub` and `Supplement.pdf` into a watched library directory, trigger a scan, and verify the PDF appears as a supplement on the book detail page (and the EPUB is the main file).
- Drop only `Supplement.pdf` into a directory and verify it imports as a main file.
- Drop `Book.epub` + `BONUS.pdf` (uppercase) and verify the PDF is classified as a supplement (case-insensitive match).
- Drop `Book.epub` + `My Book - Supplement.pdf` and verify both end up as main files (substring should not match).
- Set `pdf_supplement_filenames: []` in config and verify no PDFs are auto-classified.
- Import a `Supplement.pdf` alone (becomes main), then add `Book.epub` to the same directory and rescan — the existing PDF main file should remain main, and the new EPUB joins as a second main file.
- `mise check:quiet` passes (lint, test, test:js:fast, lint:js).