### PR TITLE
[Frontend] Add dev-only quick admin button on setup page

### DIFF
--- a/app/components/pages/Setup.tsx
+++ b/app/components/pages/Setup.tsx
@@ -46,7 +46,10 @@ const Setup = () => {
     INITIAL_VALUES.confirmPassword,
   );
   const [isLoading, setIsLoading] = useState(false);
+  const [isDevLoading, setIsDevLoading] = useState(false);
   const [changesSaved, setChangesSaved] = useState(false);
+
+  const isDevelopment = import.meta.env.DEV;
 
   // Track whether user has unsaved changes by comparing against initial values
   const hasUnsavedChanges = useMemo(() => {
@@ -112,6 +115,30 @@ const Setup = () => {
       toast.error(msg);
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  const handleCreateDevAdmin = async () => {
+    setIsDevLoading(true);
+    try {
+      const userData = await API.request<SetupResponse>("POST", "/auth/setup", {
+        username: "admin",
+        email: null,
+        password: "adminadmin",
+      });
+
+      toast.success("Dev admin account created (admin / adminadmin)");
+      setAuthUser(userData);
+      setChangesSaved(true);
+      requestNavigate("/");
+    } catch (error) {
+      let msg = "Setup failed. Please try again.";
+      if (error instanceof Error) {
+        msg = error.message;
+      }
+      toast.error(msg);
+    } finally {
+      setIsDevLoading(false);
     }
   };
 
@@ -208,6 +235,25 @@ const Setup = () => {
               "Create Admin Account"
             )}
           </Button>
+
+          {isDevelopment && (
+            <Button
+              className="w-full"
+              disabled={isDevLoading}
+              onClick={handleCreateDevAdmin}
+              type="button"
+              variant="outline"
+            >
+              {isDevLoading ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating dev admin...
+                </>
+              ) : (
+                "Create dev admin (admin / adminadmin)"
+              )}
+            </Button>
+          )}
         </form>
       </div>
 

--- a/app/components/pages/Setup.tsx
+++ b/app/components/pages/Setup.tsx
@@ -225,7 +225,11 @@ const Setup = () => {
             />
           </div>
 
-          <Button className="w-full" disabled={isLoading} type="submit">
+          <Button
+            className="w-full"
+            disabled={isLoading || isDevLoading}
+            type="submit"
+          >
             {isLoading ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -239,7 +243,7 @@ const Setup = () => {
           {isDevelopment && (
             <Button
               className="w-full"
-              disabled={isDevLoading}
+              disabled={isLoading || isDevLoading}
               onClick={handleCreateDevAdmin}
               type="button"
               variant="outline"


### PR DESCRIPTION
## Summary
- Adds a dev-only "Create dev admin (admin / adminadmin)" button on the initial setup page, gated on `import.meta.env.DEV` so it never ships to prod
- Posts to `/auth/setup` with `admin` / `adminadmin` (8-char password to satisfy the existing backend `min=8` validator), then runs the same post-success flow (set auth user, navigate home)

## Test plan
- Wipe local users (delete `tmp/data.sqlite` or otherwise force a fresh setup), run `mise start`, visit `/setup`, click the new dev button, and confirm you land on `/` authenticated as `admin`
- Log out and log back in with `admin` / `adminadmin` to confirm credentials work
- Build the frontend in production mode (`pnpm build`) and confirm the button does not appear (button is gated on `import.meta.env.DEV`)