### PR TITLE
[Frontend] Make author names clickable in gallery cards

### DIFF
--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -412,7 +412,7 @@ const BookItem = ({
           return (
             <div className="mt-1 text-xs line-clamp-2 text-neutral-500 dark:text-neutral-500">
               {uniqueAuthors.map((a, i) => (
-                <span key={`${a.name}-${i}`}>
+                <span key={a.name}>
                   {i > 0 && ", "}
                   {a.hasPerson ? (
                     <Link

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -391,12 +391,20 @@ const BookItem = ({
 
           // Dedupe by name, keeping the first person_id for linking
           const seen = new Set<string>();
-          const uniqueAuthors: { name: string; personId: number }[] = [];
+          const uniqueAuthors: {
+            name: string;
+            personId: number;
+            hasPerson: boolean;
+          }[] = [];
           for (const a of displayAuthors) {
             const name = a.person?.name ?? "Unknown";
             if (seen.has(name)) continue;
             seen.add(name);
-            uniqueAuthors.push({ name, personId: a.person_id });
+            uniqueAuthors.push({
+              name,
+              personId: a.person_id,
+              hasPerson: !!a.person,
+            });
           }
 
           if (uniqueAuthors.length === 0) return null;
@@ -406,21 +414,18 @@ const BookItem = ({
               {uniqueAuthors.map((a, i) => (
                 <span key={`${a.name}-${i}`}>
                   {i > 0 && ", "}
-                  {a.name === "Unknown" ? (
-                    a.name
-                  ) : (
+                  {a.hasPerson ? (
                     <Link
                       className={cn(
                         "hover:underline hover:text-foreground",
                         isSelectionMode && "pointer-events-none",
                       )}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                      }}
                       to={`/libraries/${libraryId}/people/${a.personId}`}
                     >
                       {a.name}
                     </Link>
+                  ) : (
+                    a.name
                   )}
                 </span>
               ))}

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -389,16 +389,41 @@ const BookItem = ({
               )
             : book.authors;
 
-          // Get unique author names
-          const uniqueNames = [
-            ...new Set(displayAuthors.map((a) => a.person?.name ?? "Unknown")),
-          ];
+          // Dedupe by name, keeping the first person_id for linking
+          const seen = new Set<string>();
+          const uniqueAuthors: { name: string; personId: number }[] = [];
+          for (const a of displayAuthors) {
+            const name = a.person?.name ?? "Unknown";
+            if (seen.has(name)) continue;
+            seen.add(name);
+            uniqueAuthors.push({ name, personId: a.person_id });
+          }
 
-          if (uniqueNames.length === 0) return null;
+          if (uniqueAuthors.length === 0) return null;
 
           return (
             <div className="mt-1 text-xs line-clamp-2 text-neutral-500 dark:text-neutral-500">
-              {uniqueNames.join(", ")}
+              {uniqueAuthors.map((a, i) => (
+                <span key={`${a.name}-${i}`}>
+                  {i > 0 && ", "}
+                  {a.name === "Unknown" ? (
+                    a.name
+                  ) : (
+                    <Link
+                      className={cn(
+                        "hover:underline hover:text-foreground",
+                        isSelectionMode && "pointer-events-none",
+                      )}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                      }}
+                      to={`/libraries/${libraryId}/people/${a.personId}`}
+                    >
+                      {a.name}
+                    </Link>
+                  )}
+                </span>
+              ))}
             </div>
           );
         })()}

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -410,10 +410,9 @@ const BookItem = ({
           if (uniqueAuthors.length === 0) return null;
 
           return (
-            <div className="mt-1 text-xs line-clamp-2 text-neutral-500 dark:text-neutral-500">
+            <div className="mt-1 text-xs line-clamp-2 text-neutral-500">
               {uniqueAuthors.map((a, i) => (
-                <span key={a.name}>
-                  {i > 0 && ", "}
+                <span key={a.personId}>
                   {a.hasPerson ? (
                     <Link
                       className={cn(
@@ -427,6 +426,7 @@ const BookItem = ({
                   ) : (
                     a.name
                   )}
+                  {i < uniqueAuthors.length - 1 && ", "}
                 </span>
               ))}
             </div>

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1229,23 +1229,31 @@ const BookDetail = () => {
                     <div className="flex flex-wrap gap-2">
                       {book.authors.map((author) => {
                         const roleLabel = getAuthorRoleLabel(author.role);
-                        return (
+                        const badge = (
+                          <Badge
+                            className={cn(
+                              author.person &&
+                                "cursor-pointer hover:bg-secondary/80",
+                            )}
+                            variant="secondary"
+                          >
+                            {author.person?.name ?? "Unknown"}
+                            {hasCBZFiles && roleLabel && (
+                              <span className="text-muted-foreground ml-1">
+                                ({roleLabel})
+                              </span>
+                            )}
+                          </Badge>
+                        );
+                        return author.person ? (
                           <Link
                             key={author.id}
                             to={`/libraries/${libraryId}/people/${author.person_id}`}
                           >
-                            <Badge
-                              className="cursor-pointer hover:bg-secondary/80"
-                              variant="secondary"
-                            >
-                              {author.person?.name ?? "Unknown"}
-                              {hasCBZFiles && roleLabel && (
-                                <span className="text-muted-foreground ml-1">
-                                  ({roleLabel})
-                                </span>
-                              )}
-                            </Badge>
+                            {badge}
                           </Link>
+                        ) : (
+                          <span key={author.id}>{badge}</span>
                         );
                       })}
                     </div>


### PR DESCRIPTION
## Summary
- Link each unique author name in the gallery `BookItem` card to its person detail page (`/libraries/:libraryId/people/:personId`), matching the existing `BookDetail` pattern.
- Dedupe by name while preserving the first author entry's `person_id` for the link.
- Selection mode disables the links via `pointer-events-none` so card-selection clicks still work; `e.stopPropagation()` prevents normal-mode clicks from bubbling to the card click handler. "Unknown" authors stay unlinked.

## Test plan
- Open the library gallery and click an author name on a book card — should navigate to that person's detail page.
- Hover an author name — should underline and shift to foreground color.
- Enter selection mode and click on an author name — should toggle book selection, not navigate.
- Click a book card outside the author text — should still open the book detail page.
- Books with multiple authors render comma-separated and each name is independently clickable.