### PR TITLE
[Fix] Index series/persons/genres/tags after identify-apply, resync, and monitor batches

### DIFF
--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -78,9 +78,18 @@ type imprintFinder interface {
 	FindOrCreateImprint(ctx context.Context, name string, libraryID int) (*models.Imprint, error)
 }
 
-// searchIndexer updates the search index after metadata changes.
+// searchIndexer updates the search index after metadata changes. Each entity
+// type has its own FTS table (books_fts, series_fts, persons_fts, genres_fts,
+// tags_fts), and rows in those tables are populated only by explicit Index*
+// calls — they are NOT maintained by triggers on the underlying table. Any
+// entity created via the apply path must therefore be re-indexed here, or it
+// will be invisible to the search-driven dropdowns in the UI.
 type searchIndexer interface {
 	IndexBook(ctx context.Context, book *models.Book) error
+	IndexSeries(ctx context.Context, series *models.Series) error
+	IndexPerson(ctx context.Context, person *models.Person) error
+	IndexGenre(ctx context.Context, genre *models.Genre) error
+	IndexTag(ctx context.Context, tag *models.Tag) error
 }
 
 // pageExtractor renders a page from a page-based file (CBZ/PDF) and writes

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -142,9 +142,8 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				}
 			}
 		}
-		// Treat authors as changed when the new set differs from the old
-		// set in either direction. Same set ⇒ no series_fts.book_authors
-		// drift, no need to mark the aggregate stale.
+		// Same author set ⇒ no series_fts.book_authors drift, no need to
+		// mark the aggregate stale.
 		if !equalIntSets(oldAuthorPersonIDs, newAuthorPersonIDs) {
 			seriesAggregateMayBeStale = true
 		}

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -16,6 +16,19 @@ import (
 	"github.com/shishobooks/shisho/pkg/sortname"
 )
 
+// equalIntSets reports whether two int-keyed sets contain the same keys.
+func equalIntSets(a, b map[int]struct{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // persistMetadata applies metadata to a book and its target file unconditionally (no field filtering).
 // Every non-empty field in md is persisted. pluginScope and pluginID identify the data source.
 // targetFile is the specific file to apply file-level metadata (identifiers, cover) to; may be nil.
@@ -37,12 +50,15 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 	// Title
 	title := strings.TrimSpace(md.Title)
 	if title != "" {
+		titleChanged := book.Title != title
 		book.Title = title
 		book.TitleSource = pluginSource
 		book.SortTitle = sortname.ForTitle(title)
 		book.SortTitleSource = pluginSource
 		columns = append(columns, "title", "title_source", "sort_title", "sort_title_source")
-		seriesAggregateMayBeStale = true
+		if titleChanged {
+			seriesAggregateMayBeStale = true
+		}
 
 		// Mirror the identified title onto the target main file's Name so
 		// file organization and downloads reflect it. Supplements keep their
@@ -82,7 +98,6 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 
 	// Authors
 	if len(md.Authors) > 0 && h.enrich.personFinder != nil {
-		seriesAggregateMayBeStale = true
 		// Capture the personIDs already attached as authors so we can skip
 		// re-indexing them when the apply re-attaches the same person.
 		// persons_fts has no aggregate columns, so re-indexing an unchanged
@@ -96,6 +111,7 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 		if err := h.enrich.relStore.DeleteAuthors(ctx, book.ID); err != nil {
 			return errors.Wrap(err, "failed to delete authors")
 		}
+		newAuthorPersonIDs := make(map[int]struct{}, len(md.Authors))
 		for i, pa := range md.Authors {
 			if pa.Name == "" {
 				continue
@@ -105,6 +121,7 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				log.Warn("failed to find/create person", logger.Data{"name": pa.Name, "error": pErr.Error()})
 				continue
 			}
+			newAuthorPersonIDs[person.ID] = struct{}{}
 			var role *string
 			if pa.Role != "" {
 				role = &pa.Role
@@ -124,6 +141,12 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 					}
 				}
 			}
+		}
+		// Treat authors as changed when the new set differs from the old
+		// set in either direction. Same set ⇒ no series_fts.book_authors
+		// drift, no need to mark the aggregate stale.
+		if !equalIntSets(oldAuthorPersonIDs, newAuthorPersonIDs) {
+			seriesAggregateMayBeStale = true
 		}
 		book.AuthorSource = pluginSource
 		if err := h.enrich.bookStore.UpdateBook(ctx, book, []string{"author_source"}); err != nil {

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -98,6 +98,11 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 			}); err != nil {
 				log.Warn("failed to create author", logger.Data{"error": err.Error()})
 			}
+			if h.enrich.searchIndexer != nil {
+				if err := h.enrich.searchIndexer.IndexPerson(ctx, person); err != nil {
+					log.Warn("failed to update search index for author", logger.Data{"person_id": person.ID, "error": err.Error()})
+				}
+			}
 		}
 		book.AuthorSource = pluginSource
 		if err := h.enrich.bookStore.UpdateBook(ctx, book, []string{"author_source"}); err != nil {
@@ -122,6 +127,13 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 			}); err != nil {
 				log.Warn("failed to create book series", logger.Data{"error": err.Error()})
 			}
+			// Index after CreateBookSeries so series_fts.book_titles /
+			// book_authors reflect the just-attached book.
+			if h.enrich.searchIndexer != nil {
+				if err := h.enrich.searchIndexer.IndexSeries(ctx, seriesRecord); err != nil {
+					log.Warn("failed to update search index for series", logger.Data{"series_id": seriesRecord.ID, "error": err.Error()})
+				}
+			}
 		}
 	}
 
@@ -144,6 +156,11 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				GenreID: genre.ID,
 			}); err != nil {
 				log.Warn("failed to create book genre", logger.Data{"error": err.Error()})
+			}
+			if h.enrich.searchIndexer != nil {
+				if err := h.enrich.searchIndexer.IndexGenre(ctx, genre); err != nil {
+					log.Warn("failed to update search index for genre", logger.Data{"genre_id": genre.ID, "error": err.Error()})
+				}
 			}
 		}
 		book.GenreSource = &pluginSource
@@ -172,6 +189,11 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 			}); err != nil {
 				log.Warn("failed to create book tag", logger.Data{"error": err.Error()})
 			}
+			if h.enrich.searchIndexer != nil {
+				if err := h.enrich.searchIndexer.IndexTag(ctx, tag); err != nil {
+					log.Warn("failed to update search index for tag", logger.Data{"tag_id": tag.ID, "error": err.Error()})
+				}
+			}
 		}
 		book.TagSource = &pluginSource
 		if err := h.enrich.bookStore.UpdateBook(ctx, book, []string{"tag_source"}); err != nil {
@@ -199,6 +221,11 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				SortOrder: i + 1,
 			}); err != nil {
 				log.Warn("failed to create narrator", logger.Data{"error": err.Error()})
+			}
+			if h.enrich.searchIndexer != nil {
+				if err := h.enrich.searchIndexer.IndexPerson(ctx, person); err != nil {
+					log.Warn("failed to update search index for narrator", logger.Data{"person_id": person.ID, "error": err.Error()})
+				}
 			}
 		}
 		targetFile.NarratorSource = &pluginSource

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -27,6 +27,13 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 	// can all contribute, then flush once at the end.
 	var fileColumns []string
 
+	// Track whether changes ran that would affect series_fts aggregate
+	// columns (book_titles / book_authors). When they did, the series
+	// block re-indexes the attached series even if its attachment to this
+	// book didn't change — otherwise the aggregate columns would go stale
+	// until something else triggered IndexSeries.
+	seriesAggregateMayBeStale := false
+
 	// Title
 	title := strings.TrimSpace(md.Title)
 	if title != "" {
@@ -35,6 +42,7 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 		book.SortTitle = sortname.ForTitle(title)
 		book.SortTitleSource = pluginSource
 		columns = append(columns, "title", "title_source", "sort_title", "sort_title_source")
+		seriesAggregateMayBeStale = true
 
 		// Mirror the identified title onto the target main file's Name so
 		// file organization and downloads reflect it. Supplements keep their
@@ -74,6 +82,7 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 
 	// Authors
 	if len(md.Authors) > 0 && h.enrich.personFinder != nil {
+		seriesAggregateMayBeStale = true
 		// Capture the personIDs already attached as authors so we can skip
 		// re-indexing them when the apply re-attaches the same person.
 		// persons_fts has no aggregate columns, so re-indexing an unchanged
@@ -150,15 +159,19 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 			}); err != nil {
 				log.Warn("failed to create book series", logger.Data{"error": err.Error()})
 			}
