### PR TITLE
[Fix] Hide identify cover picker when plugin cover_url is broken or still loading

### DIFF
--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -730,6 +730,7 @@ function ResultCoverThumbnail({
     (previewPageCount == null || coverPage < previewPageCount);
   if (
     !coverUrl &&
+    !imgError &&
     coverPageInRange &&
     previewFileId &&
     (previewFileType === "cbz" || previewFileType === "pdf")

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -416,53 +416,14 @@ export function IdentifyBookDialog({
                     >
                       <div className="flex gap-3">
                         {/* Cover thumbnail */}
-                        {(() => {
-                          const thumbClass = cn(
-                            "w-16 object-cover rounded shrink-0 bg-muted",
-                            isAudiobook ? "h-16" : "h-24",
-                          );
-                          if (result.cover_url) {
-                            return (
-                              <img
-                                alt=""
-                                className={thumbClass}
-                                src={result.cover_url}
-                              />
-                            );
-                          }
-                          const previewFileId =
-                            selectedFileId ?? selectedFile?.id;
-                          const previewPageCount = selectedFile?.page_count;
-                          const coverPageInRange =
-                            result.cover_page != null &&
-                            result.cover_page >= 0 &&
-                            (previewPageCount == null ||
-                              result.cover_page < previewPageCount);
-                          if (
-                            coverPageInRange &&
-                            previewFileId &&
-                            (selectedFileType === "cbz" ||
-                              selectedFileType === "pdf")
-                          ) {
-                            return (
-                              <img
-                                alt=""
-                                className={thumbClass}
-                                src={`/api/books/files/${previewFileId}/page/${result.cover_page}`}
-                              />
-                            );
-                          }
-                          return (
-                            <div
-                              className={cn(
-                                "w-16 rounded shrink-0 bg-muted flex items-center justify-center text-muted-foreground text-xs",
-                                isAudiobook ? "h-16" : "h-24",
-                              )}
-                            >
-                              No cover
-                            </div>
-                          );
-                        })()}
+                        <ResultCoverThumbnail
+                          coverPage={result.cover_page}
+                          coverUrl={result.cover_url}
+                          isAudiobook={isAudiobook}
+                          previewFileId={selectedFileId ?? selectedFile?.id}
+                          previewFileType={selectedFileType}
+                          previewPageCount={selectedFile?.page_count}
+                        />
 
                         {/* Details */}
                         <div className="flex-1 min-w-0">
@@ -711,4 +672,76 @@ export function IdentifyBookDialog({
       </DialogContent>
     </FormDialog>
   );
+}
+
+/** Cover thumbnail for a single search result. Falls back to a "No cover"
+ * placeholder when the plugin's cover_url 404s/errors instead of rendering a
+ * broken-image icon. */
+function ResultCoverThumbnail({
+  coverUrl,
+  coverPage,
+  isAudiobook,
+  previewFileId,
+  previewFileType,
+  previewPageCount,
+}: {
+  coverUrl?: string;
+  coverPage?: number | null;
+  isAudiobook: boolean;
+  previewFileId?: number;
+  previewFileType?: string;
+  previewPageCount?: number | null;
+}) {
+  const [imgError, setImgError] = useState(false);
+  // Reset on URL change so a previous broken result doesn't latch the
+  // placeholder when results swap in.
+  useEffect(() => {
+    setImgError(false);
+  }, [coverUrl, coverPage, previewFileId]);
+
+  const thumbClass = cn(
+    "w-16 object-cover rounded shrink-0 bg-muted",
+    isAudiobook ? "h-16" : "h-24",
+  );
+  const placeholder = (
+    <div
+      className={cn(
+        "w-16 rounded shrink-0 bg-muted flex items-center justify-center text-muted-foreground text-xs",
+        isAudiobook ? "h-16" : "h-24",
+      )}
+    >
+      No cover
+    </div>
+  );
+
+  if (coverUrl && !imgError) {
+    return (
+      <img
+        alt=""
+        className={thumbClass}
+        onError={() => setImgError(true)}
+        src={coverUrl}
+      />
+    );
+  }
+  const coverPageInRange =
+    coverPage != null &&
+    coverPage >= 0 &&
+    (previewPageCount == null || coverPage < previewPageCount);
+  if (
+    !coverUrl &&
+    coverPageInRange &&
+    previewFileId &&
+    (previewFileType === "cbz" || previewFileType === "pdf")
+  ) {
+    return (
+      <img
+        alt=""
+        className={thumbClass}
+        onError={() => setImgError(true)}
+        src={`/api/books/files/${previewFileId}/page/${coverPage}`}
+      />
+    );
+  }
+  return placeholder;
 }

--- a/app/components/library/IdentifyReviewForm.test.tsx
+++ b/app/components/library/IdentifyReviewForm.test.tsx
@@ -319,6 +319,65 @@ describe("IdentifyReviewForm component", () => {
     expect(payload.fields.series_number).toBeUndefined();
   });
 
+  it("does not auto-select a broken plugin cover_url as the default cover", async () => {
+    // Simulate every Image() load failing — mirrors plugins returning a
+    // cover_url that 404s (e.g. a goodreads `nophoto` placeholder URL or a
+    // dead CDN link). With the bug, the form would default coverSelection to
+    // "new" and POST cover_url to the apply endpoint anyway.
+    const OriginalImage = globalThis.Image;
+    class FailingImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      naturalWidth = 0;
+      naturalHeight = 0;
+      _src = "";
+      get src() {
+        return this._src;
+      }
+      set src(v: string) {
+        this._src = v;
+        Promise.resolve().then(() => this.onerror?.());
+      }
+    }
+    // @ts-expect-error - jsdom Image stub
+    globalThis.Image = FailingImage;
+
+    try {
+      const user = createUser();
+      renderForm({
+        book: makeBook({
+          files: [
+            makeFile({
+              file_type: FileTypeEPUB,
+              cover_image_filename: "book.cover.jpg",
+            }),
+          ],
+        }),
+        result: makeResult({
+          cover_url: "https://example.com/broken-cover.jpg",
+        }),
+      });
+
+      // Wait for the useImageDimensions effects to fire onerror and unmount
+      // the cover swap UI.
+      await waitFor(() => {
+        expect(screen.queryByAltText("New cover")).toBeNull();
+      });
+
+      await user.click(screen.getByRole("button", { name: /apply changes/i }));
+
+      await waitFor(() => {
+        expect(applyMock).toHaveBeenCalledTimes(1);
+      });
+
+      const payload = applyMock.mock.calls[0][0];
+      expect(payload.fields.cover_url).toBeUndefined();
+      expect(payload.fields.cover_page).toBeUndefined();
+    } finally {
+      globalThis.Image = OriginalImage;
+    }
+  });
+
   it("renders the publisher combobox with the pendingCreate dashed border for unmatched names", async () => {
     renderForm({
       result: makeResult({ publisher: "Brand New Publisher" }),

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -161,22 +161,37 @@ function useImprintSearch(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Load natural dimensions of an image URL. */
+/** Load natural dimensions of an image URL.
+ *
+ * `dims` is non-null only on successful load (null while loading and on
+ * error). `settled` flips to true once the load attempt finishes (success or
+ * error), or immediately when there's no URL to load. Callers gate the cover
+ * picker on BOTH covers being settled so `defaultCoverSelection` is computed
+ * once and the selection ring doesn't flip after the picker mounts. */
 function useImageDimensions(src: string | undefined) {
-  const [dims, setDims] = useState<{ w: number; h: number } | null>(null);
+  const [state, setState] = useState<{
+    dims: { w: number; h: number } | null;
+    settled: boolean;
+  }>(() => ({ dims: null, settled: !src }));
 
   useEffect(() => {
     if (!src) {
-      setDims(null);
+      setState({ dims: null, settled: true });
       return;
     }
+    setState({ dims: null, settled: false });
     let cancelled = false;
     const img = new Image();
     img.onload = () => {
-      if (!cancelled) setDims({ w: img.naturalWidth, h: img.naturalHeight });
+      if (!cancelled) {
+        setState({
+          dims: { w: img.naturalWidth, h: img.naturalHeight },
+          settled: true,
+        });
+      }
     };
     img.onerror = () => {
-      if (!cancelled) setDims(null);
+      if (!cancelled) setState({ dims: null, settled: true });
     };
     img.src = src;
     return () => {
@@ -184,7 +199,7 @@ function useImageDimensions(src: string | undefined) {
     };
   }, [src]);
 
-  return dims;
+  return state;
 }
 
 /** Determine field status and default value for a scalar field. */
@@ -667,7 +682,6 @@ export function IdentifyReviewForm({
   const currentCoverUrl = file?.cover_image_filename
     ? `/api/books/files/${file.id}/cover?v=${new Date(file.updated_at).getTime()}`
     : undefined;
-  const hasCoverChoice = !!newCoverPreviewUrl;
   const currentCoverPage = file?.cover_page ?? null;
   // For page-based files with a plugin-supplied cover_page, compare by page
   // number instead of pixel resolution — the cover is a page of the file
@@ -675,12 +689,29 @@ export function IdentifyReviewForm({
   const isPageBasedCoverChoice = isFilePageBased && newCoverPage != null;
   // Dimensions only matter for the resolution-based comparison on non-page
   // formats. Skip the image preload entirely for page-based choices.
-  const currentCoverDims = useImageDimensions(
+  const currentCover = useImageDimensions(
     isPageBasedCoverChoice ? undefined : currentCoverUrl,
   );
-  const newCoverDims = useImageDimensions(
+  const newCover = useImageDimensions(
     isPageBasedCoverChoice ? undefined : newCoverPreviewUrl,
   );
+  const currentCoverDims = currentCover.dims;
+  const newCoverDims = newCover.dims;
+  // For URL-based covers, wait until BOTH load attempts have settled before
+  // showing the picker. Two reasons:
+  //  - The new cover must have loaded successfully (newCoverDims non-null), so
+  //    a broken plugin cover_url never renders or gets auto-selected — Apply
+  //    would otherwise POST the broken URL to the backend.
+  //  - The current cover load must be finished too, so the resolution-based
+  //    `preferCurrentCover` comparison is final at first render. Without this
+  //    gate, when `newCoverDims` lands first the picker mounts with the ring
+  //    on "new", then `currentCoverDims` arrives and flips the default to
+  //    "current", swapping the ring visibly.
+  // Page-based covers (CBZ/PDF cover_page) skip the dims preload, so gate
+  // them on the URL alone — the page endpoint is built locally.
+  const hasCoverChoice = isPageBasedCoverChoice
+    ? !!newCoverPreviewUrl
+    : !!newCoverDims && currentCover.settled;
   // Same page → unchanged (prefer current); different page → prefer new.
   // Requires `currentCoverUrl` so we don't default to a "Current" thumbnail
   // that isn't rendered (the current button is guarded by `currentCoverUrl`).
@@ -693,21 +724,22 @@ export function IdentifyReviewForm({
       currentCoverDims.w * currentCoverDims.h >=
         newCoverDims.w * newCoverDims.h;
   // The selection we'd land on if the user didn't touch anything. Used by
-  // useState init, the auto-select effect, and `hasChanges` — keeping it in
-  // one place avoids the three sites drifting.
+  // the derived `coverSelection` and `hasChanges` — keeping it in one place
+  // avoids drift.
   const defaultCoverSelection: "current" | "new" =
     hasCoverChoice && !isDisabled("cover") && !preferCurrentCover
       ? "new"
       : "current";
-  const [coverSelection, setCoverSelection] = useState<"current" | "new">(
-    defaultCoverSelection,
-  );
-  const [coverUserTouched, setCoverUserTouched] = useState(false);
-  useEffect(() => {
-    if (!coverUserTouched) {
-      setCoverSelection(defaultCoverSelection);
-    }
-  }, [defaultCoverSelection, coverUserTouched]);
+  // Derive `coverSelection` instead of mirroring `defaultCoverSelection` into
+  // state via an effect — that approach mounted the picker with stale state
+  // ("current" from initial render) and only flipped to the real default on
+  // the next tick, which the user saw as the selection ring switching after
+  // the covers popped in.
+  const [userCoverSelection, setUserCoverSelection] = useState<
+    "current" | "new" | null
+  >(null);
+  const coverSelection: "current" | "new" =
+    userCoverSelection ?? defaultCoverSelection;
 
   // ---- Unsaved changes tracking ----
   const hasChanges = useMemo(() => {
@@ -861,8 +893,7 @@ export function IdentifyReviewForm({
                 )}
                 disabled={isDisabled("cover")}
                 onClick={() => {
-                  setCoverSelection("current");
-                  setCoverUserTouched(true);
+                  setUserCoverSelection("current");
                 }}
                 type="button"
               >
@@ -890,8 +921,7 @@ export function IdentifyReviewForm({
               )}
               disabled={isDisabled("cover")}
               onClick={() => {
-                setCoverSelection("new");
-                setCoverUserTouched(true);
+                setUserCoverSelection("new");
               }}
               type="button"
             >


### PR DESCRIPTION
## Summary
- When a plugin's `cover_url` 404s or otherwise fails to load (e.g. Goodreads `/book/show/7234268` returning a broken image), the identify search list now falls back to the existing "No cover" placeholder instead of rendering the browser's broken-image icon, and the review form no longer auto-selects the broken URL as the default cover or POSTs it through Apply.
- The review form's cover picker now waits for both the current and incoming covers to finish loading before mounting, and `coverSelection` is derived from `defaultCoverSelection` instead of mirrored through a `useEffect` — so the picker pops in with the selection ring already on the correct default rather than flipping from "current" to "new" after a render.

## Test plan
- Open the identify dialog on a book and search with a plugin that returns a broken `cover_url`. The result row shows the "No cover" placeholder (not a broken-image icon). Click into review, hit Apply without touching anything — the request payload omits `cover_url` / `cover_page`, and the book's existing cover is preserved.
- Open the identify dialog with a plugin result that has a valid `cover_url` whose image is larger than the current cover. The cover picker should pop in with the selection ring already on the new cover (no visible flip from "current" to "new").
- Open the identify dialog with a plugin result whose cover is smaller / matches the current cover. The picker should pop in with the ring already on the current cover.
- Run `pnpm vitest run app/components/library/IdentifyReviewForm.test.tsx` — includes a new regression test that mocks `Image` to fail on load and asserts the apply payload omits `cover_url` / `cover_page`.