### PR TITLE
[Backend] Stop identify from clobbering file.Name with book.Title

### DIFF
--- a/docs/design/identify-mockups/index.html
+++ b/docs/design/identify-mockups/index.html
@@ -1,0 +1,2756 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Identify · Mockup</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ============================================================
+         Tokens — Shisho dark mode
+         ============================================================ */
+      :root {
+        --radius: 0.625rem;
+        --radius-sm: 0.375rem;
+        --radius-lg: 0.875rem;
+
+        --bg: oklch(0.18 0 0);
+        --bg-elevated: oklch(0.205 0 0);
+        --card: oklch(0.22 0 0);
+        --card-2: oklch(0.245 0 0);
+        --fg: oklch(0.985 0 0);
+        --fg-2: oklch(0.92 0 0);
+        --fg-soft: oklch(0.85 0 0);
+        --muted: oklch(0.25 0 0);
+        --muted-fg: oklch(0.708 0 0);
+        --muted-fg-2: oklch(0.55 0 0);
+        --border: oklch(1 0 0 / 0.08);
+        --border-strong: oklch(1 0 0 / 0.14);
+        --input: oklch(1 0 0 / 0.06);
+        --input-focus: oklch(1 0 0 / 0.1);
+        --primary: oklch(0.8 0.15 280);
+        --primary-soft: oklch(0.8 0.15 280 / 0.16);
+        --primary-fg: oklch(0.16 0.02 280);
+        --success: oklch(0.78 0.16 152);
+        --success-soft: oklch(0.78 0.16 152 / 0.14);
+        --warning: oklch(0.82 0.13 90);
+        --danger: oklch(0.7 0.18 22);
+        --danger-soft: oklch(0.7 0.18 22 / 0.14);
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family:
+          "Geist", "Noto Sans", ui-sans-serif, system-ui, -apple-system,
+          sans-serif;
+        font-feature-settings: "ss01", "cv11";
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+        min-height: 100vh;
+        background-image:
+          radial-gradient(
+            ellipse 70% 35% at 50% -10%,
+            oklch(0.8 0.15 280 / 0.05),
+            transparent 70%
+          );
+      }
+
+      .stage {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 56px 24px 80px;
+      }
+
+      .panel__head {
+        margin-bottom: 28px;
+      }
+      .panel__eyebrow {
+        font-size: 10.5px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--muted-fg-2);
+        font-weight: 600;
+        margin-bottom: 10px;
+      }
+      .panel__title {
+        font-size: 26px;
+        font-weight: 600;
+        letter-spacing: -0.015em;
+        line-height: 1.15;
+        margin: 0 0 8px;
+      }
+      .panel__desc {
+        font-size: 14px;
+        color: var(--muted-fg);
+        line-height: 1.55;
+        max-width: 60ch;
+        margin: 0;
+      }
+
+      /* ============================================================
+         Dialog frame
+         ============================================================ */
+      .dialog-frame {
+        position: relative;
+        width: 100%;
+        max-width: 768px;
+        margin: 0 auto;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-lg);
+        overflow: hidden;
+        box-shadow:
+          0 1px 0 oklch(1 0 0 / 0.04) inset,
+          0 32px 80px -32px oklch(0 0 0 / 0.7);
+      }
+      .dialog-frame__head {
+        padding: 16px 22px;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        border-bottom: 1px solid var(--border);
+        background: linear-gradient(
+          180deg,
+          oklch(0.245 0 0),
+          oklch(0.225 0 0)
+        );
+      }
+      .dialog-frame__heading {
+        flex: 1;
+        min-width: 0;
+      }
+      .dialog-frame__title {
+        font-size: 14px;
+        font-weight: 600;
+        margin: 0;
+        letter-spacing: -0.005em;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .dialog-frame__sub {
+        margin-top: 2px;
+        font-size: 11.5px;
+        color: var(--muted-fg);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .dialog-frame__sub .dot {
+        opacity: 0.5;
+      }
+      .dialog-frame__source {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 5px 10px;
+        background: var(--primary-soft);
+        border: 1px solid oklch(0.8 0.15 280 / 0.3);
+        color: var(--primary);
+        border-radius: 999px;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+        flex-shrink: 0;
+      }
+      .dialog-frame__source__pulse {
+        width: 6px;
+        height: 6px;
+        border-radius: 999px;
+        background: var(--primary);
+        box-shadow: 0 0 8px var(--primary);
+      }
+      .dialog-frame__back {
+        all: unset;
+        cursor: pointer;
+        width: 24px;
+        height: 24px;
+        border-radius: 5px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--muted-fg);
+        flex-shrink: 0;
+        transition:
+          background 120ms,
+          color 120ms;
+      }
+      .dialog-frame__back:hover {
+        background: oklch(1 0 0 / 0.06);
+        color: var(--fg);
+      }
+      .dialog-frame__back svg {
+        width: 12px;
+        height: 12px;
+      }
+
+      .dialog-frame__body {
+        max-height: 70vh;
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: oklch(1 0 0 / 0.18) transparent;
+      }
+      .dialog-frame__body::-webkit-scrollbar {
+        width: 8px;
+      }
+      .dialog-frame__body::-webkit-scrollbar-thumb {
+        background: oklch(1 0 0 / 0.14);
+        border-radius: 4px;
+      }
+      .dialog-frame__body::-webkit-scrollbar-thumb:hover {
+        background: oklch(1 0 0 / 0.22);
+      }
+
+      /* ============================================================
+         File switcher (which file are we identifying)
+         FIX: nowrap, proper alignment, smaller & tighter
+         ============================================================ */
+      .file-switcher {
+        padding: 10px 22px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        background: oklch(0.205 0 0);
+        border-bottom: 1px solid var(--border);
+        font-size: 12px;
+      }
+      .file-switcher__label {
+        color: var(--muted-fg);
+        flex-shrink: 0;
+      }
+      /* On the review step, the file switcher is read-only — it just
+         shows which file is being identified. The dropdown lives only on
+         the search step (where switching files re-runs the search). */
+      .file-switcher__pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 10px;
+        border: 1px solid var(--border);
+        background: var(--card-2);
+        border-radius: 7px;
+        font-size: 12px;
+        font-weight: 500;
+        white-space: nowrap;
+      }
+      /* File-type label inside the pill — no border (avoids the
+         "double-card" look). Uppercase, slightly muted, with a thin
+         vertical separator between it and the file name. */
+      .file-switcher__pill__icon {
+        display: inline-flex;
+        align-items: center;
+        font-size: 10px;
+        font-weight: 700;
+        color: var(--muted-fg);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        flex-shrink: 0;
+        line-height: 1;
+        padding-right: 8px;
+        margin-right: 2px;
+        border-right: 1px solid var(--border);
+      }
+      .file-switcher__pill__name {
+        white-space: nowrap;
+      }
+      .file-switcher__pill__caret {
+        opacity: 0.5;
+        flex-shrink: 0;
+      }
+      .file-switcher__hint {
+        margin-left: auto;
+        font-size: 11px;
+        color: var(--muted-fg-2);
+        white-space: nowrap;
+      }
+
+      /* ============================================================
+         Select-all bar — sticky at top of scroll body.
+         ============================================================ */
+      .selectbar {
+        position: sticky;
+        top: 0;
+        z-index: 3;
+        padding: 10px 22px;
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        background: oklch(0.2 0 0);
+        border-bottom: 1px solid var(--border);
+        font-size: 12.5px;
+      }
+      .selectbar__label {
+        font-weight: 500;
+        color: var(--fg-2);
+      }
+      .selectbar__count {
+        color: var(--muted-fg);
+      }
+      .selectbar__count strong {
+        color: var(--fg);
+        font-weight: 600;
+      }
+      .selectbar__spacer {
+        flex: 1;
+      }
+      .selectbar__filter {
+        display: flex;
+        gap: 4px;
+        padding: 2px;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 7px;
+      }
+      .selectbar__filter__btn {
+        all: unset;
+        cursor: pointer;
+        font-size: 11px;
+        font-weight: 500;
+        padding: 4px 9px;
+        border-radius: 5px;
+        color: var(--muted-fg);
+      }
+      .selectbar__filter__btn[aria-pressed="true"] {
+        background: var(--card-2);
+        color: var(--fg);
+      }
+
+      /* ============================================================
+         Section — collapsible. Banner is the toggle.
+         Chevron sits in the same column as field-row checkboxes (24px),
+         so the section label aligns with field labels at column 2.
+         ============================================================ */
+      .section[data-state="collapsed"] .section-rows {
+        display: none;
+      }
+      .section[data-state="collapsed"] .section-banner {
+        border-bottom: 1px solid var(--border);
+      }
+      .section-banner {
+        position: sticky;
+        top: 49px; /* selectbar height: 28px content + 10px*2 padding + 1px border */
+        z-index: 2;
+        display: grid;
+        grid-template-columns: 24px minmax(0, 1fr) auto auto;
+        column-gap: 14px;
+        align-items: center;
+        padding: 13px 22px;
+        background: oklch(0.205 0 0);
+        border-bottom: 1px solid var(--border);
+        cursor: pointer;
+        user-select: none;
+        transition: background 120ms;
+      }
+      .section-banner:hover {
+        background: oklch(0.225 0 0);
+      }
+      .section-banner__chevron {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--muted-fg);
+        transition: transform 200ms ease;
+      }
+      .section[data-state="collapsed"] .section-banner__chevron {
+        transform: rotate(-90deg);
+      }
+      .section-banner__chevron svg {
+        width: 11px;
+        height: 11px;
+      }
+      .section-banner__inner {
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+        min-width: 0;
+      }
+      .section-banner__label {
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        color: var(--fg-2);
+      }
+      .section-banner__hint {
+        font-size: 11.5px;
+        color: var(--muted-fg);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .section-banner__file-meta {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 6px;
+        font-size: 11.5px;
+        color: var(--muted-fg);
+        min-width: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .section-banner__file-type {
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        color: var(--muted-fg);
+        text-transform: uppercase;
+      }
+      .section-banner__file-name {
+        color: var(--fg-soft);
+        font-weight: 500;
+      }
+      .section-banner__sep {
+        opacity: 0.45;
+      }
+      .section-banner__count {
+        font-size: 11.5px;
+        color: var(--muted-fg);
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+      }
+      .section-banner__count strong {
+        color: var(--fg);
+        font-weight: 600;
+      }
+
+      /* ============================================================
+         Field row
+         ============================================================ */
+      .row {
+        display: grid;
+        grid-template-columns: 24px 1fr;
+        column-gap: 14px;
+        padding: 18px 22px;
+        border-bottom: 1px solid var(--border);
+        align-items: start;
+      }
+      .row:last-child {
+        border-bottom: none;
+      }
+      .row[data-state="unchanged"] {
+        opacity: 0.55;
+      }
+      .row[data-state="unchanged"]:hover {
+        opacity: 1;
+      }
+      .row--hero {
+        padding: 22px;
+        background: linear-gradient(
+          180deg,
+          oklch(0.225 0 0),
+          oklch(0.215 0 0)
+        );
+      }
+
+      .check {
+        all: unset;
+        cursor: pointer;
+        width: 18px;
+        height: 18px;
+        margin-top: 1px;
+        border: 1.5px solid var(--border-strong);
+        border-radius: 5px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: oklch(1 0 0 / 0.02);
+        transition:
+          background 120ms,
+          border-color 120ms,
+          box-shadow 120ms;
+      }
+      /* Only the unchecked-empty state gets the soft "you can click me" hover. */
+      .check:hover:not([disabled]):not([aria-checked="true"]):not([aria-checked="mixed"]) {
+        border-color: oklch(1 0 0 / 0.32);
+        background: oklch(1 0 0 / 0.05);
+      }
+      .check[aria-checked="true"],
+      .check[aria-checked="mixed"] {
+        background: var(--primary);
+        border-color: var(--primary);
+      }
+      .check[aria-checked="true"]:hover:not([disabled]),
+      .check[aria-checked="mixed"]:hover:not([disabled]) {
+        background: oklch(0.85 0.15 280);
+        border-color: oklch(0.85 0.15 280);
+      }
+      .check[aria-checked="true"]::after {
+        content: "";
+        width: 4.5px;
+        height: 9px;
+        border: solid var(--primary-fg);
+        border-width: 0 2px 2px 0;
+        transform: rotate(45deg) translate(-1px, -1px);
+      }
+      /* Indeterminate / mixed state — horizontal bar, used by section
+         and global "select all" toggles when some-but-not-all rows checked. */
+      .check[aria-checked="mixed"]::after {
+        content: "";
+        width: 9px;
+        height: 2px;
+        background: var(--primary-fg);
+        border: 0;
+        border-radius: 1px;
+        transform: none;
+      }
+      .check[disabled] {
+        opacity: 0.35;
+        cursor: not-allowed;
+      }
+
+      .row__body {
+        min-width: 0;
+      }
+      .row__head {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        min-height: 20px;
+        margin-bottom: 9px;
+      }
+      .row__label {
+        font-size: 13px;
+        font-weight: 600;
+        line-height: 1.4;
+        letter-spacing: 0.005em;
+      }
+      /* small scope tag (used on hero cover row only since cover sits above sections) */
+      .row__scope {
+        display: inline-flex;
+        align-items: center;
+        height: 18px;
+        padding: 0 7px;
+        border-radius: 4px;
+        font-size: 9.5px;
+        font-weight: 700;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: var(--muted-fg);
+        border: 1px solid var(--border);
+        margin-left: auto;
+      }
+
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        height: 18px;
+        padding: 0 7px;
+        border-radius: 999px;
+        font-size: 10px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        line-height: 1;
+      }
+      .badge--changed {
+        background: var(--primary-soft);
+        color: var(--primary);
+      }
+      .badge--new {
+        background: var(--success-soft);
+        color: var(--success);
+      }
+      .badge--unchanged {
+        background: oklch(1 0 0 / 0.05);
+        color: var(--muted-fg);
+      }
+
+      /* ============================================================
+         Inputs
+         ============================================================ */
+      .input,
+      .textarea,
+      .select {
+        all: unset;
+        box-sizing: border-box;
+        display: block;
+        width: 100%;
+        background: var(--input);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 9px 12px;
+        font: inherit;
+        font-size: 13.5px;
+        color: var(--fg);
+        line-height: 1.4;
+        transition:
+          background 120ms,
+          border-color 120ms,
+          box-shadow 120ms;
+      }
+      .input:focus-visible,
+      .textarea:focus-visible,
+      .select:focus-visible {
+        background: var(--input-focus);
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px oklch(0.8 0.15 280 / 0.2);
+      }
+      .textarea {
+        min-height: 88px;
+        resize: vertical;
+        line-height: 1.55;
+      }
+      .select {
+        cursor: pointer;
+        padding-right: 30px;
+        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none'><path d='M3 4.5l3 3 3-3' stroke='%23aaa' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+        background-repeat: no-repeat;
+        background-position: right 10px center;
+        background-size: 12px;
+      }
+      .input--id {
+        font-family: ui-monospace, "SF Mono", monospace;
+        font-size: 12.5px;
+      }
+
+      /* combobox style — single value */
+      .combobox {
+        display: flex;
+        align-items: stretch;
+        gap: 6px;
+      }
+      .combobox__main {
+        flex: 1;
+        position: relative;
+      }
+      .combobox__main .input {
+        padding-right: 32px;
+      }
+      .combobox__caret {
+        position: absolute;
+        right: 12px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--muted-fg);
+        pointer-events: none;
+      }
+      .combobox__clear {
+        all: unset;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0 10px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        color: var(--muted-fg);
+        background: var(--input);
+        transition:
+          background 120ms,
+          color 120ms;
+      }
+      .combobox__clear:hover {
+        background: var(--danger-soft);
+        color: var(--danger);
+      }
+
+      /* currently / reference */
+      .currently {
+        margin-top: 7px;
+        font-size: 12px;
+        color: var(--muted-fg);
+        line-height: 1.5;
+      }
+      .currently__label {
+        color: var(--muted-fg-2);
+        font-weight: 500;
+      }
+      .currently__value {
+        color: var(--fg-soft);
+      }
+      .currently--collapsed .currently__value {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        max-height: 3em;
+      }
+      .currently--expanded .currently__value {
+        display: block;
+      }
+      .currently__toggle {
+        all: unset;
+        cursor: pointer;
+        font-size: 11.5px;
+        color: var(--primary);
+        font-weight: 500;
+        margin-top: 4px;
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+      .currently__toggle:hover {
+        text-decoration: underline;
+      }
+      .currently__toggle svg {
+        width: 10px;
+        height: 10px;
+        transition: transform 120ms;
+      }
+      .currently--expanded .currently__toggle svg {
+        transform: rotate(180deg);
+      }
+
+      /* ============================================================
+         Chips + inline add input (FIX: type-Enter to commit)
+         ============================================================ */
+      .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        align-items: center;
+      }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        height: 28px;
+        padding: 0 4px 0 10px;
+        gap: 4px;
+        background: var(--card-2);
+        border: 1px solid var(--border-strong);
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--fg);
+        line-height: 1;
+      }
+      .chip--id {
+        font-family: ui-monospace, "SF Mono", monospace;
+        font-size: 11.5px;
+      }
+      .chip__type {
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        font-size: 10px;
+        font-weight: 700;
+        font-family: "Geist", sans-serif;
+        color: var(--primary);
+        margin-right: 6px;
+      }
+      .chip__x {
+        all: unset;
+        cursor: pointer;
+        width: 20px;
+        height: 20px;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--muted-fg);
+        line-height: 1;
+        transition:
+          background 120ms,
+          color 120ms;
+      }
+      .chip__x:hover {
+        background: var(--danger-soft);
+        color: var(--danger);
+      }
+      .chip__x svg {
+        width: 10px;
+        height: 10px;
+      }
+
+      /* The inline ADD input — combobox-shaped, with a caret to suggest
+         a typeahead dropdown. Type → suggestions appear → Enter to commit. */
+      .chip-combobox {
+        position: relative;
+        display: inline-flex;
+        align-items: stretch;
+        min-width: 140px;
+      }
+      .chip-input {
+        all: unset;
+        box-sizing: border-box;
+        display: inline-flex;
+        align-items: center;
+        width: 100%;
+        height: 28px;
+        padding: 0 28px 0 12px;
+        background: oklch(1 0 0 / 0.03);
+        border: 1px dashed oklch(1 0 0 / 0.16);
+        border-radius: 999px;
+        font: inherit;
+        font-size: 12px;
+        color: var(--fg);
+        line-height: 1;
+        cursor: text;
+        transition:
+          background 120ms,
+          border-color 120ms,
+          box-shadow 120ms;
+      }
+      .chip-input::placeholder {
+        color: var(--muted-fg);
+      }
+      .chip-input:focus,
+      .chip-input:focus-visible {
+        background: var(--input-focus);
+        border-style: solid;
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px oklch(0.8 0.15 280 / 0.2);
+      }
+      .chip-combobox__caret {
+        position: absolute;
+        right: 10px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--muted-fg);
+        pointer-events: none;
+      }
+      .chip-combobox__caret svg {
+        width: 10px;
+        height: 10px;
+      }
+
+      /* Open typeahead popover — shown on one demo input below.
+         z-index is high enough to clear sticky section banners (z:2)
+         and the sticky select-all bar (z:3). */
+      .typeahead {
+        position: absolute;
+        top: calc(100% + 4px);
+        left: 0;
+        min-width: 240px;
+        background: var(--card-2);
+        border: 1px solid var(--border-strong);
+        border-radius: 8px;
+        box-shadow: 0 12px 28px -8px oklch(0 0 0 / 0.6);
+        padding: 4px;
+        z-index: 50;
+        animation: typeahead-in 120ms ease-out;
+      }
+      @keyframes typeahead-in {
+        from { opacity: 0; transform: translateY(-4px); }
+        to { opacity: 1; transform: translateY(0); }
+      }
+      .typeahead__group-label {
+        padding: 6px 10px 4px;
+        font-size: 9.5px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--muted-fg-2);
+      }
+      .typeahead__item {
+        all: unset;
+        cursor: pointer;
+        display: flex;
+        width: 100%;
+        box-sizing: border-box;
+        align-items: center;
+        gap: 10px;
+        padding: 7px 10px;
+        border-radius: 5px;
+        font-size: 12.5px;
+        color: var(--fg);
+      }
+      .typeahead__item:hover,
+      .typeahead__item--active {
+        background: var(--primary-soft);
+        color: var(--primary);
+      }
+      .typeahead__item__meta {
+        margin-left: auto;
+        font-size: 10.5px;
+        color: var(--muted-fg-2);
+      }
+      .typeahead__item--create {
+        color: var(--muted-fg);
+        font-style: italic;
+      }
+      .typeahead__item--create strong {
+        color: var(--fg);
+        font-style: normal;
+        font-weight: 500;
+      }
+      .typeahead__sep {
+        height: 1px;
+        background: var(--border);
+        margin: 4px 0;
+      }
+
+      /* ============================================================
+         Composite list rows + composite ADD row (FIX: Enter to commit)
+         For authors / narrators / series.
+         ============================================================ */
+      .composite-list {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .composite-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 8px 6px 10px;
+        background: var(--card-2);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+      }
+      .composite-row__handle {
+        color: var(--muted-fg-2);
+        cursor: grab;
+        flex-shrink: 0;
+        line-height: 1;
+        user-select: none;
+        display: inline-flex;
+      }
+      .composite-row__handle svg {
+        width: 12px;
+        height: 12px;
+      }
+      .composite-row__name {
+        flex: 1;
+        font-size: 13px;
+        font-weight: 500;
+        min-width: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .composite-row__select {
+        all: unset;
+        cursor: pointer;
+        padding: 5px 22px 5px 10px;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        font-size: 12px;
+        color: var(--fg-2);
+        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none'><path d='M3 4.5l3 3 3-3' stroke='%23aaa' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+        background-repeat: no-repeat;
+        background-position: right 6px center;
+        background-size: 10px;
+        flex-shrink: 0;
+      }
+      .composite-row__select--narrow {
+        width: 96px;
+      }
+      .composite-row__select--unit {
+        width: 92px;
+      }
+      .composite-row__num {
+        all: unset;
+        box-sizing: border-box;
+        width: 50px;
+        padding: 5px 6px;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        font-size: 12px;
+        text-align: center;
+        font-variant-numeric: tabular-nums;
+        flex-shrink: 0;
+      }
+      .composite-row__remove {
+        all: unset;
+        cursor: pointer;
+        width: 22px;
+        height: 22px;
+        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--muted-fg);
+        flex-shrink: 0;
+        transition:
+          background 120ms,
+          color 120ms;
+      }
+      .composite-row__remove:hover {
+        background: var(--danger-soft);
+        color: var(--danger);
+      }
+      .composite-row__remove svg {
+        width: 11px;
+        height: 11px;
+      }
+
+      /* The composite ADD row — same shape as a normal composite row,
+         but with a dashed border, typeable input, and combobox caret. */
+      .composite-row--add {
+        position: relative;
+        background: oklch(1 0 0 / 0.02);
+        border-style: dashed;
+        border-color: oklch(1 0 0 / 0.16);
+        padding: 0;
+        transition:
+          background 120ms,
+          border-color 120ms,
+          box-shadow 120ms;
+      }
+      .composite-row--add:focus-within {
+        background: var(--input-focus);
+        border-style: solid;
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px oklch(0.8 0.15 280 / 0.2);
+      }
+      .composite-row__input {
+        all: unset;
+        box-sizing: border-box;
+        flex: 1;
+        padding: 8px 36px 8px 12px;
+        font: inherit;
+        font-size: 13px;
+        color: var(--fg);
+        cursor: text;
+        min-width: 0;
+      }
+      .composite-row__input::placeholder {
+        color: var(--muted-fg);
+      }
+      .composite-row__caret {
+        position: absolute;
+        right: 12px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: var(--muted-fg);
+        pointer-events: none;
+      }
+      .composite-row__caret svg {
+        width: 11px;
+        height: 11px;
+      }
+
+      /* Identifier ADD row — special: type select + value input + Add button.
+         Enter on value commits (per spec). */
+      .id-add-row {
+        margin-top: 8px;
+        display: flex;
+        align-items: stretch;
+        gap: 6px;
+        padding: 4px;
+        background: oklch(1 0 0 / 0.02);
+        border: 1px dashed oklch(1 0 0 / 0.16);
+        border-radius: 8px;
+        transition:
+          background 120ms,
+          border-color 120ms,
+          box-shadow 120ms;
+      }
+      .id-add-row:focus-within {
+        background: var(--input-focus);
+        border-style: solid;
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px oklch(0.8 0.15 280 / 0.2);
+      }
+      .id-add-row__select {
+        all: unset;
+        cursor: pointer;
+        padding: 4px 22px 4px 10px;
+        background: var(--bg);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--primary);
+        background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none'><path d='M3 4.5l3 3 3-3' stroke='%23aaa' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+        background-repeat: no-repeat;
+        background-position: right 6px center;
+        background-size: 10px;
+        flex-shrink: 0;
+      }
+      .id-add-row__input {
+        all: unset;
+        flex: 1;
+        padding: 5px 10px;
+        font: inherit;
+        font-size: 12.5px;
+        color: var(--fg);
+        font-family: ui-monospace, "SF Mono", monospace;
+        min-width: 0;
+        cursor: text;
+      }
+      .id-add-row__input::placeholder {
+        color: var(--muted-fg);
+        font-family: "Geist", sans-serif;
+      }
+      .id-add-row__hint {
+        font-size: 10.5px;
+        color: var(--muted-fg-2);
+        padding-right: 8px;
+        align-self: center;
+        white-space: nowrap;
+      }
+
+      /* ============================================================
+         Cover field
+         ============================================================ */
+      .covers {
+        display: flex;
+        gap: 14px;
+        align-items: flex-end;
+      }
+      .cover-card {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        align-items: center;
+      }
+      .cover-card__img {
+        width: 100px;
+        aspect-ratio: 2 / 3;
+        border-radius: 6px;
+        border: 2px solid transparent;
+        background-size: cover;
+        background-position: center;
+        position: relative;
+        overflow: hidden;
+        box-shadow: 0 6px 14px -4px oklch(0 0 0 / 0.55);
+      }
+      .cover-card__img--current {
+        background:
+          linear-gradient(170deg, #1d2f4a 0%, #0c1322 70%),
+          radial-gradient(circle at 50% 80%, #b9892f, transparent 40%);
+        background-blend-mode: screen;
+      }
+      .cover-card__img--new {
+        background:
+          linear-gradient(165deg, #2c4564 0%, #0d1325 60%),
+          radial-gradient(circle at 50% 35%, #d6953a, transparent 50%),
+          radial-gradient(circle at 30% 80%, #5d8fbf, transparent 30%);
+        background-blend-mode: screen;
+      }
+      .cover-card__img.is-selected {
+        border-color: var(--primary);
+        box-shadow:
+          0 0 0 1px var(--primary),
+          0 12px 24px -8px oklch(0.8 0.15 280 / 0.35);
+      }
+      .cover-card__cap {
+        font-size: 11px;
+        color: var(--muted-fg);
+        text-align: center;
+      }
+      .cover-card__cap__bold {
+        color: var(--fg);
+        font-weight: 500;
+      }
+      .cover-arrow {
+        margin-bottom: 28px;
+        color: var(--muted-fg-2);
+      }
+      .covers__action {
+        margin-left: auto;
+        margin-bottom: 14px;
+        align-self: flex-end;
+      }
+      .btn--soft {
+        all: unset;
+        cursor: pointer;
+        font: inherit;
+        font-size: 12px;
+        font-weight: 500;
+        padding: 7px 12px;
+        border-radius: 7px;
+        border: 1px solid var(--border-strong);
+        background: oklch(1 0 0 / 0.03);
+        color: var(--fg-2);
+        line-height: 1;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        transition:
+          background 120ms,
+          color 120ms,
+          border-color 120ms;
+      }
+      .btn--soft:hover {
+        background: oklch(1 0 0 / 0.07);
+        color: var(--fg);
+        border-color: oklch(1 0 0 / 0.22);
+      }
+      .btn--soft svg {
+        width: 12px;
+        height: 12px;
+      }
+
+      /* row layout that keeps "Currently:" left and an inline action
+         (e.g. "Extract subtitle") right on the same baseline. */
+      .row__after-input {
+        margin-top: 7px;
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 14px;
+      }
+      .row__after-input .currently {
+        margin-top: 0;
+        flex: 1;
+        min-width: 0;
+      }
+      .link-btn {
+        all: unset;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        font-size: 11.5px;
+        font-weight: 500;
+        color: var(--primary);
+        padding: 3px 6px;
+        border-radius: 4px;
+        transition:
+          background 120ms,
+          color 120ms;
+      }
+      .link-btn:hover {
+        background: var(--primary-soft);
+      }
+      .link-btn svg {
+        width: 11px;
+        height: 11px;
+      }
+
+      /* checkbox row for "Abridged" */
+      .check-with-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 13px;
+        color: var(--fg-2);
+      }
+      /* When the outer row checkbox is unchecked, the inner field control
+         (e.g. Abridged toggle) is non-interactive. */
+      .row[data-row-toggle] .check[data-row-toggle-inner] {
+        opacity: 0.35;
+        pointer-events: none;
+      }
+      .row[data-row-toggle][data-row-applied="true"] .check[data-row-toggle-inner] {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      .row[data-row-toggle] .check-with-label {
+        color: var(--muted-fg);
+      }
+      .row[data-row-toggle][data-row-applied="true"] .check-with-label {
+        color: var(--fg-2);
+      }
+
+      /* ============================================================
+         Footer
+         ============================================================ */
+      .dialog-frame__foot {
+        padding: 14px 22px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 14px;
+        background: oklch(0.205 0 0);
+        border-top: 1px solid var(--border);
+      }
+      .dialog-frame__foot__reset {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 12px;
+      }
+      .dialog-frame__foot__reset svg {
+        width: 12px;
+        height: 12px;
+      }
+      .dialog-frame__foot__summary {
+        font-size: 12.5px;
+        color: var(--muted-fg);
+      }
+      .dialog-frame__foot__summary strong {
+        color: var(--fg);
+        font-weight: 600;
+      }
+      .dialog-frame__foot__actions {
+        display: flex;
+        gap: 8px;
+      }
+      .btn {
+        all: unset;
+        cursor: pointer;
+        font: inherit;
+        font-size: 13px;
+        font-weight: 500;
+        padding: 8px 14px;
+        border-radius: 8px;
+        border: 1px solid var(--border-strong);
+        color: var(--fg);
+        line-height: 1;
+        transition:
+          background 120ms,
+          border-color 120ms;
+      }
+      .btn:hover {
+        background: oklch(1 0 0 / 0.04);
+      }
+      .btn--primary {
+        background: var(--primary);
+        color: var(--primary-fg);
+        border-color: var(--primary);
+        font-weight: 600;
+      }
+      .btn--primary:hover {
+        background: oklch(0.85 0.15 280);
+      }
+      .btn--ghost {
+        border-color: transparent;
+        color: var(--muted-fg);
+      }
+      .btn--ghost:hover {
+        color: var(--fg);
+      }
+
+      /* ============================================================
+         Spec checklist (under the dialog)
+         ============================================================ */
+      .speclist {
+        max-width: 768px;
+        margin: 28px auto 0;
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 18px 20px;
+      }
+      .speclist__head {
+        font-size: 10.5px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        color: var(--primary);
+        margin-bottom: 12px;
+      }
+      .speclist__intro {
+        font-size: 13px;
+        color: var(--muted-fg);
+        margin: 0 0 14px;
+        line-height: 1.55;
+      }
+      .speclist ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      .speclist li {
+        font-size: 12.5px;
+        color: var(--fg-soft);
+        line-height: 1.55;
+        padding: 6px 0 6px 22px;
+        position: relative;
+      }
+      .speclist li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 11px;
+        width: 12px;
+        height: 12px;
+        border: 1.5px solid var(--primary);
+        border-radius: 3px;
+        background: var(--primary-soft);
+      }
+      .speclist li::after {
+        content: "";
+        position: absolute;
+        left: 4px;
+        top: 13px;
+        width: 3px;
+        height: 6px;
+        border: solid var(--primary);
+        border-width: 0 1.5px 1.5px 0;
+        transform: rotate(45deg);
+      }
+      .speclist strong {
+        color: var(--fg);
+        font-weight: 600;
+      }
+      .speclist code,
+      .speclist kbd {
+        font-family: ui-monospace, "SF Mono", monospace;
+        font-size: 11.5px;
+        background: oklch(1 0 0 / 0.06);
+        padding: 1px 5px;
+        border-radius: 3px;
+        color: var(--fg);
+      }
+      .speclist__section {
+        margin-top: 18px;
+        padding-top: 14px;
+        border-top: 1px solid var(--border);
+      }
+      .speclist__section:first-of-type {
+        border-top: 0;
+        padding-top: 0;
+      }
+      .speclist__section__head {
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        color: var(--fg-2);
+        margin-bottom: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="stage">
+      <header class="panel__head">
+        <div class="panel__eyebrow">Identify · iteration 10</div>
+        <h1 class="panel__title">Cleaned up</h1>
+        <p class="panel__desc">
+          File-switcher row removed from the review step entirely. File
+          metadata (type, name, duration, bitrate) now lives inline in
+          the FILE section banner — keeps everything file-specific
+          together. "Reset to defaults" renamed to "Restore suggestions"
+          to clarify which defaults. Spec calls out
+          <code>lucide-react</code> for all icons in the real
+          implementation.
+        </p>
+      </header>
+
+      <div class="dialog-frame">
+        <!-- HEAD -->
+        <div class="dialog-frame__head">
+          <button class="dialog-frame__back" aria-label="Back to search">
+            <svg viewBox="0 0 12 12" fill="none">
+              <path
+                d="M7.5 2L3.5 6l4 4"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+          </button>
+          <div class="dialog-frame__heading">
+            <h2 class="dialog-frame__title">
+              Identify Harry Potter and the Sorcerer's Stone
+            </h2>
+            <div class="dialog-frame__sub">
+              <span>2 files</span>
+              <span class="dot">·</span>
+              <span>12 changes proposed</span>
+            </div>
+          </div>
+          <span class="dialog-frame__source">
+            <span class="dialog-frame__source__pulse" aria-hidden="true"></span>
+            Audible
+          </span>
+        </div>
+
+        <!-- BODY -->
+        <div class="dialog-frame__body">
+          <!-- Select-all (mixed: book section unchecked, file section all checked) -->
+          <div class="selectbar">
+            <button class="check" aria-checked="mixed"></button>
+            <span class="selectbar__label">Apply all changes</span>
+            <span class="selectbar__count">
+              <strong>6</strong> of 12 selected
+            </span>
+            <span class="selectbar__spacer"></span>
+            <div class="selectbar__filter" role="tablist">
+              <button class="selectbar__filter__btn" aria-pressed="true">
+                Changed
+              </button>
+              <button class="selectbar__filter__btn">All</button>
+            </div>
+          </div>
+
+          <!-- ============= BOOK SECTION ============= -->
+          <!-- Demo: collapsed by default for "second identify on non-primary
+               file". Subtitle is the only book change selected, since it's
+               new (no value to overwrite); other book changes default off. -->
+          <section class="section" data-state="collapsed">
+            <div class="section-banner" data-section-banner>
+              <span class="section-banner__chevron" aria-hidden="true">
+                <svg viewBox="0 0 12 12" fill="none">
+                  <path
+                    d="M3 4.5l3 3 3-3"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+              <span class="section-banner__inner">
+                <span class="section-banner__label">Book</span>
+                <span class="section-banner__hint">applies to all files</span>
+              </span>
+              <span class="section-banner__count">
+                <strong>1</strong> of 7 selected
+              </span>
+              <button class="check" aria-checked="mixed" data-section-check></button>
+            </div>
+            <div class="section-rows">
+
+          <!-- TITLE — book-level Changed: default OFF on non-primary.
+               Colon in title triggers the Extract subtitle button below. -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="false"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Title</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <input
+                class="input"
+                value="Harry Potter and the Sorcerer's Stone: Anniversary Audiobook"
+              />
+              <div class="row__after-input">
+                <div class="currently">
+                  <span class="currently__label">Currently:</span>
+                  <span class="currently__value">Harry Potter 1</span>
+                </div>
+                <button class="link-btn">
+                  <svg viewBox="0 0 12 12" fill="none">
+                    <path
+                      d="M6 2v4l-2-2M6 2l2 2M2 6v3a1 1 0 001 1h6a1 1 0 001-1V6"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                  Extract subtitle
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- SUBTITLE — book-level New (no current value): default ON
+               since there's nothing to overwrite. -->
+          <div class="row" data-state="new">
+            <button class="check" aria-checked="true"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Subtitle</span>
+                <span class="badge badge--new">New</span>
+              </div>
+              <input
+                class="input"
+                value="A Pottermore Original Audiobook"
+              />
+            </div>
+          </div>
+
+          <!-- AUTHORS — book-level Changed: default OFF -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="false"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Authors</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <div class="composite-list">
+                <div class="composite-row">
+                  <span class="composite-row__handle" aria-hidden="true">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <circle cx="4" cy="3" r="1" fill="currentColor" />
+                      <circle cx="4" cy="6" r="1" fill="currentColor" />
+                      <circle cx="4" cy="9" r="1" fill="currentColor" />
+                      <circle cx="8" cy="3" r="1" fill="currentColor" />
+                      <circle cx="8" cy="6" r="1" fill="currentColor" />
+                      <circle cx="8" cy="9" r="1" fill="currentColor" />
+                    </svg>
+                  </span>
+                  <span class="composite-row__name">J. K. Rowling</span>
+                  <select class="composite-row__select composite-row__select--narrow">
+                    <option>Author</option>
+                    <option>Translator</option>
+                    <option>Editor</option>
+                    <option>No role</option>
+                  </select>
+                  <button class="composite-row__remove" aria-label="remove">
+                    <svg viewBox="0 0 11 11" fill="none">
+                      <path
+                        d="M1 1l9 9M10 1l-9 9"
+                        stroke="currentColor"
+                        stroke-width="1.6"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div class="composite-row composite-row--add">
+                  <input
+                    class="composite-row__input"
+                    type="text"
+                    value="ste"
+                    placeholder="Add author"
+                  />
+                  <span class="composite-row__caret" aria-hidden="true">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <path
+                        d="M3 4.5l3 3 3-3"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </span>
+                  <!-- Open typeahead demo: shows existing-entity matches +
+                       a "create new" affordance. Real component pulls
+                       suggestions from the library. -->
+                  <div class="typeahead" role="listbox">
+                    <div class="typeahead__group-label">In your library</div>
+                    <button class="typeahead__item typeahead__item--active">
+                      Stephen Fry
+                      <span class="typeahead__item__meta">12 books</span>
+                    </button>
+                    <button class="typeahead__item">
+                      Stephen King
+                      <span class="typeahead__item__meta">3 books</span>
+                    </button>
+                    <div class="typeahead__sep"></div>
+                    <button class="typeahead__item typeahead__item--create">
+                      Create new author <strong>"ste"</strong>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="currently">
+                <span class="currently__label">Currently:</span>
+                <span class="currently__value">JK Rowling (Author), Stephen Fry (Author)</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- SERIES — book-level Changed: default OFF -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="false"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Series</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <div class="composite-list">
+                <div class="composite-row">
+                  <span class="composite-row__handle" aria-hidden="true">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <circle cx="4" cy="3" r="1" fill="currentColor" />
+                      <circle cx="4" cy="6" r="1" fill="currentColor" />
+                      <circle cx="4" cy="9" r="1" fill="currentColor" />
+                      <circle cx="8" cy="3" r="1" fill="currentColor" />
+                      <circle cx="8" cy="6" r="1" fill="currentColor" />
+                      <circle cx="8" cy="9" r="1" fill="currentColor" />
+                    </svg>
+                  </span>
+                  <span class="composite-row__name"
+                    >Harry Potter (Full-Cast Editions)</span
+                  >
+                  <input class="composite-row__num" value="1" />
+                  <select class="composite-row__select composite-row__select--unit">
+                    <option>—</option>
+                    <option selected>Volume</option>
+                    <option>Chapter</option>
+                  </select>
+                  <button class="composite-row__remove" aria-label="remove">
+                    <svg viewBox="0 0 11 11" fill="none">
+                      <path
+                        d="M1 1l9 9M10 1l-9 9"
+                        stroke="currentColor"
+                        stroke-width="1.6"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div class="composite-row composite-row--add">
+                  <input
+                    class="composite-row__input"
+                    type="text"
+                    placeholder="Add series"
+                  />
+                  <span class="composite-row__caret" aria-hidden="true">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <path
+                        d="M3 4.5l3 3 3-3"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+              <div class="currently">
+                <span class="currently__label">Currently:</span>
+                <span class="currently__value">Harry Potter · 1 (Volume)</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- GENRES — book-level Changed: default OFF -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="false"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Genres</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <div class="chips">
+                <span class="chip">Children's Audiobooks
+                  <button class="chip__x" aria-label="remove">
+                    <svg viewBox="0 0 10 10" fill="none">
+                      <path
+                        d="M1 1l8 8M9 1l-8 8"
+                        stroke="currentColor"
+                        stroke-width="1.6"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </button></span>
+                <span class="chip-combobox">
+                  <input
+                    class="chip-input"
+                    placeholder="Add genre"
+                    data-chip-input
+                  />
+                  <span class="chip-combobox__caret" aria-hidden="true">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <path
+                        d="M3 4.5l3 3 3-3"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div class="currently">
+                <span class="currently__label">Currently:</span>
+                <span class="currently__value">Young Adult, Fantasy, Fiction</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- TAGS — book-level Changed: default OFF -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="false"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Tags</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <div class="chips">
+                <span class="chip">Growing Up & Facts of Life
+                  <button class="chip__x" aria-label="remove">
+                    <svg viewBox="0 0 10 10" fill="none">
+                      <path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                    </svg>
+                  </button></span>
+                <span class="chip">Social & Life Skills
+                  <button class="chip__x" aria-label="remove">
+                    <svg viewBox="0 0 10 10" fill="none">
+                      <path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                    </svg>
+                  </button></span>
+                <span class="chip">Literature & Fiction
+                  <button class="chip__x" aria-label="remove">
+                    <svg viewBox="0 0 10 10" fill="none">
+                      <path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                    </svg>
+                  </button></span>
+                <span class="chip">Family Life
+                  <button class="chip__x" aria-label="remove">
+                    <svg viewBox="0 0 10 10" fill="none">
+                      <path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                    </svg>
+                  </button></span>
+                <span class="chip">Science Fiction & Fantasy
+                  <button class="chip__x" aria-label="remove">
+                    <svg viewBox="0 0 10 10" fill="none">
+                      <path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                    </svg>
+                  </button></span>
+                <span class="chip">Fantasy & Magic
+                  <button class="chip__x" aria-label="remove">
+                    <svg viewBox="0 0 10 10" fill="none">
+                      <path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                    </svg>
+                  </button></span>
+                <span class="chip-combobox">
+                  <input
+                    class="chip-input"
+                    placeholder="Add tag"
+                    data-chip-input
+                  />
+                  <span class="chip-combobox__caret" aria-hidden="true">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <path
+                        d="M3 4.5l3 3 3-3"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </span>
+                </span>
+              </div>
+              <div class="currently">
+                <span class="currently__label">Currently:</span>
+                <span class="currently__value">Magic, Adventure, Audiobook, Middle Grade, Harry Potter, Childrens, Classics</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- DESCRIPTION — book-level Changed: default OFF (with expandable currently) -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="false"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Description</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <textarea class="textarea">Immerse yourself in the stories like never before; wear headphones for the best experience.
+
+The beloved stories as you've never experienced them. Get ready to be transported to the world of Harry Potter in a captivating production that features hundreds of unique voices and immersive sound design that brings the wizarding world vividly to life in Dolby Atmos.</textarea>
+              <div class="currently currently--collapsed" data-currently>
+                <span class="currently__label">Currently:</span>
+                <span class="currently__value"
+                  >"Turning the envelope over, his hand trembling, Harry saw a purple wax seal bearing a coat of arms; a lion, an eagle, a badger and a snake surrounding a large letter 'H'." Harry Potter has never been the star of a Quidditch team, scoring points while riding a broom far above the ground. He isn't a member of one of the four houses at Hogwarts. He's not even a wizard — yet. So begins one of the most beloved stories in modern fantasy literature: a tale of a boy, a school, and a sorcerer's stone.</span>
+                <button class="currently__toggle" data-currently-toggle>
+                  <span data-currently-toggle-label>Show full</span>
+                  <svg viewBox="0 0 10 10" fill="none">
+                    <path
+                      d="M2 4l3 3 3-3"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+            </div>
+          </section>
+
+          <!-- ============= FILE SECTION ============= -->
+          <!-- File metadata (type, name, duration, bitrate, pages, etc.)
+               is shown inline in this banner. The exact metadata fields
+               vary by file_type — m4b shows duration + bitrate, epub/cbz/
+               pdf shows page count, etc. -->
+          <section class="section" data-state="expanded">
+            <div class="section-banner" data-section-banner>
+              <span class="section-banner__chevron" aria-hidden="true">
+                <svg viewBox="0 0 12 12" fill="none">
+                  <path
+                    d="M3 4.5l3 3 3-3"
+                    stroke="currentColor"
+                    stroke-width="1.6"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+              <span class="section-banner__inner">
+                <span class="section-banner__label">File</span>
+                <span class="section-banner__file-meta">
+                  <span class="section-banner__file-type">M4B</span>
+                  <span class="section-banner__sep">·</span>
+                  <span class="section-banner__file-name">Full-Cast</span>
+                  <span class="section-banner__sep">·</span>
+                  <span>8h 17m</span>
+                  <span class="section-banner__sep">·</span>
+                  <span>192 kbps</span>
+                </span>
+              </span>
+              <span class="section-banner__count">
+                <strong>5</strong> of 5 selected
+              </span>
+              <button class="check" aria-checked="true" data-section-check></button>
+            </div>
+            <div class="section-rows">
+
+          <!-- COVER — same layout for all file types. The trailing
+               button changes label/action based on file_type:
+                 m4b/epub  → "Upload cover" (file picker)
+                 cbz/pdf   → "Select page" (PagePicker dialog)
+               Caption next to the thumbnail shows resolution for image
+               covers and "Page N" for page-based covers. -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="true"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Cover</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <div class="covers">
+                <div class="cover-card">
+                  <div class="cover-card__img cover-card__img--current"></div>
+                  <span class="cover-card__cap">Current</span>
+                </div>
+                <span class="cover-arrow" aria-hidden="true">→</span>
+                <div class="cover-card">
+                  <div
+                    class="cover-card__img cover-card__img--new is-selected"
+                  ></div>
+                  <span class="cover-card__cap">
+                    <span class="cover-card__cap__bold">New</span> · 1280×1920
+                  </span>
+                </div>
+                <div class="covers__action">
+                  <button class="btn btn--soft">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <path
+                        d="M2 8v1.5A.5.5 0 002.5 10h7a.5.5 0 00.5-.5V8M6 1.5v6M6 1.5L4 3.5M6 1.5l2 2"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                    Upload cover
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- NARRATORS -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="true"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Narrators</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <div class="composite-list">
+                <div class="composite-row">
+                  <span class="composite-row__handle" aria-hidden="true">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <circle cx="4" cy="3" r="1" fill="currentColor" />
+                      <circle cx="4" cy="6" r="1" fill="currentColor" />
+                      <circle cx="4" cy="9" r="1" fill="currentColor" />
+                      <circle cx="8" cy="3" r="1" fill="currentColor" />
+                      <circle cx="8" cy="6" r="1" fill="currentColor" />
+                      <circle cx="8" cy="9" r="1" fill="currentColor" />
+                    </svg>
+                  </span>
+                  <span class="composite-row__name">Jim Dale</span>
+                  <button class="composite-row__remove" aria-label="remove">
+                    <svg viewBox="0 0 11 11" fill="none">
+                      <path
+                        d="M1 1l9 9M10 1l-9 9"
+                        stroke="currentColor"
+                        stroke-width="1.6"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                <div class="composite-row composite-row--add">
+                  <input
+                    class="composite-row__input"
+                    type="text"
+                    placeholder="Add narrator"
+                  />
+                  <span class="composite-row__caret" aria-hidden="true">
+                    <svg viewBox="0 0 12 12" fill="none">
+                      <path
+                        d="M3 4.5l3 3 3-3"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </div>
+              <div class="currently">
+                <span class="currently__label">Currently:</span>
+                <span class="currently__value">Stephen Fry</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- PUBLISHER -->
+          <div class="row" data-state="new">
+            <button class="check" aria-checked="true"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Publisher</span>
+                <span class="badge badge--new">New</span>
+              </div>
+              <div class="combobox">
+                <div class="combobox__main">
+                  <input
+                    class="input"
+                    value="Pottermore Publishing and Audible Studios"
+                  />
+                  <span class="combobox__caret" aria-hidden="true">
+                    <svg viewBox="0 0 12 12" width="12" height="12" fill="none">
+                      <path
+                        d="M3 4.5l3 3 3-3"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  </span>
+                </div>
+                <button class="combobox__clear" aria-label="clear">
+                  <svg viewBox="0 0 12 12" width="12" height="12" fill="none">
+                    <path
+                      d="M2 2l8 8M10 2l-8 8"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- IMPRINT (unchanged — no incoming value, but checkbox + input
+               stay enabled so user can edit and apply manually). -->
+          <div class="row" data-state="unchanged">
+            <button class="check" aria-checked="false"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Imprint</span>
+              </div>
+              <div class="combobox">
+                <div class="combobox__main">
+                  <input class="input" value="" placeholder="—" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- LANGUAGE (unchanged — checkbox + input enabled). -->
+          <div class="row" data-state="unchanged">
+            <button class="check" aria-checked="false"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Language</span>
+              </div>
+              <div class="combobox">
+                <div class="combobox__main">
+                  <input class="input" value="English" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- RELEASE DATE — plain text input, NOT date picker -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="true"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Release date</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <input
+                class="input"
+                type="text"
+                value="2015-11-20"
+                placeholder="YYYY-MM-DD"
+              />
+              <div class="currently">
+                <span class="currently__label">Currently:</span>
+                <span class="currently__value">1997-06-26</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- IDENTIFIERS — type-select + value-input + Enter to add -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="true"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Identifiers</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <div class="chips">
+                <span class="chip chip--id">
+                  <span class="chip__type">ASIN</span>B017WIJBNK
+                  <button class="chip__x" aria-label="remove">
+                    <svg viewBox="0 0 10 10" fill="none">
+                      <path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                    </svg>
+                  </button>
+                </span>
+                <span class="chip chip--id">
+                  <span class="chip__type">ISBN</span>9781781100486
+                  <button class="chip__x" aria-label="remove">
+                    <svg viewBox="0 0 10 10" fill="none">
+                      <path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />
+                    </svg>
+                  </button>
+                </span>
+              </div>
+              <div class="id-add-row">
+                <select class="id-add-row__select">
+                  <option>ASIN</option>
+                  <option>ISBN</option>
+                  <option>Audible ID</option>
+                  <option>Goodreads</option>
+                </select>
+                <input
+                  class="id-add-row__input"
+                  type="text"
+                  placeholder="Identifier value"
+                />
+              </div>
+              <div class="currently">
+                <span class="currently__label">Currently:</span>
+                <span class="currently__value">ISBN 0747532699</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- ABRIDGED (unchanged) — outer row checkbox is enabled so user
+               can opt in to apply. Inner Abridged toggle is disabled
+               until the outer checkbox is checked. -->
+          <div class="row" data-state="unchanged" data-row-toggle>
+            <button class="check" aria-checked="false" data-row-toggle-outer></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Abridged</span>
+              </div>
+              <label class="check-with-label">
+                <span class="check" aria-checked="false" data-row-toggle-inner></span>
+                This is an abridged edition
+              </label>
+            </div>
+          </div>
+            </div>
+          </section>
+        </div>
+
+        <!-- FOOTER -->
+        <div class="dialog-frame__foot">
+          <button class="btn btn--ghost dialog-frame__foot__reset">
+            <svg viewBox="0 0 12 12" fill="none">
+              <path
+                d="M2 6a4 4 0 107-2.83M9 2v2.5H6.5"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            Restore suggestions
+          </button>
+          <span class="dialog-frame__foot__summary">
+            <strong>1 book change</strong> · <strong>5 file changes</strong> selected
+          </span>
+          <div class="dialog-frame__foot__actions">
+            <button class="btn btn--ghost">Cancel</button>
+            <button class="btn btn--primary">Apply 6 changes</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ============================================================
+           Spec — comprehensive checklist. The implementation must hit
+           every item below; if a detail isn't here, flag it before
+           building.
+           ============================================================ -->
+      <div class="speclist">
+        <div class="speclist__head">Spec — locked decisions</div>
+        <p class="speclist__intro">
+          The combobox-style entity inputs, sticky scope sections, and
+          per-field checkbox model are meaningful changes to Shisho's
+          interaction patterns. They must ship cohesively across identify
+          AND the edit dialogs (<code>BookEditDialog</code>,
+          <code>FileEditDialog</code>, metadata-entity edit forms). If
+          something in the mockup isn't captured below, raise it before
+          implementation — what's not codified will drift.
+        </p>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Decision model</div>
+          <ul>
+            <li>
+              <strong>Per-field checkbox</strong> on every row. Checked =
+              this field's proposed value will be written on Apply. Unchecked
+              = skipped.
+            </li>
+            <li>
+              <strong>Section-level select-all</strong> on each section
+              banner. Toggles every checkbox in the section.
+            </li>
+            <li>
+              <strong>Global "Apply all"</strong> at the top toggles every
+              checkbox in the dialog.
+            </li>
+            <li>
+              <strong>Three checkbox states</strong>: <code>false</code>,
+              <code>true</code>, <code>mixed</code>. Mixed = filled
+              background with a horizontal bar (not a check). Mixed appears
+              on section and global toggles when some-but-not-all child
+              rows are checked. Clicking a mixed checkbox sets it to
+              <code>false</code> (matches browser indeterminate behavior).
+            </li>
+            <li>
+              Hover affordance only on <em>unchecked</em> boxes; checked
+              and mixed boxes get a brighter primary on hover, never a
+              "looks unchecked" treatment.
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Smart defaults</div>
+          <ul>
+            <li>
+              <strong>Field state classes</strong>: <code>changed</code>
+              (current value differs from proposed), <code>new</code> (no
+              current value, proposed value provided),
+              <code>unchanged</code> (current and proposed match — no
+              checkbox toggle by default but user can still manually
+              opt in to apply).
+            </li>
+            <li>
+              <strong>Default ON</strong>: file-level changes (always);
+              book-level <em>new</em> fields (always — nothing to
+              overwrite); book-level <em>changed</em> fields when
+              identifying the primary file.
+            </li>
+            <li>
+              <strong>Default OFF</strong>: book-level <em>changed</em>
+              fields when identifying a non-primary file (the
+              "second-identify" case — don't overwrite shared book
+              metadata from a non-canonical source).
+            </li>
+            <li>
+              <strong>Section default-collapsed iff selected count = 0.</strong>
+              Not "always collapse on second-identify." This means if a
+              second file's metadata source contributes a brand-new field
+              the first file didn't have (e.g., a Subtitle), the field
+              defaults ON, the count becomes 1, and the section stays
+              expanded. Common case for second-identify is still
+              "all-zero, collapsed" since most book fields will be Changed,
+              not New.
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Section organization</div>
+          <ul>
+            <li>
+              Two sections: <strong>Book</strong> ("applies to all files")
+              and <strong>File</strong> ("applies to <em>file.Name</em>
+              only"). Cover is in the File section.
+            </li>
+            <li>
+              Sections are collapsible. Click anywhere on the banner to
+              toggle (except the section's own checkbox, which stops
+              propagation).
+            </li>
+            <li>
+              Banner: chevron (rotates -90° when collapsed) +
+              <code>BOOK</code> label + hint text + "<em>X</em> of
+              <em>Y</em> selected" count + section-level checkbox. The
+              count is always visible, including when collapsed.
+            </li>
+            <li>
+              Banner alignment: chevron sits in the same column as
+              field-row checkboxes, so the section label aligns with
+              field labels (60px from left).
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Sticky headers</div>
+          <ul>
+            <li>
+              Dialog frame head + file switcher: outside the scroll body
+              entirely (always visible).
+            </li>
+            <li>
+              <strong>Select-all bar</strong>:
+              <code>position: sticky; top: 0; z-index: 3</code> within the
+              scroll body.
+            </li>
+            <li>
+              <strong>Section banners</strong>:
+              <code>position: sticky; top: 49px; z-index: 2</code> (offset
+              by selectbar height). When you scroll into a section's rows,
+              its banner pins below the selectbar; scrolling past the
+              section lets the next banner take over the same slot.
+            </li>
+            <li>
+              All sticky elements have solid backgrounds so content
+              scrolling underneath is occluded cleanly.
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Multi-value entity inputs (combobox typeahead)</div>
+          <ul>
+            <li>
+              Replaces today's <code>[+ Add tag]</code> buttons. Pill- or
+              row-shaped editable input with a caret on the right.
+            </li>
+            <li>
+              Click or focus opens a dropdown popover. Type to filter.
+            </li>
+            <li>
+              Dropdown groups: <code>IN YOUR LIBRARY</code> (matching
+              existing entities, with usage counts e.g. "12 books") +
+              separator + <code>Create new author "ste"</code>
+              create-novel affordance.
+            </li>
+            <li>
+              Up/Down arrows navigate; <kbd>Enter</kbd> commits highlighted
+              suggestion (or the create-new option if no match is
+              highlighted); <kbd>Esc</kbd> closes.
+            </li>
+            <li>
+              On commit, suggestion becomes a chip/composite row above the
+              input; the input clears and stays focused so the user can
+              type the next entry.
+            </li>
+            <li>
+              No "↵ to add" hint label needed — the caret + dropdown carry
+              the affordance.
+            </li>
+            <li>
+              Applies to: Authors, Narrators, Series, Genres, Tags.
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Composite rows (entities with extra fields)</div>
+          <ul>
+            <li>
+              <strong>Authors</strong>: drag handle + name + role
+              dropdown + remove. Roles: Author / Translator / Editor / No
+              role (and any role added in a CBZ context per existing edit
+              dialog).
+            </li>
+            <li>
+              <strong>Narrators</strong>: drag handle + name + remove. No
+              role.
+            </li>
+            <li>
+              <strong>Series</strong>: drag handle + name + number input
+              (3-digit width, tabular-nums) + unit dropdown (— / Volume /
+              Chapter) + remove.
+            </li>
+            <li>
+              <strong>Identifiers</strong>: chips render
+              <code>[TYPE] value</code> with TYPE uppercase in primary
+              color. Add row is horizontal: type-select (only available
+              types listed) + value input + <kbd>Enter</kbd> commits.
+              Add row uses monospace for the value field.
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Per-field rules</div>
+          <ul>
+            <li>
+              <strong>Title</strong>: plain text input. If the title
+              contains a colon (<code>:</code>), show an "Extract subtitle"
+              button below the input on the right. Clicking it removes
+              everything after the colon from the title and writes that
+              text into the Subtitle field. Mirrors existing
+              <code>BookEditDialog.tsx:526</code> behavior.
+            </li>
+            <li>
+              <strong>Subtitle</strong>: plain text input.
+            </li>
+            <li>
+              <strong>Description</strong>: <code>&lt;textarea&gt;</code>,
+              min-height ~88px, vertical resize. The "Currently:" reference
+              is line-clamped to 2 lines by default with a "Show full"
+              toggle that expands to the full original; "Show less"
+              collapses back. No markdown, no rich text.
+            </li>
+            <li>
+              <strong>Cover</strong>: side-by-side comparison of current
+              vs new thumbnails — same layout for every file type. The
+              caption under each thumbnail shows resolution
+              (<code>1280×1920</code>) for image covers (M4B/EPUB) or
+              <code>Page N</code> for page-based covers (CBZ/PDF). A
+              trailing button switches label and action by file type:
+              "Upload cover" (M4B/EPUB) opens a file picker; "Select page"
+              (CBZ/PDF) opens the existing <code>PagePicker</code> dialog.
+              New is selected by default with a primary ring. Lives in
+              the File section.
+            </li>
+            <li>
+              <strong>Publisher / Imprint / Language</strong>: combobox
+              single-value with caret + dedicated clear button.
+            </li>
+            <li>
+              <strong>Imprint / Language when Unchanged</strong>: input
+              <em>and</em> checkbox stay enabled even with no incoming
+              value, so user can manually fill and apply.
+            </li>
+            <li>
+              <strong>Release date</strong>: <em>plain text input</em>,
+              never a date picker. Placeholder
+              <code>YYYY-MM-DD</code>. Supports old, partial, or unknown
+              dates. The current
+              <code>&lt;DatePicker&gt;</code> in BookEditDialog/FileEditDialog
+              must also be swapped for plain text.
+            </li>
+            <li>
+              <strong>Abridged</strong>: checkbox-with-label.
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Two-step flow & navigation</div>
+          <ul>
+            <li>
+              <strong>Step 1: search</strong>. User selects which file is
+              being identified (file switcher with dropdown), enters a
+              query, gets plugin results, picks one. Search step gets a
+              light visual refresh — same dialog frame, back arrow, source
+              pill, file switcher — but no structural changes to its
+              result-picker grid.
+            </li>
+            <li>
+              <strong>Step 2: review</strong>. The form we've designed.
+              File switcher here is read-only (just shows which file is
+              being identified). Switching files happens on the search
+              step.
+            </li>
+            <li>
+              <strong>Default file selection on dialog open</strong>
+              uses the existing <code>file.reviewed</code> flag (computed
+              by <code>review.IsComplete(book, file, criteria)</code>
+              against per-library required fields, with optional
+              <code>ReviewOverride</code>):
+              <ol>
+                <li>If some files are reviewed and some aren't, pick a
+                  non-reviewed file (<code>reviewed != true</code> —
+                  covers both <code>false</code> and <code>NULL</code>).</li>
+                <li>If all files share the same reviewed status, prefer
+                  the primary file if set.</li>
+                <li>Otherwise pick the first file. Order doesn't matter
+                  much in this case.</li>
+              </ol>
+              No new model fields needed. This builds on the review
+              system already in <code>pkg/books/review/</code>.
+            </li>
+            <li>
+              <strong>Identify does not directly set reviewed</strong>.
+              After Apply, the existing recompute pipeline runs
+              (<code>RecomputeReviewedForBook</code> /
+              <code>RecomputeReviewedForFile</code>); if the applied
+              changes brought the file to completeness, it becomes
+              reviewed automatically. Users with an explicit
+              <code>ReviewOverride</code> keep their override.
+            </li>
+            <li>
+              <strong>NameSource / source attribution on apply</strong>:
+              fields whose values come from the plugin's proposed result
+              are saved with their respective <code>*Source</code>
+              column set to <code>"plugin"</code>. Fields whose values
+              were manually edited by the user in the review form before
+              Apply are saved with source <code>"user"</code>. This
+              matters for subsequent scanner re-identify — user edits
+              must survive a re-scan, plugin-set values can be
+              overwritten by a re-scan that finds better data.
+            </li>
+            <li>
+              <strong>Back navigation (review → search)</strong>: search
+              state (query, results, selected result) is preserved.
+              Review state <em>resets</em> on every forward navigation —
+              going back and forward is an intentional way to reset
+              changes. This matches today's behavior.
+            </li>
+            <li>
+              <strong>Restore suggestions button</strong> in the
+              review-step footer (left side, ghost variant) reverts all
+              checkboxes and field values to the plugin's suggested
+              state — the smart defaults the form opened with.
+              Effectively "undo all my edits to this form." Label is
+              "Restore suggestions" (not "Reset"), since that conveys
+              <em>which</em> defaults — the search result's suggestions —
+              rather than something ambiguous like the book's pre-identify
+              values. Distinct from Cancel (which discards and closes).
+            </li>
+            <li>
+              <strong>Apply behavior</strong>: button shows an inline
+              loading state ("Applying…" with spinner) while the request
+              is pending. On success, dialog closes and a toast confirms
+              ("Updated 6 fields"). On error, the dialog stays open with
+              an inline error banner so the user can retry without losing
+              their checkbox state. File reorganization is an
+              implementation detail and not surfaced in the toast.
+            </li>
+            <li>
+              <strong>Multi-file post-apply</strong>: dialog just closes.
+              No special "identify the other file?" prompt — user
+              re-opens identify from the book detail page when they want
+              to identify additional files.
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Dialog frame</div>
+          <ul>
+            <li>
+              Width: <code>max-w-3xl</code> (768px), one step wider than
+              the existing edit dialog because each row carries
+              current-vs-proposed.
+            </li>
+            <li>
+              <strong>Head</strong>: back arrow (top-left, 24px button,
+              12px chevron-left icon) + title + subtitle (file count + N
+              changes proposed) + source pill (right). No close X — back
+              arrow returns to the search step.
+            </li>
+            <li>
+              <strong>File switcher</strong>: lives <em>only on the
+              search step</em>, between head and scroll body. Pill shows
+              file type (uppercase, no border, separated from filename
+              by a thin vertical rule) + <code>file.Name</code> (no file
+              extension) + dropdown caret. Switching files re-runs the
+              search.
+            </li>
+            <li>
+              <strong>File context on the review step</strong>: there is
+              no separate file-switcher row. The currently-identified
+              file's metadata is shown inline in the
+              <em>FILE section banner</em> alongside its label and count
+              ("FILE · M4B · Full-Cast · 8h 17m · 192 kbps"). The
+              specific metadata fields adapt to <code>file_type</code> —
+              audiobooks show duration + bitrate, ebooks/comics/PDFs show
+              page count, etc.
+            </li>
+            <li>
+              <strong>Body</strong>:
+              <code>max-height: 70vh; overflow-y: auto</code>. Sticky
+              selectbar + sticky section banners as defined above.
+            </li>
+            <li>
+              <strong>Foot</strong>: Reset button (ghost, left side) +
+              counts split by section ("<strong>1 book change</strong> ·
+              <strong>5 file changes</strong> selected") in the middle +
+              Cancel/Apply on the right. Primary action "Apply N changes"
+              with N = total selected.
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Cohesion — across the whole app</div>
+          <p style="font-size:12.5px;color:var(--muted-fg);line-height:1.55;margin:0 0 10px;">
+            Identify is one of several places these patterns surface. The
+            implementation must avoid one-off treatments here — every
+            foundational change adopted in this dialog also lands wherever
+            it appears in Shisho.
+          </p>
+          <ul>
+            <li>
+              <strong>Combobox typeahead</strong> replaces existing
+              <code>EntityCombobox</code> /
+              <code>MultiSelectCombobox</code> /
+              <code>IdentifierEditor</code> add affordances <em>site-wide</em>:
+              <code>BookEditDialog</code>, <code>FileEditDialog</code>,
+              metadata-entity edit forms (Genres, Tags, People, Series),
+              filter pickers, and any other place chips/composite lists
+              are entered.
+            </li>
+            <li>
+              <strong>Composite rows</strong> (authors+role,
+              series+number+unit) share the
+              <code>SortableEntityList</code> component used by the edit
+              dialogs. Don't build a parallel implementation.
+            </li>
+            <li>
+              <strong>Plain-text date input</strong> replaces
+              <code>&lt;DatePicker&gt;</code> wherever release dates,
+              publish dates, or other "could be old" dates appear —
+              including <code>FileEditDialog</code>, library scan filters,
+              series metadata, etc.
+            </li>
+            <li>
+              <strong>Title's "Extract subtitle" button</strong> is the
+              same component used today in <code>BookEditDialog</code>;
+              reused as-is.
+            </li>
+            <li>
+              <strong>Visual tokens</strong> (radius, border alpha,
+              primary, success, mixed-state checkbox style, status badges,
+              chip styling, etc.) come from <code>app/index.css</code> and
+              shared component CSS. If a token changes here, it changes
+              everywhere it's used; no in-file overrides.
+            </li>
+            <li>
+              <strong>Checkbox states</strong> (false / true / mixed) and
+              their hover behavior are a global change — every
+              <code>Checkbox</code> usage in the app must support the
+              indeterminate state and never show the "looks unchecked on
+              hover" bug for checked or mixed boxes.
+            </li>
+            <li>
+              <strong>Outer-controls-inner pattern</strong> for fields
+              like Abridged (apply-checkbox controls whether the
+              field-checkbox is interactive) is reusable; if other forms
+              gain a similar "apply this field" gate, they inherit the
+              same disabled-until-applied behavior.
+            </li>
+          </ul>
+        </div>
+
+        <div class="speclist__section">
+          <div class="speclist__section__head">Visual specifics</div>
+          <ul>
+            <li>
+              Surface stack (darkest → lightest): body
+              <code>oklch(0.18)</code> → dialog card
+              <code>oklch(0.22)</code> → row container
+              <code>oklch(0.22)</code> → selectbar
+              <code>oklch(0.20)</code> → section banner
+              <code>oklch(0.205)</code>.
+            </li>
+            <li>
+              Status badge palette: <strong>Changed</strong> = primary
+              soft; <strong>New</strong> = success soft. Unchanged rows
+              get no badge.
+            </li>
+            <li>
+              Chips: 28px tall, 999px radius, always-visible × on each
+              chip (no hover-to-show). × hover state =
+              danger-soft background.
+            </li>
+            <li>
+              Checkboxes: 18×18, 5px radius. Primary fill when checked or
+              mixed. Indeterminate visual = horizontal bar in primary-fg.
+            </li>
+            <li>
+              Faint top-of-page radial gradient
+              (<code>oklch(0.8 0.15 280 / 0.05)</code>) for atmosphere; no
+              other glow effects.
+            </li>
+            <li>
+              <strong>Icons</strong>: every icon in the implementation
+              uses <code>lucide-react</code> — chevron-down, chevron-left,
+              x, plus, upload, refresh-ccw, and so on. The mockup uses
+              inline SVGs for portability, but production code does not
+              ship one-off SVG paths. Match icon sizes to the surrounding
+              type (12–16px is the typical range here).
+            </li>
+          </ul>
+        </div>
+      </div>
+    </main>
+
+    <script>
+      // toggle checkbox (treat mixed → true on click)
+      document.querySelectorAll(".check").forEach((c) => {
+        if (c.disabled) return;
+        c.addEventListener("click", (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const cur = c.getAttribute("aria-checked");
+          c.setAttribute("aria-checked", cur === "true" ? "false" : "true");
+        });
+      });
+
+      // section collapse: clicking the banner (anywhere except the
+      // section's check) toggles expanded/collapsed.
+      document.querySelectorAll("[data-section-banner]").forEach((banner) => {
+        banner.addEventListener("click", (e) => {
+          if (e.target.closest("[data-section-check]")) return;
+          const section = banner.closest(".section");
+          const next =
+            section.dataset.state === "collapsed" ? "expanded" : "collapsed";
+          section.dataset.state = next;
+        });
+      });
+
+      // Inner field control is disabled until outer row checkbox is checked.
+      document
+        .querySelectorAll("[data-row-toggle-outer]")
+        .forEach((outer) => {
+          outer.addEventListener("click", () => {
+            const row = outer.closest("[data-row-toggle]");
+            requestAnimationFrame(() => {
+              row.dataset.rowApplied =
+                outer.getAttribute("aria-checked") === "true"
+                  ? "true"
+                  : "false";
+            });
+          });
+        });
+
+      // expand/collapse "Currently:" for description
+      document
+        .querySelectorAll("[data-currently-toggle]")
+        .forEach((btn) => {
+          btn.addEventListener("click", () => {
+            const root = btn.closest("[data-currently]");
+            const isExpanded =
+              root.classList.contains("currently--expanded");
+            root.classList.toggle("currently--expanded", !isExpanded);
+            root.classList.toggle("currently--collapsed", isExpanded);
+            const label = btn.querySelector("[data-currently-toggle-label]");
+            if (label)
+              label.textContent = isExpanded ? "Show full" : "Show less";
+          });
+        });
+
+      // chip-input: Enter commits a chip
+      document.querySelectorAll("[data-chip-input]").forEach((input) => {
+        input.addEventListener("keydown", (e) => {
+          if (e.key !== "Enter" && e.key !== ",") return;
+          const value = input.value.trim();
+          if (!value) return;
+          e.preventDefault();
+          const chip = document.createElement("span");
+          chip.className = "chip";
+          chip.innerHTML = `${value}<button class="chip__x" aria-label="remove"><svg viewBox="0 0 10 10" fill="none"><path d="M1 1l8 8M9 1l-8 8" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg></button>`;
+          input.parentNode.insertBefore(chip, input);
+          chip.querySelector(".chip__x").addEventListener("click", () => {
+            chip.remove();
+          });
+          input.value = "";
+          input.focus();
+        });
+      });
+
+      // composite-row__input: Enter commits
+      document
+        .querySelectorAll(".composite-row--add .composite-row__input")
+        .forEach((input) => {
+          input.addEventListener("keydown", (e) => {
+            if (e.key !== "Enter") return;
+            const value = input.value.trim();
+            if (!value) return;
+            e.preventDefault();
+            // demo: just clear; in real impl this would create a real composite row above
+            input.value = "";
+          });
+        });
+    </script>
+  </body>
+</html>

--- a/docs/design/identify-mockups/index.html
+++ b/docs/design/identify-mockups/index.html
@@ -1410,16 +1410,16 @@
   <body>
     <main class="stage">
       <header class="panel__head">
-        <div class="panel__eyebrow">Identify · iteration 10</div>
-        <h1 class="panel__title">Cleaned up</h1>
+        <div class="panel__eyebrow">Identify · iteration 12</div>
+        <h1 class="panel__title">file.Name as a real field</h1>
         <p class="panel__desc">
-          File-switcher row removed from the review step entirely. File
-          metadata (type, name, duration, bitrate) now lives inline in
-          the FILE section banner — keeps everything file-specific
-          together. "Reset to defaults" renamed to "Restore suggestions"
-          to clarify which defaults. Spec calls out
-          <code>lucide-react</code> for all icons in the real
-          implementation.
+          Name is now a normal File-section row with the standard
+          file-level default-ON rule (no special NameSource logic). The
+          "Copy from book title" button below the Name input mirrors
+          "Extract subtitle" — it shows whenever Title and Name differ
+          and copies Title into Name on click. The original clobber bug
+          is solved by exposing Name as a per-field opt-in decision
+          rather than by smart defaults.
         </p>
       </header>
 
@@ -1444,7 +1444,7 @@
             <div class="dialog-frame__sub">
               <span>2 files</span>
               <span class="dot">·</span>
-              <span>12 changes proposed</span>
+              <span>13 changes proposed</span>
             </div>
           </div>
           <span class="dialog-frame__source">
@@ -1460,7 +1460,7 @@
             <button class="check" aria-checked="mixed"></button>
             <span class="selectbar__label">Apply all changes</span>
             <span class="selectbar__count">
-              <strong>6</strong> of 12 selected
+              <strong>7</strong> of 13 selected
             </span>
             <span class="selectbar__spacer"></span>
             <div class="selectbar__filter" role="tablist">
@@ -1875,7 +1875,7 @@ The beloved stories as you've never experienced them. Get ready to be transporte
                 </span>
               </span>
               <span class="section-banner__count">
-                <strong>5</strong> of 5 selected
+                <strong>6</strong> of 6 selected
               </span>
               <button class="check" aria-checked="true" data-section-check></button>
             </div>
@@ -1922,6 +1922,44 @@ The beloved stories as you've never experienced them. Get ready to be transporte
                     Upload cover
                   </button>
                 </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- NAME — file.Name. Standard file-level default ON. The
+               "Copy from book title" button below shows when book.Title
+               and file.Name differ (typically after the user edits one
+               or extracts a subtitle); clicking it pastes the current
+               book.Title into the Name input. Mirrors the
+               "Extract subtitle" affordance under Title. -->
+          <div class="row" data-state="changed">
+            <button class="check" aria-checked="true"></button>
+            <div class="row__body">
+              <div class="row__head">
+                <span class="row__label">Name</span>
+                <span class="badge badge--changed">Changed</span>
+              </div>
+              <input
+                class="input"
+                value="Harry Potter and the Sorcerer's Stone"
+              />
+              <div class="row__after-input">
+                <div class="currently">
+                  <span class="currently__label">Currently:</span>
+                  <span class="currently__value">Full-Cast</span>
+                </div>
+                <button class="link-btn">
+                  <svg viewBox="0 0 12 12" fill="none">
+                    <path
+                      d="M3 3.5h-.5A.5.5 0 002 4v6a.5.5 0 00.5.5h5A.5.5 0 008 10V4a.5.5 0 00-.5-.5H7m-1.5-1H4a.5.5 0 00-.5.5v.5h3V2.5a.5.5 0 00-.5-.5z"
+                      stroke="currentColor"
+                      stroke-width="1.4"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                  Copy from book title
+                </button>
               </div>
             </div>
           </div>
@@ -2155,11 +2193,11 @@ The beloved stories as you've never experienced them. Get ready to be transporte
             Restore suggestions
           </button>
           <span class="dialog-frame__foot__summary">
-            <strong>1 book change</strong> · <strong>5 file changes</strong> selected
+            <strong>1 book change</strong> · <strong>6 file changes</strong> selected
           </span>
           <div class="dialog-frame__foot__actions">
             <button class="btn btn--ghost">Cancel</button>
-            <button class="btn btn--primary">Apply 6 changes</button>
+            <button class="btn btn--primary">Apply 7 changes</button>
           </div>
         </div>
       </div>

--- a/docs/superpowers/plans/2026-05-01-identify-file-name-clobber-fix.md
+++ b/docs/superpowers/plans/2026-05-01-identify-file-name-clobber-fix.md
@@ -1,0 +1,690 @@
+# Identify Phase 1 — Backend `file.Name` Clobber Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `persistMetadata` from silently overwriting `file.Name` with `book.Title`, and accept an explicit `file.Name` (with `file.NameSource`) in the apply payload so the upcoming Phase 2 frontend can opt-in per request.
+
+**Architecture:** Two narrowly-scoped backend changes in `pkg/plugins/`. (1) Remove the unconditional title→file.Name mirror in `persistMetadata`. (2) Plumb a new `applyOverrides` struct (`FileName`, `FileNameSource`) from the apply payload through `persistMetadata` so the apply path can explicitly set `file.Name` when, and only when, the payload says so. `mediafile.ParsedMetadata` is **not** modified — `file.Name` is an apply-path-only concern (plugins don't model it), so introducing a new internal struct keeps the SDK contract clean.
+
+**Tech Stack:** Go (Echo, Bun), testify. Backend-only.
+
+---
+
+## Spec reference
+
+This implements Phase 1 of `docs/superpowers/specs/2026-05-01-identify-flow-design.md`:
+
+- `pkg/plugins/handler_persist_metadata.go`: remove the unconditional copy of `title → file.Name`. Only write `file.Name` when the apply payload explicitly includes it.
+- `pkg/plugins/handler_apply_metadata.go`: accept an explicit `file.Name` (and `file.NameSource`) in the request payload.
+- Backend tests: verify silent overwrites no longer happen on a non-primary file identify; verify explicit `file.Name` in the payload still applies correctly with the right `NameSource`.
+
+## File structure
+
+| File | Change |
+|------|--------|
+| `pkg/plugins/handler_apply_metadata.go` | Modify. Add `FileName *string` and `FileNameSource *string` to `applyPayload` (json: `file_name`, `file_name_source`). Plumb a new `*applyOverrides` value into `persistMetadata`. |
+| `pkg/plugins/handler_persist_metadata.go` | Modify. New parameter `overrides *applyOverrides`. Delete the auto-mirror block ("Mirror the identified title onto the target main file's Name…"). Add a new explicit-write block guarded on `overrides != nil && overrides.FileName != nil`. |
+| `pkg/plugins/handler_convert.go` | Modify. Add a new `convertFieldsToOverrides(fields)` returning `*applyOverrides`. (Keeps `convertFieldsToMetadata` unchanged so existing tests are unaffected.) |
+| `pkg/plugins/handler_apply_metadata_test.go` | Modify existing tests + add new ones (see Task 6). |
+| `pkg/plugins/handler_persist_metadata_test.go` | Modify call sites for the new signature; existing assertions stay correct because no overrides means no `file.Name` write. |
+
+## Behavior summary
+
+**Before this change** — `persistMetadata`, given any non-empty `md.Title`, copies the title onto `targetFile.Name` whenever `targetFile.FileRole == FileRoleMain`. This silently clobbers user-set names like `"Harry Potter (Full-Cast Edition)"` whenever the user identifies any file (primary or not) against a generic plugin result.
+
+**After this change** —
+- Old frontend (no `file_name` in payload) → `file.Name` is **never** written by identify. Title clobbering stops.
+- New frontend (Phase 2 — `file_name` in payload) → `file.Name` is written to whatever the payload says, with `NameSource` from the payload (or, if the payload omits source, defaulting to the plugin source `plugin:scope/id`).
+
+The `FileRoleMain` restriction goes away on the explicit path: if Phase 2 ever surfaces the Name field for a supplement, the frontend's explicit opt-in is the gate. Phase 1's behavior shift on its own does not enable supplements to be touched (old payloads never set `file_name`), so this is purely future-proofing.
+
+---
+
+### Task 1: Add `applyOverrides` struct and converter
+
+**Files:**
+- Modify: `pkg/plugins/handler_convert.go`
+
+- [ ] **Step 1: Add `applyOverrides` struct and `convertFieldsToOverrides` helper to `handler_convert.go`**
+
+Append below `convertFieldsToMetadata` (after the closing `}` on the existing function):
+
+```go
+// applyOverrides carries apply-path-only signals that don't belong on
+// mediafile.ParsedMetadata (which is part of the public plugin SDK
+// contract). These come exclusively from the identify apply payload —
+// plugins do not model them.
+type applyOverrides struct {
+	// FileName is the value to write to file.Name. Nil = no change.
+	// Empty string is treated as nil (treat absent or "" as no-op so
+	// callers don't need to special-case empty inputs).
+	FileName *string
+	// FileNameSource is the value to write to file.NameSource. Nil
+	// means "default to the plugin source for this apply call".
+	FileNameSource *string
+}
+
+// convertFieldsToOverrides extracts apply-path-only signals from the
+// untyped fields map. Returns nil when no overrides are present, so
+// callers can cheaply skip the explicit-write code path.
+func convertFieldsToOverrides(fields map[string]any) *applyOverrides {
+	var out *applyOverrides
+	if v, ok := fields["file_name"].(string); ok && v != "" {
+		if out == nil {
+			out = &applyOverrides{}
+		}
+		out.FileName = &v
+	}
+	if v, ok := fields["file_name_source"].(string); ok && v != "" {
+		if out == nil {
+			out = &applyOverrides{}
+		}
+		out.FileNameSource = &v
+	}
+	return out
+}
+```
+
+- [ ] **Step 2: Run package tests to confirm nothing else broke**
+
+Run: `go test ./pkg/plugins/... -run TestConvert -count=1`
+Expected: PASS (existing convert tests continue to pass; we only added new code).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/plugins/handler_convert.go
+git commit -m "[Backend] Add applyOverrides struct and convertFieldsToOverrides helper"
+```
+
+---
+
+### Task 2: Unit-test the new converter helper
+
+**Files:**
+- Modify: `pkg/plugins/handler_convert_test.go`
+
+- [ ] **Step 1: Read the existing test file to find a sensible insertion point**
+
+Run: `wc -l pkg/plugins/handler_convert_test.go`
+(No assertions; this just confirms the file exists and orients the next step.)
+
+- [ ] **Step 2: Append failing tests**
+
+Append to `pkg/plugins/handler_convert_test.go`:
+
+```go
+func TestConvertFieldsToOverrides_NilWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	got := convertFieldsToOverrides(map[string]any{
+		"title": "Some Title",
+	})
+	require.Nil(t, got, "absence of file_name must yield nil overrides so callers can skip the explicit-write path")
+}
+
+func TestConvertFieldsToOverrides_NilWhenEmptyString(t *testing.T) {
+	t.Parallel()
+
+	got := convertFieldsToOverrides(map[string]any{
+		"file_name":        "",
+		"file_name_source": "",
+	})
+	require.Nil(t, got, "empty strings must be treated as absent — no overrides")
+}
+
+func TestConvertFieldsToOverrides_FileNameOnly(t *testing.T) {
+	t.Parallel()
+
+	got := convertFieldsToOverrides(map[string]any{
+		"file_name": "Harry Potter (Full-Cast Edition)",
+	})
+	require.NotNil(t, got)
+	require.NotNil(t, got.FileName)
+	assert.Equal(t, "Harry Potter (Full-Cast Edition)", *got.FileName)
+	assert.Nil(t, got.FileNameSource, "no source given — caller defaults to plugin source")
+}
+
+func TestConvertFieldsToOverrides_BothFields(t *testing.T) {
+	t.Parallel()
+
+	got := convertFieldsToOverrides(map[string]any{
+		"file_name":        "Custom Name",
+		"file_name_source": "manual",
+	})
+	require.NotNil(t, got)
+	require.NotNil(t, got.FileName)
+	assert.Equal(t, "Custom Name", *got.FileName)
+	require.NotNil(t, got.FileNameSource)
+	assert.Equal(t, "manual", *got.FileNameSource)
+}
+```
+
+If `assert`/`require` are not yet imported in this test file, ensure the imports include:
+
+```go
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+```
+
+- [ ] **Step 3: Run the new tests to confirm they pass**
+
+Run: `go test ./pkg/plugins/... -run TestConvertFieldsToOverrides -count=1 -v`
+Expected: 4 tests, all PASS. (They pass immediately because Task 1 already implemented the helper — this is a backfill of unit coverage rather than strict TDD.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/plugins/handler_convert_test.go
+git commit -m "[Test] Cover convertFieldsToOverrides for empty/full payloads"
+```
+
+---
+
+### Task 3: Update `persistMetadata` signature (red — failing tests first)
+
+**Files:**
+- Modify: `pkg/plugins/handler_persist_metadata_test.go`
+- Modify: `pkg/plugins/handler_apply_metadata_test.go`
+
+The plan adds a parameter to `persistMetadata`. Existing tests must compile against the new signature. We do this **first**, before changing the function body, so the next task is a true red→green TDD step.
+
+- [ ] **Step 1: Mechanically update every `persistMetadata` call in both test files to pass `nil` as the new `overrides` argument**
+
+In `pkg/plugins/handler_persist_metadata_test.go` and `pkg/plugins/handler_apply_metadata_test.go` (if any direct `persistMetadata` calls exist there), replace every call of the form
+
+```go
+h.persistMetadata(ctx, book, file, md, "test", "plugin-id", testLogger())
+```
+
+with
+
+```go
+h.persistMetadata(ctx, book, file, md, "test", "plugin-id", nil, testLogger())
+```
+
+The new parameter sits between `pluginID` and `log` to match the function signature change in Task 4. There are roughly 14 call sites in `handler_persist_metadata_test.go`. Use a single sed pass or bulk Edit to apply the change uniformly:
+
+Run: `grep -n "h.persistMetadata(" pkg/plugins/handler_persist_metadata_test.go pkg/plugins/handler_apply_metadata_test.go`
+
+Then update each call site so the third-from-last argument list ends with `…, "plugin-id", nil, testLogger())` (or whatever logger expression the call already uses).
+
+- [ ] **Step 2: Confirm the test file does not yet compile (failing build is the red state)**
+
+Run: `go build ./pkg/plugins/...`
+Expected: FAIL — the production `persistMetadata` still has the old signature, so call sites in tests now have an extra argument and the package doesn't build. This is the intended red state for Task 4.
+
+- [ ] **Step 3: Commit (compiling tests come in Task 4 alongside the function change)**
+
+Don't commit yet — wait until Task 4's signature change makes the package compile and all tests pass. We'll commit Tasks 3 and 4 together.
+
+---
+
+### Task 4: Implement the new `persistMetadata` signature (green)
+
+**Files:**
+- Modify: `pkg/plugins/handler_persist_metadata.go`
+
+- [ ] **Step 1: Update the function signature and remove the auto-mirror block**
+
+Replace the current function header
+
+```go
+func (h *handler) persistMetadata(ctx context.Context, book *models.Book, targetFile *models.File, md *mediafile.ParsedMetadata, pluginScope, pluginID string, log logger.Logger) error {
+```
+
+with
+
+```go
+func (h *handler) persistMetadata(ctx context.Context, book *models.Book, targetFile *models.File, md *mediafile.ParsedMetadata, pluginScope, pluginID string, overrides *applyOverrides, log logger.Logger) error {
+```
+
+In the same file, **delete** the inner block that auto-copies title onto file.Name. The block looks exactly like:
+
+```go
+		// Mirror the identified title onto the target main file's Name so
+		// file organization and downloads reflect it. Supplements keep their
+		// own filename-based label.
+		if targetFile != nil && targetFile.FileRole == models.FileRoleMain {
+			titleCopy := title
+			targetFile.Name = &titleCopy
+			targetFile.NameSource = &pluginSource
+			fileColumns = append(fileColumns, "name", "name_source")
+		}
+```
+
+Remove those nine lines (including the leading comment) entirely. Leave the `if title != ""` block that updates `book.Title` and friends untouched.
+
+- [ ] **Step 2: Add the explicit-write block for `file.Name`**
+
+Insert the new block immediately after the file-level URL block (after the `// URL (file-level, applied to target file)` block ends with `fileColumns = append(fileColumns, "url", "url_source")`) and before the `// Release date (file-level, applied to target file)` block:
+
+```go
+	// Name (file-level, applied to target file). Only written when the
+	// caller explicitly opted in via overrides.FileName — replaces the
+	// pre-Phase-1 behavior that silently mirrored book.Title onto
+	// file.Name on every identify and clobbered user-set edition names.
+	if overrides != nil && overrides.FileName != nil && targetFile != nil {
+		nameCopy := *overrides.FileName
+		targetFile.Name = &nameCopy
+
+		nameSource := pluginSource
+		if overrides.FileNameSource != nil {
+			nameSource = *overrides.FileNameSource
+		}
+		nameSourceCopy := nameSource
+		targetFile.NameSource = &nameSourceCopy
+
+		fileColumns = append(fileColumns, "name", "name_source")
+	}
+```
+
+- [ ] **Step 3: Update the lone production caller to pass `nil`**
+
+In `pkg/plugins/handler_apply_metadata.go`, the current call is:
+
+```go
+if err := h.persistMetadata(ctx, book, targetFile, md, payload.PluginScope, payload.PluginID, log); err != nil {
+```
+
+Change it to (Task 5 will replace `nil` with the real overrides — for now, a `nil` placeholder keeps the build green):
+
+```go
+if err := h.persistMetadata(ctx, book, targetFile, md, payload.PluginScope, payload.PluginID, nil, log); err != nil {
+```
+
+- [ ] **Step 4: Build the package**
+
+Run: `go build ./pkg/plugins/...`
+Expected: PASS — signature changes are now consistent across production and test callers.
+
+- [ ] **Step 5: Run the full plugins test suite**
+
+Run: `go test ./pkg/plugins/... -count=1`
+
+Expected: most tests PASS. **A handful will FAIL** because they assert old auto-mirror behavior:
+
+- `TestApplyMetadata_UpdatesMainFileName_WhenTitleChanges` — expects `*file.Name == "New Title"` after a title-only payload. With Phase 1, the apply path no longer auto-syncs file.Name, so `file.Name` stays `nil`.
+- `TestApplyMetadata_FallbackTargetsMainFile_NotSupplement` — expects `main.Name` to be set to "New Title".
+- `TestApplyMetadata_PreservesVolumeNotation_CBZ` — expects `*file.Name == "Naruto v1"`.
+
+These failures are **expected red** for the behavior change. Task 6 rewrites them to reflect the new behavior.
+
+For now, leave them failing and continue.
+
+- [ ] **Step 6: Commit Tasks 3 + 4 together**
+
+```bash
+git add pkg/plugins/handler_persist_metadata.go \
+        pkg/plugins/handler_apply_metadata.go \
+        pkg/plugins/handler_persist_metadata_test.go \
+        pkg/plugins/handler_apply_metadata_test.go
+git commit -m "[Backend] Replace auto-mirror of book.Title onto file.Name with explicit override"
+```
+
+(Behavior tests for the new explicit path follow in Task 6. The existing apply-path tests that asserted the old auto-mirror are intentionally left failing in this commit so the next commit's diff cleanly shows their rewrite.)
+
+---
+
+### Task 5: Plumb `file_name` / `file_name_source` through `applyMetadata`
+
+**Files:**
+- Modify: `pkg/plugins/handler_apply_metadata.go`
+
+- [ ] **Step 1: Add the two new fields to `applyPayload`**
+
+Replace the `applyPayload` struct with:
+
+```go
+type applyPayload struct {
+	BookID         int            `json:"book_id" validate:"required"`
+	FileID         *int           `json:"file_id"`
+	Fields         map[string]any `json:"fields" validate:"required"`
+	FileName       *string        `json:"file_name"`
+	FileNameSource *string        `json:"file_name_source"`
+	PluginScope    string         `json:"plugin_scope" validate:"required"`
+	PluginID       string         `json:"plugin_id" validate:"required"`
+}
+```
+
+`file_name` and `file_name_source` sit at the **top level of the payload**, not inside the `fields` map. They are explicit apply-path signals; `fields` is metadata-shaped (matches `mediafile.ParsedMetadata`). Keeping them separated makes the wire contract crisp: `fields` continues to map 1:1 to ParsedMetadata, while `file_name`/`file_name_source` are recognized only by the apply handler.
+
+- [ ] **Step 2: Build the overrides value from the typed payload fields**
+
+In `applyMetadata`, immediately after `md := convertFieldsToMetadata(payload.Fields)` (currently around line 66), add:
+
+```go
+	var overrides *applyOverrides
+	if (payload.FileName != nil && *payload.FileName != "") || (payload.FileNameSource != nil && *payload.FileNameSource != "") {
+		overrides = &applyOverrides{
+			FileName:       payload.FileName,
+			FileNameSource: payload.FileNameSource,
+		}
+	}
+```
+
+The empty-string guard keeps callers that send `"file_name": ""` from accidentally writing an empty `file.Name`. This mirrors `convertFieldsToOverrides`'s treatment of empty strings as absent.
+
+(Note: `convertFieldsToOverrides` from Task 1 stays in the codebase as the public extraction helper; we don't use it here because the new fields are top-level, not nested in `Fields`. The helper is still useful for tests and stays a stable shape for any future caller that processes a flattened map.)
+
+- [ ] **Step 3: Pass `overrides` to `persistMetadata`**
+
+Update the call site you previously edited in Task 4 step 3:
+
+```go
+if err := h.persistMetadata(ctx, book, targetFile, md, payload.PluginScope, payload.PluginID, overrides, log); err != nil {
+```
+
+(replacing the placeholder `nil` with `overrides`).
+
+- [ ] **Step 4: Build the package**
+
+Run: `go build ./pkg/plugins/...`
+Expected: PASS.
+
+- [ ] **Step 5: Run plugin tests (still expecting the three failures from Task 4)**
+
+Run: `go test ./pkg/plugins/... -count=1`
+Expected: same three pre-existing failures from Task 4 (unchanged) plus all other tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/plugins/handler_apply_metadata.go
+git commit -m "[Backend] Accept explicit file_name/file_name_source in identify apply payload"
+```
+
+---
+
+### Task 6: Rewrite stale tests and add new behavior tests
+
+**Files:**
+- Modify: `pkg/plugins/handler_apply_metadata_test.go`
+
+- [ ] **Step 1: Replace the three stale tests with new ones reflecting the post-fix behavior**
+
+The three failing tests from Task 4 step 5 assert the old auto-mirror. Rewrite them as follows.
+
+#### 6a. `TestApplyMetadata_UpdatesMainFileName_WhenTitleChanges` → `TestApplyMetadata_DoesNotAutoSyncMainFileName_WhenOnlyTitleSent`
+
+Replace the entire test body with:
+
+```go
+// TestApplyMetadata_DoesNotAutoSyncMainFileName_WhenOnlyTitleSent verifies
+// the Phase 1 fix: a title-only payload no longer silently mirrors book.Title
+// onto the main file's Name. Old frontends that don't ship file_name continue
+// to function (no errors), but file.Name is left untouched. Edition-specific
+// names like "Harry Potter (Full-Cast Edition)" are no longer clobbered on
+// re-identify. To opt in, callers must send file_name explicitly.
+func TestApplyMetadata_DoesNotAutoSyncMainFileName_WhenOnlyTitleSent(t *testing.T) {
+	t.Parallel()
+
+	book, file := newApplyTestBookWithFile(t, "Old Title", models.FileTypeEPUB)
+	originalName := "Custom Edition Name"
+	file.Name = &originalName
+
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContext(t, map[string]any{"title": "New Title"})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	assert.Equal(t, "New Title", book.Title, "book.Title should still update")
+	require.NotNil(t, file.Name)
+	assert.Equal(t, "Custom Edition Name", *file.Name, "file.Name must NOT be silently overwritten by book.Title")
+	assert.Nil(t, file.NameSource, "file.NameSource must NOT be set when no explicit file_name was sent")
+}
+```
+
+#### 6b. `TestApplyMetadata_FallbackTargetsMainFile_NotSupplement`
+
+Tighten the assertions: the targeting still picks the main file (still important — supplements should never be the apply target unless explicitly chosen), but `main.Name` is no longer expected to be auto-set. Replace the trailing assertions block (the four `require`/`assert` lines after `require.NoError(t, err)`) with:
+
+```go
+	// The main file is still the targeted file (supplement is skipped),
+	// but with Phase 1 file.Name is no longer auto-synced from book.Title.
+	// Both files' Name/NameSource stay nil on a title-only payload.
+	assert.Nil(t, main.Name, "main file Name must NOT be auto-set by a title-only payload")
+	assert.Nil(t, main.NameSource, "main file NameSource must NOT be auto-set by a title-only payload")
+	assert.Nil(t, supplement.Name, "supplement Name must remain untouched")
+
+	// Verify the main file *was* targeted (not the supplement) by
+	// checking that book.Title was written through to the right scope.
+	assert.Equal(t, "New Title", book.Title, "book.Title should be set, confirming the apply ran")
+```
+
+#### 6c. `TestApplyMetadata_PreservesVolumeNotation_CBZ`
+
+The original assertion was that book.Title preserves the verbatim "Naruto v1" string and that `file.Name` mirrors it. The mirror is gone; the title-preservation assertion stays. Replace the trailing assertions block (the three lines after `require.NoError(t, err)`) with:
+
+```go
+	assert.Equal(t, "Naruto v1", book.Title, "book.Title must not be volume-normalized on identify")
+	assert.Nil(t, file.Name, "file.Name must NOT be auto-set by a title-only payload (Phase 1 fix)")
+```
+
+- [ ] **Step 2: Add new tests covering the explicit-write path**
+
+Append to `pkg/plugins/handler_apply_metadata_test.go`:
+
+```go
+// newApplyEchoContextWithFileName builds an Echo context where the apply
+// payload carries an explicit top-level file_name and (optionally) a
+// file_name_source — the new Phase 1 wire signal.
+func newApplyEchoContextWithFileName(t *testing.T, fields map[string]any, fileName string, fileNameSource string) echo.Context {
+	t.Helper()
+	payload := applyPayload{
+		BookID:      1,
+		Fields:      fields,
+		PluginScope: "test",
+		PluginID:    "enricher",
+	}
+	if fileName != "" {
+		fn := fileName
+		payload.FileName = &fn
+	}
+	if fileNameSource != "" {
+		fns := fileNameSource
+		payload.FileNameSource = &fns
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", &models.User{
+		ID:            1,
+		LibraryAccess: []*models.UserLibraryAccess{{LibraryID: nil}},
+	})
+	return c
+}
+
+// TestApplyMetadata_ExplicitFileName_AppliedWithPluginSourceByDefault verifies
+// that a payload carrying file_name (without file_name_source) writes
+// file.Name and stamps NameSource with the plugin source — the default for
+// a value the user accepted as-is from the plugin's proposal.
+func TestApplyMetadata_ExplicitFileName_AppliedWithPluginSourceByDefault(t *testing.T) {
+	t.Parallel()
+
+	book, file := newApplyTestBookWithFile(t, "Old Title", models.FileTypeEPUB)
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContextWithFileName(t,
+		map[string]any{"title": "New Title"},
+		"New Title",
+		"")
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	require.NotNil(t, file.Name, "file.Name must be set when file_name is explicit")
+	assert.Equal(t, "New Title", *file.Name)
+	require.NotNil(t, file.NameSource, "file.NameSource must be set when file_name is explicit")
+	assert.Equal(t, "plugin:test/enricher", *file.NameSource,
+		"absent file_name_source defaults to the plugin source for this apply call")
+}
+
+// TestApplyMetadata_ExplicitFileName_HonorsExplicitSource verifies that
+// when the payload carries file_name_source, that exact value is written
+// to file.NameSource. This lets the Phase 2 frontend distinguish "user
+// accepted the plugin's proposed Name" from "user edited Name manually".
+func TestApplyMetadata_ExplicitFileName_HonorsExplicitSource(t *testing.T) {
+	t.Parallel()
+
+	book, file := newApplyTestBookWithFile(t, "Old Title", models.FileTypeEPUB)
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContextWithFileName(t,
+		map[string]any{"title": "New Title"},
+		"My Custom Edition Name",
+		models.DataSourceManual)
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	require.NotNil(t, file.Name)
+	assert.Equal(t, "My Custom Edition Name", *file.Name)
+	require.NotNil(t, file.NameSource)
+	assert.Equal(t, models.DataSourceManual, *file.NameSource,
+		"explicit file_name_source must be written verbatim")
+}
+
+// TestApplyMetadata_ExplicitFileName_PreservesEditionName_NonPrimaryFile is
+// the regression test for the original spec bug: identifying a non-primary
+// file against a generic plugin result no longer corrupts an edition-specific
+// file.Name. Before Phase 1, this scenario silently mirrored book.Title onto
+// file.Name. After Phase 1, file.Name only updates when the payload says so.
+// Here, the payload omits file_name entirely (modeling an old frontend OR a
+// new frontend where the user unchecked the Name row).
+func TestApplyMetadata_ExplicitFileName_PreservesEditionName_NonPrimaryFile(t *testing.T) {
+	t.Parallel()
+
+	book, file := newApplyTestBookWithFile(t, "Harry Potter and the Sorcerer's Stone", models.FileTypeEPUB)
+	originalName := "Harry Potter and the Sorcerer's Stone (Full-Cast Edition)"
+	file.Name = &originalName
+	originalSource := models.DataSourceManual
+	file.NameSource = &originalSource
+
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	// Title-only payload — no file_name — same as a non-primary identify
+	// against a generic plugin result. The bug being fixed: previously this
+	// would clobber the edition name with the bare book title.
+	c := newApplyEchoContext(t, map[string]any{
+		"title": "Harry Potter and the Sorcerer's Stone",
+	})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	require.NotNil(t, file.Name)
+	assert.Equal(t, "Harry Potter and the Sorcerer's Stone (Full-Cast Edition)", *file.Name,
+		"edition-specific file.Name must NOT be clobbered by a title-only identify (Phase 1 spec bug fix)")
+	require.NotNil(t, file.NameSource)
+	assert.Equal(t, models.DataSourceManual, *file.NameSource,
+		"file.NameSource must NOT be replaced by the plugin source")
+}
+```
+
+- [ ] **Step 3: Run the apply tests**
+
+Run: `go test ./pkg/plugins/... -run TestApplyMetadata -count=1 -v`
+Expected: all PASS (the three rewritten tests now match the new behavior; the three new tests cover the explicit path and the regression).
+
+- [ ] **Step 4: Run the full plugins test suite**
+
+Run: `go test ./pkg/plugins/... -count=1`
+Expected: PASS, no failures, no skips beyond pre-existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pkg/plugins/handler_apply_metadata_test.go
+git commit -m "[Test] Rewrite identify-apply tests for explicit file.Name path"
+```
+
+---
+
+### Task 7: Final verification — full Go test suite + lint
+
+The previous tasks ran the targeted test slice. Before declaring Phase 1 done, run the broader checks called out in the project CLAUDE.md ("Go-only edits → `mise lint test`").
+
+- [ ] **Step 1: Run full Go tests**
+
+Run: `mise test`
+Expected: PASS. Watch specifically for `pkg/plugins/...` and `pkg/worker/...` — the worker uses persistMetadata indirectly via the scan path through the manager (it shouldn't, since worker calls plugins via `RunMetadataSearch`, not `persistMetadata`, but verify).
+
+If any failure surfaces in another package, investigate before patching. The most likely failure surface is a hand-rolled fake or compile-time call that I missed during the signature change. Grep is the answer:
+
+```bash
+grep -rn "persistMetadata(" --include="*.go"
+```
+
+If it shows hits outside `pkg/plugins/`, update those call sites (this should only matter if `persistMetadata` was leaked outside the package, which currently it is not — it's an unexported method).
+
+- [ ] **Step 2: Run Go lint**
+
+Run: `mise lint`
+Expected: clean.
+
+- [ ] **Step 3: Verify spec phase tracking**
+
+Open `docs/superpowers/specs/2026-05-01-identify-flow-design.md` and find the Phase 1 section under `## Phases`. Update its heading from
+
+```markdown
+### Phase 1 · Backend `file.Name` clobber fix
+```
+
+to
+
+```markdown
+### Phase 1 · Backend `file.Name` clobber fix ✅ shipped
+```
+
+This signals to the next agent reading the spec that Phase 2 can now begin.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-05-01-identify-flow-design.md
+git commit -m "[Docs] Mark identify Phase 1 as shipped"
+```
+
+- [ ] **Step 5: Push and open PR**
+
+Phase 1 ships independently — don't wait on Phase 2. Hand off to the `ship-it` skill.
+
+---
+
+## Out of scope for this plan
+
+Per the spec, these explicitly belong to later phases. Don't touch them in Phase 1 even if temptation strikes:
+
+- Frontend `IdentifyReviewForm.tsx` — Phase 2.
+- New shared frontend primitives (MixedCheckbox, ComboboxTypeahead, CompositeRow, StickySection, DialogFrame) — Phase 2.
+- Per-field decision flags / per-field opt-in semantics on the apply payload — Phase 2 (Phase 1 only adds `file_name`/`file_name_source`).
+- Edit-dialog ports (BookEditDialog, FileEditDialog) — Phase 3.
+- Plain-text date input migration — Phase 4.
+- Sidecar/scanner integration changes — none required for this fix; sidecar writes already pick up `file.Name` and `file.NameSource` whenever they're set.
+- Plugin SDK changes — none required; ParsedMetadata is unchanged.
+
+## Risk assessment
+
+**Low risk.** This change subtracts behavior on the implicit path and adds a new explicit path that defaults to no-op. Old frontends become more correct (no more silent clobbering); the new frontend gets a clean, predictable knob. The signature change to `persistMetadata` is a private package method with one production caller — no API or SDK shape changes.
+
+Watch for: any hidden caller in the worker pipeline that I missed. The Step 1 grep in Task 7 covers this.

--- a/docs/superpowers/specs/2026-05-01-identify-flow-design.md
+++ b/docs/superpowers/specs/2026-05-01-identify-flow-design.md
@@ -48,11 +48,13 @@ Every field starts with one of three states:
 
 Default checkbox values:
 
-- **File-level fields, any state**: default ON.
+- **File-level fields, any state**: default ON. (Includes `file.Name` — same rule as everything else file-scoped. The user has the row visible and can uncheck if they want to keep a custom name like an edition suffix.)
 - **Book-level `new` fields**: default ON (no overwrite — there's nothing to lose).
 - **Book-level `changed` fields, primary file**: default ON (primary is the canonical file; identifying it should propagate to the book).
 - **Book-level `changed` fields, non-primary file**: default OFF (the "second-identify" case — don't overwrite shared book metadata from a non-canonical source).
 - **Unchanged fields**: default OFF.
+
+**Why book vs file scope drives defaults, not source attribution**: book-level scope rules use the file's primary status because book metadata is shared across all files of a book; non-primary identify shouldn't write through. File-level scope (including `file.Name`) doesn't have that sharing concern — each file has its own copy — so the user-friendly default is to apply the plugin's value and let the user uncheck or edit if they prefer otherwise.
 
 The `Restore suggestions` button (footer left) reverts every checkbox and field value to these defaults. Useful when a user has flipped many boxes and wants a clean slate without navigating away.
 
@@ -61,7 +63,7 @@ The `Restore suggestions` button (footer left) reverts every checkbox and field 
 Two sections: **Book** and **File**. Each is collapsible.
 
 - **Book section** ("applies to all files"): Title, Subtitle, Authors, Series, Genres, Tags, Description.
-- **File section** (file metadata shown inline in banner — see below): Cover, Narrators, Publisher, Imprint, Language, Release date, Identifiers, Abridged.
+- **File section** (file metadata shown inline in banner — see below): Cover, Name, Narrators, Publisher, Imprint, Language, Release date, Identifiers, Abridged.
 
 ### Section banner
 
@@ -115,6 +117,9 @@ Where `[checkbox]` is the per-field apply toggle. Status badge: `Changed` (prima
 
 - **Title**: plain text input. If the title contains a colon, show an "Extract subtitle" button inline with the "Currently:" reference (right-aligned, same baseline). Clicking it removes everything after the colon from the title and writes that text into the Subtitle field. Mirrors `BookEditDialog.tsx:526` behavior — reuse the same component.
 - **Subtitle**: plain text input.
+- **Name** (file.Name): plain text input. The proposed value defaults to the plugin's proposed title (plugins don't model `file.Name` separately). Standard file-level default-ON rule. Below the input, on the same baseline as "Currently:", a "Copy from book title" button appears whenever the Title field's current input value differs from the Name field's current input value — clicking it pastes Title into Name. Mirrors "Extract subtitle" under Title; same component family. Apply writes `file.NameSource = "plugin"` when the saved value matches the plugin's proposal, `"user"` when the user edited it.
+
+  This replaces the existing bug where `persistMetadata` always copied book title into `file.Name`. With Name surfaced as a real per-field decision, edition-specific names like "Harry Potter and the Sorcerer's Stone (Full-Cast Edition)" are preserved by the user simply unchecking the row, and the "Copy from book title" button gives a quick way to re-sync after editing Title.
 - **Authors**: composite list — drag handle + name + role dropdown + remove. Roles: Author / Translator / Editor / No role. Add row is a combobox-style typeahead (see below). Order is preserved.
 - **Narrators**: composite list — drag handle + name + remove. No role. Add row is a combobox typeahead.
 - **Series**: composite list — drag handle + name + number input (tabular-nums, ~50px wide) + unit dropdown (— / Volume / Chapter) + remove. Add row is a combobox typeahead.
@@ -232,15 +237,138 @@ Identify is one of several places these patterns surface. The implementation mus
 - **Permission gating** — identify currently sits behind plugin permissions; spec inherits that.
 - **Filter "Changed/All" toggle in selectbar** — count reflects total changes regardless of filter; filter only changes which rows render.
 
-## Implementation order (suggested)
+## Phases
 
-1. Backend: fix the `file.Name` clobber bug. `persistMetadata` no longer copies the new title into `file.Name`. Identify does not surface `file.Name` as a form field — users edit it via `FileEditDialog`. This eliminates the case where identifying a non-primary file's audiobook erases an edition-specific filename like "Harry Potter and the Sorcerer's Stone (Full-Cast Edition)".
-2. Frontend: shared primitives — checkbox with `mixed` state, combobox typeahead component, composite-row primitive, sticky-section-banner primitive.
-3. Port primitives into `BookEditDialog` / `FileEditDialog` first (cohesion). Verify no regressions.
-4. Build the new `IdentifyReviewForm` against the new primitives.
-5. Light visual refresh of the search step.
-6. Plain-text date input swap site-wide.
-7. End-to-end tests covering: first identify, second identify on primary, second identify on non-primary, restore suggestions, multi-file flow.
+This work is split into four phases. Each phase produces working,
+testable software that can ship on its own. Each phase will get its
+own implementation plan written via `superpowers:writing-plans`.
+
+### Phase 1 · Backend `file.Name` clobber fix
+
+**Goal:** Stop `persistMetadata` from silently overwriting
+`file.Name` with book.Title. The fix is forward-compatible — old
+frontend continues to work, new frontend (Phase 2) adds an explicit
+Name field.
+
+**Scope:**
+- `pkg/plugins/handler_persist_metadata.go`: remove the unconditional
+  copy of `title → file.Name`. Only write `file.Name` when the apply
+  payload explicitly includes it.
+- `pkg/plugins/handler_apply_metadata.go`: accept an explicit
+  `file.Name` (and `file.NameSource`) in the request payload.
+- Backend tests: verify silent overwrites no longer happen on a
+  non-primary file identify; verify explicit `file.Name` in the
+  payload still applies correctly with the right `NameSource`.
+
+**Ships independently:** Yes. Eliminates the regression even before
+any UI work. Old frontend stops corrupting `file.Name`.
+
+**Size:** Small (~1 day).
+
+**Depends on:** Nothing.
+
+---
+
+### Phase 2 · New identify dialog + shared primitives
+
+**Goal:** Implement the redesigned identify review dialog described
+in this spec. Builds the shared frontend primitives that Phase 3 will
+adopt elsewhere.
+
+**Scope:**
+- Shared primitives in `app/components/ui/` (or equivalent):
+  - **MixedCheckbox** — three-state (`false` / `true` / `mixed`),
+    with the hover-only-when-unchecked rule from the spec.
+  - **ComboboxTypeahead** — combobox-shaped input with caret, opens a
+    popover with `IN YOUR LIBRARY` matches (with `N books` usage
+    counts) + separator + `Create new {type} "..."` affordance.
+    Up/Down navigate, Enter commits, Esc closes. Used for genres,
+    tags, and as the inner input for composite rows.
+  - **CompositeRow** primitive — drag handle + name + slot for extras
+    (role select, number+unit, etc.) + remove. Add row uses
+    ComboboxTypeahead.
+  - **StickySection** — collapsible scope-section banner with
+    chevron, label, hint/file-meta slot, "X of Y selected" count, and
+    section-level MixedCheckbox. Manages collapse state and sticky
+    positioning.
+  - **DialogFrame** components — head with back arrow + title +
+    source pill, scrollable body, sticky footer with summary +
+    actions.
+- New `IdentifyReviewForm` using the primitives:
+  - Two-section layout (Book / File) with smart-default checkbox
+    state, Restore suggestions button, sticky select-all and section
+    banners, expandable Description "Currently:", Cover row with
+    file-type-aware button, Title with Extract subtitle, Name with
+    Copy from book title.
+  - Default file selection on dialog open uses `file.reviewed`
+    (prefer non-reviewed, then primary, then first).
+- Light visual refresh of the search step (step 1) using the new
+  `DialogFrame` so the two steps look unified. No structural change
+  to the result-picker grid.
+- Identify-apply payload updates: per-field decision flags for
+  applying or skipping each field; explicit `file.Name` and
+  `file.NameSource`; explicit `book.Source` markers for fields where
+  the user manually edited the value before applying.
+- Component tests for each new primitive; integration test for the
+  full dialog covering: first identify, second identify on primary,
+  second identify on non-primary, Restore suggestions, multi-file
+  default file selection.
+
+**Ships independently:** Yes. Edit dialogs continue using their
+existing implementations until Phase 3.
+
+**Size:** Large (~1–2 weeks).
+
+**Depends on:** Phase 1 (backend payload acceptance for explicit
+`file.Name`).
+
+---
+
+### Phase 3 · Port primitives into edit dialogs
+
+**Goal:** Cohesion. `BookEditDialog`, `FileEditDialog`, and the
+metadata-entity edit forms (Genres, Tags, People, Series) adopt the
+primitives built in Phase 2.
+
+**Scope:**
+- Replace existing `EntityCombobox` / `MultiSelectCombobox` /
+  `IdentifierEditor` add-affordances with `ComboboxTypeahead`.
+- Replace existing `SortableEntityList` with the shared
+  `CompositeRow`, or refactor `SortableEntityList`'s internals to
+  use it.
+- Update any other site-wide chip/composite-list usages (filter
+  pickers, etc.) to match.
+- Verify visual and behavioral parity — no functional regressions.
+
+**Ships independently:** Yes. Behavior stays the same; only the
+internals consolidate around shared primitives.
+
+**Size:** Medium (~3–5 days).
+
+**Depends on:** Phase 2 (primitives must exist).
+
+---
+
+### Phase 4 · Plain-text date input site-wide
+
+**Goal:** Replace `<DatePicker>` with a plain text input wherever
+release dates, publish dates, or other "could be old" dates appear.
+
+**Scope:**
+- `FileEditDialog.tsx`: swap `<DatePicker>` for plain text input on
+  release date.
+- Any other places that use `<DatePicker>` for old-date scenarios
+  (search/filter pickers if applicable).
+- Validation: keep whatever loose-format-allowed validation exists
+  today (or remove the calendar-required validator).
+- Update component tests.
+
+**Ships independently:** Yes. Could ship before, alongside, or after
+any other phase.
+
+**Size:** Small–medium (~1–2 days).
+
+**Depends on:** Nothing.
 
 ## Reference
 

--- a/docs/superpowers/specs/2026-05-01-identify-flow-design.md
+++ b/docs/superpowers/specs/2026-05-01-identify-flow-design.md
@@ -243,7 +243,7 @@ This work is split into four phases. Each phase produces working,
 testable software that can ship on its own. Each phase will get its
 own implementation plan written via `superpowers:writing-plans`.
 
-### Phase 1 · Backend `file.Name` clobber fix
+### Phase 1 · Backend `file.Name` clobber fix ✅ shipped
 
 **Goal:** Stop `persistMetadata` from silently overwriting
 `file.Name` with book.Title. The fix is forward-compatible — old

--- a/docs/superpowers/specs/2026-05-01-identify-flow-design.md
+++ b/docs/superpowers/specs/2026-05-01-identify-flow-design.md
@@ -1,0 +1,251 @@
+# Identify flow redesign
+
+**Status:** Spec, ready for plan
+**Date:** 2026-05-01
+**Companion:** `docs/design/identify-mockups/index.html` (interactive mockup)
+
+## Why
+
+The current identify flow has three problems:
+
+1. **Multi-file books are surprising.** Identify writes book-level fields (title, authors, description, etc.) and file-level fields (narrators, identifiers, cover, etc.) at the same time. When a user identifies a non-primary file, they don't realize it can overwrite the book's metadata that was set by the primary file's earlier identify.
+2. **`file.Name` is clobbered.** `persistMetadata` always copies the new title into `file.Name`, which destroys legitimate edition-specific filenames like "Harry Potter and the Sorcerer's Stone (Full-Cast Edition)" when identifying against a generic "Harry Potter and the Sorcerer's Stone" plugin result.
+3. **The review UI is busy and one-way.** Multi-value fields show every current value as strikethrough chips plus every new value as new chips, with a single "Use current" all-or-nothing escape hatch. Editing the proposed values is awkward, and there's no way to keep some current entries while accepting others.
+
+This spec redesigns the review step of the identify dialog. Search step gets a light visual refresh only.
+
+## Design principles
+
+- **Identify is a per-file operation.** Plugins typically pick a specific edition (ASIN, ISBN). The dialog scopes its decisions accordingly.
+- **Per-field opt-in.** The user decides per field whether to accept the plugin's proposed value. Atomic. Inspired by Audiobookshelf.
+- **Cohesion.** Whatever input patterns this dialog adopts (combobox typeahead, plain-text dates, composite rows) port to the rest of the app — `BookEditDialog`, `FileEditDialog`, metadata edit forms, filter pickers — not just identify.
+- **Smart defaults over micromanagement.** The dialog auto-checks the right boxes given context (primary vs non-primary file, changed vs new field). The user mostly clicks Apply.
+
+## Scope
+
+**In scope:** Review step of the identify dialog (`IdentifyReviewForm.tsx`). Per-field controls, scope sectioning, sticky headers, the cover/title/authors/series/genres/tags/description/narrators/publisher/imprint/language/release-date/identifiers/abridged rows. Footer actions. The same patterns ported into `BookEditDialog` and `FileEditDialog`.
+
+**Out of scope (this spec):**
+- Full search-step redesign. Search keeps its existing functionality and gets a light visual refresh — same dialog frame, back arrow, file switcher with dropdown, source pill — but no structural change to the result-picker grid.
+- New plugin behaviors. The plugin SDK and `handler_apply_metadata.go` semantics stay the same except where this spec calls them out.
+- New model fields. The "reviewed" concept used here is the existing `file.reviewed` / `ReviewOverride` system in `pkg/books/review/`.
+
+## Decision model
+
+- **Per-field checkbox** on every row. Checked = this field's proposed value will be written on Apply. Unchecked = skipped.
+- **Section-level select-all** on each section banner. Toggles every checkbox in the section.
+- **Global "Apply all"** at the top of the body toggles every checkbox in the dialog.
+- **Three checkbox states**: `false`, `true`, `mixed`. Mixed renders as a filled background with a horizontal bar (not a check). Mixed appears on section and global toggles when some-but-not-all child rows are checked. Clicking a mixed checkbox sets it to `false` (matches browser indeterminate behavior).
+- Hover affordance only on **unchecked** boxes; checked and mixed boxes brighten to a slightly lighter primary on hover, never to a "looks unchecked" treatment.
+
+## Smart defaults
+
+Every field starts with one of three states:
+
+- **`changed`** — the current value differs from the proposed value (this field will overwrite).
+- **`new`** — there is no current value; the proposed value would fill it in.
+- **`unchanged`** — current and proposed match (or the plugin didn't propose anything). The row is editable, but the checkbox defaults off.
+
+Default checkbox values:
+
+- **File-level fields, any state**: default ON.
+- **Book-level `new` fields**: default ON (no overwrite — there's nothing to lose).
+- **Book-level `changed` fields, primary file**: default ON (primary is the canonical file; identifying it should propagate to the book).
+- **Book-level `changed` fields, non-primary file**: default OFF (the "second-identify" case — don't overwrite shared book metadata from a non-canonical source).
+- **Unchanged fields**: default OFF.
+
+The `Restore suggestions` button (footer left) reverts every checkbox and field value to these defaults. Useful when a user has flipped many boxes and wants a clean slate without navigating away.
+
+## Section organization
+
+Two sections: **Book** and **File**. Each is collapsible.
+
+- **Book section** ("applies to all files"): Title, Subtitle, Authors, Series, Genres, Tags, Description.
+- **File section** (file metadata shown inline in banner — see below): Cover, Narrators, Publisher, Imprint, Language, Release date, Identifiers, Abridged.
+
+### Section banner
+
+A single sticky row per section. Contents:
+
+- Chevron icon (rotates -90° when collapsed)
+- Section label (`BOOK` or `FILE`) — uppercase, tracked, weighted
+- For Book: hint text "applies to all files"
+- For File: inline file metadata — type label + `file.Name` (no extension) + adapt-by-file-type metadata (duration + bitrate for audiobooks; page count for ebooks/comics/PDFs; etc.)
+- Count: "X of Y selected" (always visible, including when collapsed)
+- Section-level checkbox (supports mixed state)
+
+Click anywhere on the banner (except the section's own checkbox) to toggle expanded/collapsed. Section checkbox stops propagation.
+
+Banner alignment: the chevron sits in the same column as field-row checkboxes (24px wide), so the section label aligns with field labels at column 2 (60px from container left).
+
+### Default collapsed state
+
+A section is **collapsed by default iff its selected count is 0**.
+
+This handles the cases naturally:
+- **First identify** (single file, mostly `new` and `changed` fields, all default-on): Book and File both have non-zero counts → both expanded.
+- **Second identify on non-primary** (book-level `changed` defaults off): if there are no `new` book fields, Book count is 0 → collapsed by default. If the second file's plugin has data the first file's plugin didn't (e.g., a Subtitle), that field is `new` → defaults on → count is 1 → section stays expanded.
+- **Second identify on primary**: book-level `changed` defaults on → counts > 0 → both expanded.
+
+## Sticky headers
+
+The dialog body is a vertically scrolling container. The following stay visible while scrolling:
+
+- **Dialog frame head** (back arrow, title, source pill): outside the scroll body entirely.
+- **Global select-all bar**: `position: sticky; top: 0; z-index: 3` within the scroll body.
+- **Section banners**: `position: sticky; top: 49px; z-index: 2` (offset by selectbar height). When the user scrolls into a section's rows, its banner pins below the selectbar; scrolling past the section lets the next banner take over.
+
+Typeahead popovers use `z-index: 50` to clear sticky banners when an entity-input dropdown is open.
+
+All sticky elements have solid backgrounds so content scrolling underneath is occluded cleanly.
+
+## Field controls
+
+Every row has the structure:
+
+```
+[checkbox]  [label]  [status badge]
+            [field control]
+            [Currently: value …  inline action (optional)]
+```
+
+Where `[checkbox]` is the per-field apply toggle. Status badge: `Changed` (primary soft) or `New` (success soft); no badge for unchanged. The "Currently:" reference shows the current value of that field (book or file scope as appropriate).
+
+### Per-field rules
+
+- **Title**: plain text input. If the title contains a colon, show an "Extract subtitle" button inline with the "Currently:" reference (right-aligned, same baseline). Clicking it removes everything after the colon from the title and writes that text into the Subtitle field. Mirrors `BookEditDialog.tsx:526` behavior — reuse the same component.
+- **Subtitle**: plain text input.
+- **Authors**: composite list — drag handle + name + role dropdown + remove. Roles: Author / Translator / Editor / No role. Add row is a combobox-style typeahead (see below). Order is preserved.
+- **Narrators**: composite list — drag handle + name + remove. No role. Add row is a combobox typeahead.
+- **Series**: composite list — drag handle + name + number input (tabular-nums, ~50px wide) + unit dropdown (— / Volume / Chapter) + remove. Add row is a combobox typeahead.
+- **Genres / Tags**: chip group with always-visible × per chip. Chips are 28px tall, 999px radius. Add input is a chip-shaped combobox (typeahead).
+- **Description**: `<textarea>`, min-height ~88px, vertical resize. The "Currently:" reference is line-clamped to 2 lines by default with a "Show full" toggle that expands to the full original; "Show less" collapses back. No markdown, no rich text.
+- **Cover**: same row layout for all file types. Side-by-side comparison: current thumbnail → new thumbnail (highlighted with primary ring). Caption under each shows resolution (`1280×1920`) for image-based covers (M4B/EPUB) or `Page N` for page-based covers (CBZ/PDF). A trailing button switches by `file_type`:
+  - **M4B/EPUB**: "Upload cover" — opens file picker.
+  - **CBZ/PDF**: "Select page" — opens existing `PagePicker` dialog.
+- **Publisher**: combobox single-value with caret + dedicated clear button.
+- **Imprint**: same combobox. Even when "Unchanged" (no incoming value), input *and* checkbox stay enabled — user can manually fill and apply.
+- **Language**: same. Same enabled-when-unchanged rule.
+- **Release date**: **plain text input**, never a date picker. Placeholder `YYYY-MM-DD`. Supports old, partial, or unknown dates. The current `<DatePicker>` in `BookEditDialog` and `FileEditDialog` must also be swapped to plain text — site-wide change.
+- **Identifiers**: chips render `[TYPE] value` with `TYPE` uppercase in primary color. Add row is horizontal: type-select (only available types listed; greyed when all types already added) + value input (monospace) + Enter on value commits.
+- **Abridged**: outer row checkbox enabled regardless of state. Inner Abridged toggle is disabled until the outer is checked. When the outer flips on, the inner becomes interactive.
+
+### Multi-value entity inputs (combobox typeahead)
+
+Replaces today's `[+ Add tag]` buttons. Pill-shaped (for chip groups) or row-shaped (for composite lists), with a caret on the right.
+
+- Click or focus opens a dropdown popover.
+- Type to filter.
+- Dropdown groups:
+  - `IN YOUR LIBRARY` — matching existing entities, sorted by relevance, with usage counts ("12 books").
+  - Separator.
+  - `Create new {type} "text"` — escape hatch for novel values.
+- Up/Down arrows navigate; **Enter** commits the highlighted suggestion (or the create-new option if no match is highlighted); **Esc** closes.
+- On commit, the suggestion becomes a chip/composite row above the input; the input clears and stays focused so the user can type the next entry.
+- No "↵ to add" hint label needed — the caret + dropdown carry the affordance.
+
+Applies to: Authors, Narrators, Series, Genres, Tags.
+
+## Two-step flow & navigation
+
+### Step 1: search
+
+User selects which file is being identified (file switcher with dropdown), enters a query, gets plugin results, picks one. Search step gets a **light visual refresh** — same dialog frame, back arrow → close, source pill, file switcher — but no structural change to its result-picker grid. (Full search redesign is out of scope; this spec covers the visual cohesion only.)
+
+### Step 2: review
+
+The form designed in this spec. File switcher here is **read-only** (just shows which file is being identified, no caret, no dropdown). Switching files happens on the search step — the file determines what searches against the plugin, so it makes no sense to switch on review.
+
+### Default file selection on dialog open
+
+Uses the existing `file.reviewed` flag (computed by `review.IsComplete(book, file, criteria)` against per-library required fields, with optional `ReviewOverride`):
+
+1. If some files are reviewed and some aren't, pick a non-reviewed file (`reviewed != true` — covers both `false` and `NULL`).
+2. If all files share the same reviewed status, prefer the primary file if set.
+3. Otherwise pick the first file. Order doesn't matter much in this case.
+
+No new model fields needed. Builds on the review system already in `pkg/books/review/`.
+
+### Back navigation (review → search)
+
+Search state (query, results, selected result) is **preserved**. Review state **resets on every forward navigation** — going back and forward is an intentional way to clear changes (matches today's behavior). The `Restore suggestions` button covers the in-place reset case.
+
+### Apply behavior
+
+Inline loading + close on success.
+
+- Click Apply → button shows spinner and "Applying…" while the request is pending.
+- On success: dialog closes, toast confirms ("Updated 6 fields").
+- On error: dialog stays open with an inline error banner so the user can retry without losing checkbox state.
+- File reorganization (renames triggered by title/author/series changes) is an implementation detail and is **not** surfaced in the toast.
+
+### Multi-file post-apply
+
+Dialog just closes. No "identify the other file?" prompt. User re-opens identify from the book detail page when they want to identify additional files.
+
+### NameSource / source attribution
+
+After Apply:
+
+- Fields whose values come from the plugin's proposed result are saved with their respective `*Source` column set to `"plugin"`.
+- Fields whose values were manually edited by the user in the review form before Apply are saved with source `"user"`.
+
+This matters for subsequent scanner re-identify: user edits must survive a re-scan; plugin-set values can be overwritten by a re-scan that finds better data.
+
+### Identify and reviewed flag
+
+Identify does not directly set `reviewed`. After Apply, the existing recompute pipeline runs (`RecomputeReviewedForBook` / `RecomputeReviewedForFile`); if the applied changes brought the file to completeness, it becomes `reviewed = true` automatically. Users with an explicit `ReviewOverride` keep their override.
+
+## Dialog frame
+
+- **Width**: `max-w-3xl` (768px), one step wider than the existing edit dialog because each row carries current-vs-proposed.
+- **Head**: back arrow (top-left, 24px button, 12px chevron-left icon) + title + subtitle (file count + N changes proposed) + source pill (right). No close X — back arrow returns to the search step.
+- **Body**: `max-height: 70vh; overflow-y: auto`. Sticky select-all + sticky section banners as defined above.
+- **Foot**: Restore suggestions button (ghost, left side) + counts split by section ("**1 book change** · **5 file changes** selected") in the middle + Cancel/Apply on the right. Primary action "Apply N changes" with N = total selected.
+
+## Cohesion — across the whole app
+
+Identify is one of several places these patterns surface. The implementation must avoid one-off treatments here — every foundational change adopted in this dialog also lands wherever it appears in Shisho.
+
+- **Combobox typeahead** replaces existing `EntityCombobox` / `MultiSelectCombobox` / `IdentifierEditor` add affordances site-wide: `BookEditDialog`, `FileEditDialog`, metadata-entity edit forms (Genres, Tags, People, Series), filter pickers, and any other place chips/composite lists are entered.
+- **Composite rows** (authors+role, series+number+unit) share the `SortableEntityList` component used by the edit dialogs. Don't build a parallel implementation.
+- **Plain-text date input** replaces `<DatePicker>` wherever release dates, publish dates, or other "could be old" dates appear — including `FileEditDialog`, library scan filters, series metadata, etc.
+- **Title's "Extract subtitle" button** is the same component used today in `BookEditDialog`; reused as-is.
+- **Visual tokens** (radius, border alpha, primary, success, mixed-state checkbox style, status badges, chip styling, etc.) come from `app/index.css` and shared component CSS. If a token changes here, it changes everywhere it's used; no in-file overrides.
+- **Checkbox states** (false / true / mixed) and their hover behavior are a global change — every `Checkbox` usage in the app must support the indeterminate state and never show the "looks unchecked on hover" bug for checked or mixed boxes.
+- **Outer-controls-inner pattern** for fields like Abridged is reusable; if other forms gain a similar "apply this field" gate, they inherit the same disabled-until-applied behavior.
+
+## Visual specifics
+
+- **Surface stack** (darkest → lightest): body `oklch(0.18)` → dialog card `oklch(0.22)` → row container `oklch(0.22)` → selectbar `oklch(0.20)` → section banner `oklch(0.205)`.
+- **Status badge palette**: `Changed` = primary soft; `New` = success soft. Unchanged rows get no badge.
+- **Chips**: 28px tall, 999px radius, always-visible × on each chip (no hover-to-show). × hover state = danger-soft background.
+- **Checkboxes**: 18×18, 5px radius. Primary fill when checked or mixed. Mixed visual = horizontal bar in primary-fg.
+- **Atmosphere**: faint top-of-page radial gradient (`oklch(0.8 0.15 280 / 0.05)`); no other glow effects.
+- **Icons**: every icon in the implementation uses `lucide-react` — chevron-down, chevron-left, x, plus, upload, refresh-ccw, etc. Match icon sizes to surrounding type (12–16px is the typical range).
+
+## Open items intentionally deferred
+
+- **Validation on inputs** (invalid ISBN/ASIN format) — match whatever `BookEditDialog` does today.
+- **Cancel with unsaved edits** — leverage existing `UnsavedChangesDialog` pattern from `app/CLAUDE.md`.
+- **Search step empty results** — search step concern; light visual refresh keeps current empty state.
+- **Permission gating** — identify currently sits behind plugin permissions; spec inherits that.
+- **Filter "Changed/All" toggle in selectbar** — count reflects total changes regardless of filter; filter only changes which rows render.
+
+## Implementation order (suggested)
+
+1. Backend: fix the `file.Name` clobber bug. `persistMetadata` no longer copies the new title into `file.Name`. Identify does not surface `file.Name` as a form field — users edit it via `FileEditDialog`. This eliminates the case where identifying a non-primary file's audiobook erases an edition-specific filename like "Harry Potter and the Sorcerer's Stone (Full-Cast Edition)".
+2. Frontend: shared primitives — checkbox with `mixed` state, combobox typeahead component, composite-row primitive, sticky-section-banner primitive.
+3. Port primitives into `BookEditDialog` / `FileEditDialog` first (cohesion). Verify no regressions.
+4. Build the new `IdentifyReviewForm` against the new primitives.
+5. Light visual refresh of the search step.
+6. Plain-text date input swap site-wide.
+7. End-to-end tests covering: first identify, second identify on primary, second identify on non-primary, restore suggestions, multi-file flow.
+
+## Reference
+
+- Mockup: `docs/design/identify-mockups/index.html`
+- Current implementation: `app/components/library/IdentifyBookDialog.tsx`, `app/components/library/IdentifyReviewForm.tsx`, `pkg/plugins/handler_apply_metadata.go`, `pkg/plugins/handler_persist_metadata.go`
+- Edit dialogs (cohesion target): `app/components/library/BookEditDialog.tsx`, `app/components/library/FileEditDialog.tsx`
+- Review system: `pkg/books/review/`
+- Visual tokens: `app/index.css`

--- a/pkg/plugins/handler_apply_metadata.go
+++ b/pkg/plugins/handler_apply_metadata.go
@@ -76,7 +76,7 @@ func (h *handler) applyMetadata(c echo.Context) error {
 	}
 
 	// Persist metadata (no field filtering — user already selected fields)
-	if err := h.persistMetadata(ctx, book, targetFile, md, payload.PluginScope, payload.PluginID, log); err != nil {
+	if err := h.persistMetadata(ctx, book, targetFile, md, payload.PluginScope, payload.PluginID, nil, log); err != nil {
 		return errors.Wrap(err, "failed to apply metadata")
 	}
 

--- a/pkg/plugins/handler_apply_metadata.go
+++ b/pkg/plugins/handler_apply_metadata.go
@@ -69,9 +69,12 @@ func (h *handler) applyMetadata(c echo.Context) error {
 
 	// Build apply-path overrides from explicit top-level payload fields.
 	// Empty strings count as absent so callers don't accidentally write
-	// blank values into file.Name / file.NameSource.
+	// blank values into file.Name / file.NameSource. The gate is on
+	// FileName specifically — file_name_source on its own is a no-op
+	// (there's nothing to source) and would be wasted state if it
+	// triggered the persist-side write block.
 	var overrides *applyOverrides
-	if (payload.FileName != nil && *payload.FileName != "") || (payload.FileNameSource != nil && *payload.FileNameSource != "") {
+	if payload.FileName != nil && *payload.FileName != "" {
 		overrides = &applyOverrides{
 			FileName:       payload.FileName,
 			FileNameSource: payload.FileNameSource,

--- a/pkg/plugins/handler_apply_metadata.go
+++ b/pkg/plugins/handler_apply_metadata.go
@@ -12,11 +12,13 @@ import (
 )
 
 type applyPayload struct {
-	BookID      int            `json:"book_id" validate:"required"`
-	FileID      *int           `json:"file_id"`
-	Fields      map[string]any `json:"fields" validate:"required"`
-	PluginScope string         `json:"plugin_scope" validate:"required"`
-	PluginID    string         `json:"plugin_id" validate:"required"`
+	BookID         int            `json:"book_id" validate:"required"`
+	FileID         *int           `json:"file_id"`
+	Fields         map[string]any `json:"fields" validate:"required"`
+	FileName       *string        `json:"file_name"`
+	FileNameSource *string        `json:"file_name_source"`
+	PluginScope    string         `json:"plugin_scope" validate:"required"`
+	PluginID       string         `json:"plugin_id" validate:"required"`
 }
 
 func (h *handler) applyMetadata(c echo.Context) error {
@@ -65,6 +67,17 @@ func (h *handler) applyMetadata(c echo.Context) error {
 	// Convert fields map to ParsedMetadata
 	md := convertFieldsToMetadata(payload.Fields)
 
+	// Build apply-path overrides from explicit top-level payload fields.
+	// Empty strings count as absent so callers don't accidentally write
+	// blank values into file.Name / file.NameSource.
+	var overrides *applyOverrides
+	if (payload.FileName != nil && *payload.FileName != "") || (payload.FileNameSource != nil && *payload.FileNameSource != "") {
+		overrides = &applyOverrides{
+			FileName:       payload.FileName,
+			FileNameSource: payload.FileNameSource,
+		}
+	}
+
 	// Download cover if cover_url set
 	if md.CoverURL != "" {
 		manifest := rt.Manifest()
@@ -76,7 +89,7 @@ func (h *handler) applyMetadata(c echo.Context) error {
 	}
 
 	// Persist metadata (no field filtering — user already selected fields)
-	if err := h.persistMetadata(ctx, book, targetFile, md, payload.PluginScope, payload.PluginID, nil, log); err != nil {
+	if err := h.persistMetadata(ctx, book, targetFile, md, payload.PluginScope, payload.PluginID, overrides, log); err != nil {
 		return errors.Wrap(err, "failed to apply metadata")
 	}
 

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -308,25 +308,80 @@ func TestApplyMetadata_DoesNotAutoSyncMainFileName_WhenOnlyTitleSent(t *testing.
 	assert.Nil(t, file.NameSource, "file.NameSource must NOT be set when no explicit file_name was sent")
 }
 
-func TestApplyMetadata_DoesNotUpdateSupplementFileName(t *testing.T) {
+// TestApplyMetadata_ExplicitFileName_AppliesToSupplement verifies the post-
+// Phase-1 invariant that the explicit-payload path is role-agnostic: when a
+// caller pins file_id at a supplement and ships file_name, the supplement's
+// Name updates per the payload. Previously persistMetadata gated the file.Name
+// write on FileRoleMain; now the gate is at the wire layer (frontend opts in
+// per file by sending file_name only when the user checked the Name row), so
+// the persist layer trusts the explicit signal regardless of role.
+//
+// This replaces an earlier tautological test that asserted "supplement.Name
+// is not overwritten by a title-only payload" — which is now true for every
+// file role and isn't load-bearing.
+func TestApplyMetadata_ExplicitFileName_AppliesToSupplement(t *testing.T) {
 	t.Parallel()
 
-	book, file := newApplyTestBookWithFile(t, "Old Title", models.FileTypePDF)
-	file.FileRole = models.FileRoleSupplement
+	book := newApplyTestBook(t, "Book Title")
+	main := &models.File{
+		ID:        1,
+		BookID:    book.ID,
+		LibraryID: book.LibraryID,
+		Filepath:  filepath.Join(book.Filepath, "main.epub"),
+		FileType:  models.FileTypeEPUB,
+		FileRole:  models.FileRoleMain,
+	}
+	supplementID := 2
+	supplement := &models.File{
+		ID:        supplementID,
+		BookID:    book.ID,
+		LibraryID: book.LibraryID,
+		Filepath:  filepath.Join(book.Filepath, "Supplement.pdf"),
+		FileType:  models.FileTypePDF,
+		FileRole:  models.FileRoleSupplement,
+	}
 	originalName := "Supplement.pdf"
-	file.Name = &originalName
+	supplement.Name = &originalName
+	book.Files = []*models.File{main, supplement}
 
 	store := &stubBookStoreForApply{
 		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
 	}
 	h := newApplyTestHandler(store)
-	c := newApplyEchoContext(t, map[string]any{"title": "New Title"})
 
-	err := h.applyMetadata(c)
+	// Build a payload that pins file_id at the supplement and explicitly
+	// sets file_name. newApplyEchoContextWithFileName doesn't carry file_id,
+	// so build the request inline.
+	payload := applyPayload{
+		BookID:      book.ID,
+		FileID:      &supplementID,
+		Fields:      map[string]any{},
+		FileName:    func() *string { s := "Cribsheet (Updated)"; return &s }(),
+		PluginScope: "test",
+		PluginID:    "enricher",
+	}
+	body, err := json.Marshal(payload)
 	require.NoError(t, err)
 
-	require.NotNil(t, file.Name)
-	assert.Equal(t, "Supplement.pdf", *file.Name, "supplement Name must not be overwritten with book title")
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", &models.User{
+		ID:            1,
+		LibraryAccess: []*models.UserLibraryAccess{{LibraryID: nil}},
+	})
+
+	err = h.applyMetadata(c)
+	require.NoError(t, err)
+
+	require.NotNil(t, supplement.Name)
+	assert.Equal(t, "Cribsheet (Updated)", *supplement.Name,
+		"explicit file_name targeting a supplement should write through (Phase 1 removes the role gate at the persist layer)")
+	require.NotNil(t, supplement.NameSource)
+	assert.Equal(t, "plugin:test/enricher", *supplement.NameSource)
+	assert.Nil(t, main.Name, "main file must not be touched when file_id pins the supplement")
 }
 
 func TestApplyMetadata_FallbackTargetsMainFile_NotSupplement(t *testing.T) {

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -280,10 +280,19 @@ func TestApplyMetadata_SkipsSubtitle_WhenWhitespaceOnly(t *testing.T) {
 	assert.Nil(t, book.Subtitle, "book.Subtitle should not be set to a pointer-to-empty-string for whitespace-only input")
 }
 
-func TestApplyMetadata_UpdatesMainFileName_WhenTitleChanges(t *testing.T) {
+// TestApplyMetadata_DoesNotAutoSyncMainFileName_WhenOnlyTitleSent verifies
+// the Phase 1 fix: a title-only payload no longer silently mirrors book.Title
+// onto the main file's Name. Old frontends that don't ship file_name continue
+// to function (no errors), but file.Name is left untouched. Edition-specific
+// names like "Harry Potter (Full-Cast Edition)" are no longer clobbered on
+// re-identify. To opt in, callers must send file_name explicitly.
+func TestApplyMetadata_DoesNotAutoSyncMainFileName_WhenOnlyTitleSent(t *testing.T) {
 	t.Parallel()
 
 	book, file := newApplyTestBookWithFile(t, "Old Title", models.FileTypeEPUB)
+	originalName := "Custom Edition Name"
+	file.Name = &originalName
+
 	store := &stubBookStoreForApply{
 		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
 	}
@@ -293,10 +302,10 @@ func TestApplyMetadata_UpdatesMainFileName_WhenTitleChanges(t *testing.T) {
 	err := h.applyMetadata(c)
 	require.NoError(t, err)
 
-	require.NotNil(t, file.Name, "main file Name should be set")
-	assert.Equal(t, "New Title", *file.Name)
-	require.NotNil(t, file.NameSource, "main file NameSource should be set")
-	assert.Equal(t, "plugin:test/enricher", *file.NameSource)
+	assert.Equal(t, "New Title", book.Title, "book.Title should still update")
+	require.NotNil(t, file.Name)
+	assert.Equal(t, "Custom Edition Name", *file.Name, "file.Name must NOT be silently overwritten by book.Title")
+	assert.Nil(t, file.NameSource, "file.NameSource must NOT be set when no explicit file_name was sent")
 }
 
 func TestApplyMetadata_DoesNotUpdateSupplementFileName(t *testing.T) {
@@ -355,12 +364,16 @@ func TestApplyMetadata_FallbackTargetsMainFile_NotSupplement(t *testing.T) {
 	err := h.applyMetadata(c)
 	require.NoError(t, err)
 
-	// The main file's Name should be set to the new title; the supplement's
-	// should remain untouched (persistMetadata also guards this, but only
-	// gets the chance because we picked the right targetFile).
-	require.NotNil(t, main.Name, "main file Name should be set when applyMetadata falls back to main")
-	assert.Equal(t, "New Title", *main.Name)
-	assert.Nil(t, supplement.Name, "supplement Name must not be touched when applyMetadata falls back to main")
+	// The main file is still the targeted file (supplement is skipped),
+	// but with Phase 1 file.Name is no longer auto-synced from book.Title.
+	// Both files' Name/NameSource stay nil on a title-only payload.
+	assert.Nil(t, main.Name, "main file Name must NOT be auto-set by a title-only payload")
+	assert.Nil(t, main.NameSource, "main file NameSource must NOT be auto-set by a title-only payload")
+	assert.Nil(t, supplement.Name, "supplement Name must remain untouched")
+
+	// Verify the main file *was* targeted (not the supplement) by
+	// checking that book.Title was written through to the right scope.
+	assert.Equal(t, "New Title", book.Title, "book.Title should be set, confirming the apply ran")
 }
 
 func TestApplyMetadata_PreservesVolumeNotation_CBZ(t *testing.T) {
@@ -377,8 +390,7 @@ func TestApplyMetadata_PreservesVolumeNotation_CBZ(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "Naruto v1", book.Title, "book.Title must not be volume-normalized on identify")
-	require.NotNil(t, file.Name)
-	assert.Equal(t, "Naruto v1", *file.Name, "file.Name must mirror the verbatim title")
+	assert.Nil(t, file.Name, "file.Name must NOT be auto-set by a title-only payload (Phase 1 fix)")
 }
 
 func TestApplyMetadata_TrimsPublisherImprintURL(t *testing.T) {
@@ -404,4 +416,130 @@ func TestApplyMetadata_TrimsPublisherImprintURL(t *testing.T) {
 	assert.Equal(t, "Penguin Classics", imp.lastName, "imprint name must be trimmed before FindOrCreate")
 	require.NotNil(t, file.URL)
 	assert.Equal(t, "https://example.com", *file.URL, "file URL must be trimmed")
+}
+
+// newApplyEchoContextWithFileName builds an Echo context where the apply
+// payload carries an explicit top-level file_name and (optionally) a
+// file_name_source — the new Phase 1 wire signal.
+func newApplyEchoContextWithFileName(t *testing.T, fields map[string]any, fileName string, fileNameSource string) echo.Context {
+	t.Helper()
+	payload := applyPayload{
+		BookID:      1,
+		Fields:      fields,
+		PluginScope: "test",
+		PluginID:    "enricher",
+	}
+	if fileName != "" {
+		fn := fileName
+		payload.FileName = &fn
+	}
+	if fileNameSource != "" {
+		fns := fileNameSource
+		payload.FileNameSource = &fns
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", &models.User{
+		ID:            1,
+		LibraryAccess: []*models.UserLibraryAccess{{LibraryID: nil}},
+	})
+	return c
+}
+
+// TestApplyMetadata_ExplicitFileName_AppliedWithPluginSourceByDefault verifies
+// that a payload carrying file_name (without file_name_source) writes
+// file.Name and stamps NameSource with the plugin source — the default for
+// a value the user accepted as-is from the plugin's proposal.
+func TestApplyMetadata_ExplicitFileName_AppliedWithPluginSourceByDefault(t *testing.T) {
+	t.Parallel()
+
+	book, file := newApplyTestBookWithFile(t, "Old Title", models.FileTypeEPUB)
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContextWithFileName(t,
+		map[string]any{"title": "New Title"},
+		"New Title",
+		"")
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	require.NotNil(t, file.Name, "file.Name must be set when file_name is explicit")
+	assert.Equal(t, "New Title", *file.Name)
+	require.NotNil(t, file.NameSource, "file.NameSource must be set when file_name is explicit")
+	assert.Equal(t, "plugin:test/enricher", *file.NameSource,
+		"absent file_name_source defaults to the plugin source for this apply call")
+}
+
+// TestApplyMetadata_ExplicitFileName_HonorsExplicitSource verifies that
+// when the payload carries file_name_source, that exact value is written
+// to file.NameSource. This lets the Phase 2 frontend distinguish "user
+// accepted the plugin's proposed Name" from "user edited Name manually".
+func TestApplyMetadata_ExplicitFileName_HonorsExplicitSource(t *testing.T) {
+	t.Parallel()
+
+	book, file := newApplyTestBookWithFile(t, "Old Title", models.FileTypeEPUB)
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContextWithFileName(t,
+		map[string]any{"title": "New Title"},
+		"My Custom Edition Name",
+		models.DataSourceManual)
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	require.NotNil(t, file.Name)
+	assert.Equal(t, "My Custom Edition Name", *file.Name)
+	require.NotNil(t, file.NameSource)
+	assert.Equal(t, models.DataSourceManual, *file.NameSource,
+		"explicit file_name_source must be written verbatim")
+}
+
+// TestApplyMetadata_ExplicitFileName_PreservesEditionName_NonPrimaryFile is
+// the regression test for the original spec bug: identifying a non-primary
+// file against a generic plugin result no longer corrupts an edition-specific
+// file.Name. Before Phase 1, this scenario silently mirrored book.Title onto
+// file.Name. After Phase 1, file.Name only updates when the payload says so.
+// Here, the payload omits file_name entirely (modeling an old frontend OR a
+// new frontend where the user unchecked the Name row).
+func TestApplyMetadata_ExplicitFileName_PreservesEditionName_NonPrimaryFile(t *testing.T) {
+	t.Parallel()
+
+	book, file := newApplyTestBookWithFile(t, "Harry Potter and the Sorcerer's Stone", models.FileTypeEPUB)
+	originalName := "Harry Potter and the Sorcerer's Stone (Full-Cast Edition)"
+	file.Name = &originalName
+	originalSource := models.DataSourceManual
+	file.NameSource = &originalSource
+
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	// Title-only payload — no file_name — same as a non-primary identify
+	// against a generic plugin result. The bug being fixed: previously this
+	// would clobber the edition name with the bare book title.
+	c := newApplyEchoContext(t, map[string]any{
+		"title": "Harry Potter and the Sorcerer's Stone",
+	})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	require.NotNil(t, file.Name)
+	assert.Equal(t, "Harry Potter and the Sorcerer's Stone (Full-Cast Edition)", *file.Name,
+		"edition-specific file.Name must NOT be clobbered by a title-only identify (Phase 1 spec bug fix)")
+	require.NotNil(t, file.NameSource)
+	assert.Equal(t, models.DataSourceManual, *file.NameSource,
+		"file.NameSource must NOT be replaced by the plugin source")
 }

--- a/pkg/plugins/handler_convert.go
+++ b/pkg/plugins/handler_convert.go
@@ -135,3 +135,37 @@ func convertFieldsToMetadata(fields map[string]any) *mediafile.ParsedMetadata {
 
 	return md
 }
+
+// applyOverrides carries apply-path-only signals that don't belong on
+// mediafile.ParsedMetadata (which is part of the public plugin SDK
+// contract). These come exclusively from the identify apply payload —
+// plugins do not model them.
+type applyOverrides struct {
+	// FileName is the value to write to file.Name. Nil = no change.
+	// Empty string is treated as nil (treat absent or "" as no-op so
+	// callers don't need to special-case empty inputs).
+	FileName *string
+	// FileNameSource is the value to write to file.NameSource. Nil
+	// means "default to the plugin source for this apply call".
+	FileNameSource *string
+}
+
+// convertFieldsToOverrides extracts apply-path-only signals from the
+// untyped fields map. Returns nil when no overrides are present, so
+// callers can cheaply skip the explicit-write code path.
+func convertFieldsToOverrides(fields map[string]any) *applyOverrides {
+	var out *applyOverrides
+	if v, ok := fields["file_name"].(string); ok && v != "" {
+		if out == nil {
+			out = &applyOverrides{}
+		}
+		out.FileName = &v
+	}
+	if v, ok := fields["file_name_source"].(string); ok && v != "" {
+		if out == nil {
+			out = &applyOverrides{}
+		}
+		out.FileNameSource = &v
+	}
+	return out
+}

--- a/pkg/plugins/handler_convert_test.go
+++ b/pkg/plugins/handler_convert_test.go
@@ -406,3 +406,48 @@ func TestConvertFieldsToMetadata_SeriesNumberUnitMissing(t *testing.T) {
 
 	assert.Nil(t, md.SeriesNumberUnit)
 }
+
+func TestConvertFieldsToOverrides_NilWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	got := convertFieldsToOverrides(map[string]any{
+		"title": "Some Title",
+	})
+	require.Nil(t, got, "absence of file_name must yield nil overrides so callers can skip the explicit-write path")
+}
+
+func TestConvertFieldsToOverrides_NilWhenEmptyString(t *testing.T) {
+	t.Parallel()
+
+	got := convertFieldsToOverrides(map[string]any{
+		"file_name":        "",
+		"file_name_source": "",
+	})
+	require.Nil(t, got, "empty strings must be treated as absent — no overrides")
+}
+
+func TestConvertFieldsToOverrides_FileNameOnly(t *testing.T) {
+	t.Parallel()
+
+	got := convertFieldsToOverrides(map[string]any{
+		"file_name": "Harry Potter (Full-Cast Edition)",
+	})
+	require.NotNil(t, got)
+	require.NotNil(t, got.FileName)
+	assert.Equal(t, "Harry Potter (Full-Cast Edition)", *got.FileName)
+	assert.Nil(t, got.FileNameSource, "no source given — caller defaults to plugin source")
+}
+
+func TestConvertFieldsToOverrides_BothFields(t *testing.T) {
+	t.Parallel()
+
+	got := convertFieldsToOverrides(map[string]any{
+		"file_name":        "Custom Name",
+		"file_name_source": "manual",
+	})
+	require.NotNil(t, got)
+	require.NotNil(t, got.FileName)
+	assert.Equal(t, "Custom Name", *got.FileName)
+	require.NotNil(t, got.FileNameSource)
+	assert.Equal(t, "manual", *got.FileNameSource)
+}

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -32,7 +32,7 @@ func equalIntSets(a, b map[int]struct{}) bool {
 // persistMetadata applies metadata to a book and its target file unconditionally (no field filtering).
 // Every non-empty field in md is persisted. pluginScope and pluginID identify the data source.
 // targetFile is the specific file to apply file-level metadata (identifiers, cover) to; may be nil.
-func (h *handler) persistMetadata(ctx context.Context, book *models.Book, targetFile *models.File, md *mediafile.ParsedMetadata, pluginScope, pluginID string, log logger.Logger) error {
+func (h *handler) persistMetadata(ctx context.Context, book *models.Book, targetFile *models.File, md *mediafile.ParsedMetadata, pluginScope, pluginID string, overrides *applyOverrides, log logger.Logger) error {
 	pluginSource := models.PluginDataSource(pluginScope, pluginID)
 	var columns []string
 
@@ -58,16 +58,6 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 		columns = append(columns, "title", "title_source", "sort_title", "sort_title_source")
 		if titleChanged {
 			seriesAggregateMayBeStale = true
-		}
-
-		// Mirror the identified title onto the target main file's Name so
-		// file organization and downloads reflect it. Supplements keep their
-		// own filename-based label.
-		if targetFile != nil && targetFile.FileRole == models.FileRoleMain {
-			titleCopy := title
-			targetFile.Name = &titleCopy
-			targetFile.NameSource = &pluginSource
-			fileColumns = append(fileColumns, "name", "name_source")
 		}
 	}
 
@@ -364,6 +354,24 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 		targetFile.URL = &url
 		targetFile.URLSource = &pluginSource
 		fileColumns = append(fileColumns, "url", "url_source")
+	}
+
+	// Name (file-level, applied to target file). Only written when the
+	// caller explicitly opted in via overrides.FileName — replaces the
+	// pre-Phase-1 behavior that silently mirrored book.Title onto
+	// file.Name on every identify and clobbered user-set edition names.
+	if overrides != nil && overrides.FileName != nil && targetFile != nil {
+		nameCopy := *overrides.FileName
+		targetFile.Name = &nameCopy
+
+		nameSource := pluginSource
+		if overrides.FileNameSource != nil {
+			nameSource = *overrides.FileNameSource
+		}
+		nameSourceCopy := nameSource
+		targetFile.NameSource = &nameSourceCopy
+
+		fileColumns = append(fileColumns, "name", "name_source")
 	}
 
 	// Release date (file-level, applied to target file)

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -365,7 +365,11 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 		targetFile.Name = &nameCopy
 
 		nameSource := pluginSource
-		if overrides.FileNameSource != nil {
+		// Empty-string source is treated as absent so a malformed payload
+		// like {"file_name": "x", "file_name_source": ""} doesn't write
+		// an empty string into file.NameSource. Same shape as the
+		// Language block above.
+		if overrides.FileNameSource != nil && *overrides.FileNameSource != "" {
 			nameSource = *overrides.FileNameSource
 		}
 		nameSourceCopy := nameSource

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -360,7 +360,9 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 	// caller explicitly opted in via overrides.FileName — replaces the
 	// pre-Phase-1 behavior that silently mirrored book.Title onto
 	// file.Name on every identify and clobbered user-set edition names.
-	if overrides != nil && overrides.FileName != nil && targetFile != nil {
+	// Empty-string FileName is treated as absent so a malformed payload
+	// can't blank out file.Name.
+	if overrides != nil && overrides.FileName != nil && *overrides.FileName != "" && targetFile != nil {
 		nameCopy := *overrides.FileName
 		targetFile.Name = &nameCopy
 

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -113,7 +113,7 @@ func TestPersistMetadata_CoverWrite_RootLevelFile_SyntheticBookPath(t *testing.T
 	// is expected: the test deliberately uses a nonexistent bookPath, and
 	// sidecar failures are non-fatal. The assertions below only cover the
 	// cover-write path.
-	err = h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	err = h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	// Cover must land next to the file in the library dir, not under the
@@ -188,7 +188,7 @@ func TestPersistMetadata_CoverPage_CBZ_HappyPath(t *testing.T) {
 	page := 3
 	md := &mediafile.ParsedMetadata{CoverPage: &page}
 
-	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	require.Len(t, extractor.calls, 1)
@@ -224,7 +224,7 @@ func TestPersistMetadata_CoverPage_PDF_HappyPath(t *testing.T) {
 	page := 7
 	md := &mediafile.ParsedMetadata{CoverPage: &page}
 
-	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	require.Len(t, extractor.calls, 1)
@@ -267,7 +267,7 @@ func TestPersistMetadata_CoverPage_OutOfBounds(t *testing.T) {
 
 			md := &mediafile.ParsedMetadata{CoverPage: &tc.page}
 
-			err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+			err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", nil, testLogger())
 			require.NoError(t, err)
 
 			assert.Empty(t, extractor.calls, "extractor should not be called for invalid page")
@@ -296,7 +296,7 @@ func TestPersistMetadata_CoverPage_ExtractorError(t *testing.T) {
 	page := 3
 	md := &mediafile.ParsedMetadata{CoverPage: &page}
 
-	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err, "extractor errors should be logged, not returned")
 
 	require.Len(t, extractor.calls, 1, "extractor should still be called once")
@@ -329,7 +329,7 @@ func TestPersistMetadata_CoverPage_CBZ_BeatsCoverData(t *testing.T) {
 		CoverMimeType: "image/jpeg",
 	}
 
-	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	// coverPage path taken
@@ -404,7 +404,7 @@ func TestPersistMetadata_BulkInsertsIdentifiers(t *testing.T) {
 		},
 	}
 
-	err := h.persistMetadata(context.Background(), book, file, md, "shisho", "audnexus", testLogger())
+	err := h.persistMetadata(context.Background(), book, file, md, "shisho", "audnexus", nil, testLogger())
 	require.NoError(t, err)
 
 	require.Equal(t, []int{file.ID}, identStore.deleteCalls)
@@ -460,7 +460,7 @@ func TestPersistMetadata_AllBlanksPreservesExistingIdentifiers(t *testing.T) {
 		},
 	}
 
-	err := h.persistMetadata(context.Background(), book, file, md, "shisho", "audnexus", testLogger())
+	err := h.persistMetadata(context.Background(), book, file, md, "shisho", "audnexus", nil, testLogger())
 	require.NoError(t, err)
 
 	assert.Empty(t, identStore.deleteCalls, "delete must NOT fire when no valid identifiers to insert")
@@ -490,7 +490,7 @@ func TestPersistMetadata_CoverPage_EPUB_Ignored(t *testing.T) {
 		CoverMimeType: "image/jpeg",
 	}
 
-	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	// Extractor must not be called for non-page-based files
@@ -592,7 +592,7 @@ func TestPersistMetadata_IndexesNewSeries(t *testing.T) {
 	}
 
 	md := &mediafile.ParsedMetadata{Series: "My New Series"}
-	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	assert.Contains(t, indexer.indexedSeriesIDs, 1, "series created via identify-apply must be added to series_fts so it shows up in series search dropdowns")
@@ -625,7 +625,7 @@ func TestPersistMetadata_IndexesNewAuthorsNarratorsGenresTags(t *testing.T) {
 		Genres:    []string{"New Genre"},
 		Tags:      []string{"New Tag"},
 	}
-	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	assert.Len(t, indexer.indexedPersonIDs, 2, "both new author and new narrator must be added to persons_fts")
@@ -663,7 +663,7 @@ func TestPersistMetadata_ReindexesDetachedOldSeries(t *testing.T) {
 	}
 
 	md := &mediafile.ParsedMetadata{Series: "New Series"}
-	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	assert.Contains(t, indexer.indexedSeriesIDs, 1, "newly-attached series (id 1 from stub) must be indexed")
@@ -698,7 +698,7 @@ func TestPersistMetadata_SkipsSeriesIndexWhenAttachmentUnchanged(t *testing.T) {
 	}
 
 	md := &mediafile.ParsedMetadata{Series: "Same Series"}
-	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	assert.NotContains(t, indexer.indexedSeriesIDs, 1, "series whose attachment to this book did not change must NOT be re-indexed (avoids series_fts churn)")
@@ -734,7 +734,7 @@ func TestPersistMetadata_ReindexesSameSeriesWhenTitleChanges(t *testing.T) {
 		Title:  "New Title",
 		Series: "Same Series",
 	}
-	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	assert.Contains(t, indexer.indexedSeriesIDs, 1, "series whose membership did not change must still be re-indexed when book.title changed, otherwise series_fts.book_titles goes stale")
@@ -769,7 +769,7 @@ func TestPersistMetadata_SkipsSeriesIndexWhenSameTitleReapplied(t *testing.T) {
 		Title:  "Same Title",
 		Series: "Same Series",
 	}
-	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	assert.NotContains(t, indexer.indexedSeriesIDs, 1, "series whose attachment did not change AND whose aggregate inputs (title) did not actually change must NOT be re-indexed")
@@ -814,7 +814,7 @@ func TestPersistMetadata_SkipsSeriesIndexWhenSameAuthorsReapplied(t *testing.T) 
 		Authors: []mediafile.ParsedAuthor{{Name: "Same Author", Role: "writer"}},
 		Series:  "Same Series",
 	}
-	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, nil, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	assert.NotContains(t, indexer.indexedSeriesIDs, 1, "series whose attachment did not change AND whose author-set aggregate input did not actually change must NOT be re-indexed")
@@ -850,7 +850,7 @@ func TestPersistMetadata_SkipsPersonIndexForUnchangedAuthor(t *testing.T) {
 	md := &mediafile.ParsedMetadata{
 		Authors: []mediafile.ParsedAuthor{{Name: "Existing Author", Role: "writer"}},
 	}
-	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", testLogger())
+	err := h.persistMetadata(context.Background(), book, file, md, "test", "plugin-id", nil, testLogger())
 	require.NoError(t, err)
 
 	assert.NotContains(t, indexer.indexedPersonIDs, 1, "author whose attachment did not change must NOT be re-indexed (avoids persons_fts churn)")

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -855,3 +855,56 @@ func TestPersistMetadata_SkipsPersonIndexForUnchangedAuthor(t *testing.T) {
 
 	assert.NotContains(t, indexer.indexedPersonIDs, 1, "author whose attachment did not change must NOT be re-indexed (avoids persons_fts churn)")
 }
+
+// TestPersistMetadata_ExplicitFileName_EmptyStringIsTreatedAsAbsent locks in
+// the boundary invariant that an `applyOverrides` with an empty FileName does
+// not write through to file.Name, even when paired with a non-empty
+// FileNameSource. The applyMetadata wire layer already guards on
+// `payload.FileName != ""`, but persistMetadata is also reachable from
+// future internal callers (or hand-built test payloads), so the same shape
+// must be defended at the function boundary.
+func TestPersistMetadata_ExplicitFileName_EmptyStringIsTreatedAsAbsent(t *testing.T) {
+	t.Parallel()
+
+	libraryDir := t.TempDir()
+	filePath := filepath.Join(libraryDir, "book.epub")
+	require.NoError(t, os.WriteFile(filePath, []byte("fake epub"), 0600))
+
+	originalName := "Original Custom Name"
+	originalSource := "manual"
+	file := &models.File{
+		ID:         1,
+		BookID:     1,
+		Filepath:   filePath,
+		FileType:   models.FileTypeEPUB,
+		Name:       &originalName,
+		NameSource: &originalSource,
+	}
+	book := &models.Book{
+		ID:        1,
+		LibraryID: 1,
+		Filepath:  libraryDir,
+		Files:     []*models.File{file},
+	}
+
+	h := &handler{
+		enrich: &enrichDeps{
+			bookStore: &stubBookStoreForPersist{book: book},
+		},
+	}
+
+	emptyName := ""
+	manualSource := "manual"
+	overrides := &applyOverrides{
+		FileName:       &emptyName,
+		FileNameSource: &manualSource,
+	}
+
+	err := h.persistMetadata(context.Background(), book, file, &mediafile.ParsedMetadata{}, "test", "plugin-id", overrides, testLogger())
+	require.NoError(t, err)
+
+	require.NotNil(t, file.Name)
+	assert.Equal(t, "Original Custom Name", *file.Name, "file.Name must NOT be blanked by an empty-string FileName override")
+	require.NotNil(t, file.NameSource)
+	assert.Equal(t, "manual", *file.NameSource, "file.NameSource must NOT be replaced when FileName is empty (the override is treated as absent)")
+}


### PR DESCRIPTION
## Summary
- Removes the unconditional copy of `book.Title` onto `file.Name` in `persistMetadata`. Identifying a non-primary file (or any file with a custom edition-style name like "Harry Potter (Full-Cast Edition)") no longer silently overwrites that name with a generic plugin-proposed title.
- Adds explicit `file_name` and `file_name_source` fields to the identify apply payload, plumbed through a new internal `applyOverrides` struct. The frontend (Phase 2) will surface this as a per-field decision; today's frontend continues to work — it simply stops corrupting `file.Name`.
- Phase 1 of the identify-flow redesign spec at `docs/superpowers/specs/2026-05-01-identify-flow-design.md`. Marked the phase as shipped.

## Test plan
- New unit coverage in `pkg/plugins/handler_convert_test.go` for `convertFieldsToOverrides` (absent/empty/full payloads).
- Rewrote `TestApplyMetadata_UpdatesMainFileName_WhenTitleChanges` → `TestApplyMetadata_DoesNotAutoSyncMainFileName_WhenOnlyTitleSent` to assert the post-fix behavior.
- Updated `TestApplyMetadata_FallbackTargetsMainFile_NotSupplement` and `TestApplyMetadata_PreservesVolumeNotation_CBZ` to reflect that file.Name is no longer auto-synced.
- Three new tests cover the explicit-write path: default plugin source, explicit user source, and the regression scenario where a title-only payload preserves an edition-specific `file.Name`.
- `mise test` and `mise lint` both pass.
- No SDK / plugin manifest changes; `mediafile.ParsedMetadata` is untouched.