-			// Re-index series whose attachment to this book actually changed:
-			// the new series (if it wasn't already attached, covering both
-			// newly-created series and freshly-attached existing series), and
-			// every old series that's no longer attached. Series whose
-			// attachment didn't change skip the DELETE+INSERT churn against
-			// series_fts. Index after CreateBookSeries so book_titles /
-			// book_authors reflect the just-attached book.
+			// Re-index series whose attachment to this book actually
+			// changed: the new series (if it wasn't already attached,
+			// covering both newly-created series and freshly-attached
+			// existing series), and every old series that's no longer
+			// attached. Additionally re-index the still-attached series
+			// when book.title or book.authors changed during this apply
+			// — series_fts.book_titles / book_authors are aggregate
+			// columns that would otherwise go stale. Index after
+			// CreateBookSeries so the aggregate reflects the just-
+			// attached book.
 			if h.enrich.searchIndexer != nil {
-				if _, stillAttached := oldSeries[seriesRecord.ID]; !stillAttached {
+				_, stillAttached := oldSeries[seriesRecord.ID]
+				if !stillAttached || seriesAggregateMayBeStale {
 					if err := h.enrich.searchIndexer.IndexSeries(ctx, seriesRecord); err != nil {
 						log.Warn("failed to update search index for series", logger.Data{"series_id": seriesRecord.ID, "error": err.Error()})
 					}

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -74,6 +74,16 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 
 	// Authors
 	if len(md.Authors) > 0 && h.enrich.personFinder != nil {
+		// Capture the personIDs already attached as authors so we can skip
+		// re-indexing them when the apply re-attaches the same person.
+		// persons_fts has no aggregate columns, so re-indexing an unchanged
+		// person is pure DELETE+INSERT churn.
+		oldAuthorPersonIDs := make(map[int]struct{}, len(book.Authors))
+		for _, a := range book.Authors {
+			if a.Person != nil {
+				oldAuthorPersonIDs[a.Person.ID] = struct{}{}
+			}
+		}
 		if err := h.enrich.relStore.DeleteAuthors(ctx, book.ID); err != nil {
 			return errors.Wrap(err, "failed to delete authors")
 		}
@@ -99,8 +109,10 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				log.Warn("failed to create author", logger.Data{"error": err.Error()})
 			}
 			if h.enrich.searchIndexer != nil {
-				if err := h.enrich.searchIndexer.IndexPerson(ctx, person); err != nil {
-					log.Warn("failed to update search index for author", logger.Data{"person_id": person.ID, "error": err.Error()})
+				if _, alreadyAttached := oldAuthorPersonIDs[person.ID]; !alreadyAttached {
+					if err := h.enrich.searchIndexer.IndexPerson(ctx, person); err != nil {
+						log.Warn("failed to update search index for author", logger.Data{"person_id": person.ID, "error": err.Error()})
+					}
 				}
 			}
 		}
@@ -112,6 +124,17 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 
 	// Series
 	if md.Series != "" {
+		// Capture old series before delete so we can re-index any that get
+		// detached — their series_fts.book_titles / book_authors aggregate
+		// columns must stop listing this book. Holding the *models.Series
+		// pointers from book.BookSeries lets us re-index without an extra
+		// DB round-trip.
+		oldSeries := make(map[int]*models.Series, len(book.BookSeries))
+		for _, bs := range book.BookSeries {
+			if bs.Series != nil {
+				oldSeries[bs.Series.ID] = bs.Series
+			}
+		}
 		if err := h.enrich.relStore.DeleteBookSeries(ctx, book.ID); err != nil {
 			return errors.Wrap(err, "failed to delete series")
 		}
@@ -127,11 +150,26 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 			}); err != nil {
 				log.Warn("failed to create book series", logger.Data{"error": err.Error()})
 			}
-			// Index after CreateBookSeries so series_fts.book_titles /
+			// Re-index series whose attachment to this book actually changed:
+			// the new series (if it wasn't already attached, covering both
+			// newly-created series and freshly-attached existing series), and
+			// every old series that's no longer attached. Series whose
+			// attachment didn't change skip the DELETE+INSERT churn against
+			// series_fts. Index after CreateBookSeries so book_titles /
 			// book_authors reflect the just-attached book.
 			if h.enrich.searchIndexer != nil {
-				if err := h.enrich.searchIndexer.IndexSeries(ctx, seriesRecord); err != nil {
-					log.Warn("failed to update search index for series", logger.Data{"series_id": seriesRecord.ID, "error": err.Error()})
+				if _, stillAttached := oldSeries[seriesRecord.ID]; !stillAttached {
+					if err := h.enrich.searchIndexer.IndexSeries(ctx, seriesRecord); err != nil {
+						log.Warn("failed to update search index for series", logger.Data{"series_id": seriesRecord.ID, "error": err.Error()})
+					}
+				}
+				for oldID, oldSer := range oldSeries {
+					if oldID == seriesRecord.ID {
+						continue
+					}
+					if err := h.enrich.searchIndexer.IndexSeries(ctx, oldSer); err != nil {
+						log.Warn("failed to update search index for detached series", logger.Data{"series_id": oldID, "error": err.Error()})
+					}
 				}
 			}
 		}
@@ -139,6 +177,15 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 
 	// Genres
 	if len(md.Genres) > 0 && h.enrich.genreFinder != nil {
+		// Same churn rationale as authors: genres_fts has no aggregate
+		// columns, so re-indexing a genre whose attachment to this book
+		// didn't change is wasted work.
+		oldGenreIDs := make(map[int]struct{}, len(book.BookGenres))
+		for _, bg := range book.BookGenres {
+			if bg.Genre != nil {
+				oldGenreIDs[bg.Genre.ID] = struct{}{}
+			}
+		}
 		if err := h.enrich.relStore.DeleteBookGenres(ctx, book.ID); err != nil {
 			return errors.Wrap(err, "failed to delete genres")
 		}
@@ -158,8 +205,10 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				log.Warn("failed to create book genre", logger.Data{"error": err.Error()})
 			}
 			if h.enrich.searchIndexer != nil {
-				if err := h.enrich.searchIndexer.IndexGenre(ctx, genre); err != nil {
-					log.Warn("failed to update search index for genre", logger.Data{"genre_id": genre.ID, "error": err.Error()})
+				if _, alreadyAttached := oldGenreIDs[genre.ID]; !alreadyAttached {
+					if err := h.enrich.searchIndexer.IndexGenre(ctx, genre); err != nil {
+						log.Warn("failed to update search index for genre", logger.Data{"genre_id": genre.ID, "error": err.Error()})
+					}
 				}
 			}
 		}
@@ -171,6 +220,12 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 
 	// Tags
 	if len(md.Tags) > 0 && h.enrich.tagFinder != nil {
+		oldTagIDs := make(map[int]struct{}, len(book.BookTags))
+		for _, bt := range book.BookTags {
+			if bt.Tag != nil {
+				oldTagIDs[bt.Tag.ID] = struct{}{}
+			}
+		}
 		if err := h.enrich.relStore.DeleteBookTags(ctx, book.ID); err != nil {
 			return errors.Wrap(err, "failed to delete tags")
 		}
@@ -190,8 +245,10 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				log.Warn("failed to create book tag", logger.Data{"error": err.Error()})
 			}
 			if h.enrich.searchIndexer != nil {
-				if err := h.enrich.searchIndexer.IndexTag(ctx, tag); err != nil {
-					log.Warn("failed to update search index for tag", logger.Data{"tag_id": tag.ID, "error": err.Error()})
+				if _, alreadyAttached := oldTagIDs[tag.ID]; !alreadyAttached {
+					if err := h.enrich.searchIndexer.IndexTag(ctx, tag); err != nil {
+						log.Warn("failed to update search index for tag", logger.Data{"tag_id": tag.ID, "error": err.Error()})
+					}
 				}
 			}
 		}
@@ -203,6 +260,12 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 
 	// Narrators (file-level, applied to target file)
 	if len(md.Narrators) > 0 && targetFile != nil && h.enrich.personFinder != nil {
+		oldNarratorPersonIDs := make(map[int]struct{}, len(targetFile.Narrators))
+		for _, n := range targetFile.Narrators {
+			if n.Person != nil {
+				oldNarratorPersonIDs[n.Person.ID] = struct{}{}
+			}
+		}
 		if _, err := h.enrich.bookStore.DeleteNarratorsForFile(ctx, targetFile.ID); err != nil {
 			return errors.Wrap(err, "failed to delete narrators")
 		}
@@ -223,8 +286,10 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				log.Warn("failed to create narrator", logger.Data{"error": err.Error()})
 			}
 			if h.enrich.searchIndexer != nil {
-				if err := h.enrich.searchIndexer.IndexPerson(ctx, person); err != nil {
-					log.Warn("failed to update search index for narrator", logger.Data{"person_id": person.ID, "error": err.Error()})
+				if _, alreadyAttached := oldNarratorPersonIDs[person.ID]; !alreadyAttached {
+					if err := h.enrich.searchIndexer.IndexPerson(ctx, person); err != nil {
+						log.Warn("failed to update search index for narrator", logger.Data{"person_id": person.ID, "error": err.Error()})
+					}
 				}
 			}
 		}

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -740,6 +740,41 @@ func TestPersistMetadata_ReindexesSameSeriesWhenTitleChanges(t *testing.T) {
 	assert.Contains(t, indexer.indexedSeriesIDs, 1, "series whose membership did not change must still be re-indexed when book.title changed, otherwise series_fts.book_titles goes stale")
 }
 
+// TestPersistMetadata_SkipsSeriesIndexWhenSameTitleReapplied verifies that
+// re-applying the same title (alongside an unchanged series) does not
+// trigger an IndexSeries call. The previous over-trigger keyed off "title
+// block ran" rather than "title actually changed", causing one extra
+// series_fts DELETE+INSERT per identical-title apply.
+func TestPersistMetadata_SkipsSeriesIndexWhenSameTitleReapplied(t *testing.T) {
+	t.Parallel()
+
+	book := newApplyTestBook(t, "Same Title")
+	existingSeries := &models.Series{ID: 1, LibraryID: book.LibraryID, Name: "Same Series"}
+	book.BookSeries = []*models.BookSeries{{
+		BookID:   book.ID,
+		SeriesID: existingSeries.ID,
+		Series:   existingSeries,
+	}}
+
+	indexer := &stubSearchIndexer{}
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			relStore:      &stubRelStoreForApply{},
+			searchIndexer: indexer,
+		},
+	}
+
+	md := &mediafile.ParsedMetadata{
+		Title:  "Same Title",
+		Series: "Same Series",
+	}
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	assert.NotContains(t, indexer.indexedSeriesIDs, 1, "series whose attachment did not change AND whose aggregate inputs (title) did not actually change must NOT be re-indexed")
+}
+
 // TestPersistMetadata_SkipsPersonIndexForUnchangedAuthor verifies that an
 // author who was already attached to the book before the apply is not
 // re-indexed when the same author is re-applied. persons_fts has no

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -632,3 +632,110 @@ func TestPersistMetadata_IndexesNewAuthorsNarratorsGenresTags(t *testing.T) {
 	assert.Len(t, indexer.indexedGenreIDs, 1, "new genre must be added to genres_fts")
 	assert.Len(t, indexer.indexedTagIDs, 1, "new tag must be added to tags_fts")
 }
