### PR TITLE
[Fix] Refresh plugin config and related caches on enable/disable

### DIFF
--- a/app/hooks/queries/plugins.test.ts
+++ b/app/hooks/queries/plugins.test.ts
@@ -99,6 +99,94 @@ describe("useUpdatePlugin", () => {
   // Malfunctioned + load_error persisted), so the detail page needs the
   // installed-plugins query refetched on error too — otherwise the error
   // alert doesn't appear until the user reloads.
+  // The config endpoint returns an empty schema while the plugin runtime is
+  // unloaded (i.e. while disabled). Enabling the plugin loads the runtime and
+  // the schema becomes available, so the cached PluginConfig must be
+  // invalidated — otherwise the config form stays empty until manual reload.
+  it("invalidates PluginConfig on success so the config form refetches after enable/disable", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    client.setQueryData([QueryKey.PluginConfig, "shisho", "test"], {
+      schema: {},
+      values: {},
+      declaredFields: [],
+      fieldSettings: {},
+      confidence_threshold: null,
+    });
+
+    const { result } = renderHook(() => useUpdatePlugin(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: "test",
+        payload: { enabled: true },
+        scope: "shisho",
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.PluginConfig, "shisho", "test"])
+          ?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  // LoadPlugin (called when transitioning to enabled) registers the plugin's
+  // identifier types and appends the plugin to each hook's order. The first
+  // time a plugin is enabled the identifier dropdowns and the hook-order
+  // pages must refetch to pick those up.
+  it("invalidates PluginIdentifierTypes and plugin orders (global and library-scoped) on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    client.setQueryData([QueryKey.PluginIdentifierTypes], []);
+    client.setQueryData([QueryKey.PluginOrder, "metadataEnricher"], []);
+    client.setQueryData(
+      ["libraries", "lib-1", "plugins", "order", "metadataEnricher"],
+      { customized: false, plugins: [] },
+    );
+    // Sanity guard — the unrelated library-prefixed query must NOT be swept up.
+    client.setQueryData(["libraries", "lib-1", "books"], []);
+
+    const { result } = renderHook(() => useUpdatePlugin(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: "test",
+        payload: { enabled: true },
+        scope: "shisho",
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.PluginIdentifierTypes])?.isInvalidated,
+      ).toBe(true);
+    });
+    expect(
+      client.getQueryState([QueryKey.PluginOrder, "metadataEnricher"])
+        ?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState([
+        "libraries",
+        "lib-1",
+        "plugins",
+        "order",
+        "metadataEnricher",
+      ])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState(["libraries", "lib-1", "books"])?.isInvalidated,
+    ).toBe(false);
+  });
+
   it("invalidates PluginsInstalled when the mutation fails", async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },

