### PR TITLE
[Fix] Promote root-level files into book folder during organize

### DIFF
--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -890,13 +890,7 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 	isDirectoryBased := filepath.Dir(files[0].Filepath) == book.Filepath
 
 	// Check if this is a root-level book (files directly in a library path, not yet organized into folders)
-	isRootLevelBook := false
-	for _, libraryPath := range library.LibraryPaths {
-		if filepath.Dir(files[0].Filepath) == libraryPath.Filepath {
-			isRootLevelBook = true
-			break
-		}
-	}
+	isRootLevelBook := isFileAtLibraryRoot(files[0].Filepath, library.LibraryPaths)
 
 	if isDirectoryBased {
 		// For directory-based books, rename the folder and update all file paths
@@ -977,9 +971,12 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 			// folder rather than renaming it in place. RenameOrganizedFile
 			// only operates within the file's own directory, so without this
 			// branch the file (and its sidecar/cover) would be left at the
-			// library root.
+			// library root. Pass book.Filepath explicitly so the destination
+			// matches the rest of the book's files even when the per-file
+			// opts (file.Name override, CBZ + series number, etc.) would
+			// otherwise generate a different folder name.
 			if isFileAtLibraryRoot(file.Filepath, library.LibraryPaths) {
-				result, organizeErr := fileutils.OrganizeRootLevelFile(file.Filepath, organizeOpts)
+				result, organizeErr := fileutils.MoveFileIntoOrganizedFolder(file.Filepath, book.Filepath, organizeOpts)
 				if organizeErr != nil {
 					log.Error("failed to promote root-level file into book folder", logger.Data{
 						"file_id": file.ID,

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -972,6 +972,38 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 				}
 			}
 
+			// If this file sits at a library root (e.g. user dropped a second
+			// file for an already-organized book), promote it into the book
+			// folder rather than renaming it in place. RenameOrganizedFile
+			// only operates within the file's own directory, so without this
+			// branch the file (and its sidecar/cover) would be left at the
+			// library root.
+			if isFileAtLibraryRoot(file.Filepath, library.LibraryPaths) {
+				result, organizeErr := fileutils.OrganizeRootLevelFile(file.Filepath, organizeOpts)
+				if organizeErr != nil {
+					log.Error("failed to promote root-level file into book folder", logger.Data{
+						"file_id": file.ID,
+						"path":    file.Filepath,
+						"error":   organizeErr.Error(),
+					})
+					continue
+				}
+				if result.Moved {
+					log.Info("promoted root-level file into book folder", logger.Data{
+						"file_id":  file.ID,
+						"old_path": result.OriginalPath,
+						"new_path": result.NewPath,
+					})
+					pathUpdates = append(pathUpdates, struct {
+						fileID         int
+						oldPath        string
+						newPath        string
+						coverImagePath *string
+					}{file.ID, result.OriginalPath, result.NewPath, file.CoverImageFilename})
+				}
+				continue
+			}
+
 			// Rename the file to the organized name
 			newPath, err := fileutils.RenameOrganizedFile(currentPath, organizeOpts)
 			if err != nil {
@@ -1173,6 +1205,19 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 	}
 
 	return nil
+}
+
+// isFileAtLibraryRoot reports whether the file's parent directory is one of
+// the library's configured root paths — i.e. the file was dropped at the
+// library root rather than living inside an organized book folder.
+func isFileAtLibraryRoot(filePath string, libraryPaths []*models.LibraryPath) bool {
+	dir := filepath.Dir(filePath)
+	for _, lp := range libraryPaths {
+		if dir == lp.Filepath {
+			return true
+		}
+	}
+	return false
 }
 
 // cleanUpStaleRootLevelBookFolder removes the synthetic book folder that

--- a/pkg/books/service_organize_test.go
+++ b/pkg/books/service_organize_test.go
@@ -442,12 +442,20 @@ func TestOrganizeBookFiles_MixedLayout_PromotesRootLevelFileIntoBookFolder(t *te
 	// The EPUB stays put.
 	assert.FileExists(t, epubPath, "existing organized epub should remain in place")
 
-	// DB filepath for the m4b reflects the new location.
+	// DB filepath for the m4b reflects the new location, and
+	// CoverImageFilename remains filename-only (the project's "stores
+	// filename, not full path" invariant — see CLAUDE.md).
 	reloadedFiles, err := svc.ListFiles(ctx, ListFilesOptions{BookID: &book.ID})
 	require.NoError(t, err)
+	var foundM4b bool
 	for _, f := range reloadedFiles {
 		if f.FileType == models.FileTypeM4B {
+			foundM4b = true
 			assert.Equal(t, expectedM4bPath, f.Filepath, "m4b filepath in DB should reflect new location")
+			require.NotNil(t, f.CoverImageFilename, "m4b cover_image_filename should be set")
+			assert.Equal(t, "Wind and Truth.m4b.cover.jpg", *f.CoverImageFilename,
+				"cover_image_filename must remain filename-only after promotion")
 		}
 	}
+	assert.True(t, foundM4b, "expected to find the m4b file in the DB")
 }

--- a/pkg/books/service_organize_test.go
+++ b/pkg/books/service_organize_test.go
@@ -320,3 +320,134 @@ func TestOrganizeBookFiles_DirectoryBased_WritesFreshSidecarAfterFolderRename(t 
 	require.NoError(t, err)
 	assert.Equal(t, newBookFolder, reloaded.Filepath)
 }
+
+// TestOrganizeBookFiles_MixedLayout_PromotesRootLevelFileIntoBookFolder pins
+// the bug where a second file (e.g. an M4B) dropped at the library root for a
+// book whose first file is already organized into a folder is left at the
+// root by organizeBookFiles. The function previously decided the layout
+// strategy from files[0] alone — finding it inside book.Filepath made it pick
+// the directory-based branch, which only renames each file in its own
+// directory and never moves the root-level file into the book folder. Its
+// sidecar and cover were similarly left at the root because
+// renameAssociatedFiles operates in the file's own directory.
+func TestOrganizeBookFiles_MixedLayout_PromotesRootLevelFileIntoBookFolder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	libDir := t.TempDir()
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	libraryPath := &models.LibraryPath{LibraryID: library.ID, Filepath: libDir}
+	_, err = db.NewInsert().Model(libraryPath).Exec(ctx)
+	require.NoError(t, err)
+
+	// Existing organized EPUB inside the book folder.
+	bookFolder := filepath.Join(libDir, "[Test Author] Wind and Truth")
+	require.NoError(t, os.MkdirAll(bookFolder, 0755))
+	epubPath := filepath.Join(bookFolder, "Wind and Truth.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub"), 0644))
+
+	// Newly-dropped M4B at the library root, plus its cover and file sidecar
+	// (created by the scanner in the file's own directory).
+	m4bPath := filepath.Join(libDir, "Wind and Truth.m4b")
+	require.NoError(t, os.WriteFile(m4bPath, []byte("m4b"), 0644))
+	rootCoverPath := m4bPath + ".cover.jpg"
+	require.NoError(t, os.WriteFile(rootCoverPath, []byte("cover"), 0644))
+	rootFileSidecarPath := m4bPath + ".metadata.json"
+	require.NoError(t, os.WriteFile(rootFileSidecarPath, []byte("{}"), 0644))
+
+	person := &models.Person{
+		LibraryID: library.ID,
+		Name:      "Test Author",
+		SortName:  "Author, Test",
+	}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Wind and Truth",
+		TitleSource:     models.DataSourceFileMetadata,
+		SortTitle:       "Wind and Truth",
+		SortTitleSource: models.DataSourceFileMetadata,
+		AuthorSource:    models.DataSourceFileMetadata,
+		Filepath:        bookFolder,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	author := &models.Author{BookID: book.ID, PersonID: person.ID, SortOrder: 1}
+	_, err = db.NewInsert().Model(author).Exec(ctx)
+	require.NoError(t, err)
+
+	// Insert EPUB first so it sorts ahead by created_at — this reproduces the
+	// real-world ordering where the existing organized file is files[0] and
+	// the new root-level file is files[1].
+	coverFilenameEpub := "Wind and Truth.epub.cover.jpg"
+	epubFile := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           epubPath,
+		FilesizeBytes:      4,
+		CoverImageFilename: &coverFilenameEpub,
+	}
+	_, err = db.NewInsert().Model(epubFile).Exec(ctx)
+	require.NoError(t, err)
+
+	coverFilenameM4b := "Wind and Truth.m4b.cover.jpg"
+	m4bFile := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeM4B,
+		FileRole:           models.FileRoleMain,
+		Filepath:           m4bPath,
+		FilesizeBytes:      3,
+		CoverImageFilename: &coverFilenameM4b,
+	}
+	_, err = db.NewInsert().Model(m4bFile).Exec(ctx)
+	require.NoError(t, err)
+
+	loadedBook, err := svc.RetrieveBook(ctx, RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+
+	require.NoError(t, svc.OrganizeBookFiles(ctx, loadedBook))
+
+	// The M4B + its cover + its file sidecar must all land inside the book
+	// folder, alongside the existing EPUB.
+	expectedM4bPath := filepath.Join(bookFolder, "Wind and Truth.m4b")
+	expectedCoverPath := expectedM4bPath + ".cover.jpg"
+	expectedFileSidecarPath := expectedM4bPath + ".metadata.json"
+
+	assert.FileExists(t, expectedM4bPath, "m4b should be moved into the book folder")
+	assert.FileExists(t, expectedCoverPath, "m4b cover should be moved into the book folder")
+	assert.FileExists(t, expectedFileSidecarPath, "m4b file sidecar should be moved into the book folder")
+
+	// Nothing should remain at the root.
+	assert.NoFileExists(t, m4bPath, "m4b should not remain at library root")
+	assert.NoFileExists(t, rootCoverPath, "m4b cover should not remain at library root")
+	assert.NoFileExists(t, rootFileSidecarPath, "m4b file sidecar should not remain at library root")
+
+	// The EPUB stays put.
+	assert.FileExists(t, epubPath, "existing organized epub should remain in place")
+
+	// DB filepath for the m4b reflects the new location.
+	reloadedFiles, err := svc.ListFiles(ctx, ListFilesOptions{BookID: &book.ID})
+	require.NoError(t, err)
+	for _, f := range reloadedFiles {
+		if f.FileType == models.FileTypeM4B {
+			assert.Equal(t, expectedM4bPath, f.Filepath, "m4b filepath in DB should reflect new location")
+		}
+	}
+}