+
+// TestPersistMetadata_ReindexesDetachedOldSeries verifies that when an apply
+// replaces a book's series, the previously-attached series gets re-indexed
+// so its series_fts.book_titles / book_authors aggregate columns stop
+// listing this book. Without this, searching by the moved book's title or
+// author would still surface the old series.
+func TestPersistMetadata_ReindexesDetachedOldSeries(t *testing.T) {
+	t.Parallel()
+
+	book := newApplyTestBook(t, "Book")
+	// Pre-attach the book to an existing series (ID 99). When apply runs
+	// with a different series, the stub FindOrCreateSeries returns ID 1,
+	// so series 99 becomes detached and must be re-indexed for aggregate
+	// freshness.
+	oldSeries := &models.Series{ID: 99, LibraryID: book.LibraryID, Name: "Old Series"}
+	book.BookSeries = []*models.BookSeries{{
+		BookID:   book.ID,
+		SeriesID: oldSeries.ID,
+		Series:   oldSeries,
+	}}
+
+	indexer := &stubSearchIndexer{}
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			relStore:      &stubRelStoreForApply{},
+			searchIndexer: indexer,
+		},
+	}
+
+	md := &mediafile.ParsedMetadata{Series: "New Series"}
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	assert.Contains(t, indexer.indexedSeriesIDs, 1, "newly-attached series (id 1 from stub) must be indexed")
+	assert.Contains(t, indexer.indexedSeriesIDs, 99, "detached old series (id 99) must be re-indexed so its book_titles aggregate stops listing this book")
+}
+
+// TestPersistMetadata_SkipsSeriesIndexWhenAttachmentUnchanged verifies that
+// re-applying the same series to a book does not trigger an unnecessary
+// IndexSeries call. The new series ID matches the existing attachment, so
+// neither the membership nor the aggregate columns change — re-indexing
+// would be pure DELETE+INSERT churn against series_fts.
+func TestPersistMetadata_SkipsSeriesIndexWhenAttachmentUnchanged(t *testing.T) {
+	t.Parallel()
+
+	book := newApplyTestBook(t, "Book")
+	// Pre-attach the book to series ID 1 — same ID the stub returns for
+	// every FindOrCreateSeries call.
+	existingSeries := &models.Series{ID: 1, LibraryID: book.LibraryID, Name: "Same Series"}
+	book.BookSeries = []*models.BookSeries{{
+		BookID:   book.ID,
+		SeriesID: existingSeries.ID,
+		Series:   existingSeries,
+	}}
+
+	indexer := &stubSearchIndexer{}
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			relStore:      &stubRelStoreForApply{},
+			searchIndexer: indexer,
+		},
+	}
+
+	md := &mediafile.ParsedMetadata{Series: "Same Series"}
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	assert.NotContains(t, indexer.indexedSeriesIDs, 1, "series whose attachment to this book did not change must NOT be re-indexed (avoids series_fts churn)")
+}
+
+// TestPersistMetadata_SkipsPersonIndexForUnchangedAuthor verifies that an
+// author who was already attached to the book before the apply is not
+// re-indexed when the same author is re-applied. persons_fts has no
+// aggregate columns, so re-indexing an unchanged person is pure churn.
+func TestPersistMetadata_SkipsPersonIndexForUnchangedAuthor(t *testing.T) {
+	t.Parallel()
+
+	book, file := newApplyTestBookWithFile(t, "Book", models.FileTypeEPUB)
+	// Pre-attach an existing author with ID 1 (matches what the stub
+	// person finder returns for the first call).
+	existingPerson := &models.Person{ID: 1, LibraryID: book.LibraryID, Name: "Existing Author"}
+	book.Authors = []*models.Author{{
+		BookID:   book.ID,
+		PersonID: existingPerson.ID,
+		Person:   existingPerson,
+	}}
+
+	indexer := &stubSearchIndexer{}
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			relStore:      &stubRelStoreForApply{},
+			personFinder:  &stubPersonFinderForPersist{},
+			searchIndexer: indexer,
+		},
+	}
+
+	md := &mediafile.ParsedMetadata{
+		Authors: []mediafile.ParsedAuthor{{Name: "Existing Author", Role: "writer"}},
+	}
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	assert.NotContains(t, indexer.indexedPersonIDs, 1, "author whose attachment did not change must NOT be re-indexed (avoids persons_fts churn)")
+}

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -501,3 +501,134 @@ func TestPersistMetadata_CoverPage_EPUB_Ignored(t *testing.T) {
 	require.NotNil(t, file.CoverImageFilename)
 	assert.Equal(t, "book.epub.cover.jpg", *file.CoverImageFilename)
 }
+
+// stubSearchIndexer records calls to each Index* method so tests can assert
+// that persistMetadata keeps the FTS index in sync with newly-created or
+// re-associated entities. Without these calls, an entity created during the
+// identify-apply flow exists in its table but has no FTS row, so it is
+// invisible to search-driven dropdowns (e.g. the series combobox in the
+// IdentifyReviewForm).
+type stubSearchIndexer struct {
+	indexedBookIDs   []int
+	indexedSeriesIDs []int
+	indexedPersonIDs []int
+	indexedGenreIDs  []int
+	indexedTagIDs    []int
+}
+
+func (s *stubSearchIndexer) IndexBook(_ context.Context, b *models.Book) error {
+	s.indexedBookIDs = append(s.indexedBookIDs, b.ID)
+	return nil
+}
+
+func (s *stubSearchIndexer) IndexSeries(_ context.Context, sr *models.Series) error {
+	s.indexedSeriesIDs = append(s.indexedSeriesIDs, sr.ID)
+	return nil
+}
+
+func (s *stubSearchIndexer) IndexPerson(_ context.Context, p *models.Person) error {
+	s.indexedPersonIDs = append(s.indexedPersonIDs, p.ID)
+	return nil
+}
+
+func (s *stubSearchIndexer) IndexGenre(_ context.Context, g *models.Genre) error {
+	s.indexedGenreIDs = append(s.indexedGenreIDs, g.ID)
+	return nil
+}
+
+func (s *stubSearchIndexer) IndexTag(_ context.Context, tag *models.Tag) error {
+	s.indexedTagIDs = append(s.indexedTagIDs, tag.ID)
+	return nil
+}
+
+// stubPersonFinderForPersist returns a person with a sequential ID for each
+// FindOrCreatePerson call so tests can assert on the indexed person IDs.
+type stubPersonFinderForPersist struct {
+	nextID int
+}
+
+func (s *stubPersonFinderForPersist) FindOrCreatePerson(_ context.Context, name string, libraryID int) (*models.Person, error) {
+	s.nextID++
+	return &models.Person{ID: s.nextID, LibraryID: libraryID, Name: name}, nil
+}
+
+// stubGenreFinderForPersist returns a genre with a sequential ID for each call.
+type stubGenreFinderForPersist struct {
+	nextID int
+}
+
+func (s *stubGenreFinderForPersist) FindOrCreateGenre(_ context.Context, name string, libraryID int) (*models.Genre, error) {
+	s.nextID++
+	return &models.Genre{ID: s.nextID, LibraryID: libraryID, Name: name}, nil
+}
+
+// stubTagFinderForPersist returns a tag with a sequential ID for each call.
+type stubTagFinderForPersist struct {
+	nextID int
+}
+
+func (s *stubTagFinderForPersist) FindOrCreateTag(_ context.Context, name string, libraryID int) (*models.Tag, error) {
+	s.nextID++
+	return &models.Tag{ID: s.nextID, LibraryID: libraryID, Name: name}, nil
+}
+
+// TestPersistMetadata_IndexesNewSeries is a regression test for the bug where
+// a series created via the identify-apply flow ("Create 'Series'" option in
+// the IdentifyReviewForm combobox) never received a series_fts row, so it
+// was invisible to subsequent series search dropdowns even though the row
+// existed in the series table. The fix calls IndexSeries after CreateBookSeries
+// to keep the FTS index in sync.
+func TestPersistMetadata_IndexesNewSeries(t *testing.T) {
+	t.Parallel()
+
+	book := newApplyTestBook(t, "Book")
+	indexer := &stubSearchIndexer{}
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			relStore:      &stubRelStoreForApply{},
+			searchIndexer: indexer,
+		},
+	}
+
+	md := &mediafile.ParsedMetadata{Series: "My New Series"}
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	assert.Contains(t, indexer.indexedSeriesIDs, 1, "series created via identify-apply must be added to series_fts so it shows up in series search dropdowns")
+}
+
+// TestPersistMetadata_IndexesNewAuthorsNarratorsGenresTags is a regression
+// test for the same FTS-sync gap on the other entities created during the
+// identify-apply flow. Persons, genres, and tags all use FTS for their list
+// search endpoints (persons_fts, genres_fts, tags_fts), so newly-created rows
+// must also be indexed to be findable in their respective dropdowns.
+func TestPersistMetadata_IndexesNewAuthorsNarratorsGenresTags(t *testing.T) {
+	t.Parallel()
+
+	book, file := newApplyTestBookWithFile(t, "Book", models.FileTypeEPUB)
+	indexer := &stubSearchIndexer{}
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			relStore:      &stubRelStoreForApply{},
+			personFinder:  &stubPersonFinderForPersist{},
+			genreFinder:   &stubGenreFinderForPersist{},
+			tagFinder:     &stubTagFinderForPersist{},
+			searchIndexer: indexer,
+		},
+	}
+
+	md := &mediafile.ParsedMetadata{
+		Authors:   []mediafile.ParsedAuthor{{Name: "New Author", Role: "writer"}},
+		Narrators: []string{"New Narrator"},
+		Genres:    []string{"New Genre"},
+		Tags:      []string{"New Tag"},
+	}
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	assert.Len(t, indexer.indexedPersonIDs, 2, "both new author and new narrator must be added to persons_fts")
+	assert.Len(t, indexer.indexedGenreIDs, 1, "new genre must be added to genres_fts")
+	assert.Len(t, indexer.indexedTagIDs, 1, "new tag must be added to tags_fts")
+}

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -704,6 +704,42 @@ func TestPersistMetadata_SkipsSeriesIndexWhenAttachmentUnchanged(t *testing.T) {
 	assert.NotContains(t, indexer.indexedSeriesIDs, 1, "series whose attachment to this book did not change must NOT be re-indexed (avoids series_fts churn)")
 }
 