--- a/app/hooks/queries/plugins.test.ts
+++ b/app/hooks/queries/plugins.test.ts
@@ -95,10 +95,6 @@ describe("useUninstallPlugin", () => {
 });
 
 describe("useUpdatePlugin", () => {
-  // A failed enable still mutates server state (the plugin row gets
-  // Malfunctioned + load_error persisted), so the detail page needs the
-  // installed-plugins query refetched on error too — otherwise the error
-  // alert doesn't appear until the user reloads.
   // The config endpoint returns an empty schema while the plugin runtime is
   // unloaded (i.e. while disabled). Enabling the plugin loads the runtime and
   // the schema becomes available, so the cached PluginConfig must be
@@ -187,6 +183,10 @@ describe("useUpdatePlugin", () => {
     ).toBe(false);
   });
 
+  // A failed enable still mutates server state (the plugin row gets
+  // Malfunctioned + load_error persisted), so the detail page needs the
+  // installed-plugins query refetched on error too — otherwise the error
+  // alert doesn't appear until the user reloads.
   it("invalidates PluginsInstalled when the mutation fails", async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -308,9 +308,40 @@ export const useUpdatePlugin = () => {
     // Refetch on both success and failure: a failed enable still mutates
     // server state (Malfunctioned status + load_error get persisted), which
     // the detail page needs to render the error alert without a manual reload.
+    // Also refetch PluginConfig — the config endpoint returns an empty schema
+    // while the runtime is unloaded, so toggling enabled (or saving config)
+    // must reload the form's schema/values. The first time a plugin is
+    // enabled, LoadPlugin also registers identifier types and appends the
+    // plugin to each hook's order (global + per-library fallback), so those
+    // caches need to refetch too.
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKey.PluginsInstalled],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.PluginConfig],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.PluginIdentifierTypes],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.PluginOrder],
+      });
+      // Library-scoped orders (LibraryPluginsTab) are keyed under
+      // ["libraries", libraryId, "plugins", "order", hookType]. Invalidate
+      // only those — the shared "libraries" prefix is used by other hooks
+      // too (books, settings) and blanket-invalidating it would trigger
+      // unrelated refetches on every enable/disable.
+      queryClient.invalidateQueries({
+        predicate: (query) => {
+          const key = query.queryKey;
+          return (
+            Array.isArray(key) &&
+            key[0] === "libraries" &&
+            key[2] === "plugins" &&
+            key[3] === "order"
+          );
+        },
       });
     },
   });

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -305,16 +305,23 @@ export const useUpdatePlugin = () => {
     mutationFn: ({ scope, id, payload }) => {
       return API.request("PATCH", `/plugins/installed/${scope}/${id}`, payload);
     },
-    // Refetch on both success and failure: a failed enable still mutates
-    // server state (Malfunctioned status + load_error get persisted), which
-    // the detail page needs to render the error alert without a manual reload.
-    // Also refetch PluginConfig — the config endpoint returns an empty schema
-    // while the runtime is unloaded, so toggling enabled (or saving config)
-    // must reload the form's schema/values. The first time a plugin is
-    // enabled, LoadPlugin also registers identifier types and appends the
-    // plugin to each hook's order (global + per-library fallback), so those
-    // caches need to refetch too.
-    onSettled: () => {
+    // A failed enable still mutates server state (Malfunctioned status +
+    // load_error get persisted), so the detail page needs PluginsInstalled
+    // refetched on error too — otherwise the error alert doesn't appear
+    // until manual reload.
+    onError: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.PluginsInstalled],
+      });
+    },
+    // PluginConfig: the config endpoint returns an empty schema while the
+    // runtime is unloaded, so toggling enabled (or saving config) must
+    // reload the form's schema/values. The first time a plugin is enabled,
+    // LoadPlugin also registers identifier types and appends the plugin to
+    // each hook's order (global + per-library fallback), so those caches
+    // need to refetch too. None of these change on a failed enable, so
+    // they're scoped to onSuccess.
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKey.PluginsInstalled],
       });


### PR DESCRIPTION
## Summary
- The plugin config endpoint returns an empty schema while the runtime is unloaded, and `LoadPlugin` (called on enable) registers identifier types and appends the plugin to each hook's order. `useUpdatePlugin` only invalidated `PluginsInstalled`, so enabling a plugin left the config form, identifier dropdowns, and hook-order lists showing stale data until a manual reload.
- Mirror `useUninstallPlugin`'s invalidation set in `useUpdatePlugin.onSettled`: `PluginsInstalled`, `PluginConfig`, `PluginIdentifierTypes`, `PluginOrder`, plus library-scoped `["libraries", id, "plugins", "order", hookType]` queries via predicate so unrelated `libraries`-prefixed caches (books, settings) aren't swept up.
- Added two unit tests covering config invalidation and the identifier-types/order/library-order invalidations, with a sanity guard that an unrelated library-prefixed query is left alone.

## Test plan
- `pnpm exec vitest run app/hooks/queries/plugins.test.ts` — all 5 tests pass.
- Manually: install a plugin, leave it disabled, navigate to its detail page, enable it, and confirm the config form populates without a manual page reload.
- Manually: enable a plugin that registers a new identifier type and confirm the identifier dropdown picks it up immediately.
- Manually: enable a plugin and confirm it appears in the global hook-order list and per-library hook-order list without reload.