### PR TITLE
[Fix] Detect ASIN under Calibre's MOBI-ASIN/AMAZON scheme variants

### DIFF
--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -27,32 +27,33 @@ var (
 )
 
 // DetectType determines the identifier type from a value and optional scheme.
-// If scheme is provided, it takes precedence. Otherwise, pattern matching is used.
+// If the scheme is recognized, it takes precedence. Unknown or empty schemes
+// fall through to value-based pattern matching so we still pick up identifiers
+// emitted with vendor-specific scheme names (e.g. Calibre's "MOBI-ASIN", or
+// arbitrary publisher tags) when the value itself is unambiguous.
 func DetectType(value, scheme string) Type {
 	value = strings.TrimSpace(value)
 	scheme = strings.ToUpper(strings.TrimSpace(scheme))
 
-	// Check explicit scheme first
+	// Calibre and KindleGen emit ASINs under several scheme names: "ASIN",
+	// "MOBI-ASIN", and "AMAZON"/"AMAZON_<COUNTRY>" for storefront-scoped IDs.
+	// All carry the same B0XXXXXXXX format.
+	if scheme == "ASIN" || scheme == "MOBI-ASIN" || scheme == "AMAZON" || strings.HasPrefix(scheme, "AMAZON_") {
+		return TypeASIN
+	}
+
 	switch scheme {
 	case "ISBN":
 		return detectISBNType(value)
-	case "ASIN":
-		return TypeASIN
 	case "GOODREADS":
 		return TypeGoodreads
 	case "GOOGLE":
 		return TypeGoogle
 	case "UUID":
 		return TypeUUID
-	case "":
-		// No scheme, use pattern matching
-		break
-	default:
-		// Unknown scheme
-		return TypeUnknown
 	}
 
-	// Pattern matching on value
+	// Empty or unrecognized scheme: fall through to value-based pattern matching.
 	normalized := NormalizeISBN(value)
 	if len(normalized) == 13 && ValidateISBN13(normalized) {
 		return TypeISBN13

--- a/pkg/identifiers/identifiers.go
+++ b/pkg/identifiers/identifiers.go
@@ -35,9 +35,10 @@ func DetectType(value, scheme string) Type {
 	value = strings.TrimSpace(value)
 	scheme = strings.ToUpper(strings.TrimSpace(scheme))
 
-	// Calibre and KindleGen emit ASINs under several scheme names: "ASIN",
-	// "MOBI-ASIN", and "AMAZON"/"AMAZON_<COUNTRY>" for storefront-scoped IDs.
-	// All carry the same B0XXXXXXXX format.
+	// Calibre emits ASINs under several scheme names: "ASIN", "MOBI-ASIN"
+	// (typically on EPUBs converted from MOBI/AZW3), and "AMAZON" /
+	// "AMAZON_<COUNTRY>" for storefront-scoped IDs. All carry the same
+	// B0XXXXXXXX format.
 	if scheme == "ASIN" || scheme == "MOBI-ASIN" || scheme == "AMAZON" || strings.HasPrefix(scheme, "AMAZON_") {
 		return TypeASIN
 	}

--- a/pkg/identifiers/identifiers_test.go
+++ b/pkg/identifiers/identifiers_test.go
@@ -23,6 +23,15 @@ func TestDetectType(t *testing.T) {
 		{"isbn13 hyphens with scheme", "978-0-316-76948-8", "ISBN", TypeISBN13},
 		// ASIN with scheme
 		{"asin with scheme", "B08N5WRWNW", "ASIN", TypeASIN},
+		// Calibre-style MOBI-ASIN scheme (used by KindleGen output and many converted EPUBs)
+		{"mobi-asin scheme", "B002MQYOFW", "MOBI-ASIN", TypeASIN},
+		// Amazon storefront schemes used by Calibre (amazon, amazon_de, amazon_uk, ...)
+		{"amazon scheme", "B08N5WRWNW", "AMAZON", TypeASIN},
+		{"amazon_de scheme", "B08N5WRWNW", "AMAZON_DE", TypeASIN},
+		// Unknown scheme but ASIN-shaped value should still be detected via pattern fallback
+		{"unknown scheme asin value", "B002MQYOFW", "SOMETHING-WEIRD", TypeASIN},
+		// Unknown scheme but valid ISBN-13 value should still be detected
+		{"unknown scheme isbn13 value", "9780316769488", "VENDOR-X", TypeISBN13},
 		// Goodreads with scheme
 		{"goodreads with scheme", "12345678", "GOODREADS", TypeGoodreads},
 		// Google with scheme

--- a/pkg/identifiers/identifiers_test.go
+++ b/pkg/identifiers/identifiers_test.go
@@ -23,8 +23,10 @@ func TestDetectType(t *testing.T) {
 		{"isbn13 hyphens with scheme", "978-0-316-76948-8", "ISBN", TypeISBN13},
 		// ASIN with scheme
 		{"asin with scheme", "B08N5WRWNW", "ASIN", TypeASIN},
-		// Calibre-style MOBI-ASIN scheme (used by KindleGen output and many converted EPUBs)
+		// Calibre-style MOBI-ASIN scheme, typically on EPUBs converted from MOBI/AZW3
 		{"mobi-asin scheme", "B002MQYOFW", "MOBI-ASIN", TypeASIN},
+		// Scheme matching is case-insensitive (lowercased input still resolves)
+		{"mobi-asin lowercase scheme", "B002MQYOFW", "mobi-asin", TypeASIN},
 		// Amazon storefront schemes used by Calibre (amazon, amazon_de, amazon_uk, ...)
 		{"amazon scheme", "B08N5WRWNW", "AMAZON", TypeASIN},
 		{"amazon_de scheme", "B08N5WRWNW", "AMAZON_DE", TypeASIN},


### PR DESCRIPTION
## Summary
- EPUBs converted by Calibre/KindleGen often emit ASINs as `<dc:identifier opf:scheme="MOBI-ASIN">` or `AMAZON`/`AMAZON_<COUNTRY>`. The previous `DetectType` returned `TypeUnknown` for any scheme outside a hardcoded allowlist, so these identifiers were silently dropped during EPUB metadata parsing.
- Recognize `MOBI-ASIN`, `AMAZON`, and `AMAZON_<COUNTRY>` explicitly.
- Fall through any other unknown scheme to value-based pattern matching so unambiguous values (validated ISBN-10/13, ASIN-shaped `B0XXXXXXXX`, UUID) are still detected regardless of vendor scheme name.

## Test plan
- `go test ./pkg/identifiers/` — 5 new `TestDetectType` cases (`mobi-asin scheme`, `amazon scheme`, `amazon_de scheme`, `unknown scheme asin value`, `unknown scheme isbn13 value`) all pass; existing cases unchanged.
- `go test ./pkg/epub/ ./pkg/cbz/ ./pkg/mp4/ ./pkg/pdf/ ./pkg/sidecar/ ./pkg/worker/` — all green; the only callers of `DetectType` are `pkg/epub/opf.go` (now correctly detects more ASINs) and `pkg/cbz/cbz.go` (passes empty scheme, behavior unchanged).
- Manually verified against a real Calibre EPUB whose OPF contains `<dc:identifier opf:scheme="MOBI-ASIN">B002MQYOFW</dc:identifier>` — value now resolves to `TypeASIN` and would be persisted on the next scan.