--- a/pkg/fileutils/operations.go
+++ b/pkg/fileutils/operations.go
@@ -37,20 +37,30 @@ type OrganizeFileResult struct {
 	CoversError   error
 }
 
-// OrganizeRootLevelFile creates a folder and moves a root-level file into it.
+// OrganizeRootLevelFile creates a folder (derived from opts) and moves a
+// root-level file into it. Use this when the destination folder should be
+// computed from the file's metadata. To move a file into an already-known
+// folder (e.g. joining an existing directory-backed book), use
+// MoveFileIntoOrganizedFolder.
 func OrganizeRootLevelFile(originalPath string, opts OrganizedNameOptions) (*OrganizeFileResult, error) {
+	baseDir := filepath.Dir(originalPath)
+	folderName := GenerateOrganizedFolderName(opts)
+	targetFolder := filepath.Join(baseDir, folderName)
+	return MoveFileIntoOrganizedFolder(originalPath, targetFolder, opts)
+}
+
+// MoveFileIntoOrganizedFolder moves a file (and its associated covers and
+// file sidecar) into the given target folder, computing the destination
+// filename from opts. The target folder is created if missing. After a
+// successful move the source directory is cleaned up if empty. Use this when
+// the destination folder is already known (e.g. promoting a root-level file
+// into an existing book folder), so the caller doesn't have to re-derive the
+// folder from opts and risk landing in a different folder than intended.
+func MoveFileIntoOrganizedFolder(originalPath, targetFolder string, opts OrganizedNameOptions) (*OrganizeFileResult, error) {
 	result := &OrganizeFileResult{
 		OriginalPath: originalPath,
 	}
 
-	// Get the directory containing the original file
-	baseDir := filepath.Dir(originalPath)
-
-	// Generate the organized folder name
-	folderName := GenerateOrganizedFolderName(opts)
-	targetFolder := filepath.Join(baseDir, folderName)
-
-	// Generate the organized filename
 	filename := GenerateOrganizedFileName(opts, originalPath)
 	targetPath := filepath.Join(targetFolder, filename)
 
@@ -58,9 +68,7 @@ func OrganizeRootLevelFile(originalPath string, opts OrganizedNameOptions) (*Org
 
 	// Check if target folder already exists
 	if _, err := os.Stat(targetFolder); os.IsNotExist(err) {
-		// Create the target folder
-		err := os.MkdirAll(targetFolder, 0755)
-		if err != nil {
+		if err := os.MkdirAll(targetFolder, 0755); err != nil {
 			return result, errors.WithStack(err)
 		}
 		result.FolderCreated = true
@@ -74,8 +82,7 @@ func OrganizeRootLevelFile(originalPath string, opts OrganizedNameOptions) (*Org
 	}
 
 	// Move the file
-	err := moveFile(originalPath, targetPath)
-	if err != nil {
+	if err := moveFile(originalPath, targetPath); err != nil {
 		// If we created the folder and the move failed, try to clean up
 		if result.FolderCreated {
 			os.RemoveAll(targetFolder)


### PR DESCRIPTION
## Summary
- `organizeBookFiles` decided its layout strategy from `files[0]` alone. When a book already had an organized file in its folder and the user dropped a second file (e.g. an M4B for an existing EPUB) at the library root, the directory-based branch ran for every file and only renamed each file within its own directory — leaving the root-level file, its sidecar, and its cover at the library root.
- Now decide per-file: if a file's parent dir matches a library root, call `OrganizeRootLevelFile` to move it (with its associated sidecar and cover) into the book folder. Otherwise keep the existing in-place rename.
- Added `TestOrganizeBookFiles_MixedLayout_PromotesRootLevelFileIntoBookFolder` reproducing the bug (organized EPUB in book folder + M4B at root) and pinning the new behavior.

## Test plan
- `mise test` (or `go test ./pkg/books/ ./pkg/worker/ ./pkg/fileutils/`) passes
- Manually: with `organize_file_structure` enabled and an already-organized book on disk, drop a second-format file (e.g. `.m4b` for a book whose `.epub` is in `[Author] Title/`) at the library root; verify after the monitor processes the event that the file, its `.cover.jpg`, and its `.metadata.json` all land in the book folder
- Existing organize tests (`TestOrganizeBookFiles_RootLevel_*`, `TestOrganizeBookFiles_DirectoryBased_*`) still pass — the per-file decision is additive