### PR TITLE
[Frontend] Convert filter sheet genre/tags to combobox with shared chip

### DIFF
--- a/app/components/library/ActiveFilterChips.tsx
+++ b/app/components/library/ActiveFilterChips.tsx
@@ -1,41 +1,7 @@
-import { Bookmark, Eye, File, Languages, Tags, X } from "lucide-react";
-import type { ReactNode } from "react";
-
-import { Badge } from "@/components/ui/badge";
+import { FilterChip } from "@/components/library/FilterChip";
 import { FILE_TYPE_OPTIONS } from "@/constants/fileTypes";
 import { getLanguageName } from "@/constants/languages";
 import type { Genre, Tag } from "@/types";
-
-interface FilterTypeConfig {
-  icon: ReactNode;
-  colorClass: string;
-}
-
-const FILTER_TYPES: Record<
-  "fileType" | "genre" | "tag" | "language" | "reviewState",
-  FilterTypeConfig
-> = {
-  fileType: {
-    icon: <File className="h-3 w-3 shrink-0" />,
-    colorClass: "text-chart-5",
-  },
-  genre: {
-    icon: <Bookmark className="h-3 w-3 shrink-0" />,
-    colorClass: "text-primary",
-  },
-  tag: {
-    icon: <Tags className="h-3 w-3 shrink-0" />,
-    colorClass: "text-chart-2",
-  },
-  language: {
-    icon: <Languages className="h-3 w-3 shrink-0" />,
-    colorClass: "text-chart-5",
-  },
-  reviewState: {
-    icon: <Eye className="h-3 w-3 shrink-0" />,
-    colorClass: "text-chart-3",
-  },
-};
 
 const REVIEWED_FILTER_LABELS: Record<string, string> = {
   needs_review: "Needs review",
@@ -77,73 +43,45 @@ export const ActiveFilterChips = ({
     <div className="flex flex-wrap items-center gap-2">
       <span className="text-xs text-muted-foreground">Filtering by</span>
       {selectedFileTypes.map((fileType) => (
-        <Badge
-          className="cursor-pointer gap-1.5"
+        <FilterChip
           key={fileType}
-          onClick={() => onToggleFileType(fileType)}
-          variant="secondary"
-        >
-          <span className={FILTER_TYPES.fileType.colorClass}>
-            {FILTER_TYPES.fileType.icon}
-          </span>
-          {FILE_TYPE_OPTIONS.find((o) => o.value === fileType)?.label ??
-            fileType}
-          <X className="h-3 w-3 text-muted-foreground" />
-        </Badge>
+          kind="fileType"
+          label={
+            FILE_TYPE_OPTIONS.find((o) => o.value === fileType)?.label ??
+            fileType
+          }
+          onRemove={() => onToggleFileType(fileType)}
+        />
       ))}
       {selectedGenres.map((genre) => (
-        <Badge
-          className="cursor-pointer gap-1.5"
+        <FilterChip
           key={genre.id}
-          onClick={() => onToggleGenre(genre.id)}
-          variant="secondary"
-        >
-          <span className={FILTER_TYPES.genre.colorClass}>
-            {FILTER_TYPES.genre.icon}
-          </span>
-          {genre.name}
-          <X className="h-3 w-3 text-muted-foreground" />
-        </Badge>
+          kind="genre"
+          label={genre.name}
+          onRemove={() => onToggleGenre(genre.id)}
+        />
       ))}
       {selectedTags.map((tag) => (
-        <Badge
-          className="cursor-pointer gap-1.5"
+        <FilterChip
           key={tag.id}
-          onClick={() => onToggleTag(tag.id)}
-          variant="secondary"
-        >
-          <span className={FILTER_TYPES.tag.colorClass}>
-            {FILTER_TYPES.tag.icon}
-          </span>
-          {tag.name}
-          <X className="h-3 w-3 text-muted-foreground" />
-        </Badge>
+          kind="tag"
+          label={tag.name}
+          onRemove={() => onToggleTag(tag.id)}
+        />
       ))}
       {languageParam && (
-        <Badge
-          className="cursor-pointer gap-1.5"
-          onClick={onClearLanguage}
-          variant="secondary"
-        >
-          <span className={FILTER_TYPES.language.colorClass}>
-            {FILTER_TYPES.language.icon}
-          </span>
-          {getLanguageName(languageParam) ?? languageParam}
-          <X className="h-3 w-3 text-muted-foreground" />
-        </Badge>
+        <FilterChip
+          kind="language"
+          label={getLanguageName(languageParam) ?? languageParam}
+          onRemove={onClearLanguage}
+        />
       )}
       {reviewedFilter && reviewedFilter !== "all" && (
-        <Badge
-          className="cursor-pointer gap-1.5"
-          onClick={onClearReviewedFilter}
-          variant="secondary"
-        >
-          <span className={FILTER_TYPES.reviewState.colorClass}>
-            {FILTER_TYPES.reviewState.icon}
-          </span>
-          {REVIEWED_FILTER_LABELS[reviewedFilter] ?? reviewedFilter}
-          <X className="h-3 w-3 text-muted-foreground" />
-        </Badge>
+        <FilterChip
+          kind="reviewState"
+          label={REVIEWED_FILTER_LABELS[reviewedFilter] ?? reviewedFilter}
+          onRemove={onClearReviewedFilter}
+        />
       )}
       <button
         className="text-xs text-muted-foreground underline-offset-2 hover:underline hover:text-foreground ml-1 cursor-pointer"

--- a/app/components/library/FilterChip.tsx
+++ b/app/components/library/FilterChip.tsx
@@ -44,15 +44,17 @@ export const FilterChip = ({ kind, label, onRemove }: FilterChipProps) => {
   const { icon, color } = KIND_CONFIG[kind];
   return (
     <Badge
+      asChild
       className="cursor-pointer gap-1.5 max-w-full"
-      onClick={onRemove}
       variant="secondary"
     >
-      <span className={color}>{icon}</span>
-      <span className="truncate" title={label}>
-        {label}
-      </span>
-      <X className="h-3 w-3 text-muted-foreground shrink-0" />
+      <button aria-label={`Remove ${label}`} onClick={onRemove} type="button">
+        <span className={color}>{icon}</span>
+        <span className="truncate" title={label}>
+          {label}
+        </span>
+        <X className="h-3 w-3 text-muted-foreground shrink-0" />
+      </button>
     </Badge>
   );
 };

--- a/app/components/library/FilterChip.tsx
+++ b/app/components/library/FilterChip.tsx
@@ -1,0 +1,58 @@
+import { Bookmark, Eye, File, Languages, Tags, X } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+
+export type FilterChipKind =
+  | "fileType"
+  | "genre"
+  | "tag"
+  | "language"
+  | "reviewState";
+
+const KIND_CONFIG: Record<FilterChipKind, { icon: ReactNode; color: string }> =
+  {
+    fileType: {
+      icon: <File className="h-3 w-3 shrink-0" />,
+      color: "text-chart-5",
+    },
+    genre: {
+      icon: <Bookmark className="h-3 w-3 shrink-0" />,
+      color: "text-primary",
+    },
+    tag: {
+      icon: <Tags className="h-3 w-3 shrink-0" />,
+      color: "text-chart-2",
+    },
+    language: {
+      icon: <Languages className="h-3 w-3 shrink-0" />,
+      color: "text-chart-5",
+    },
+    reviewState: {
+      icon: <Eye className="h-3 w-3 shrink-0" />,
+      color: "text-chart-3",
+    },
+  };
+
+interface FilterChipProps {
+  kind: FilterChipKind;
+  label: string;
+  onRemove: () => void;
+}
+
+export const FilterChip = ({ kind, label, onRemove }: FilterChipProps) => {
+  const { icon, color } = KIND_CONFIG[kind];
+  return (
+    <Badge
+      className="cursor-pointer gap-1.5 max-w-full"
+      onClick={onRemove}
+      variant="secondary"
+    >
+      <span className={color}>{icon}</span>
+      <span className="truncate" title={label}>
+        {label}
+      </span>
+      <X className="h-3 w-3 text-muted-foreground shrink-0" />
+    </Badge>
+  );
+};

--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -1,5 +1,6 @@
 import {
   Bookmark,
+  ChevronsUpDown,
   Eye,
   File,
   Languages,
@@ -8,8 +9,12 @@ import {
   SquareCheckBig,
   Tags,
 } from "lucide-react";
-import { forwardRef } from "react";
+import { forwardRef, useState } from "react";
 
+import {
+  FilterChip,
+  type FilterChipKind,
+} from "@/components/library/FilterChip";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -30,6 +35,11 @@ import {
   DrawerTrigger,
 } from "@/components/ui/drawer";
 import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Select,
@@ -57,6 +67,7 @@ interface FilterSheetProps {
   fileTypeOptions: readonly { value: string; label: string }[];
   onToggleFileType: (fileType: string) => void;
   selectedGenreIds: number[];
+  selectedGenres: Genre[];
   genres: Genre[];
   genresLoading: boolean;
   genresError: boolean;
@@ -64,6 +75,7 @@ interface FilterSheetProps {
   onGenreSearchChange: (value: string) => void;
   onToggleGenre: (genreId: number) => void;
   selectedTagIds: number[];
+  selectedTags: Tag[];
   tags: Tag[];
   tagsLoading: boolean;
   tagsError: boolean;
@@ -108,11 +120,124 @@ const SectionHeader = ({
   </div>
 );
 
+interface FilterComboboxOption {
+  id: number;
+  name: string;
+  book_count: number;
+}
+
+const FilterCombobox = ({
+  chipKind,
+  selected,
+  options,
+  loading,
+  error,
+  errorText,
+  searchInput,
+  onSearchChange,
+  onToggle,
+  triggerLabel,
+  searchPlaceholder,
+  emptyText,
+}: {
+  chipKind: FilterChipKind;
+  selected: FilterComboboxOption[];
+  options: FilterComboboxOption[];
+  loading: boolean;
+  error: boolean;
+  errorText: string;
+  searchInput: string;
+  onSearchChange: (value: string) => void;
+  onToggle: (id: number) => void;
+  triggerLabel: string;
+  searchPlaceholder: string;
+  emptyText: string;
+}) => {
+  const [open, setOpen] = useState(false);
+  const selectedIds = new Set(selected.map((s) => s.id));
+
+  return (
+    <div className="space-y-2">
+      {selected.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selected.map((item) => (
+            <FilterChip
+              key={item.id}
+              kind={chipKind}
+              label={item.name}
+              onRemove={() => onToggle(item.id)}
+            />
+          ))}
+        </div>
+      )}
+      <Popover modal onOpenChange={setOpen} open={open}>
+        <PopoverTrigger asChild>
+          <Button
+            aria-expanded={open}
+            className="w-full justify-between font-normal text-muted-foreground"
+            role="combobox"
+            variant="outline"
+          >
+            {triggerLabel}
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-[var(--radix-popover-trigger-width)] p-0"
+        >
+          <Command shouldFilter={false}>
+            <CommandInput
+              onValueChange={onSearchChange}
+              placeholder={searchPlaceholder}
+              value={searchInput}
+            />
+            <CommandList>
+              {loading ? (
+                <div className="py-6 text-center text-sm text-muted-foreground">
+                  Loading...
+                </div>
+              ) : error ? (
+                <div className="py-6 text-center text-sm text-destructive">
+                  {errorText}
+                </div>
+              ) : options.length === 0 ? (
+                <CommandEmpty>{emptyText}</CommandEmpty>
+              ) : (
+                <CommandGroup>
+                  {options.map((opt) => (
+                    <CommandItem
+                      key={opt.id}
+                      onSelect={() => onToggle(opt.id)}
+                      value={opt.name}
+                    >
+                      {selectedIds.has(opt.id) ? (
+                        <SquareCheckBig className="mr-2 h-4 w-4" />
+                      ) : (
+                        <Square className="mr-2 h-4 w-4" />
+                      )}
+                      {opt.name}
+                      <span className="ml-auto text-xs text-muted-foreground">
+                        {opt.book_count}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              )}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+};
+
 const FilterContent = ({
   selectedFileTypes,
   fileTypeOptions,
   onToggleFileType,
   selectedGenreIds,
+  selectedGenres,
   genres,
   genresLoading,
   genresError,
@@ -120,6 +245,7 @@ const FilterContent = ({
   onGenreSearchChange,
   onToggleGenre,
   selectedTagIds,
+  selectedTags,
   tags,
   tagsLoading,
   tagsError,
@@ -178,46 +304,20 @@ const FilterContent = ({
         icon={<Bookmark className="h-3 w-3" />}
         label="Genres"
       />
-      <Command shouldFilter={false}>
-        <CommandInput
-          onValueChange={onGenreSearchChange}
-          placeholder="Search genres..."
-          value={genreSearchInput}
-        />
-        <CommandList>
-          {genresLoading ? (
-            <div className="py-6 text-center text-sm text-muted-foreground">
-              Loading...
-            </div>
-          ) : genresError ? (
-            <div className="py-6 text-center text-sm text-destructive">
-              Error loading genres
-            </div>
-          ) : genres.length === 0 ? (
-            <CommandEmpty>No genres found.</CommandEmpty>
-          ) : (
-            <CommandGroup>
-              {genres.map((genre: Genre) => (
-                <CommandItem
-                  key={genre.id}
-                  onSelect={() => onToggleGenre(genre.id)}
-                  value={genre.name}
-                >
-                  {selectedGenreIds.includes(genre.id) ? (
-                    <SquareCheckBig className="mr-2 h-4 w-4" />
-                  ) : (
-                    <Square className="mr-2 h-4 w-4" />
-                  )}
-                  {genre.name}
-                  <span className="ml-auto text-xs text-muted-foreground">
-                    {genre.book_count}
-                  </span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          )}
-        </CommandList>
-      </Command>
+      <FilterCombobox
+        chipKind="genre"
+        emptyText="No genres found."
+        error={genresError}
+        errorText="Error loading genres"
+        loading={genresLoading}
+        onSearchChange={onGenreSearchChange}
+        onToggle={onToggleGenre}
+        options={genres}
+        searchInput={genreSearchInput}
+        searchPlaceholder="Search genres..."
+        selected={selectedGenres}
+        triggerLabel="Add genres..."
+      />
     </div>
 
     {/* Tags */}
@@ -232,46 +332,20 @@ const FilterContent = ({
         icon={<Tags className="h-3 w-3" />}
         label="Tags"
       />
-      <Command shouldFilter={false}>
-        <CommandInput
-          onValueChange={onTagSearchChange}
-          placeholder="Search tags..."
-          value={tagSearchInput}
-        />
-        <CommandList>
-          {tagsLoading ? (
-            <div className="py-6 text-center text-sm text-muted-foreground">
-              Loading...
-            </div>
-          ) : tagsError ? (
-            <div className="py-6 text-center text-sm text-destructive">
-              Error loading tags
-            </div>
-          ) : tags.length === 0 ? (
-            <CommandEmpty>No tags found.</CommandEmpty>
-          ) : (
-            <CommandGroup>
-              {tags.map((tag: Tag) => (
-                <CommandItem
-                  key={tag.id}
-                  onSelect={() => onToggleTag(tag.id)}
-                  value={tag.name}
-                >
-                  {selectedTagIds.includes(tag.id) ? (
-                    <SquareCheckBig className="mr-2 h-4 w-4" />
-                  ) : (
-                    <Square className="mr-2 h-4 w-4" />
-                  )}
-                  {tag.name}
-                  <span className="ml-auto text-xs text-muted-foreground">
-                    {tag.book_count}
-                  </span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          )}
-        </CommandList>
-      </Command>
+      <FilterCombobox
+        chipKind="tag"
+        emptyText="No tags found."
+        error={tagsError}
+        errorText="Error loading tags"
+        loading={tagsLoading}
+        onSearchChange={onTagSearchChange}
+        onToggle={onToggleTag}
+        options={tags}
+        searchInput={tagSearchInput}
+        searchPlaceholder="Search tags..."
+        selected={selectedTags}
+        triggerLabel="Add tags..."
+      />
     </div>
 
     {/* Language */}

--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -11,10 +11,7 @@ import {
 } from "lucide-react";
 import { forwardRef, useState } from "react";
 
-import {
-  FilterChip,
-  type FilterChipKind,
-} from "@/components/library/FilterChip";
+import { FilterChip } from "@/components/library/FilterChip";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -140,7 +137,7 @@ const FilterCombobox = ({
   searchPlaceholder,
   emptyText,
 }: {
-  chipKind: FilterChipKind;
+  chipKind: "genre" | "tag";
   selected: FilterComboboxOption[];
   options: FilterComboboxOption[];
   loading: boolean;

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -578,7 +578,9 @@ const HomeContent = () => {
             reviewedFilter={reviewedFilterParam}
             selectedFileTypes={selectedFileTypes}
             selectedGenreIds={selectedGenreIds}
+            selectedGenres={selectedGenres}
             selectedTagIds={selectedTagIds}
+            selectedTags={selectedTags}
             tagSearchInput={tagSearchInput}
             tags={tags}
             tagsError={tagsQuery.isError}

--- a/app/components/ui/select.tsx
+++ b/app/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 cursor-pointer",
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 cursor-pointer",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Replace the inline scrollable Command lists for Genres and Tags in the FilterSheet with a Popover-based combobox (same pattern as the book edit dialog), so the sections collapse to a single trigger row plus chips for current selections — they no longer dominate the sheet or hijack wheel-scroll.
- Extract a shared `FilterChip` component used by both `ActiveFilterChips` (the filter row above the gallery) and `FilterSheet`'s selected items, so the same selection renders identically in both places.
- Switch `SelectTrigger` to `focus-visible:` (matching `Button`) so clicking the Language select no longer flashes a focus ring.

## Test plan
- Open the library and click Filter. Genre and Tag sections appear as compact triggers, not 300px scrolling lists.
- Click a trigger; popover opens with search and a list of options. Toggling an option adds/removes it from the chip row above.
- Selected genre/tag chips in the sheet match the chips in the "Filtering by" row above the gallery (icon, color, X behavior).
- Click the X on a chip in either location; the filter clears.
- Tab through the Filters: focus rings appear on keyboard focus. Click the Language select with the mouse; no focus ring appears.
- Scroll the filter sheet by dragging from anywhere — including over the (closed) genre/tag triggers — and verify the sheet scrolls without being trapped.