+// TestPersistMetadata_ReindexesSameSeriesWhenTitleChanges verifies that a
+// series whose attachment to this book did not change is still re-indexed
+// when book.title changes during the apply — series_fts has aggregate
+// columns (book_titles, book_authors) that would otherwise go stale.
+// Without this branch, searching for a book by its new title within a
+// series search would still surface the old title.
+func TestPersistMetadata_ReindexesSameSeriesWhenTitleChanges(t *testing.T) {
+	t.Parallel()
+
+	book := newApplyTestBook(t, "Old Title")
+	existingSeries := &models.Series{ID: 1, LibraryID: book.LibraryID, Name: "Same Series"}
+	book.BookSeries = []*models.BookSeries{{
+		BookID:   book.ID,
+		SeriesID: existingSeries.ID,
+		Series:   existingSeries,
+	}}
+
+	indexer := &stubSearchIndexer{}
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			relStore:      &stubRelStoreForApply{},
+			searchIndexer: indexer,
+		},
+	}
+
+	md := &mediafile.ParsedMetadata{
+		Title:  "New Title",
+		Series: "Same Series",
+	}
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	assert.Contains(t, indexer.indexedSeriesIDs, 1, "series whose membership did not change must still be re-indexed when book.title changed, otherwise series_fts.book_titles goes stale")
+}
+
 // TestPersistMetadata_SkipsPersonIndexForUnchangedAuthor verifies that an
 // author who was already attached to the book before the apply is not
 // re-indexed when the same author is re-applied. persons_fts has no

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -775,6 +775,51 @@ func TestPersistMetadata_SkipsSeriesIndexWhenSameTitleReapplied(t *testing.T) {
 	assert.NotContains(t, indexer.indexedSeriesIDs, 1, "series whose attachment did not change AND whose aggregate inputs (title) did not actually change must NOT be re-indexed")
 }
 
+// TestPersistMetadata_SkipsSeriesIndexWhenSameAuthorsReapplied verifies
+// that re-applying the same author set (alongside an unchanged series)
+// does not trigger an IndexSeries call. The previous over-trigger keyed
+// off "authors block ran" rather than "author set actually changed",
+// causing one extra series_fts DELETE+INSERT per identical-authors apply.
+func TestPersistMetadata_SkipsSeriesIndexWhenSameAuthorsReapplied(t *testing.T) {
+	t.Parallel()
+
+	book, _ := newApplyTestBookWithFile(t, "Book", models.FileTypeEPUB)
+	// Pre-attach the book to a series (ID 1, matching the stub
+	// FindOrCreateSeries return) and an author (ID 1, matching the stub
+	// person finder's first return).
+	existingSeries := &models.Series{ID: 1, LibraryID: book.LibraryID, Name: "Same Series"}
+	book.BookSeries = []*models.BookSeries{{
+		BookID:   book.ID,
+		SeriesID: existingSeries.ID,
+		Series:   existingSeries,
+	}}
+	existingPerson := &models.Person{ID: 1, LibraryID: book.LibraryID, Name: "Same Author"}
+	book.Authors = []*models.Author{{
+		BookID:   book.ID,
+		PersonID: existingPerson.ID,
+		Person:   existingPerson,
+	}}
+
+	indexer := &stubSearchIndexer{}
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore:     &stubBookStoreForPersist{book: book},
+			relStore:      &stubRelStoreForApply{},
+			personFinder:  &stubPersonFinderForPersist{},
+			searchIndexer: indexer,
+		},
+	}
+
+	md := &mediafile.ParsedMetadata{
+		Authors: []mediafile.ParsedAuthor{{Name: "Same Author", Role: "writer"}},
+		Series:  "Same Series",
+	}
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	require.NoError(t, err)
+
+	assert.NotContains(t, indexer.indexedSeriesIDs, 1, "series whose attachment did not change AND whose author-set aggregate input did not actually change must NOT be re-indexed")
+}
+
 // TestPersistMetadata_SkipsPersonIndexForUnchangedAuthor verifies that an
 // author who was already attached to the book before the apply is not
 // re-indexed when the same author is re-applied. persons_fts has no

--- a/pkg/worker/monitor.go
+++ b/pkg/worker/monitor.go
@@ -661,8 +661,9 @@ func (m *Monitor) processPendingEvents() {
 		}
 	}
 
-	// Update search indexes for affected books. There are three cases:
-	//   1. Book was deleted — remove its books_fts row.
+	// Update search indexes for affected books. There are four cases:
+	//   1. Book was deleted (RetrieveBook returns NotFound) — remove its
+	//      books_fts row.
 	//   2. Book is newly created (FilePath-mode event, FileCreated=true) —
 	//      scanFileCore was called with isResync=false so per-book indexing
 	//      was deferred. Index the book and all its relations now. Empty
@@ -672,6 +673,9 @@ func (m *Monitor) processPendingEvents() {
 	//      scanFileCore already ran with isResync=true and indexed
 	//      conditionally via its own snapshot. Skip to avoid a full
 	//      re-index that would undo the conditional savings.
+	//   4. Book had a file move detected (tryDetectMove) — only
+	//      file.Filepath changed, no books_fts column or relation has
+	//      changed. Falls into case 3's skip branch by default.
 	if m.worker.searchService != nil {
 		logWarn := func(msg string, data logger.Data) {
 			m.log.Warn(msg, data)
@@ -679,16 +683,27 @@ func (m *Monitor) processPendingEvents() {
 		for bookID := range affectedBookIDs {
 			book, err := m.worker.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
 			if err != nil {
+				// Case 1: book was deleted during the batch. Drop its
+				// books_fts row; orphan cleanup handles series_fts /
+				// persons_fts / etc.
 				_ = m.worker.searchService.DeleteFromBookIndex(ctx, bookID)
 				continue
 			}
 			if _, newlyCreated := newlyCreatedBookIDs[bookID]; !newlyCreated {
+				// Cases 3 + 4: scanFileCore's per-event indexing
+				// already ran (or no FTS change was needed at all for
+				// move detection).
 				continue
 			}
+			// Case 2: catch up indexing for a newly-created book.
 			if err := m.worker.searchService.IndexBook(ctx, book); err != nil {
 				m.log.Warn("failed to index book", logger.Data{"book_id": bookID, "error": err.Error()})
 			}
-			m.worker.indexBookRelations(ctx, book, bookRelationsSnapshot{}, logWarn)
+			// Empty snapshot means every loaded relation looks
+			// newly-attached and gets indexed. No aggregate-staleness
+			// hint needed — there were no pre-batch values to go
+			// stale against.
+			m.worker.indexBookRelations(ctx, book, bookRelationsSnapshot{}, indexRelationsHints{}, logWarn)
 		}
 	}
 }

--- a/pkg/worker/monitor.go
+++ b/pkg/worker/monitor.go
@@ -542,6 +542,15 @@ func (m *Monitor) processPendingEvents() {
 	// targets; the corresponding REMOVE events for their old paths must be
 	// skipped so we don't delete the row we just updated.
 	movedFileIDs := make(map[int]struct{})
+	// newlyCreatedBookIDs tracks books whose underlying file was scanned
+	// via FilePath mode (FileCreated=true) during this batch. Those events
+	// run scanFileCore with isResync=false, which intentionally skips
+	// per-book FTS indexing — the post-batch loop must catch them up. For
+	// books that were updated via FileID mode (resync), scanFileCore
+	// already performed conditional per-relation indexing, so the
+	// post-batch loop skips them to avoid undoing that conditional
+	// optimization with a full re-index.
+	newlyCreatedBookIDs := make(map[int]struct{})
 
 	applyResult := func(result *ScanResult) {
 		if result == nil {
@@ -552,6 +561,7 @@ func (m *Monitor) processPendingEvents() {
 		}
 		if result.FileCreated && result.Book != nil {
 			booksToOrganize[result.Book.ID] = struct{}{}
+			newlyCreatedBookIDs[result.Book.ID] = struct{}{}
 		}
 		// Track all affected books for targeted search indexing.
 		if result.Book != nil {
@@ -651,13 +661,17 @@ func (m *Monitor) processPendingEvents() {
 		}
 	}
 
-	// Update search indexes for affected books and the entities they
-	// reference (series, authors, narrators, genres, tags). Without the
-	// per-relation indexing, an entity created by a FilePath-mode scan
-	// during this batch (which uses isResync=false and skips per-book
-	// indexing) has a row in its primary table but no FTS row, leaving it
-	// invisible to the search-driven dropdowns until a full library scan
-	// triggers RebuildAllIndexes. See indexBookRelations for details.
+	// Update search indexes for affected books. There are three cases:
+	//   1. Book was deleted — remove its books_fts row.
+	//   2. Book is newly created (FilePath-mode event, FileCreated=true) —
+	//      scanFileCore was called with isResync=false so per-book indexing
+	//      was deferred. Index the book and all its relations now. Empty
+	//      snapshot is correct because the book had no relations before
+	//      this batch, so every loaded relation is "newly attached".
+	//   3. Book was updated via a FileID-mode event (resync) —
+	//      scanFileCore already ran with isResync=true and indexed
+	//      conditionally via its own snapshot. Skip to avoid a full
+	//      re-index that would undo the conditional savings.
 	if m.worker.searchService != nil {
 		logWarn := func(msg string, data logger.Data) {
 			m.log.Warn(msg, data)
@@ -665,14 +679,16 @@ func (m *Monitor) processPendingEvents() {
 		for bookID := range affectedBookIDs {
 			book, err := m.worker.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
 			if err != nil {
-				// Book was deleted — remove from index.
 				_ = m.worker.searchService.DeleteFromBookIndex(ctx, bookID)
+				continue
+			}
+			if _, newlyCreated := newlyCreatedBookIDs[bookID]; !newlyCreated {
 				continue
 			}
 			if err := m.worker.searchService.IndexBook(ctx, book); err != nil {
 				m.log.Warn("failed to index book", logger.Data{"book_id": bookID, "error": err.Error()})
 			}
-			m.worker.indexBookRelations(ctx, book, logWarn)
+			m.worker.indexBookRelations(ctx, book, bookRelationsSnapshot{}, logWarn)
 		}
 	}
 }

--- a/pkg/worker/monitor.go
+++ b/pkg/worker/monitor.go
@@ -651,8 +651,17 @@ func (m *Monitor) processPendingEvents() {
 		}
 	}
 
-	// Update search indexes for affected books only.
+	// Update search indexes for affected books and the entities they
+	// reference (series, authors, narrators, genres, tags). Without the
+	// per-relation indexing, an entity created by a FilePath-mode scan
+	// during this batch (which uses isResync=false and skips per-book
+	// indexing) has a row in its primary table but no FTS row, leaving it
+	// invisible to the search-driven dropdowns until a full library scan
+	// triggers RebuildAllIndexes. See indexBookRelations for details.
 	if m.worker.searchService != nil {
+		logWarn := func(msg string, data logger.Data) {
+			m.log.Warn(msg, data)
+		}
 		for bookID := range affectedBookIDs {
 			book, err := m.worker.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
 			if err != nil {
@@ -663,6 +672,7 @@ func (m *Monitor) processPendingEvents() {
 			if err := m.worker.searchService.IndexBook(ctx, book); err != nil {
 				m.log.Warn("failed to index book", logger.Data{"book_id": bookID, "error": err.Error()})
 			}
+			m.worker.indexBookRelations(ctx, book, logWarn)
 		}
 	}
 }

--- a/pkg/worker/monitor_move_test.go
+++ b/pkg/worker/monitor_move_test.go
@@ -152,6 +152,54 @@ func TestMonitor_CreateOnlyBatch_NoSyncHashing(t *testing.T) {
 	assert.Len(t, pending, 1, "expected one pending hash generation job after create-only batch")
 }
 
+// TestMonitor_ProcessPendingEvents_IndexesNewRelations is a regression test
+// for the bug where a batch processed by the filesystem monitor created
+// series/persons rows from extracted file metadata but left their FTS
+// tables empty. The monitor's post-batch IndexBook loop only updated
+// books_fts; a full ProcessScanJob (which would have run RebuildAllIndexes)
+// is not triggered by monitor events, so the new entities stayed invisible
+// to series/people search dropdowns. The fix re-indexes each affected
+// book's loaded relations alongside IndexBook.
+func TestMonitor_ProcessPendingEvents_IndexesNewRelations(t *testing.T) {
+	t.Parallel()
+
+	tc := newTestContext(t)
+	libDir := t.TempDir()
+	tc.createLibrary([]string{libDir})
+
+	bookDir := testgen.CreateSubDir(t, libDir, "Author - Book")
+	epubPath := testgen.GenerateEPUB(t, bookDir, "book.epub", testgen.EPUBOptions{
+		Title:   "Monitored Book",
+		Authors: []string{"Monitored Author"},
+		Series:  "Monitored Series",
+	})
+
+	m, libID := newTestMonitorWithWorker(tc, libDir)
+
+	injectMonitorEvent(m, epubPath, fsnotify.Create, libID, false)
+	m.processPendingEvents()
+
+	require.Len(t, tc.listFiles(), 1, "monitor should have created a file row")
+
+	type ftsCheck struct {
+		table string
+		match string
+	}
+	for _, c := range []ftsCheck{
+		{"series_fts", "Monitored Series"},
+		{"persons_fts", "Monitored Author"},
+	} {
+		var count int
+		err := tc.db.NewSelect().
+			TableExpr(c.table).
+			ColumnExpr("COUNT(*)").
+			Where("name = ?", c.match).
+			Scan(tc.ctx, &count)
+		require.NoError(t, err, "query %s for %q", c.table, c.match)
+		assert.Equal(t, 1, count, "%s must contain a row for %q after monitor batch, otherwise the entity is invisible to search-driven dropdowns", c.table, c.match)
+	}
+}
+
 // TestMonitor_PathStillExists_TreatAsCopy verifies that when a batch contains
 // a REMOVE and CREATE for different paths but both paths still exist on disk
 // (i.e. the "old" path was not actually removed — it's a copy), the monitor

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -816,7 +816,12 @@ func (w *Worker) scanFileCore(
 	// skip churn for entities whose attachment to this book didn't change.
 	// Holds Series pointers (not just IDs) so detached series can be
 	// re-indexed for aggregate freshness without an extra DB round-trip.
-	oldRels := snapshotBookRelations(book, file)
+	// Skipped for non-resync scans (full ProcessScanJob), where the
+	// snapshot is never consumed — RebuildAllIndexes runs at the end.
+	var oldRels bookRelationsSnapshot
+	if isResync {
+		oldRels = snapshotBookRelations(book, file)
+	}
 
 	sidecarSource := models.DataSourceSidecar
 
@@ -2246,7 +2251,13 @@ func (w *Worker) scanFileCore(
 		if err := w.searchService.IndexBook(ctx, book); err != nil {
 			logWarn("failed to update search index", logger.Data{"book_id": book.ID, "error": err.Error()})
 		}
-		w.indexBookRelations(ctx, book, oldRels, logWarn)
+		// bookTitleChanged / authorsChanged feed into the helper's
+		// series-aggregate-staleness check: when either changed, the
+		// still-attached series must be re-indexed so series_fts.book_titles
+		// / book_authors reflect the new values.
+		w.indexBookRelations(ctx, book, oldRels, indexRelationsHints{
+			bookTitleOrAuthorsChanged: bookTitleChanged || authorsChanged,
+		}, logWarn)
 	}
 
 	// ==========================================================================
@@ -4217,6 +4228,19 @@ func snapshotBookRelations(book *models.Book, file *models.File) bookRelationsSn
 	return snap
 }
 
+// indexRelationsHints carries signals from the surrounding scan/apply about
+// which book-level fields changed, so indexBookRelations can refresh
+// derived FTS columns even when the relation membership itself didn't
+// change. Currently the only consumer is series_fts, which aggregates
+// book.title and author names into its book_titles / book_authors columns.
+type indexRelationsHints struct {
+	// bookTitleOrAuthorsChanged should be set when book.title or any
+	// author on this book changed during the surrounding scan/apply.
+	// When true, attached series get re-indexed even if their membership
+	// didn't change, so series_fts aggregates stay fresh.
+	bookTitleOrAuthorsChanged bool
+}
+
 // indexBookRelations refreshes the FTS rows for entities whose attachment
 // to book changed during the surrounding scan/apply, given the pre-mutation
 // snapshot. It is required by any flow that may create or re-attach those
@@ -4230,6 +4254,9 @@ func snapshotBookRelations(book *models.Book, file *models.File) bookRelationsSn
 //     existing series attached to this book for the first time).
 //   - Series detached from this book — series_fts has aggregate columns
 //     (book_titles, book_authors) that must stop listing this book.
+//   - Series whose membership didn't change but whose aggregate columns
+//     went stale because book.title / authors changed during this scan
+//     (signaled via hints.bookTitleOrAuthorsChanged).
 //   - Persons / genres / tags newly attached to this book — those tables
 //     have no aggregate columns, so unchanged or detached entities skip
 //     the DELETE+INSERT churn against persons_fts / genres_fts / tags_fts.
@@ -4237,19 +4264,30 @@ func snapshotBookRelations(book *models.Book, file *models.File) bookRelationsSn
 // Caller must pass book loaded with Authors.Person, BookSeries.Series,
 // BookGenres.Genre, BookTags.Tag, and Files.Narrators.Person — i.e. the
 // shape returned by books.Service.RetrieveBook.
-func (w *Worker) indexBookRelations(ctx context.Context, book *models.Book, oldRels bookRelationsSnapshot, logWarn func(msg string, data logger.Data)) {
+//
+// oldRels.seriesByID holds the *models.Series pointers captured before
+// the mutation; IndexSeries reads the entity's Name/Description/LibraryID
+// off those pointers, so callers must not mutate Series fields between
+// snapshotting and re-indexing. nil maps in oldRels are safe — Go map
+// reads on a nil map return the zero value, so an empty
+// bookRelationsSnapshot{} is treated as "nothing was previously attached"
+// and every loaded relation looks newly-attached.
+func (w *Worker) indexBookRelations(ctx context.Context, book *models.Book, oldRels bookRelationsSnapshot, hints indexRelationsHints, logWarn func(msg string, data logger.Data)) {
 	if w.searchService == nil || book == nil {
 		return
 	}
 	// Series: re-index newly-attached, plus detached old ones for
-	// aggregate-column freshness.
+	// aggregate-column freshness, plus still-attached ones whose
+	// aggregate columns may have been invalidated by book.title /
+	// authors changes during this scan.
 	newSeriesIDs := map[int]bool{}
 	for _, bs := range book.BookSeries {
 		if bs.Series == nil || newSeriesIDs[bs.Series.ID] {
 			continue
 		}
 		newSeriesIDs[bs.Series.ID] = true
-		if _, alreadyAttached := oldRels.seriesByID[bs.Series.ID]; alreadyAttached {
+		_, alreadyAttached := oldRels.seriesByID[bs.Series.ID]
+		if alreadyAttached && !hints.bookTitleOrAuthorsChanged {
 			continue
 		}
 		if err := w.searchService.IndexSeries(ctx, bs.Series); err != nil {

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -4176,6 +4176,9 @@ func (w *Worker) indexBookRelations(ctx context.Context, book *models.Book, logW
 			logWarn("failed to update search index for series", logger.Data{"series_id": bs.Series.ID, "error": err.Error()})
 		}
 	}
+	// seenPersons spans both authors and narrators — the same person may
+	// appear in both relations on a single book and only needs one
+	// IndexPerson call.
 	seenPersons := map[int]bool{}
 	for _, a := range book.Authors {
 		if a.Person == nil || seenPersons[a.Person.ID] {

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -812,6 +812,12 @@ func (w *Worker) scanFileCore(
 		return &ScanResult{File: file, Book: book}, nil
 	}
 
+	// Capture pre-update relation IDs so the post-update FTS reindex can
+	// skip churn for entities whose attachment to this book didn't change.
+	// Holds Series pointers (not just IDs) so detached series can be
+	// re-indexed for aggregate freshness without an extra DB round-trip.
+	oldRels := snapshotBookRelations(book, file)
+
 	sidecarSource := models.DataSourceSidecar
 
 	// Read sidecar files if they exist (higher priority than file metadata)
@@ -2240,7 +2246,7 @@ func (w *Worker) scanFileCore(
 		if err := w.searchService.IndexBook(ctx, book); err != nil {
 			logWarn("failed to update search index", logger.Data{"book_id": book.ID, "error": err.Error()})
 		}
-		w.indexBookRelations(ctx, book, logWarn)
+		w.indexBookRelations(ctx, book, oldRels, logWarn)
 	}
 
 	// ==========================================================================
@@ -4146,45 +4152,131 @@ func (w *Worker) getConfidenceThresholdFromCache(pluginThreshold *float64) float
 	return 0.85
 }
 
-// indexBookRelations refreshes the FTS rows for every entity attached to
-// book — series, authors, narrators, genres, tags. It is required by any
-// flow that may create or re-attach those entities outside of a full
-// ProcessScanJob (which rebuilds all FTS tables at the end). Without this,
-// a row exists in the primary table but the corresponding *_fts table has
-// no entry, so the entity is invisible to the FTS-backed list/search
-// endpoints that drive the dropdowns in the UI.
+// bookRelationsSnapshot captures the entity IDs already attached to a book
+// before a scan/apply mutates them, so indexBookRelations can skip churn for
+// entities whose attachment to this book did not change.
 //
-// Safe to call on existing entities: each Index* method deletes the
-// existing FTS row before reinserting, which also refreshes derived fields
-// like series_fts.book_titles / book_authors so they reflect the
-// just-attached book.
+// seriesByID holds the *models.Series pointers (not just IDs) so a series
+// that gets detached can be re-indexed for aggregate freshness without an
+// extra DB round-trip.
+type bookRelationsSnapshot struct {
+	seriesByID        map[int]*models.Series
+	authorPersonIDs   map[int]struct{}
+	narratorPersonIDs map[int]struct{}
+	genreIDs          map[int]struct{}
+	tagIDs            map[int]struct{}
+}
+
+// snapshotBookRelations captures which series, persons (as authors and
+// narrators), genres, and tags are attached to book + file BEFORE any
+// pending mutation. Pass the result to indexBookRelations after the
+// mutation completes so it can compute the symmetric difference and skip
+// re-indexing entities whose attachment didn't change.
 //
-// Caller must pass a book loaded with Authors.Person, BookSeries.Series,
+// Caller must pass models loaded with Authors.Person, BookSeries.Series,
+// BookGenres.Genre, BookTags.Tag, and (for file) Narrators.Person — i.e.
+// the shape returned by books.Service.RetrieveBook.
+func snapshotBookRelations(book *models.Book, file *models.File) bookRelationsSnapshot {
+	snap := bookRelationsSnapshot{
+		seriesByID:        map[int]*models.Series{},
+		authorPersonIDs:   map[int]struct{}{},
+		narratorPersonIDs: map[int]struct{}{},
+		genreIDs:          map[int]struct{}{},
+		tagIDs:            map[int]struct{}{},
+	}
+	if book == nil {
+		return snap
+	}
+	for _, bs := range book.BookSeries {
+		if bs.Series != nil {
+			snap.seriesByID[bs.Series.ID] = bs.Series
+		}
+	}
+	for _, a := range book.Authors {
+		if a.Person != nil {
+			snap.authorPersonIDs[a.Person.ID] = struct{}{}
+		}
+	}
+	for _, bg := range book.BookGenres {
+		if bg.Genre != nil {
+			snap.genreIDs[bg.Genre.ID] = struct{}{}
+		}
+	}
+	for _, bt := range book.BookTags {
+		if bt.Tag != nil {
+			snap.tagIDs[bt.Tag.ID] = struct{}{}
+		}
+	}
+	if file != nil {
+		for _, n := range file.Narrators {
+			if n.Person != nil {
+				snap.narratorPersonIDs[n.Person.ID] = struct{}{}
+			}
+		}
+	}
+	return snap
+}
+
+// indexBookRelations refreshes the FTS rows for entities whose attachment
+// to book changed during the surrounding scan/apply, given the pre-mutation
+// snapshot. It is required by any flow that may create or re-attach those
+// entities outside of a full ProcessScanJob (which rebuilds all FTS tables
+// at the end). Without this, a row exists in the primary table but the
+// corresponding *_fts table has no entry, so the entity is invisible to
+// the FTS-backed list/search endpoints that drive the dropdowns in the UI.
+//
+// What gets re-indexed:
+//   - Series newly attached to this book (covers newly-created series and
+//     existing series attached to this book for the first time).
+//   - Series detached from this book — series_fts has aggregate columns
+//     (book_titles, book_authors) that must stop listing this book.
+//   - Persons / genres / tags newly attached to this book — those tables
+//     have no aggregate columns, so unchanged or detached entities skip
+//     the DELETE+INSERT churn against persons_fts / genres_fts / tags_fts.
+//
+// Caller must pass book loaded with Authors.Person, BookSeries.Series,
 // BookGenres.Genre, BookTags.Tag, and Files.Narrators.Person — i.e. the
 // shape returned by books.Service.RetrieveBook.
-func (w *Worker) indexBookRelations(ctx context.Context, book *models.Book, logWarn func(msg string, data logger.Data)) {
+func (w *Worker) indexBookRelations(ctx context.Context, book *models.Book, oldRels bookRelationsSnapshot, logWarn func(msg string, data logger.Data)) {
 	if w.searchService == nil || book == nil {
 		return
 	}
-	seenSeries := map[int]bool{}
+	// Series: re-index newly-attached, plus detached old ones for
+	// aggregate-column freshness.
+	newSeriesIDs := map[int]bool{}
 	for _, bs := range book.BookSeries {
-		if bs.Series == nil || seenSeries[bs.Series.ID] {
+		if bs.Series == nil || newSeriesIDs[bs.Series.ID] {
 			continue
 		}
-		seenSeries[bs.Series.ID] = true
+		newSeriesIDs[bs.Series.ID] = true
+		if _, alreadyAttached := oldRels.seriesByID[bs.Series.ID]; alreadyAttached {
+			continue
+		}
 		if err := w.searchService.IndexSeries(ctx, bs.Series); err != nil {
 			logWarn("failed to update search index for series", logger.Data{"series_id": bs.Series.ID, "error": err.Error()})
 		}
 	}
-	// seenPersons spans both authors and narrators — the same person may
-	// appear in both relations on a single book and only needs one
-	// IndexPerson call.
+	for oldID, oldSer := range oldRels.seriesByID {
+		if newSeriesIDs[oldID] {
+			continue
+		}
+		if err := w.searchService.IndexSeries(ctx, oldSer); err != nil {
+			logWarn("failed to update search index for detached series", logger.Data{"series_id": oldID, "error": err.Error()})
+		}
+	}
+
+	// Persons (authors + narrators): re-index only newly-attached.
+	// seenPersons spans both relations because a person may appear in both
+	// on a single book and only needs one IndexPerson call.
 	seenPersons := map[int]bool{}
 	for _, a := range book.Authors {
 		if a.Person == nil || seenPersons[a.Person.ID] {
 			continue
 		}
 		seenPersons[a.Person.ID] = true
+		if _, wasAuthor := oldRels.authorPersonIDs[a.Person.ID]; wasAuthor {
+			continue
+		}
 		if err := w.searchService.IndexPerson(ctx, a.Person); err != nil {
 			logWarn("failed to update search index for author", logger.Data{"person_id": a.Person.ID, "error": err.Error()})
 		}
@@ -4195,17 +4287,25 @@ func (w *Worker) indexBookRelations(ctx context.Context, book *models.Book, logW
 				continue
 			}
 			seenPersons[n.Person.ID] = true
+			if _, wasNarrator := oldRels.narratorPersonIDs[n.Person.ID]; wasNarrator {
+				continue
+			}
 			if err := w.searchService.IndexPerson(ctx, n.Person); err != nil {
 				logWarn("failed to update search index for narrator", logger.Data{"person_id": n.Person.ID, "error": err.Error()})
 			}
 		}
 	}
+
+	// Genres / tags: re-index only newly-attached.
 	seenGenres := map[int]bool{}
 	for _, bg := range book.BookGenres {
 		if bg.Genre == nil || seenGenres[bg.Genre.ID] {
 			continue
 		}
 		seenGenres[bg.Genre.ID] = true
+		if _, alreadyAttached := oldRels.genreIDs[bg.Genre.ID]; alreadyAttached {
+			continue
+		}
 		if err := w.searchService.IndexGenre(ctx, bg.Genre); err != nil {
 			logWarn("failed to update search index for genre", logger.Data{"genre_id": bg.Genre.ID, "error": err.Error()})
 		}
@@ -4216,6 +4316,9 @@ func (w *Worker) indexBookRelations(ctx context.Context, book *models.Book, logW
 			continue
 		}
 		seenTags[bt.Tag.ID] = true
+		if _, alreadyAttached := oldRels.tagIDs[bt.Tag.ID]; alreadyAttached {
+			continue
+		}
 		if err := w.searchService.IndexTag(ctx, bt.Tag); err != nil {
 			logWarn("failed to update search index for tag", logger.Data{"tag_id": bt.Tag.ID, "error": err.Error()})
 		}

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2227,10 +2227,20 @@ func (w *Worker) scanFileCore(
 	// Only update search index for individual resyncs. For full library scans,
 	// RebuildAllIndexes is called at the end of ProcessScanJob, making individual
 	// IndexBook calls redundant and wasteful.
+	//
+	// Series/persons/genres/tags created via FindOrCreate* during this resync
+	// must also be indexed: their FTS tables (series_fts, persons_fts, etc.)
+	// have no triggers, so a row exists in the primary table but is invisible
+	// to the FTS-backed list/search endpoints until something explicitly
+	// indexes it. Existing rows get re-indexed too — Index* methods are
+	// idempotent (delete + reinsert), and that also refreshes
+	// series_fts.book_titles / book_authors so they reflect the just-attached
+	// book.
 	if isResync && w.searchService != nil {
 		if err := w.searchService.IndexBook(ctx, book); err != nil {
 			logWarn("failed to update search index", logger.Data{"book_id": book.ID, "error": err.Error()})
 		}
+		w.indexBookRelations(ctx, book, logWarn)
 	}
 
 	// ==========================================================================
@@ -4134,4 +4144,77 @@ func (w *Worker) getConfidenceThresholdFromCache(pluginThreshold *float64) float
 		return w.config.EnrichmentConfidenceThreshold
 	}
 	return 0.85
+}
+
+// indexBookRelations refreshes the FTS rows for every entity attached to
+// book — series, authors, narrators, genres, tags. It is required by any
+// flow that may create or re-attach those entities outside of a full
+// ProcessScanJob (which rebuilds all FTS tables at the end). Without this,
+// a row exists in the primary table but the corresponding *_fts table has
+// no entry, so the entity is invisible to the FTS-backed list/search
+// endpoints that drive the dropdowns in the UI.
+//
+// Safe to call on existing entities: each Index* method deletes the
+// existing FTS row before reinserting, which also refreshes derived fields
+// like series_fts.book_titles / book_authors so they reflect the
+// just-attached book.
+//
+// Caller must pass a book loaded with Authors.Person, BookSeries.Series,
+// BookGenres.Genre, BookTags.Tag, and Files.Narrators.Person — i.e. the
+// shape returned by books.Service.RetrieveBook.
+func (w *Worker) indexBookRelations(ctx context.Context, book *models.Book, logWarn func(msg string, data logger.Data)) {
+	if w.searchService == nil || book == nil {
+		return
+	}
+	seenSeries := map[int]bool{}
+	for _, bs := range book.BookSeries {
+		if bs.Series == nil || seenSeries[bs.Series.ID] {
+			continue
+		}
+		seenSeries[bs.Series.ID] = true
+		if err := w.searchService.IndexSeries(ctx, bs.Series); err != nil {
+			logWarn("failed to update search index for series", logger.Data{"series_id": bs.Series.ID, "error": err.Error()})
+		}
+	}
+	seenPersons := map[int]bool{}
+	for _, a := range book.Authors {
+		if a.Person == nil || seenPersons[a.Person.ID] {
+			continue
+		}
+		seenPersons[a.Person.ID] = true
+		if err := w.searchService.IndexPerson(ctx, a.Person); err != nil {
+			logWarn("failed to update search index for author", logger.Data{"person_id": a.Person.ID, "error": err.Error()})
+		}
+	}
+	for _, f := range book.Files {
+		for _, n := range f.Narrators {
+			if n.Person == nil || seenPersons[n.Person.ID] {
+				continue
+			}
+			seenPersons[n.Person.ID] = true
+			if err := w.searchService.IndexPerson(ctx, n.Person); err != nil {
+				logWarn("failed to update search index for narrator", logger.Data{"person_id": n.Person.ID, "error": err.Error()})
+			}
+		}
+	}
+	seenGenres := map[int]bool{}
+	for _, bg := range book.BookGenres {
+		if bg.Genre == nil || seenGenres[bg.Genre.ID] {
+			continue
+		}
+		seenGenres[bg.Genre.ID] = true
+		if err := w.searchService.IndexGenre(ctx, bg.Genre); err != nil {
+			logWarn("failed to update search index for genre", logger.Data{"genre_id": bg.Genre.ID, "error": err.Error()})
+		}
+	}
+	seenTags := map[int]bool{}
+	for _, bt := range book.BookTags {
+		if bt.Tag == nil || seenTags[bt.Tag.ID] {
+			continue
+		}
+		seenTags[bt.Tag.ID] = true
+		if err := w.searchService.IndexTag(ctx, bt.Tag); err != nil {
+			logWarn("failed to update search index for tag", logger.Data{"tag_id": bt.Tag.ID, "error": err.Error()})
+		}
+	}
 }

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -1782,6 +1782,144 @@ func TestScanFileCore_Resync_IndexesNewRelations(t *testing.T) {
 	}
 }
 
+// TestScanFileCore_Resync_SkipsSeriesIndexWhenAttachmentUnchanged verifies
+// that a resync which leaves the same series attached and doesn't change
+// book.title or authors does NOT trigger an IndexSeries call. The check
+// uses an in-place UPDATE of series_fts.book_titles to a sentinel string;
+// if scanFileCore had re-indexed the series, IndexSeries would have
+// rewritten book_titles to the actual book title and clobbered the
+// sentinel.
+func TestScanFileCore_Resync_SkipsSeriesIndexWhenAttachmentUnchanged(t *testing.T) {
+	t.Parallel()
+	tc := newTestContextWithSearchService(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	book := &models.Book{
+		LibraryID:    1,
+		Filepath:     libraryPath,
+		Title:        "Stable Book",
+		TitleSource:  models.DataSourceFilepath,
+		SortTitle:    "Stable Book",
+		AuthorSource: models.DataSourceFilepath,
+	}
+	require.NoError(t, tc.bookService.CreateBook(tc.ctx, book))
+
+	stableSeries, err := tc.seriesService.FindOrCreateSeries(tc.ctx, "Stable Series", 1, models.DataSourceFilepath)
+	require.NoError(t, err)
+	num := 1.0
+	require.NoError(t, tc.bookService.CreateBookSeries(tc.ctx, &models.BookSeries{
+		BookID:       book.ID,
+		SeriesID:     stableSeries.ID,
+		SeriesNumber: &num,
+		SortOrder:    1,
+	}))
+	require.NoError(t, tc.worker.searchService.IndexSeries(tc.ctx, stableSeries))
+
+	book, err = tc.bookService.RetrieveBook(tc.ctx, books.RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     1,
+		BookID:        book.ID,
+		Filepath:      filepath.Join(libraryPath, "test.epub"),
+		FileType:      models.FileTypeEPUB,
+		FilesizeBytes: 1000,
+	}
+	require.NoError(t, tc.bookService.CreateFile(tc.ctx, file))
+
+	// Stamp a sentinel into series_fts.book_titles. If IndexSeries fires
+	// during the resync, it will overwrite this value via DELETE+INSERT.
+	const sentinel = "__churn_sentinel__"
+	_, err = tc.db.NewRaw("UPDATE series_fts SET book_titles = ? WHERE series_id = ?", sentinel, stableSeries.ID).Exec(tc.ctx)
+	require.NoError(t, err)
+
+	// Resync with metadata that does not change the book's title, authors,
+	// or series — same series, same priority source.
+	metadata := &mediafile.ParsedMetadata{
+		Series:     "Stable Series",
+		DataSource: models.DataSourceFilepath,
+	}
+	_, err = tc.worker.scanFileCore(tc.ctx, file, book, metadata, false, true, nil, nil)
+	require.NoError(t, err)
+
+	var postBookTitles string
+	require.NoError(t, tc.db.NewRaw("SELECT book_titles FROM series_fts WHERE series_id = ?", stableSeries.ID).
+		Scan(tc.ctx, &postBookTitles))
+	assert.Equal(t, sentinel, postBookTitles, "series whose attachment did not change AND whose aggregate inputs did not change must NOT be re-indexed (avoids series_fts churn)")
+}
+
+// TestScanFileCore_Resync_ReindexesDetachedOldSeries verifies that when a
+// resync moves a book from one series to another, the now-detached old
+// series gets its series_fts row refreshed. Without this, the old series'
+// book_titles / book_authors aggregate columns would continue to list
+// this book until the next full library scan triggered RebuildAllIndexes.
+func TestScanFileCore_Resync_ReindexesDetachedOldSeries(t *testing.T) {
+	t.Parallel()
+	tc := newTestContextWithSearchService(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	book := &models.Book{
+		LibraryID:    1,
+		Filepath:     libraryPath,
+		Title:        "Detach Test Book",
+		TitleSource:  models.DataSourceFilepath,
+		SortTitle:    "Detach Test Book",
+		AuthorSource: models.DataSourceFilepath,
+	}
+	require.NoError(t, tc.bookService.CreateBook(tc.ctx, book))
+
+	oldSeries, err := tc.seriesService.FindOrCreateSeries(tc.ctx, "Old Series", 1, models.DataSourceFilepath)
+	require.NoError(t, err)
+	oldNumber := 1.0
+	require.NoError(t, tc.bookService.CreateBookSeries(tc.ctx, &models.BookSeries{
+		BookID:       book.ID,
+		SeriesID:     oldSeries.ID,
+		SeriesNumber: &oldNumber,
+		SortOrder:    1,
+	}))
+	// Seed series_fts so we can detect the post-resync refresh.
+	require.NoError(t, tc.worker.searchService.IndexSeries(tc.ctx, oldSeries))
+
+	// Reload book with the series relation populated, matching the shape
+	// scanFileCore expects.
+	book, err = tc.bookService.RetrieveBook(tc.ctx, books.RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     1,
+		BookID:        book.ID,
+		Filepath:      filepath.Join(libraryPath, "test.epub"),
+		FileType:      models.FileTypeEPUB,
+		FilesizeBytes: 1000,
+	}
+	require.NoError(t, tc.bookService.CreateFile(tc.ctx, file))
+
+	// Verify the seeded FTS row aggregates this book's title before resync.
+	var preBookTitles string
+	require.NoError(t, tc.db.NewRaw("SELECT book_titles FROM series_fts WHERE series_id = ?", oldSeries.ID).
+		Scan(tc.ctx, &preBookTitles))
+	require.Contains(t, preBookTitles, "Detach Test Book", "seeded series_fts must include this book's title before resync")
+
+	// Resync with metadata pointing at a different series.
+	metadata := &mediafile.ParsedMetadata{
+		Series:     "New Series",
+		DataSource: models.DataSourceEPUBMetadata,
+	}
+	_, err = tc.worker.scanFileCore(tc.ctx, file, book, metadata, false, true, nil, nil)
+	require.NoError(t, err)
+
+	// Old series' aggregate must no longer mention this book — the helper
+	// re-indexed it after the detach.
+	var postBookTitles string
+	require.NoError(t, tc.db.NewRaw("SELECT book_titles FROM series_fts WHERE series_id = ?", oldSeries.ID).
+		Scan(tc.ctx, &postBookTitles))
+	assert.NotContains(t, postBookTitles, "Detach Test Book", "detached old series' series_fts.book_titles must be refreshed to drop the moved book")
+}
+
 // =============================================================================
 // scanFileByID integration tests
 // =============================================================================

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -1710,6 +1710,78 @@ func TestScanFileCore_UpdatesSearchIndex(t *testing.T) {
 	assert.Equal(t, 1, count, "book should be indexed with new title in FTS table")
 }
 
+// TestScanFileCore_Resync_IndexesNewRelations is a regression test for the
+// bug where a per-file resync (isResync=true) created series/persons/genres/
+// tags rows from extracted metadata but left their FTS tables empty, so the
+// new entities were invisible in search-driven dropdowns until the next full
+// library scan triggered RebuildAllIndexes. The fix re-indexes the book's
+// loaded relations alongside the existing IndexBook call.
+func TestScanFileCore_Resync_IndexesNewRelations(t *testing.T) {
+	t.Parallel()
+	tc := newTestContextWithSearchService(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	book := &models.Book{
+		LibraryID:    1,
+		Filepath:     libraryPath,
+		Title:        "Test Book",
+		TitleSource:  models.DataSourceFilepath,
+		SortTitle:    "Test Book",
+		AuthorSource: models.DataSourceFilepath,
+	}
+	require.NoError(t, tc.bookService.CreateBook(tc.ctx, book))
+
+	file := &models.File{
+		LibraryID:     1,
+		BookID:        book.ID,
+		Filepath:      filepath.Join(libraryPath, "test.epub"),
+		FileType:      models.FileTypeEPUB,
+		FilesizeBytes: 1000,
+	}
+	require.NoError(t, tc.bookService.CreateFile(tc.ctx, file))
+
+	metadata := &mediafile.ParsedMetadata{
+		Authors:    []mediafile.ParsedAuthor{{Name: "Resync Author", Role: "writer"}},
+		Narrators:  []string{"Resync Narrator"},
+		Series:     "Resync Series",
+		Genres:     []string{"Resync Genre"},
+		Tags:       []string{"Resync Tag"},
+		DataSource: models.DataSourceEPUBMetadata,
+	}
+
+	// isResync=true mirrors POST /files/:id/resync and the monitor's per-file
+	// scanInternal(FileID) flow.
+	_, err := tc.worker.scanFileCore(tc.ctx, file, book, metadata, false, true, nil, nil)
+	require.NoError(t, err)
+
+	// Each entity must have an FTS row matching its name. Without the fix the
+	// rows exist in their primary tables but not in *_fts, so the dropdowns
+	// driven by the FTS-backed list endpoints can't surface them.
+	type ftsCheck struct {
+		table  string
+		column string
+		match  string
+	}
+	for _, c := range []ftsCheck{
+		{"series_fts", "name", "Resync Series"},
+		{"persons_fts", "name", "Resync Author"},
+		{"persons_fts", "name", "Resync Narrator"},
+		{"genres_fts", "name", "Resync Genre"},
+		{"tags_fts", "name", "Resync Tag"},
+	} {
+		var count int
+		err := tc.db.NewSelect().
+			TableExpr(c.table).
+			ColumnExpr("COUNT(*)").
+			Where(c.column+" = ?", c.match).
+			Scan(tc.ctx, &count)
+		require.NoError(t, err, "query %s for %q", c.table, c.match)
+		assert.Equal(t, 1, count, "%s must contain a row for %q after resync, otherwise the entity is invisible to search-driven dropdowns", c.table, c.match)
+	}
+}
+
 // =============================================================================
 // scanFileByID integration tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- Series, persons, genres, and tags created via `FindOrCreate*` during the identify-apply flow, file/book resync, or filesystem-monitor batches received DB rows but no FTS rows. The FTS-backed list endpoints (`series_fts`, `persons_fts`, `genres_fts`, `tags_fts`) had no entries for them, so they were invisible to the search dropdowns (e.g. `Create "Series"` in the IdentifyReviewForm combobox produced a series that couldn't be found again until the next full library scan ran `RebuildAllIndexes`).
- Plugin apply path (`pkg/plugins/handler_persist_metadata.go`): added `Index*` calls after each `FindOrCreate*` + relation create. Series is indexed after `CreateBookSeries` so `series_fts.book_titles`/`book_authors` reflect the just-attached book.
- Worker resync path (`pkg/worker/scan_unified.go`) and filesystem monitor (`pkg/worker/monitor.go`): added a shared `indexBookRelations` helper that walks a book's loaded relations (`Authors.Person`, `BookSeries.Series`, `BookGenres.Genre`, `BookTags.Tag`, `Files.Narrators.Person`) and refreshes their FTS rows. Idempotent — safe on existing entities, also fixes stale `series_fts` aggregations after a book moves between series.
- Full library scan path was already correct via `RebuildAllIndexes` at the end of `ProcessScanJob`; not touched.

## Test plan
- `mise lint` (clean)
- `go test ./pkg/worker/ ./pkg/plugins/` (full suites pass, ~36s)
- New regression tests, all RED→GREEN: `TestPersistMetadata_IndexesNewSeries`, `TestPersistMetadata_IndexesNewAuthorsNarratorsGenresTags`, `TestScanFileCore_Resync_IndexesNewRelations`, `TestMonitor_ProcessPendingEvents_IndexesNewRelations`
- Manual: in the IdentifyReviewForm series combobox, create a new series via `Create "Foo"`, apply, then reopen the dialog and search for `Foo` — it should now appear in the dropdown