### PR TITLE
[Feature] Identify Phase 3: shared entity-search hooks and multi-series support

### DIFF
--- a/app/components/common/EntityCombobox.test.tsx
+++ b/app/components/common/EntityCombobox.test.tsx
@@ -35,6 +35,24 @@ describe("EntityCombobox", () => {
     expect(onChange).toHaveBeenCalledWith({ id: 1, name: "Tor Books" });
   });
 
+  it("shows 'In your library' heading when options are present", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const hook = makeHook([{ id: 1, name: "Tor Books" }]);
+
+    render(
+      <EntityCombobox<Person>
+        getOptionLabel={(p) => p.name}
+        hook={hook}
+        label="Publisher"
+        onChange={vi.fn()}
+        value={null}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByText("In your library")).toBeInTheDocument();
+  });
+
   it("offers Create when typed value has no match and emits __create payload", async () => {
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     const onChange = vi.fn();
@@ -55,7 +73,7 @@ describe("EntityCombobox", () => {
       screen.getByPlaceholderText(/Search publisher/i),
       "Penguin",
     );
-    await user.click(screen.getByText(/Create "Penguin"/));
+    await user.click(screen.getByText(/Create new publisher "Penguin"/));
 
     expect(onChange).toHaveBeenCalledWith({ __create: "Penguin" });
   });
@@ -101,7 +119,7 @@ describe("EntityCombobox", () => {
     await user.click(screen.getByRole("combobox"));
     await user.type(screen.getByPlaceholderText(/Search person/i), "X");
 
-    expect(screen.queryByText(/Create "X"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Create new person "X"/)).not.toBeInTheDocument();
   });
 
   it("renders status badge when status prop set", () => {

--- a/app/components/common/EntityCombobox.tsx
+++ b/app/components/common/EntityCombobox.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronsUpDown, Plus } from "lucide-react";
+import { ChevronsUpDown, Plus } from "lucide-react";
 import { useState } from "react";
 
 import {
@@ -30,6 +30,7 @@ export interface EntityComboboxProps<T extends object> {
   onChange: (next: T | { __create: string }) => void;
   getOptionLabel: (item: T) => string;
   getOptionKey?: (item: T) => string | number;
+  getOptionDescription?: (item: T) => string | undefined;
   canCreate?: boolean;
   exclude?: (item: T) => boolean;
   status?: EntityStatus;
@@ -43,6 +44,7 @@ export function EntityCombobox<T extends object>({
   onChange,
   getOptionLabel,
   getOptionKey,
+  getOptionDescription,
   canCreate = true,
   exclude,
   status,
@@ -124,8 +126,12 @@ export function EntityCombobox<T extends object>({
                         }}
                         value={getOptionLabel(item)}
                       >
-                        <Check className="mr-2 h-4 w-4 shrink-0 opacity-0" />
                         <span className="truncate">{getOptionLabel(item)}</span>
+                        {getOptionDescription?.(item) && (
+                          <span className="ml-auto pl-2 text-xs text-muted-foreground shrink-0">
+                            {getOptionDescription(item)}
+                          </span>
+                        )}
                       </CommandItem>
                     );
                   })}

--- a/app/components/common/EntityCombobox.tsx
+++ b/app/components/common/EntityCombobox.tsx
@@ -12,6 +12,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "@/components/ui/command";
 import {
   Popover,
@@ -106,8 +107,8 @@ export function EntityCombobox<T extends object>({
                     : `No ${label.toLowerCase()} available.${canCreate ? " Type to create one." : ""}`}
                 </div>
               )}
-              {!isLoading && (
-                <CommandGroup>
+              {!isLoading && filtered.length > 0 && (
+                <CommandGroup heading="In your library">
                   {filtered.map((item) => {
                     const key = getOptionKey
                       ? getOptionKey(item)
@@ -128,7 +129,12 @@ export function EntityCombobox<T extends object>({
                       </CommandItem>
                     );
                   })}
-                  {showCreate && (
+                </CommandGroup>
+              )}
+              {!isLoading && showCreate && (
+                <>
+                  {filtered.length > 0 && <CommandSeparator />}
+                  <CommandGroup>
                     <CommandItem
                       className="cursor-pointer"
                       onSelect={() => {
@@ -139,10 +145,12 @@ export function EntityCombobox<T extends object>({
                       value={`create-${trimmed}`}
                     >
                       <Plus className="mr-2 h-4 w-4 shrink-0" />
-                      <span className="truncate">Create "{trimmed}"</span>
+                      <span className="truncate">
+                        Create new {label.toLowerCase()} &quot;{trimmed}&quot;
+                      </span>
                     </CommandItem>
-                  )}
-                </CommandGroup>
+                  </CommandGroup>
+                </>
               )}
             </CommandList>
           </Command>

--- a/app/components/common/SortableEntityList.tsx
+++ b/app/components/common/SortableEntityList.tsx
@@ -22,7 +22,12 @@ interface SortableEntityListProps<T extends object> {
   onAppend: (next: T | { __create: string }) => void;
   comboboxProps: Pick<
     EntityComboboxProps<T>,
-    "hook" | "label" | "getOptionLabel" | "getOptionKey" | "canCreate"
+    | "hook"
+    | "label"
+    | "getOptionLabel"
+    | "getOptionKey"
+    | "getOptionDescription"
+    | "canCreate"
   >;
   renderExtras?: (item: T, index: number) => ReactNode;
   status?: (item: T, index: number) => EntityStatus | undefined;

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -236,7 +236,7 @@ export function BookEditDialog({
 
   const handleAuthorRoleChange = (index: number, role: string | undefined) => {
     const updated = [...authors];
-    updated[index] = { ...updated[index], role };
+    updated[index].role = role;
     setAuthors(updated);
   };
 
@@ -269,7 +269,7 @@ export function BookEditDialog({
     unit: "" | "volume" | "chapter",
   ) => {
     const updated = [...seriesEntries];
-    updated[index] = { ...updated[index], unit };
+    updated[index].unit = unit;
     setSeriesEntries(updated);
   };
 

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -28,12 +28,13 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { useUpdateBook } from "@/hooks/queries/books";
-import { useGenresList } from "@/hooks/queries/genres";
-import { usePeopleList } from "@/hooks/queries/people";
+import {
+  useAuthorSearch,
+  useGenreSearch,
+  useSeriesSearch,
+  useTagSearch,
+} from "@/hooks/queries/entity-search";
 import { useSetBookReview } from "@/hooks/queries/review";
-import { useSeriesList } from "@/hooks/queries/series";
-import { useTagsList } from "@/hooks/queries/tags";
-import { useDebounce } from "@/hooks/useDebounce";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
 import {
   AuthorRoleWriter,
@@ -59,62 +60,6 @@ interface SeriesEntry {
   name: string;
   number: string;
   unit: "" | "volume" | "chapter"; // "" means unspecified
-}
-
-// Adapter hooks: bridge useXxxList query hooks to EntityCombobox's `hook` prop
-// signature. Defined at module scope so they're stable references and the same
-// hooks run in the same order on every render.
-//
-// Each adapter maps the API list-result shape (PersonWithCounts, Series) to the
-// parent list's item shape (AuthorInput, SeriesEntry). The combobox only needs
-// `name` to display each option; the extra fields specific to the parent list
-// (role, number) are filled in by `onAppend` when the user picks an option.
-
-function usePeopleSearch(
-  libraryId: number | undefined,
-  enabled: boolean,
-  query: string,
-): { data?: AuthorInput[]; isLoading: boolean } {
-  const { data, isLoading } = usePeopleList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  // PersonWithCounts has many extra fields; the combobox only needs `name`.
-  // We expose AuthorInput-shaped objects so the SortableEntityList<AuthorInput>
-  // type lines up cleanly. The id is preserved on the object so getOptionKey
-  // can use it.
-  const adapted = data?.people.map<AuthorInput & { id: number }>((p) => ({
-    name: p.name,
-    id: p.id,
-  }));
-  return { data: adapted, isLoading };
-}
-
-function useSeriesSearch(
-  libraryId: number | undefined,
-  enabled: boolean,
-  query: string,
-): { data?: SeriesEntry[]; isLoading: boolean } {
-  const { data, isLoading } = useSeriesList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  // Adapt Series[] -> SeriesEntry[] so the type matches the parent list's item
-  // shape. The combobox only displays `name`; `number` is filled in when added.
-  const adapted = data?.series.map<SeriesEntry>((s) => ({
-    name: s.name,
-    number: "",
-    unit: "",
-  }));
-  return { data: adapted, isLoading };
 }
 
 export function BookEditDialog({
@@ -144,40 +89,16 @@ export function BookEditDialog({
   const [genres, setGenres] = useState<string[]>(
     book.book_genres?.map((bg) => bg.genre?.name || "").filter(Boolean) || [],
   );
-  const [genreSearch, setGenreSearch] = useState("");
-  const debouncedGenreSearch = useDebounce(genreSearch, 200);
 
   const [tags, setTags] = useState<string[]>(
     book.book_tags?.map((bt) => bt.tag?.name || "").filter(Boolean) || [],
   );
-  const [tagSearch, setTagSearch] = useState("");
-  const debouncedTagSearch = useDebounce(tagSearch, 200);
 
   const updateBookMutation = useUpdateBook();
   const setBookReviewMutation = useSetBookReview();
 
   // Check if book has CBZ files (determines whether to show role selection)
   const hasCBZFiles = book.files?.some((f) => f.file_type === FileTypeCBZ);
-
-  // Query for genres in this library with server-side search
-  const { data: genresData, isLoading: isLoadingGenres } = useGenresList(
-    {
-      library_id: book.library_id,
-      limit: 50,
-      search: debouncedGenreSearch || undefined,
-    },
-    { enabled: open && !!book.library_id },
-  );
-
-  // Query for tags in this library with server-side search
-  const { data: tagsData, isLoading: isLoadingTags } = useTagsList(
-    {
-      library_id: book.library_id,
-      limit: 50,
-      search: debouncedTagSearch || undefined,
-    },
-    { enabled: open && !!book.library_id },
-  );
 
   // Draft review override — toggling the panel updates this; the actual
   // setBookReview mutation only fires on Save.
@@ -259,9 +180,7 @@ export function BookEditDialog({
     setAuthors(initialAuthors);
     setSeriesEntries(initialSeries);
     setGenres(initialGenres);
-    setGenreSearch("");
     setTags(initialTags);
-    setTagSearch("");
     setDraftReviewOverride(initialReviewOverride);
 
     // Store initial values for comparison (use effective sort title, not semantic)
@@ -552,13 +471,13 @@ export function BookEditDialog({
             </div>
             <SortableEntityList<AuthorInput>
               comboboxProps={{
-                // Author options carry an extra `id` field (see usePeopleSearch);
+                // Author options carry an extra `id` field (see useAuthorSearch);
                 // use it as the option key when present, fall back to name.
                 getOptionKey: (p) =>
                   (p as AuthorInput & { id?: number }).id ?? p.name,
                 getOptionLabel: (p) => p.name,
                 hook: function useAuthorOptions(q) {
-                  return usePeopleSearch(book.library_id, open, q);
+                  return useAuthorSearch(book.library_id, open, q);
                 },
                 label: "Author",
               }}
@@ -623,7 +542,13 @@ export function BookEditDialog({
                 getOptionKey: (s) => s.name,
                 getOptionLabel: (s) => s.name,
                 hook: function useSeriesOptions(q) {
-                  return useSeriesSearch(book.library_id, open, q);
+                  // useSeriesSearch returns NameOption[]; the combobox only
+                  // needs `name` for display. `onAppend` fills in number/unit.
+                  const result = useSeriesSearch(book.library_id, open, q);
+                  return result as {
+                    data?: SeriesEntry[];
+                    isLoading: boolean;
+                  };
                 },
                 label: "Series",
               }}
@@ -673,13 +598,12 @@ export function BookEditDialog({
           <div className="space-y-2">
             <Label>Genres</Label>
             <MultiSelectCombobox
-              isLoading={isLoadingGenres}
-              label="Genres"
+              hook={function useGenreOptions(q) {
+                return useGenreSearch(book.library_id, open, q);
+              }}
+              label="Genre"
               onChange={setGenres}
-              onSearch={setGenreSearch}
-              options={genresData?.genres.map((g) => g.name) || []}
               placeholder="Add genres..."
-              searchValue={genreSearch}
               values={genres}
             />
           </div>
@@ -688,13 +612,12 @@ export function BookEditDialog({
           <div className="space-y-2">
             <Label>Tags</Label>
             <MultiSelectCombobox
-              isLoading={isLoadingTags}
-              label="Tags"
+              hook={function useTagOptions(q) {
+                return useTagSearch(book.library_id, open, q);
+              }}
+              label="Tag"
               onChange={setTags}
-              onSearch={setTagSearch}
-              options={tagsData?.tags.map((t) => t.name) || []}
               placeholder="Add tags..."
-              searchValue={tagSearch}
               values={tags}
             />
           </div>

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -33,6 +33,7 @@ import {
   useGenreSearch,
   useSeriesSearch,
   useTagSearch,
+  type NameWithBookCount,
 } from "@/hooks/queries/entity-search";
 import { useSetBookReview } from "@/hooks/queries/review";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
@@ -476,6 +477,14 @@ export function BookEditDialog({
                 getOptionKey: (p) =>
                   (p as AuthorInput & { id?: number }).id ?? p.name,
                 getOptionLabel: (p) => p.name,
+                getOptionDescription: (p) => {
+                  const c = (
+                    p as AuthorInput & { authored_book_count?: number }
+                  ).authored_book_count;
+                  return c != null
+                    ? `${c} ${c === 1 ? "book" : "books"}`
+                    : undefined;
+                },
                 hook: function useAuthorOptions(q) {
                   return useAuthorSearch(book.library_id, open, q);
                 },
@@ -541,9 +550,14 @@ export function BookEditDialog({
               comboboxProps={{
                 getOptionKey: (s) => s.name,
                 getOptionLabel: (s) => s.name,
+                getOptionDescription: (s) => {
+                  const c = (s as SeriesEntry & { book_count?: number })
+                    .book_count;
+                  return c != null
+                    ? `${c} ${c === 1 ? "book" : "books"}`
+                    : undefined;
+                },
                 hook: function useSeriesOptions(q) {
-                  // useSeriesSearch returns NameOption[]; the combobox only
-                  // needs `name` for display. `onAppend` fills in number/unit.
                   const result = useSeriesSearch(book.library_id, open, q);
                   return result as {
                     data?: SeriesEntry[];
@@ -597,7 +611,12 @@ export function BookEditDialog({
           {/* Genres */}
           <div className="space-y-2">
             <Label>Genres</Label>
-            <MultiSelectCombobox
+            <MultiSelectCombobox<NameWithBookCount>
+              getOptionCount={(g) => g.book_count}
+              getOptionDescription={(g) =>
+                `${g.book_count} ${g.book_count === 1 ? "book" : "books"}`
+              }
+              getOptionLabel={(g) => g.name}
               hook={function useGenreOptions(q) {
                 return useGenreSearch(book.library_id, open, q);
               }}
@@ -611,7 +630,12 @@ export function BookEditDialog({
           {/* Tags */}
           <div className="space-y-2">
             <Label>Tags</Label>
-            <MultiSelectCombobox
+            <MultiSelectCombobox<NameWithBookCount>
+              getOptionCount={(t) => t.book_count}
+              getOptionDescription={(t) =>
+                `${t.book_count} ${t.book_count === 1 ? "book" : "books"}`
+              }
+              getOptionLabel={(t) => t.name}
               hook={function useTagOptions(q) {
                 return useTagSearch(book.library_id, open, q);
               }}

--- a/app/components/library/FileEditDialog.test.tsx
+++ b/app/components/library/FileEditDialog.test.tsx
@@ -52,14 +52,10 @@ vi.mock("@/hooks/queries/books", () => ({
   }),
 }));
 
-// Mock the list hooks with empty data
-vi.mock("@/hooks/queries/people", () => ({
-  usePeopleList: () => ({ data: { people: [] } }),
-}));
-
-vi.mock("@/hooks/queries/publishers", () => ({
-  usePublishersList: () => ({ data: { publishers: [] } }),
-  useImprintsList: () => ({ data: { imprints: [] } }),
+vi.mock("@/hooks/queries/entity-search", () => ({
+  usePeopleSearch: () => ({ data: [], isLoading: false }),
+  usePublisherSearch: () => ({ data: [], isLoading: false }),
+  useImprintSearch: () => ({ data: [], isLoading: false }),
 }));
 
 vi.mock("@/hooks/queries/plugins", () => ({

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -36,10 +36,13 @@ import {
   useUpdateFile,
   useUploadFileCover,
 } from "@/hooks/queries/books";
-import { useImprintsList } from "@/hooks/queries/imprints";
-import { usePeopleList } from "@/hooks/queries/people";
+import {
+  useImprintSearch,
+  usePeopleSearch,
+  usePublisherSearch,
+  type NameOption,
+} from "@/hooks/queries/entity-search";
 import { usePluginIdentifierTypes } from "@/hooks/queries/plugins";
-import { usePublishersList } from "@/hooks/queries/publishers";
 import { useSetFileReview } from "@/hooks/queries/review";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
 import { cn, isPageBasedFileType } from "@/libraries/utils";
@@ -62,69 +65,6 @@ interface FileEditDialogProps {
   book?: Book;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-}
-
-interface NameOption {
-  name: string;
-}
-
-// Adapter hooks: bridge useXxxList query hooks to EntityCombobox's `hook` prop
-// signature. Defined at module scope so they're stable references and the same
-// hooks run in the same order on every render.
-//
-// Each adapter maps the API list-result shape to a `{ name }` shape that the
-// EntityCombobox / SortableEntityList renders. The combobox only needs `name`
-// to display each option; row-specific extras are filled in by `onAppend`.
-
-function usePeopleSearch(
-  libraryId: number | undefined,
-  enabled: boolean,
-  query: string,
-): { data?: NameOption[]; isLoading: boolean } {
-  const { data, isLoading } = usePeopleList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  const adapted = data?.people.map((p) => ({ name: p.name }));
-  return { data: adapted, isLoading };
-}
-
-function usePublisherSearch(
-  libraryId: number | undefined,
-  enabled: boolean,
-  query: string,
-): { data?: NameOption[]; isLoading: boolean } {
-  const { data, isLoading } = usePublishersList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  const adapted = data?.publishers.map((p) => ({ name: p.name }));
-  return { data: adapted, isLoading };
-}
-
-function useImprintSearch(
-  libraryId: number | undefined,
-  enabled: boolean,
-  query: string,
-): { data?: NameOption[]; isLoading: boolean } {
-  const { data, isLoading } = useImprintsList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  const adapted = data?.imprints.map((i) => ({ name: i.name }));
-  return { data: adapted, isLoading };
 }
 
 // Helper to format date to YYYY-MM-DD for input[type="date"]

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -41,6 +41,7 @@ import {
   usePeopleSearch,
   usePublisherSearch,
   type NameOption,
+  type NameWithFileCount,
 } from "@/hooks/queries/entity-search";
 import { usePluginIdentifierTypes } from "@/hooks/queries/plugins";
 import { useSetFileReview } from "@/hooks/queries/review";
@@ -792,6 +793,14 @@ export function FileEditDialog({
                     comboboxProps={{
                       getOptionKey: (p) => p.name,
                       getOptionLabel: (p) => p.name,
+                      getOptionDescription: (p) => {
+                        const c = (
+                          p as NameOption & { narrated_file_count?: number }
+                        ).narrated_file_count;
+                        return c != null
+                          ? `${c} ${c === 1 ? "file" : "files"}`
+                          : undefined;
+                      },
                       hook: function useNarratorOptions(q) {
                         return usePeopleSearch(file.library_id, open, q);
                       },
@@ -861,6 +870,12 @@ export function FileEditDialog({
                 <div className="flex items-center gap-2">
                   <div className="flex-1">
                     <EntityCombobox<NameOption>
+                      getOptionDescription={(p) => {
+                        const c = (p as NameWithFileCount).file_count;
+                        return c != null
+                          ? `${c} ${c === 1 ? "file" : "files"}`
+                          : undefined;
+                      }}
                       getOptionKey={(item) => item.name}
                       getOptionLabel={(item) => item.name}
                       hook={function usePublisherOptions(q) {
@@ -896,6 +911,12 @@ export function FileEditDialog({
                 <div className="flex items-center gap-2">
                   <div className="flex-1">
                     <EntityCombobox<NameOption>
+                      getOptionDescription={(p) => {
+                        const c = (p as NameWithFileCount).file_count;
+                        return c != null
+                          ? `${c} ${c === 1 ? "file" : "files"}`
+                          : undefined;
+                      }}
                       getOptionKey={(item) => item.name}
                       getOptionLabel={(item) => item.name}
                       hook={function useImprintOptions(q) {

--- a/app/components/library/IdentifyReviewForm.test.tsx
+++ b/app/components/library/IdentifyReviewForm.test.tsx
@@ -63,78 +63,14 @@ vi.mock("@/hooks/queries/plugins", async () => {
   };
 });
 
-vi.mock("@/hooks/queries/people", async () => {
-  const actual = await vi.importActual<typeof import("@/hooks/queries/people")>(
-    "@/hooks/queries/people",
-  );
-  return {
-    ...actual,
-    usePeopleList: () => ({
-      data: { people: [], total: 0 },
-      isLoading: false,
-    }),
-  };
-});
-vi.mock("@/hooks/queries/series", async () => {
-  const actual = await vi.importActual<typeof import("@/hooks/queries/series")>(
-    "@/hooks/queries/series",
-  );
-  return {
-    ...actual,
-    useSeriesList: () => ({
-      data: { series: [], total: 0 },
-      isLoading: false,
-    }),
-  };
-});
-vi.mock("@/hooks/queries/publishers", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/hooks/queries/publishers")
-  >("@/hooks/queries/publishers");
-  return {
-    ...actual,
-    usePublishersList: () => ({
-      data: { publishers: [], total: 0 },
-      isLoading: false,
-    }),
-  };
-});
-vi.mock("@/hooks/queries/imprints", async () => {
-  const actual = await vi.importActual<
-    typeof import("@/hooks/queries/imprints")
-  >("@/hooks/queries/imprints");
-  return {
-    ...actual,
-    useImprintsList: () => ({
-      data: { imprints: [], total: 0 },
-      isLoading: false,
-    }),
-  };
-});
-vi.mock("@/hooks/queries/genres", async () => {
-  const actual = await vi.importActual<typeof import("@/hooks/queries/genres")>(
-    "@/hooks/queries/genres",
-  );
-  return {
-    ...actual,
-    useGenresList: () => ({
-      data: { genres: [], total: 0 },
-      isLoading: false,
-    }),
-  };
-});
-vi.mock("@/hooks/queries/tags", async () => {
-  const actual = await vi.importActual<typeof import("@/hooks/queries/tags")>(
-    "@/hooks/queries/tags",
-  );
-  return {
-    ...actual,
-    useTagsList: () => ({
-      data: { tags: [], total: 0 },
-      isLoading: false,
-    }),
-  };
-});
+vi.mock("@/hooks/queries/entity-search", () => ({
+  usePeopleSearch: () => ({ data: [], isLoading: false }),
+  useSeriesSearch: () => ({ data: [], isLoading: false }),
+  usePublisherSearch: () => ({ data: [], isLoading: false }),
+  useImprintSearch: () => ({ data: [], isLoading: false }),
+  useGenreSearch: () => ({ data: [], isLoading: false }),
+  useTagSearch: () => ({ data: [], isLoading: false }),
+}));
 
 vi.mock("@/libraries/api", async () => {
   const actual =

--- a/app/components/library/IdentifyReviewForm.test.tsx
+++ b/app/components/library/IdentifyReviewForm.test.tsx
@@ -222,16 +222,16 @@ describe("IdentifyReviewForm component", () => {
     expect(screen.getByText("Narrators")).toBeInTheDocument();
   });
 
-  it("clears series and series_number when the Clear series button is pressed", async () => {
+  it("clears series when the Remove button is pressed on the series row", async () => {
     const user = createUser();
     renderForm({
       result: makeResult({ series: "Some Series", series_number: 1 }),
     });
 
-    const clearButton = await screen.findByRole("button", {
-      name: /clear series/i,
+    const removeButton = await screen.findByRole("button", {
+      name: /remove some series/i,
     });
-    await user.click(clearButton);
+    await user.click(removeButton);
 
     await user.click(getApplyButton());
 
@@ -240,8 +240,7 @@ describe("IdentifyReviewForm component", () => {
     });
 
     const payload = applyMock.mock.calls[0][0];
-    expect(payload.fields.series).toBe("");
-    expect(payload.fields.series_number).toBeUndefined();
+    expect(payload.fields.series).toEqual([]);
   });
 
   it("does not auto-select a broken plugin cover_url as the default cover", async () => {

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -1517,10 +1517,7 @@ export function IdentifyReviewForm({
                           className="w-24"
                           onChange={(e) => {
                             const updated = [...seriesEntries];
-                            updated[idx] = {
-                              ...updated[idx],
-                              number: e.target.value,
-                            };
+                            updated[idx].number = e.target.value;
                             setSeriesEntries(updated);
                           }}
                           placeholder="#"
@@ -1531,13 +1528,10 @@ export function IdentifyReviewForm({
                           <Select
                             onValueChange={(value) => {
                               const updated = [...seriesEntries];
-                              updated[idx] = {
-                                ...updated[idx],
-                                unit:
-                                  value === "unspecified"
-                                    ? ""
-                                    : (value as "volume" | "chapter"),
-                              };
+                              updated[idx].unit =
+                                value === "unspecified"
+                                  ? ""
+                                  : (value as "volume" | "chapter");
                               setSeriesEntries(updated);
                             }}
                             value={

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -42,9 +42,15 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { getLanguageName } from "@/constants/languages";
-import { useGenresList } from "@/hooks/queries/genres";
-import { useImprintsList } from "@/hooks/queries/imprints";
-import { usePeopleList } from "@/hooks/queries/people";
+import {
+  useGenreSearch,
+  useImprintSearch,
+  usePeopleSearch,
+  usePublisherSearch,
+  useSeriesSearch,
+  useTagSearch,
+  type NameOption,
+} from "@/hooks/queries/entity-search";
 import {
   usePluginApply,
   usePluginIdentifierTypes,
@@ -52,10 +58,6 @@ import {
   type PluginApplyPayload,
   type PluginSearchResult,
 } from "@/hooks/queries/plugins";
-import { usePublishersList } from "@/hooks/queries/publishers";
-import { useSeriesList } from "@/hooks/queries/series";
-import { useTagsList } from "@/hooks/queries/tags";
-import { useDebounce } from "@/hooks/useDebounce";
 import { cn, isPageBasedFileType } from "@/libraries/utils";
 import { AuthorRoleWriter, FileTypeCBZ, type Book, type File } from "@/types";
 import { AUTHOR_ROLES, getAuthorRoleLabel } from "@/utils/authorRoles";
@@ -92,10 +94,6 @@ interface IdentifyReviewFormProps {
 interface AuthorEntry {
   name: string;
   role?: string;
-}
-
-interface NameOption {
-  name: string;
 }
 
 type BookFieldKey =
@@ -165,78 +163,6 @@ const PLUGIN_FIELD_ALIASES: Record<FieldKey, string[]> = {
 
 function fieldScope(k: FieldKey): FieldScope {
   return (BOOK_FIELDS as string[]).includes(k) ? "book" : "file";
-}
-
-// Adapter hooks: bridge useXxxList query hooks to EntityCombobox's `hook` prop
-// signature. Defined at module scope so they're stable references and the same
-// hooks run in the same order on every render.
-
-function usePeopleSearch(
-  libraryId: number | undefined,
-  enabled: boolean,
-  query: string,
-): { data?: NameOption[]; isLoading: boolean } {
-  const { data, isLoading } = usePeopleList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  const adapted = data?.people.map((p) => ({ name: p.name }));
-  return { data: adapted, isLoading };
-}
-
-function useSeriesSearch(
-  libraryId: number | undefined,
-  enabled: boolean,
-  query: string,
-): { data?: NameOption[]; isLoading: boolean } {
-  const { data, isLoading } = useSeriesList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  const adapted = data?.series.map((s) => ({ name: s.name }));
-  return { data: adapted, isLoading };
-}
-
-function usePublisherSearch(
-  libraryId: number | undefined,
-  enabled: boolean,
-  query: string,
-): { data?: NameOption[]; isLoading: boolean } {
-  const { data, isLoading } = usePublishersList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  const adapted = data?.publishers.map((p) => ({ name: p.name }));
-  return { data: adapted, isLoading };
-}
-
-function useImprintSearch(
-  libraryId: number | undefined,
-  enabled: boolean,
-  query: string,
-): { data?: NameOption[]; isLoading: boolean } {
-  const { data, isLoading } = useImprintsList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  const adapted = data?.imprints.map((i) => ({ name: i.name }));
-  return { data: adapted, isLoading };
 }
 
 // ---------------------------------------------------------------------------
@@ -650,29 +576,6 @@ export function IdentifyReviewForm({
     if (cur === initialName) return "unchanged";
     return "changed";
   }, [file?.name, initialName]);
-
-  // ---- Genre / tag option pools (server-side search) ----
-  const [genreSearch, setGenreSearch] = useState("");
-  const debouncedGenreSearch = useDebounce(genreSearch, 200);
-  const [tagSearch, setTagSearch] = useState("");
-  const debouncedTagSearch = useDebounce(tagSearch, 200);
-
-  const { data: genresData, isLoading: isLoadingGenres } = useGenresList(
-    {
-      library_id: book.library_id,
-      limit: 50,
-      search: debouncedGenreSearch || undefined,
-    },
-    { enabled: !!book.library_id },
-  );
-  const { data: tagsData, isLoading: isLoadingTags } = useTagsList(
-    {
-      library_id: book.library_id,
-      limit: 50,
-      search: debouncedTagSearch || undefined,
-    },
-    { enabled: !!book.library_id },
-  );
 
   // ---- Identifier types ----
   const availableIdentifierTypes = useMemo(
@@ -1604,13 +1507,12 @@ export function IdentifyReviewForm({
                   status={fieldStatus.genres}
                 >
                   <MultiSelectCombobox
-                    isLoading={isLoadingGenres}
+                    hook={function useGenreOptions(q) {
+                      return useGenreSearch(book.library_id, true, q);
+                    }}
                     label="Genre"
                     onChange={setGenres}
-                    onSearch={setGenreSearch}
-                    options={genresData?.genres.map((g) => g.name) ?? []}
                     placeholder="Add genres..."
-                    searchValue={genreSearch}
                     values={genres}
                   />
                 </FieldRow>
@@ -1628,13 +1530,12 @@ export function IdentifyReviewForm({
                   status={fieldStatus.tags}
                 >
                   <MultiSelectCombobox
-                    isLoading={isLoadingTags}
+                    hook={function useTagOptions(q) {
+                      return useTagSearch(book.library_id, true, q);
+                    }}
                     label="Tag"
                     onChange={setTags}
-                    onSearch={setTagSearch}
-                    options={tagsData?.tags.map((t) => t.name) ?? []}
                     placeholder="Add tags..."
-                    searchValue={tagSearch}
                     values={tags}
                   />
                 </FieldRow>

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -50,6 +50,8 @@ import {
   useSeriesSearch,
   useTagSearch,
   type NameOption,
+  type NameWithBookCount,
+  type NameWithFileCount,
 } from "@/hooks/queries/entity-search";
 import {
   usePluginApply,
@@ -1363,6 +1365,14 @@ export function IdentifyReviewForm({
                     comboboxProps={{
                       getOptionKey: (p) => p.name,
                       getOptionLabel: (p) => p.name,
+                      getOptionDescription: (p) => {
+                        const c = (
+                          p as AuthorEntry & { authored_book_count?: number }
+                        ).authored_book_count;
+                        return c != null
+                          ? `${c} ${c === 1 ? "book" : "books"}`
+                          : undefined;
+                      },
                       hook: function useAuthorOptions(q) {
                         return usePeopleSearch(book.library_id, true, q);
                       },
@@ -1452,6 +1462,12 @@ export function IdentifyReviewForm({
                   <div className="flex items-center gap-2">
                     <div className="flex-1">
                       <EntityCombobox<NameOption>
+                        getOptionDescription={(s) => {
+                          const c = (s as NameWithBookCount).book_count;
+                          return c != null
+                            ? `${c} ${c === 1 ? "book" : "books"}`
+                            : undefined;
+                        }}
                         getOptionKey={(s) => s.name}
                         getOptionLabel={(s) => s.name}
                         hook={function useSeriesOptions(q) {
@@ -1506,7 +1522,12 @@ export function IdentifyReviewForm({
                   onDecisionChange={(v) => setDecision("genres", v)}
                   status={fieldStatus.genres}
                 >
-                  <MultiSelectCombobox
+                  <MultiSelectCombobox<NameWithBookCount>
+                    getOptionCount={(g) => g.book_count}
+                    getOptionDescription={(g) =>
+                      `${g.book_count} ${g.book_count === 1 ? "book" : "books"}`
+                    }
+                    getOptionLabel={(g) => g.name}
                     hook={function useGenreOptions(q) {
                       return useGenreSearch(book.library_id, true, q);
                     }}
@@ -1529,7 +1550,12 @@ export function IdentifyReviewForm({
                   onDecisionChange={(v) => setDecision("tags", v)}
                   status={fieldStatus.tags}
                 >
-                  <MultiSelectCombobox
+                  <MultiSelectCombobox<NameWithBookCount>
+                    getOptionCount={(t) => t.book_count}
+                    getOptionDescription={(t) =>
+                      `${t.book_count} ${t.book_count === 1 ? "book" : "books"}`
+                    }
+                    getOptionLabel={(t) => t.name}
                     hook={function useTagOptions(q) {
                       return useTagSearch(book.library_id, true, q);
                     }}
@@ -1712,6 +1738,14 @@ export function IdentifyReviewForm({
                       comboboxProps={{
                         getOptionKey: (p) => p.name,
                         getOptionLabel: (p) => p.name,
+                        getOptionDescription: (p) => {
+                          const c = (
+                            p as NameOption & { narrated_file_count?: number }
+                          ).narrated_file_count;
+                          return c != null
+                            ? `${c} ${c === 1 ? "file" : "files"}`
+                            : undefined;
+                        },
                         hook: function useNarratorOptions(q) {
                           return usePeopleSearch(book.library_id, true, q);
                         },
@@ -1756,6 +1790,12 @@ export function IdentifyReviewForm({
                   <div className="flex items-center gap-2">
                     <div className="flex-1">
                       <EntityCombobox<NameOption>
+                        getOptionDescription={(p) => {
+                          const c = (p as NameWithFileCount).file_count;
+                          return c != null
+                            ? `${c} ${c === 1 ? "file" : "files"}`
+                            : undefined;
+                        }}
                         getOptionKey={(p) => p.name}
                         getOptionLabel={(p) => p.name}
                         hook={function usePublisherOptions(q) {
@@ -1798,6 +1838,12 @@ export function IdentifyReviewForm({
                   <div className="flex items-center gap-2">
                     <div className="flex-1">
                       <EntityCombobox<NameOption>
+                        getOptionDescription={(p) => {
+                          const c = (p as NameWithFileCount).file_count;
+                          return c != null
+                            ? `${c} ${c === 1 ? "file" : "files"}`
+                            : undefined;
+                        }}
                         getOptionKey={(p) => p.name}
                         getOptionLabel={(p) => p.name}
                         hook={function useImprintOptions(q) {

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -98,6 +98,12 @@ interface AuthorEntry {
   role?: string;
 }
 
+interface SeriesEntry {
+  name: string;
+  number: string;
+  unit: "" | "volume" | "chapter";
+}
+
 type BookFieldKey =
   | "title"
   | "subtitle"
@@ -264,6 +270,26 @@ function resolveAuthors(
   if (current.length > 0 && incoming.length === 0)
     return { value: current, status: "unchanged" };
   const key = (a: AuthorEntry) => `${a.name}|${a.role ?? ""}`;
+  const curKeys = current.map(key).sort();
+  const incKeys = incoming.map(key).sort();
+  if (
+    curKeys.length === incKeys.length &&
+    curKeys.every((v, i) => v === incKeys[i])
+  ) {
+    return { value: current, status: "unchanged" };
+  }
+  return { value: incoming, status: "changed" };
+}
+
+function resolveSeries(
+  current: SeriesEntry[],
+  incoming: SeriesEntry[],
+): { value: SeriesEntry[]; status: FieldStatus } {
+  if (current.length === 0 && incoming.length > 0)
+    return { value: incoming, status: "new" };
+  if (current.length > 0 && incoming.length === 0)
+    return { value: current, status: "unchanged" };
+  const key = (s: SeriesEntry) => `${s.name}|${s.number}|${s.unit}`;
   const curKeys = current.map(key).sort();
   const incKeys = incoming.map(key).sort();
   if (
@@ -456,11 +482,15 @@ export function IdentifyReviewForm({
     [file?.narrators],
   );
 
-  const currentSeries = book.book_series?.[0]?.series?.name ?? "";
-  const currentSeriesNumber =
-    book.book_series?.[0]?.series_number?.toString() ?? "";
-  const currentSeriesNumberUnit =
-    book.book_series?.[0]?.series_number_unit ?? "";
+  const currentSeriesEntries: SeriesEntry[] = useMemo(
+    () =>
+      (book.book_series ?? []).map((bs) => ({
+        name: bs.series?.name ?? "",
+        number: bs.series_number?.toString() ?? "",
+        unit: (bs.series_number_unit ?? "") as SeriesEntry["unit"],
+      })),
+    [book.book_series],
+  );
 
   const currentGenres: string[] = useMemo(
     () => (book.book_genres ?? []).map((bg) => bg.genre?.name ?? ""),
@@ -491,21 +521,23 @@ export function IdentifyReviewForm({
       result.identifiers ?? []
     ).map((id) => ({ type: id.type, value: id.value }));
 
+    const incomingSeries: SeriesEntry[] = result.series
+      ? [
+          {
+            name: result.series,
+            number: result.series_number?.toString() ?? "",
+            unit: (result.series_number_unit ?? "") as SeriesEntry["unit"],
+          },
+        ]
+      : [];
+
     return {
       title: resolveScalar(book.title, result.title),
       subtitle: resolveScalar(book.subtitle, result.subtitle),
       description: resolveScalar(book.description, result.description),
       authors: resolveAuthors(currentAuthors, incomingAuthors),
       narrators: resolveArray(currentNarrators, result.narrators ?? []),
-      series: resolveScalar(currentSeries, result.series),
-      seriesNumber: resolveScalar(
-        currentSeriesNumber,
-        result.series_number?.toString(),
-      ),
-      seriesNumberUnit: resolveScalar(
-        currentSeriesNumberUnit,
-        result.series_number_unit ?? undefined,
-      ),
+      series: resolveSeries(currentSeriesEntries, incomingSeries),
       genres: resolveArray(currentGenres, result.genres ?? []),
       tags: resolveArray(currentTags, result.tags ?? []),
       publisher: resolveScalar(file?.publisher?.name, result.publisher),
@@ -524,9 +556,7 @@ export function IdentifyReviewForm({
     result,
     currentAuthors,
     currentNarrators,
-    currentSeries,
-    currentSeriesNumber,
-    currentSeriesNumberUnit,
+    currentSeriesEntries,
     currentGenres,
     currentTags,
     currentIdentifiers,
@@ -545,10 +575,8 @@ export function IdentifyReviewForm({
     () => narrators.map((name) => ({ name })),
     [narrators],
   );
-  const [series, setSeries] = useState(defaults.series.value);
-  const [seriesNumber, setSeriesNumber] = useState(defaults.seriesNumber.value);
-  const [seriesNumberUnit, setSeriesNumberUnit] = useState(
-    defaults.seriesNumberUnit.value,
+  const [seriesEntries, setSeriesEntries] = useState<SeriesEntry[]>(
+    defaults.series.value,
   );
   const [genres, setGenres] = useState<string[]>(defaults.genres.value);
   const [tags, setTags] = useState<string[]>(defaults.tags.value);
@@ -662,16 +690,7 @@ export function IdentifyReviewForm({
 
   // ---- Initial field statuses (plugin vs saved — for default decisions) ----
   const initialFieldStatus: Record<FieldKey, FieldStatus> = useMemo(() => {
-    const seriesStatus: FieldStatus =
-      defaults.series.status === "changed" ||
-      defaults.seriesNumber.status === "changed" ||
-      defaults.seriesNumberUnit.status === "changed"
-        ? "changed"
-        : defaults.series.status === "new" ||
-            defaults.seriesNumber.status === "new" ||
-            defaults.seriesNumberUnit.status === "new"
-          ? "new"
-          : "unchanged";
+    const seriesStatus: FieldStatus = defaults.series.status;
 
     const coverStatus: FieldStatus =
       hasCoverChoice && !preferCurrentCover
@@ -721,23 +740,18 @@ export function IdentifyReviewForm({
       return "changed";
     };
 
-    const seriesSaved = currentSeries.trim();
-    const seriesNumSaved = currentSeriesNumber.trim();
-    const seriesUnitSaved = currentSeriesNumberUnit.trim();
-    const seriesChanged =
-      series.trim() !== seriesSaved ||
-      seriesNumber.trim() !== seriesNumSaved ||
-      seriesNumberUnit.trim() !== seriesUnitSaved;
-    const seriesIsNew =
-      !seriesSaved &&
-      !seriesNumSaved &&
-      !seriesUnitSaved &&
-      (series.trim() || seriesNumber.trim() || seriesNumberUnit.trim());
-    const seriesStatus: FieldStatus = seriesChanged
-      ? seriesIsNew
+    const seriesKey = (s: SeriesEntry) =>
+      `${s.name.trim()}|${s.number.trim()}|${s.unit}`;
+    const seriesSavedKeys = currentSeriesEntries.map(seriesKey).sort();
+    const seriesCurrentKeys = seriesEntries.map(seriesKey).sort();
+    const seriesMatch =
+      seriesSavedKeys.length === seriesCurrentKeys.length &&
+      seriesSavedKeys.every((v, i) => v === seriesCurrentKeys[i]);
+    const seriesStatus: FieldStatus = seriesMatch
+      ? "unchanged"
+      : currentSeriesEntries.length === 0 && seriesEntries.length > 0
         ? "new"
-        : "changed"
-      : "unchanged";
+        : "changed";
 
     const arrayStatus = (saved: string[], current: string[]): FieldStatus => {
       if (saved.length === 0 && current.length > 0) return "new";
@@ -818,9 +832,7 @@ export function IdentifyReviewForm({
     description,
     authors,
     narrators,
-    series,
-    seriesNumber,
-    seriesNumberUnit,
+    seriesEntries,
     genres,
     tags,
     publisher,
@@ -833,9 +845,7 @@ export function IdentifyReviewForm({
     name,
     currentAuthors,
     currentNarrators,
-    currentSeries,
-    currentSeriesNumber,
-    currentSeriesNumberUnit,
+    currentSeriesEntries,
     currentGenres,
     currentTags,
     currentIdentifiers,
@@ -1029,9 +1039,7 @@ export function IdentifyReviewForm({
     setDescription(defaults.description.value);
     setAuthors(defaults.authors.value);
     setNarrators(defaults.narrators.value);
-    setSeries(defaults.series.value);
-    setSeriesNumber(defaults.seriesNumber.value);
-    setSeriesNumberUnit(defaults.seriesNumberUnit.value);
+    setSeriesEntries(defaults.series.value);
     setGenres(defaults.genres.value);
     setTags(defaults.tags.value);
     setPublisher(defaults.publisher.value);
@@ -1057,9 +1065,7 @@ export function IdentifyReviewForm({
       description !== defaults.description.value ||
       !equal(authors, defaults.authors.value) ||
       !equal(narrators, defaults.narrators.value) ||
-      series !== defaults.series.value ||
-      seriesNumber !== defaults.seriesNumber.value ||
-      seriesNumberUnit !== defaults.seriesNumberUnit.value ||
+      !equal(seriesEntries, defaults.series.value) ||
       !equal(genres, defaults.genres.value) ||
       !equal(tags, defaults.tags.value) ||
       publisher !== defaults.publisher.value ||
@@ -1081,9 +1087,7 @@ export function IdentifyReviewForm({
     description,
     authors,
     narrators,
-    series,
-    seriesNumber,
-    seriesNumberUnit,
+    seriesEntries,
     genres,
     tags,
     publisher,
@@ -1113,11 +1117,13 @@ export function IdentifyReviewForm({
     }
     if (decisions.narrators) fields.narrators = narrators;
     if (decisions.series) {
-      fields.series = series;
-      fields.series_number =
-        seriesNumber !== "" ? parseFloat(seriesNumber) : undefined;
-      fields.series_number_unit =
-        seriesNumberUnit !== "" ? seriesNumberUnit : undefined;
+      fields.series = seriesEntries
+        .filter((s) => s.name.trim())
+        .map((s) => ({
+          name: s.name,
+          number: s.number ? parseFloat(s.number) : undefined,
+          series_number_unit: s.unit !== "" ? s.unit : undefined,
+        }));
     }
     if (decisions.genres) fields.genres = genres;
     if (decisions.tags) fields.tags = tags;
@@ -1444,12 +1450,17 @@ export function IdentifyReviewForm({
                 {/* Series */}
                 <FieldRow
                   currentValue={
-                    currentSeries
-                      ? `${currentSeries}${
-                          currentSeriesNumber
-                            ? ` ${formatSeriesNumber(parseFloat(currentSeriesNumber), currentSeriesNumberUnit || null, primaryFileType)}`
-                            : ""
-                        }`
+                    currentSeriesEntries.length > 0
+                      ? currentSeriesEntries
+                          .map(
+                            (s) =>
+                              `${s.name}${
+                                s.number
+                                  ? ` ${formatSeriesNumber(parseFloat(s.number), s.unit || null, primaryFileType)}`
+                                  : ""
+                              }`,
+                          )
+                          .join(", ")
                       : undefined
                   }
                   decision={decisions.series}
@@ -1459,53 +1470,95 @@ export function IdentifyReviewForm({
                   onDecisionChange={(v) => setDecision("series", v)}
                   status={fieldStatus.series}
                 >
-                  <div className="flex items-center gap-2">
-                    <div className="flex-1">
-                      <EntityCombobox<NameOption>
-                        getOptionDescription={(s) => {
-                          const c = (s as NameWithBookCount).book_count;
-                          return c != null
-                            ? `${c} ${c === 1 ? "book" : "books"}`
-                            : undefined;
-                        }}
-                        getOptionKey={(s) => s.name}
-                        getOptionLabel={(s) => s.name}
-                        hook={function useSeriesOptions(q) {
-                          return useSeriesSearch(book.library_id, true, q);
-                        }}
-                        label="Series"
-                        onChange={(next) =>
-                          setSeries(
-                            "__create" in next ? next.__create : next.name,
-                          )
-                        }
-                        value={series ? { name: series } : null}
-                      />
-                    </div>
-                    <Input
-                      className="w-24"
-                      disabled={isDisabled("series")}
-                      onChange={(e) => setSeriesNumber(e.target.value)}
-                      placeholder="#"
-                      type="number"
-                      value={seriesNumber}
-                    />
-                    {series && !isDisabled("series") && (
-                      <Button
-                        aria-label="Clear series"
-                        className="shrink-0 cursor-pointer"
-                        onClick={() => {
-                          setSeries("");
-                          setSeriesNumber("");
-                        }}
-                        size="icon"
-                        type="button"
-                        variant="ghost"
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
+                  <SortableEntityList<SeriesEntry>
+                    comboboxProps={{
+                      getOptionKey: (s) => s.name,
+                      getOptionLabel: (s) => s.name,
+                      getOptionDescription: (s) => {
+                        const c = (s as SeriesEntry & { book_count?: number })
+                          .book_count;
+                        return c != null
+                          ? `${c} ${c === 1 ? "book" : "books"}`
+                          : undefined;
+                      },
+                      hook: function useSeriesOptions(q) {
+                        const result = useSeriesSearch(
+                          book.library_id,
+                          true,
+                          q,
+                        );
+                        return result as {
+                          data?: SeriesEntry[];
+                          isLoading: boolean;
+                        };
+                      },
+                      label: "Series",
+                    }}
+                    items={seriesEntries}
+                    onAppend={(next) => {
+                      const name =
+                        "__create" in next ? next.__create : next.name;
+                      if (!name.trim()) return;
+                      if (seriesEntries.some((s) => s.name === name)) return;
+                      setSeriesEntries([
+                        ...seriesEntries,
+                        { name, number: "", unit: "" },
+                      ]);
+                    }}
+                    onRemove={(index) => {
+                      setSeriesEntries(
+                        seriesEntries.filter((_, i) => i !== index),
+                      );
+                    }}
+                    onReorder={setSeriesEntries}
+                    renderExtras={(entry, idx) => (
+                      <>
+                        <Input
+                          className="w-24"
+                          onChange={(e) => {
+                            const updated = [...seriesEntries];
+                            updated[idx] = {
+                              ...updated[idx],
+                              number: e.target.value,
+                            };
+                            setSeriesEntries(updated);
+                          }}
+                          placeholder="#"
+                          type="number"
+                          value={entry.number}
+                        />
+                        <div className="w-32">
+                          <Select
+                            onValueChange={(value) => {
+                              const updated = [...seriesEntries];
+                              updated[idx] = {
+                                ...updated[idx],
+                                unit:
+                                  value === "unspecified"
+                                    ? ""
+                                    : (value as "volume" | "chapter"),
+                              };
+                              setSeriesEntries(updated);
+                            }}
+                            value={
+                              entry.unit === "" ? "unspecified" : entry.unit
+                            }
+                          >
+                            <SelectTrigger>
+                              <SelectValue placeholder="Unit" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="unspecified">
+                                Unspecified
+                              </SelectItem>
+                              <SelectItem value="volume">Volume</SelectItem>
+                              <SelectItem value="chapter">Chapter</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                      </>
                     )}
-                  </div>
+                  />
                 </FieldRow>
 
                 {/* Genres */}

--- a/app/components/ui/MultiSelectCombobox.test.tsx
+++ b/app/components/ui/MultiSelectCombobox.test.tsx
@@ -4,23 +4,23 @@ import { describe, expect, it, vi } from "vitest";
 
 import { MultiSelectCombobox } from "./MultiSelectCombobox";
 
+function makeHook(items: string[], isLoading = false) {
+  return () => ({ data: items, isLoading });
+}
+
 describe("MultiSelectCombobox", () => {
-  it("renders chips without status badges", () => {
+  it("renders chips for selected values", () => {
     render(
       <MultiSelectCombobox
-        isLoading={false}
+        hook={makeHook([])}
         label="Genre"
         onChange={vi.fn()}
-        onSearch={vi.fn()}
-        options={[]}
-        searchValue=""
         values={["Sci-Fi", "Fantasy"]}
       />,
     );
 
     expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
     expect(screen.getByText("Fantasy")).toBeInTheDocument();
-    expect(screen.queryByTestId("ms-status-badge")).not.toBeInTheDocument();
   });
 
   it("removes a chip when X is clicked", async () => {
@@ -29,17 +29,84 @@ describe("MultiSelectCombobox", () => {
 
     render(
       <MultiSelectCombobox
-        isLoading={false}
+        hook={makeHook([])}
         label="Genre"
         onChange={onChange}
-        onSearch={vi.fn()}
-        options={[]}
-        searchValue=""
         values={["Sci-Fi", "Fantasy"]}
       />,
     );
 
     await user.click(screen.getByLabelText(/Remove Sci-Fi/i));
     expect(onChange).toHaveBeenCalledWith(["Fantasy"]);
+  });
+
+  it("shows 'In your library' heading when options exist", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(
+      <MultiSelectCombobox
+        hook={makeHook(["Fantasy", "Horror"])}
+        label="Genre"
+        onChange={vi.fn()}
+        values={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(screen.getByText("In your library")).toBeInTheDocument();
+  });
+
+  it("selects an option and calls onChange", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onChange = vi.fn();
+
+    render(
+      <MultiSelectCombobox
+        hook={makeHook(["Fantasy", "Horror"])}
+        label="Genre"
+        onChange={onChange}
+        values={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByText("Fantasy"));
+    expect(onChange).toHaveBeenCalledWith(["Fantasy"]);
+  });
+
+  it("excludes already-selected values from dropdown", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(
+      <MultiSelectCombobox
+        hook={makeHook(["Fantasy", "Horror"])}
+        label="Genre"
+        onChange={vi.fn()}
+        values={["Fantasy"]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    expect(
+      screen.queryByRole("option", { name: "Fantasy" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Horror")).toBeInTheDocument();
+  });
+
+  it("shows Create option for unmatched search text", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    render(
+      <MultiSelectCombobox
+        hook={makeHook([])}
+        label="Genre"
+        onChange={vi.fn()}
+        values={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText(/Search genre/i), "Thriller");
+    expect(screen.getByText(/Create new genre "Thriller"/)).toBeInTheDocument();
   });
 });

--- a/app/components/ui/MultiSelectCombobox.test.tsx
+++ b/app/components/ui/MultiSelectCombobox.test.tsx
@@ -12,6 +12,7 @@ describe("MultiSelectCombobox", () => {
   it("renders chips for selected values", () => {
     render(
       <MultiSelectCombobox
+        getOptionLabel={(s) => s}
         hook={makeHook([])}
         label="Genre"
         onChange={vi.fn()}
@@ -29,6 +30,7 @@ describe("MultiSelectCombobox", () => {
 
     render(
       <MultiSelectCombobox
+        getOptionLabel={(s) => s}
         hook={makeHook([])}
         label="Genre"
         onChange={onChange}
@@ -45,6 +47,7 @@ describe("MultiSelectCombobox", () => {
 
     render(
       <MultiSelectCombobox
+        getOptionLabel={(s) => s}
         hook={makeHook(["Fantasy", "Horror"])}
         label="Genre"
         onChange={vi.fn()}
@@ -62,6 +65,7 @@ describe("MultiSelectCombobox", () => {
 
     render(
       <MultiSelectCombobox
+        getOptionLabel={(s) => s}
         hook={makeHook(["Fantasy", "Horror"])}
         label="Genre"
         onChange={onChange}
@@ -79,6 +83,7 @@ describe("MultiSelectCombobox", () => {
 
     render(
       <MultiSelectCombobox
+        getOptionLabel={(s) => s}
         hook={makeHook(["Fantasy", "Horror"])}
         label="Genre"
         onChange={vi.fn()}
@@ -98,6 +103,7 @@ describe("MultiSelectCombobox", () => {
 
     render(
       <MultiSelectCombobox
+        getOptionLabel={(s) => s}
         hook={makeHook([])}
         label="Genre"
         onChange={vi.fn()}

--- a/app/components/ui/MultiSelectCombobox.tsx
+++ b/app/components/ui/MultiSelectCombobox.tsx
@@ -1,5 +1,5 @@
-import { Check, ChevronsUpDown, Plus, X } from "lucide-react";
-import { useState } from "react";
+import { ChevronsUpDown, Plus, X } from "lucide-react";
+import { useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -18,39 +18,59 @@ import {
 } from "@/components/ui/popover";
 import { useDebounce } from "@/hooks/useDebounce";
 
-interface MultiSelectComboboxProps {
+interface MultiSelectComboboxProps<T> {
   values: string[];
   onChange: (values: string[]) => void;
-  hook: (query: string) => { data?: string[]; isLoading: boolean };
+  hook: (query: string) => { data?: T[]; isLoading: boolean };
   label: string;
+  getOptionLabel: (item: T) => string;
+  getOptionDescription?: (item: T) => string | undefined;
+  getOptionCount?: (item: T) => number | undefined;
   placeholder?: string;
 }
 
-export function MultiSelectCombobox({
+export function MultiSelectCombobox<T>({
   values,
   onChange,
   hook,
   label,
+  getOptionLabel,
+  getOptionDescription,
+  getOptionCount,
   placeholder,
-}: MultiSelectComboboxProps) {
+}: MultiSelectComboboxProps<T>) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebounce(search, 200);
   const { data: items = [], isLoading } = hook(debouncedSearch);
 
+  const chipCounts = useRef(new Map<string, number>());
+  if (getOptionCount) {
+    for (const item of items) {
+      const c = getOptionCount(item);
+      if (c != null) chipCounts.current.set(getOptionLabel(item), c);
+    }
+  }
+
   const filtered = items.filter(
-    (opt) => !values.some((v) => v.toLowerCase() === opt.toLowerCase()),
+    (opt) =>
+      !values.some(
+        (v) => v.toLowerCase() === getOptionLabel(opt).toLowerCase(),
+      ),
   );
 
   const trimmed = search.trim();
   const showCreate =
     !!trimmed &&
-    !filtered.some((opt) => opt.toLowerCase() === trimmed.toLowerCase()) &&
+    !filtered.some(
+      (opt) => getOptionLabel(opt).toLowerCase() === trimmed.toLowerCase(),
+    ) &&
     !values.some((v) => v.toLowerCase() === trimmed.toLowerCase());
 
-  const handleSelect = (value: string) => {
-    if (!values.includes(value)) {
-      onChange([...values, value]);
+  const handleSelect = (item: T) => {
+    const itemLabel = getOptionLabel(item);
+    if (!values.includes(itemLabel)) {
+      onChange([...values, itemLabel]);
     }
     setSearch("");
   };
@@ -73,26 +93,34 @@ export function MultiSelectCombobox({
     <div className="space-y-2">
       {values.length > 0 && (
         <div className="flex flex-wrap items-center gap-2">
-          {values.map((value) => (
-            <Badge
-              className="flex items-center gap-1 max-w-full"
-              data-testid="ms-chip"
-              key={value}
-              variant="secondary"
-            >
-              <span className="truncate" title={value}>
-                {value}
-              </span>
-              <button
-                aria-label={`Remove ${value}`}
-                className="ml-1 cursor-pointer hover:text-destructive shrink-0"
-                onClick={() => handleRemove(value)}
-                type="button"
+          {values.map((value) => {
+            const count = chipCounts.current.get(value);
+            return (
+              <Badge
+                className="flex items-center gap-1 max-w-full"
+                data-testid="ms-chip"
+                key={value}
+                variant="secondary"
               >
-                <X className="h-3 w-3" />
-              </button>
-            </Badge>
-          ))}
+                <span className="truncate" title={value}>
+                  {value}
+                  {count != null && (
+                    <span className="text-muted-foreground ml-1">
+                      ({count})
+                    </span>
+                  )}
+                </span>
+                <button
+                  aria-label={`Remove ${value}`}
+                  className="ml-1 cursor-pointer hover:text-destructive shrink-0"
+                  onClick={() => handleRemove(value)}
+                  type="button"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </Badge>
+            );
+          })}
           {values.length > 1 && (
             <button
               className="text-xs text-muted-foreground hover:text-destructive cursor-pointer"
@@ -139,17 +167,24 @@ export function MultiSelectCombobox({
               )}
               {!isLoading && filtered.length > 0 && (
                 <CommandGroup heading="In your library">
-                  {filtered.map((opt) => (
-                    <CommandItem
-                      className="cursor-pointer"
-                      key={opt}
-                      onSelect={() => handleSelect(opt)}
-                      value={opt}
-                    >
-                      <Check className="mr-2 h-4 w-4 opacity-0" />
-                      {opt}
-                    </CommandItem>
-                  ))}
+                  {filtered.map((opt) => {
+                    const optLabel = getOptionLabel(opt);
+                    return (
+                      <CommandItem
+                        className="cursor-pointer"
+                        key={optLabel}
+                        onSelect={() => handleSelect(opt)}
+                        value={optLabel}
+                      >
+                        <span className="truncate">{optLabel}</span>
+                        {getOptionDescription?.(opt) && (
+                          <span className="ml-auto pl-2 text-xs text-muted-foreground shrink-0">
+                            {getOptionDescription(opt)}
+                          </span>
+                        )}
+                      </CommandItem>
+                    );
+                  })}
                 </CommandGroup>
               )}
               {!isLoading && showCreate && (

--- a/app/components/ui/MultiSelectCombobox.tsx
+++ b/app/components/ui/MultiSelectCombobox.tsx
@@ -9,73 +9,68 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "@/components/ui/command";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { useDebounce } from "@/hooks/useDebounce";
 
 interface MultiSelectComboboxProps {
   values: string[];
   onChange: (values: string[]) => void;
-  options: string[];
-  onSearch: (query: string) => void;
-  searchValue: string;
-  placeholder?: string;
-  isLoading?: boolean;
+  hook: (query: string) => { data?: string[]; isLoading: boolean };
   label: string;
+  placeholder?: string;
 }
 
 export function MultiSelectCombobox({
   values,
   onChange,
-  options,
-  onSearch,
-  searchValue,
-  placeholder = "Search...",
-  isLoading = false,
+  hook,
   label,
+  placeholder,
 }: MultiSelectComboboxProps) {
   const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, 200);
+  const { data: items = [], isLoading } = hook(debouncedSearch);
+
+  const filtered = items.filter(
+    (opt) => !values.some((v) => v.toLowerCase() === opt.toLowerCase()),
+  );
+
+  const trimmed = search.trim();
+  const showCreate =
+    !!trimmed &&
+    !filtered.some((opt) => opt.toLowerCase() === trimmed.toLowerCase()) &&
+    !values.some((v) => v.toLowerCase() === trimmed.toLowerCase());
 
   const handleSelect = (value: string) => {
     if (!values.includes(value)) {
       onChange([...values, value]);
     }
-    onSearch("");
+    setSearch("");
   };
 
   const handleCreate = () => {
-    const trimmed = searchValue.trim();
     if (
       trimmed &&
       !values.some((v) => v.toLowerCase() === trimmed.toLowerCase())
     ) {
       onChange([...values, trimmed]);
     }
-    onSearch("");
+    setSearch("");
   };
 
   const handleRemove = (value: string) => {
     onChange(values.filter((v) => v !== value));
   };
 
-  // Filter out already-selected values from options
-  const filteredOptions = options.filter(
-    (opt) => !values.some((v) => v.toLowerCase() === opt.toLowerCase()),
-  );
-
-  const showCreateOption =
-    searchValue.trim() &&
-    !filteredOptions.some(
-      (opt) => opt.toLowerCase() === searchValue.toLowerCase(),
-    ) &&
-    !values.some((v) => v.toLowerCase() === searchValue.toLowerCase());
-
   return (
     <div className="space-y-2">
-      {/* Selected values as unified chips: label + status text + X */}
       {values.length > 0 && (
         <div className="flex flex-wrap items-center gap-2">
           {values.map((value) => (
@@ -110,7 +105,6 @@ export function MultiSelectCombobox({
         </div>
       )}
 
-      {/* Combobox */}
       <Popover modal onOpenChange={setOpen} open={open}>
         <PopoverTrigger asChild>
           <Button
@@ -119,16 +113,16 @@ export function MultiSelectCombobox({
             role="combobox"
             variant="outline"
           >
-            {placeholder}
+            {placeholder ?? `Add ${label.toLowerCase()}...`}
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
         <PopoverContent align="start" className="w-full p-0">
           <Command shouldFilter={false}>
             <CommandInput
-              onValueChange={onSearch}
+              onValueChange={setSearch}
               placeholder={`Search ${label.toLowerCase()}...`}
-              value={searchValue}
+              value={search}
             />
             <CommandList>
               {isLoading && (
@@ -136,19 +130,18 @@ export function MultiSelectCombobox({
                   Loading...
                 </div>
               )}
-              {!isLoading &&
-                filteredOptions.length === 0 &&
-                !showCreateOption && (
-                  <div className="p-4 text-center text-sm text-muted-foreground">
-                    {!searchValue
-                      ? `No ${label.toLowerCase()} available. Type to create one.`
-                      : `No matching ${label.toLowerCase()}.`}
-                  </div>
-                )}
-              {!isLoading && (
-                <CommandGroup>
-                  {filteredOptions.map((opt) => (
+              {!isLoading && filtered.length === 0 && !showCreate && (
+                <div className="p-4 text-center text-sm text-muted-foreground">
+                  {!trimmed
+                    ? `No ${label.toLowerCase()} available. Type to create one.`
+                    : `No matching ${label.toLowerCase()}.`}
+                </div>
+              )}
+              {!isLoading && filtered.length > 0 && (
+                <CommandGroup heading="In your library">
+                  {filtered.map((opt) => (
                     <CommandItem
+                      className="cursor-pointer"
                       key={opt}
                       onSelect={() => handleSelect(opt)}
                       value={opt}
@@ -157,16 +150,22 @@ export function MultiSelectCombobox({
                       {opt}
                     </CommandItem>
                   ))}
-                  {showCreateOption && (
+                </CommandGroup>
+              )}
+              {!isLoading && showCreate && (
+                <>
+                  {filtered.length > 0 && <CommandSeparator />}
+                  <CommandGroup>
                     <CommandItem
+                      className="cursor-pointer"
                       onSelect={handleCreate}
-                      value={`create-${searchValue}`}
+                      value={`create-${trimmed}`}
                     >
                       <Plus className="mr-2 h-4 w-4" />
-                      Create "{searchValue}"
+                      Create new {label.toLowerCase()} &quot;{trimmed}&quot;
                     </CommandItem>
-                  )}
-                </CommandGroup>
+                  </CommandGroup>
+                </>
               )}
             </CommandList>
           </Command>

--- a/app/hooks/queries/entity-search.test.ts
+++ b/app/hooks/queries/entity-search.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  useGenreSearch,
+  useImprintSearch,
+  usePeopleSearch,
+  usePublisherSearch,
+  useSeriesSearch,
+  useTagSearch,
+} from "./entity-search";
+
+const mockPeopleData = {
+  people: [
+    { id: 1, name: "Alice", authored_book_count: 3, narrated_file_count: 0 },
+    { id: 2, name: "Bob", authored_book_count: 1, narrated_file_count: 5 },
+  ],
+  total: 2,
+};
+
+vi.mock("./people", () => ({
+  usePeopleList: () => ({ data: mockPeopleData, isLoading: false }),
+}));
+vi.mock("./genres", () => ({
+  useGenresList: () => ({
+    data: { genres: [{ name: "Fantasy" }, { name: "Sci-Fi" }], total: 2 },
+    isLoading: false,
+  }),
+}));
+vi.mock("./tags", () => ({
+  useTagsList: () => ({
+    data: { tags: [{ name: "favorite" }], total: 1 },
+    isLoading: false,
+  }),
+}));
+vi.mock("./series", () => ({
+  useSeriesList: () => ({
+    data: { series: [{ name: "Dune" }], total: 1 },
+    isLoading: false,
+  }),
+}));
+vi.mock("./publishers", () => ({
+  usePublishersList: () => ({
+    data: { publishers: [{ name: "Tor" }], total: 1 },
+    isLoading: false,
+  }),
+}));
+vi.mock("./imprints", () => ({
+  useImprintsList: () => ({
+    data: { imprints: [{ name: "Orbit" }], total: 1 },
+    isLoading: false,
+  }),
+}));
+
+describe("entity-search adapter hooks", () => {
+  it("usePeopleSearch adapts PersonWithCounts to { name, id }", () => {
+    const result = usePeopleSearch(1, true, "");
+    expect(result.isLoading).toBe(false);
+    expect(result.data).toEqual([
+      { id: 1, name: "Alice" },
+      { id: 2, name: "Bob" },
+    ]);
+  });
+
+  it("useGenreSearch returns string[]", () => {
+    const result = useGenreSearch(1, true, "");
+    expect(result.data).toEqual(["Fantasy", "Sci-Fi"]);
+  });
+
+  it("useTagSearch returns string[]", () => {
+    const result = useTagSearch(1, true, "");
+    expect(result.data).toEqual(["favorite"]);
+  });
+
+  it("useSeriesSearch adapts to { name }", () => {
+    const result = useSeriesSearch(1, true, "");
+    expect(result.data).toEqual([{ name: "Dune" }]);
+  });
+
+  it("usePublisherSearch adapts to { name }", () => {
+    const result = usePublisherSearch(1, true, "");
+    expect(result.data).toEqual([{ name: "Tor" }]);
+  });
+
+  it("useImprintSearch adapts to { name }", () => {
+    const result = useImprintSearch(1, true, "");
+    expect(result.data).toEqual([{ name: "Orbit" }]);
+  });
+});

--- a/app/hooks/queries/entity-search.test.ts
+++ b/app/hooks/queries/entity-search.test.ts
@@ -22,67 +22,76 @@ vi.mock("./people", () => ({
 }));
 vi.mock("./genres", () => ({
   useGenresList: () => ({
-    data: { genres: [{ name: "Fantasy" }, { name: "Sci-Fi" }], total: 2 },
+    data: {
+      genres: [
+        { name: "Fantasy", book_count: 5 },
+        { name: "Sci-Fi", book_count: 12 },
+      ],
+      total: 2,
+    },
     isLoading: false,
   }),
 }));
 vi.mock("./tags", () => ({
   useTagsList: () => ({
-    data: { tags: [{ name: "favorite" }], total: 1 },
+    data: { tags: [{ name: "favorite", book_count: 2 }], total: 1 },
     isLoading: false,
   }),
 }));
 vi.mock("./series", () => ({
   useSeriesList: () => ({
-    data: { series: [{ name: "Dune" }], total: 1 },
+    data: { series: [{ name: "Dune", book_count: 6 }], total: 1 },
     isLoading: false,
   }),
 }));
 vi.mock("./publishers", () => ({
   usePublishersList: () => ({
-    data: { publishers: [{ name: "Tor" }], total: 1 },
+    data: { publishers: [{ name: "Tor", file_count: 8 }], total: 1 },
     isLoading: false,
   }),
 }));
 vi.mock("./imprints", () => ({
   useImprintsList: () => ({
-    data: { imprints: [{ name: "Orbit" }], total: 1 },
+    data: { imprints: [{ name: "Orbit", file_count: 3 }], total: 1 },
     isLoading: false,
   }),
 }));
 
 describe("entity-search adapter hooks", () => {
-  it("usePeopleSearch adapts PersonWithCounts to { name, id }", () => {
+  it("usePeopleSearch includes counts", () => {
     const result = usePeopleSearch(1, true, "");
     expect(result.isLoading).toBe(false);
     expect(result.data).toEqual([
-      { id: 1, name: "Alice" },
-      { id: 2, name: "Bob" },
+      { id: 1, name: "Alice", authored_book_count: 3, narrated_file_count: 0 },
+      { id: 2, name: "Bob", authored_book_count: 1, narrated_file_count: 5 },
     ]);
   });
 
-  it("useGenreSearch returns string[]", () => {
+  it("useGenreSearch returns objects with book_count", () => {
     const result = useGenreSearch(1, true, "");
-    expect(result.data).toEqual(["Fantasy", "Sci-Fi"]);
+    expect(result.data).toEqual([
+      { name: "Fantasy", book_count: 5 },
+      { name: "Sci-Fi", book_count: 12 },
+    ]);
   });
 
-  it("useTagSearch returns string[]", () => {
+  it("useTagSearch returns objects with book_count", () => {
     const result = useTagSearch(1, true, "");
-    expect(result.data).toEqual(["favorite"]);
+    expect(result.data).toEqual([{ name: "favorite", book_count: 2 }]);
   });
 
-  it("useSeriesSearch adapts to { name }", () => {
+  it("useSeriesSearch includes book_count", () => {
     const result = useSeriesSearch(1, true, "");
-    expect(result.data).toEqual([{ name: "Dune" }]);
+    expect(result.data).toEqual([{ name: "Dune", book_count: 6 }]);
   });
 
-  it("usePublisherSearch adapts to { name }", () => {
+  it("usePublisherSearch includes file_count", () => {
     const result = usePublisherSearch(1, true, "");
-    expect(result.data).toEqual([{ name: "Tor" }]);
+    expect(result.data).toEqual([{ name: "Tor", file_count: 8 }]);
   });
 
-  it("useImprintSearch adapts to { name }", () => {
+  it("useImprintSearch includes file_count", () => {
     const result = useImprintSearch(1, true, "");
-    expect(result.data).toEqual([{ name: "Orbit" }]);
+    expect(result.data).toEqual([{ name: "Orbit", file_count: 3 }]);
   });
 });

--- a/app/hooks/queries/entity-search.ts
+++ b/app/hooks/queries/entity-search.ts
@@ -54,21 +54,7 @@ export function useAuthorSearch(
   enabled: boolean,
   query: string,
 ): { data?: (AuthorInput & PersonOption)[]; isLoading: boolean } {
-  const { data, isLoading } = usePeopleList(
-    {
-      library_id: libraryId,
-      limit: 50,
-      search: query.trim() || undefined,
-    },
-    { enabled: enabled && !!libraryId },
-  );
-  const adapted = data?.people.map((p: PersonWithCounts) => ({
-    name: p.name,
-    id: p.id,
-    authored_book_count: p.authored_book_count,
-    narrated_file_count: p.narrated_file_count,
-  }));
-  return { data: adapted, isLoading };
+  return usePeopleSearch(libraryId, enabled, query);
 }
 
 export function useSeriesSearch(

--- a/app/hooks/queries/entity-search.ts
+++ b/app/hooks/queries/entity-search.ts
@@ -13,11 +13,25 @@ interface NameOption {
 
 export type { NameOption };
 
+export interface PersonOption extends NameOption {
+  id: number;
+  authored_book_count: number;
+  narrated_file_count: number;
+}
+
+export interface NameWithBookCount extends NameOption {
+  book_count: number;
+}
+
+export interface NameWithFileCount extends NameOption {
+  file_count: number;
+}
+
 export function usePeopleSearch(
   libraryId: number | undefined,
   enabled: boolean,
   query: string,
-): { data?: (NameOption & { id: number })[]; isLoading: boolean } {
+): { data?: PersonOption[]; isLoading: boolean } {
   const { data, isLoading } = usePeopleList(
     {
       library_id: libraryId,
@@ -29,6 +43,8 @@ export function usePeopleSearch(
   const adapted = data?.people.map((p: PersonWithCounts) => ({
     name: p.name,
     id: p.id,
+    authored_book_count: p.authored_book_count,
+    narrated_file_count: p.narrated_file_count,
   }));
   return { data: adapted, isLoading };
 }
@@ -37,7 +53,7 @@ export function useAuthorSearch(
   libraryId: number | undefined,
   enabled: boolean,
   query: string,
-): { data?: (AuthorInput & { id: number })[]; isLoading: boolean } {
+): { data?: (AuthorInput & PersonOption)[]; isLoading: boolean } {
   const { data, isLoading } = usePeopleList(
     {
       library_id: libraryId,
@@ -49,6 +65,8 @@ export function useAuthorSearch(
   const adapted = data?.people.map((p: PersonWithCounts) => ({
     name: p.name,
     id: p.id,
+    authored_book_count: p.authored_book_count,
+    narrated_file_count: p.narrated_file_count,
   }));
   return { data: adapted, isLoading };
 }
@@ -57,7 +75,7 @@ export function useSeriesSearch(
   libraryId: number | undefined,
   enabled: boolean,
   query: string,
-): { data?: NameOption[]; isLoading: boolean } {
+): { data?: NameWithBookCount[]; isLoading: boolean } {
   const { data, isLoading } = useSeriesList(
     {
       library_id: libraryId,
@@ -66,7 +84,10 @@ export function useSeriesSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.series.map((s) => ({ name: s.name }));
+  const adapted = data?.series.map((s) => ({
+    name: s.name,
+    book_count: s.book_count,
+  }));
   return { data: adapted, isLoading };
 }
 
@@ -74,7 +95,7 @@ export function usePublisherSearch(
   libraryId: number | undefined,
   enabled: boolean,
   query: string,
-): { data?: NameOption[]; isLoading: boolean } {
+): { data?: NameWithFileCount[]; isLoading: boolean } {
   const { data, isLoading } = usePublishersList(
     {
       library_id: libraryId,
@@ -83,7 +104,10 @@ export function usePublisherSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.publishers.map((p) => ({ name: p.name }));
+  const adapted = data?.publishers.map((p) => ({
+    name: p.name,
+    file_count: p.file_count,
+  }));
   return { data: adapted, isLoading };
 }
 
@@ -91,7 +115,7 @@ export function useImprintSearch(
   libraryId: number | undefined,
   enabled: boolean,
   query: string,
-): { data?: NameOption[]; isLoading: boolean } {
+): { data?: NameWithFileCount[]; isLoading: boolean } {
   const { data, isLoading } = useImprintsList(
     {
       library_id: libraryId,
@@ -100,7 +124,10 @@ export function useImprintSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.imprints.map((i) => ({ name: i.name }));
+  const adapted = data?.imprints.map((i) => ({
+    name: i.name,
+    file_count: i.file_count,
+  }));
   return { data: adapted, isLoading };
 }
 
@@ -108,7 +135,7 @@ export function useGenreSearch(
   libraryId: number | undefined,
   enabled: boolean,
   query: string,
-): { data?: string[]; isLoading: boolean } {
+): { data?: NameWithBookCount[]; isLoading: boolean } {
   const { data, isLoading } = useGenresList(
     {
       library_id: libraryId,
@@ -117,7 +144,10 @@ export function useGenreSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.genres.map((g) => g.name);
+  const adapted = data?.genres.map((g) => ({
+    name: g.name,
+    book_count: g.book_count,
+  }));
   return { data: adapted, isLoading };
 }
 
@@ -125,7 +155,7 @@ export function useTagSearch(
   libraryId: number | undefined,
   enabled: boolean,
   query: string,
-): { data?: string[]; isLoading: boolean } {
+): { data?: NameWithBookCount[]; isLoading: boolean } {
   const { data, isLoading } = useTagsList(
     {
       library_id: libraryId,
@@ -134,6 +164,9 @@ export function useTagSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.tags.map((t) => t.name);
+  const adapted = data?.tags.map((t) => ({
+    name: t.name,
+    book_count: t.book_count,
+  }));
   return { data: adapted, isLoading };
 }

--- a/app/hooks/queries/entity-search.ts
+++ b/app/hooks/queries/entity-search.ts
@@ -1,0 +1,139 @@
+import type { AuthorInput } from "@/types";
+
+import { useGenresList } from "./genres";
+import { useImprintsList } from "./imprints";
+import { usePeopleList, type PersonWithCounts } from "./people";
+import { usePublishersList } from "./publishers";
+import { useSeriesList } from "./series";
+import { useTagsList } from "./tags";
+
+interface NameOption {
+  name: string;
+}
+
+export type { NameOption };
+
+export function usePeopleSearch(
+  libraryId: number | undefined,
+  enabled: boolean,
+  query: string,
+): { data?: (NameOption & { id: number })[]; isLoading: boolean } {
+  const { data, isLoading } = usePeopleList(
+    {
+      library_id: libraryId,
+      limit: 50,
+      search: query.trim() || undefined,
+    },
+    { enabled: enabled && !!libraryId },
+  );
+  const adapted = data?.people.map((p: PersonWithCounts) => ({
+    name: p.name,
+    id: p.id,
+  }));
+  return { data: adapted, isLoading };
+}
+
+export function useAuthorSearch(
+  libraryId: number | undefined,
+  enabled: boolean,
+  query: string,
+): { data?: (AuthorInput & { id: number })[]; isLoading: boolean } {
+  const { data, isLoading } = usePeopleList(
+    {
+      library_id: libraryId,
+      limit: 50,
+      search: query.trim() || undefined,
+    },
+    { enabled: enabled && !!libraryId },
+  );
+  const adapted = data?.people.map((p: PersonWithCounts) => ({
+    name: p.name,
+    id: p.id,
+  }));
+  return { data: adapted, isLoading };
+}
+
+export function useSeriesSearch(
+  libraryId: number | undefined,
+  enabled: boolean,
+  query: string,
+): { data?: NameOption[]; isLoading: boolean } {
+  const { data, isLoading } = useSeriesList(
+    {
+      library_id: libraryId,
+      limit: 50,
+      search: query.trim() || undefined,
+    },
+    { enabled: enabled && !!libraryId },
+  );
+  const adapted = data?.series.map((s) => ({ name: s.name }));
+  return { data: adapted, isLoading };
+}
+
+export function usePublisherSearch(
+  libraryId: number | undefined,
+  enabled: boolean,
+  query: string,
+): { data?: NameOption[]; isLoading: boolean } {
+  const { data, isLoading } = usePublishersList(
+    {
+      library_id: libraryId,
+      limit: 50,
+      search: query.trim() || undefined,
+    },
+    { enabled: enabled && !!libraryId },
+  );
+  const adapted = data?.publishers.map((p) => ({ name: p.name }));
+  return { data: adapted, isLoading };
+}
+
+export function useImprintSearch(
+  libraryId: number | undefined,
+  enabled: boolean,
+  query: string,
+): { data?: NameOption[]; isLoading: boolean } {
+  const { data, isLoading } = useImprintsList(
+    {
+      library_id: libraryId,
+      limit: 50,
+      search: query.trim() || undefined,
+    },
+    { enabled: enabled && !!libraryId },
+  );
+  const adapted = data?.imprints.map((i) => ({ name: i.name }));
+  return { data: adapted, isLoading };
+}
+
+export function useGenreSearch(
+  libraryId: number | undefined,
+  enabled: boolean,
+  query: string,
+): { data?: string[]; isLoading: boolean } {
+  const { data, isLoading } = useGenresList(
+    {
+      library_id: libraryId,
+      limit: 50,
+      search: query.trim() || undefined,
+    },
+    { enabled: enabled && !!libraryId },
+  );
+  const adapted = data?.genres.map((g) => g.name);
+  return { data: adapted, isLoading };
+}
+
+export function useTagSearch(
+  libraryId: number | undefined,
+  enabled: boolean,
+  query: string,
+): { data?: string[]; isLoading: boolean } {
+  const { data, isLoading } = useTagsList(
+    {
+      library_id: libraryId,
+      limit: 50,
+      search: query.trim() || undefined,
+    },
+    { enabled: enabled && !!libraryId },
+  );
+  const adapted = data?.tags.map((t) => t.name);
+  return { data: adapted, isLoading };
+}

--- a/pkg/plugins/handler_apply_metadata.go
+++ b/pkg/plugins/handler_apply_metadata.go
@@ -81,6 +81,14 @@ func (h *handler) applyMetadata(c echo.Context) error {
 		}
 	}
 
+	// Extract multi-series entries from fields (array format from identify form).
+	if seriesEntries := extractSeriesEntries(payload.Fields); seriesEntries != nil {
+		if overrides == nil {
+			overrides = &applyOverrides{}
+		}
+		overrides.SeriesEntries = seriesEntries
+	}
+
 	// Download cover if cover_url set
 	if md.CoverURL != "" {
 		manifest := rt.Manifest()
@@ -100,7 +108,8 @@ func (h *handler) applyMetadata(c echo.Context) error {
 	// Trim title/series first so whitespace-only values don't trigger a no-op organize pass —
 	// persistMetadata already trims before persisting, so untrimmed values would never change the book.
 	// organizeBookFiles checks the library's OrganizeFileStructure setting internally.
-	if strings.TrimSpace(md.Title) != "" || len(md.Authors) > 0 || len(md.Narrators) > 0 || strings.TrimSpace(md.Series) != "" {
+	hasSeriesEntries := overrides != nil && overrides.SeriesEntries != nil && len(*overrides.SeriesEntries) > 0
+	if strings.TrimSpace(md.Title) != "" || len(md.Authors) > 0 || len(md.Narrators) > 0 || strings.TrimSpace(md.Series) != "" || hasSeriesEntries {
 		freshBook, err := h.enrich.bookStore.RetrieveBook(ctx, payload.BookID)
 		if err != nil {
 			log.Warn("failed to retrieve book for file organization", logger.Data{"book_id": payload.BookID, "error": err.Error()})

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -652,7 +652,7 @@ func TestApplyMetadata_ScalarSeries_WritesSeriesNumberUnit(t *testing.T) {
 	require.Len(t, rel.capturedBookSeries, 1)
 	bs := rel.capturedBookSeries[0]
 	require.NotNil(t, bs.SeriesNumber)
-	assert.Equal(t, 5.0, *bs.SeriesNumber)
+	assert.InDelta(t, 5.0, *bs.SeriesNumber, 0.001)
 	require.NotNil(t, bs.SeriesNumberUnit, "scalar series path must write SeriesNumberUnit")
 	assert.Equal(t, "volume", *bs.SeriesNumberUnit)
 }

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -225,6 +225,27 @@ func TestApplyMetadata_OrganizesFiles_WhenSeriesChanges(t *testing.T) {
 	assert.True(t, store.organizeCalled, "OrganizeBookFiles should be called when series changes")
 }
 
+func TestApplyMetadata_OrganizesFiles_WhenMultiSeriesArraySent(t *testing.T) {
+	t.Parallel()
+
+	book := newApplyTestBook(t, "Book")
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h := newApplyTestHandler(store)
+	c := newApplyEchoContext(t, map[string]any{
+		"series": []any{
+			map[string]any{"name": "Series A", "number": 1.0},
+			map[string]any{"name": "Series B", "number": 2.0, "series_number_unit": "volume"},
+		},
+	})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	assert.True(t, store.organizeCalled, "OrganizeBookFiles should be called when multi-series array is sent")
+}
+
 func TestApplyMetadata_SkipsOrganize_WhenNoRelevantFieldsChange(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -27,14 +27,18 @@ func (s *stubBookStoreForApply) OrganizeBookFiles(_ context.Context, _ *models.B
 }
 
 // stubRelStoreForApply is a no-op relationStore for applyMetadata tests.
-type stubRelStoreForApply struct{}
+// When captureBookSeries is non-nil, CreateBookSeries appends to it.
+type stubRelStoreForApply struct {
+	capturedBookSeries []*models.BookSeries
+}
 
 func (s *stubRelStoreForApply) DeleteAuthors(_ context.Context, _ int) error { return nil }
 func (s *stubRelStoreForApply) CreateAuthor(_ context.Context, _ *models.Author) error {
 	return nil
 }
 func (s *stubRelStoreForApply) DeleteBookSeries(_ context.Context, _ int) error { return nil }
-func (s *stubRelStoreForApply) CreateBookSeries(_ context.Context, _ *models.BookSeries) error {
+func (s *stubRelStoreForApply) CreateBookSeries(_ context.Context, bs *models.BookSeries) error {
+	s.capturedBookSeries = append(s.capturedBookSeries, bs)
 	return nil
 }
 func (s *stubRelStoreForApply) FindOrCreateSeries(_ context.Context, _ string, _ int, _ string) (*models.Series, error) {
@@ -87,6 +91,14 @@ type stubImprintFinder struct {
 func (s *stubImprintFinder) FindOrCreateImprint(_ context.Context, name string, _ int) (*models.Imprint, error) {
 	s.lastName = name
 	return &models.Imprint{ID: 1, Name: name}, nil
+}
+
+// newApplyTestHandlerWithRelStore creates a handler and returns the relStore stub
+// so tests can inspect captured CreateBookSeries calls.
+func newApplyTestHandlerWithRelStore(store *stubBookStoreForApply) (*handler, *stubRelStoreForApply) {
+	h := newApplyTestHandler(store)
+	rel := h.enrich.relStore.(*stubRelStoreForApply)
+	return h, rel
 }
 
 // newApplyTestHandlerWithFinders wires publisher/imprint finders so tests can
@@ -618,4 +630,29 @@ func TestApplyMetadata_ExplicitFileName_PreservesEditionName_NonPrimaryFile(t *t
 	require.NotNil(t, file.NameSource)
 	assert.Equal(t, models.DataSourceManual, *file.NameSource,
 		"file.NameSource must NOT be replaced by the plugin source")
+}
+
+func TestApplyMetadata_ScalarSeries_WritesSeriesNumberUnit(t *testing.T) {
+	t.Parallel()
+
+	book := newApplyTestBook(t, "Book")
+	store := &stubBookStoreForApply{
+		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
+	}
+	h, rel := newApplyTestHandlerWithRelStore(store)
+	c := newApplyEchoContext(t, map[string]any{
+		"series":             "Naruto",
+		"series_number":      5.0,
+		"series_number_unit": "volume",
+	})
+
+	err := h.applyMetadata(c)
+	require.NoError(t, err)
+
+	require.Len(t, rel.capturedBookSeries, 1)
+	bs := rel.capturedBookSeries[0]
+	require.NotNil(t, bs.SeriesNumber)
+	assert.Equal(t, 5.0, *bs.SeriesNumber)
+	require.NotNil(t, bs.SeriesNumberUnit, "scalar series path must write SeriesNumberUnit")
+	assert.Equal(t, "volume", *bs.SeriesNumberUnit)
 }

--- a/pkg/plugins/handler_convert.go
+++ b/pkg/plugins/handler_convert.go
@@ -136,6 +136,15 @@ func convertFieldsToMetadata(fields map[string]any) *mediafile.ParsedMetadata {
 	return md
 }
 
+// SeriesEntry represents a single series association in the multi-series
+// apply payload. Used by the identify form which supports multiple series
+// per book, unlike the plugin SDK which models a single series.
+type SeriesEntry struct {
+	Name             string
+	Number           *float64
+	SeriesNumberUnit *string
+}
+
 // applyOverrides carries apply-path-only signals that don't belong on
 // mediafile.ParsedMetadata (which is part of the public plugin SDK
 // contract). These come exclusively from the identify apply payload —
@@ -148,6 +157,10 @@ type applyOverrides struct {
 	// FileNameSource is the value to write to file.NameSource. Nil
 	// means "default to the plugin source for this apply call".
 	FileNameSource *string
+	// SeriesEntries, when non-nil, replaces the book's series associations
+	// with the provided list. An empty slice clears all series. Nil means
+	// "don't touch series" (the identify form's series checkbox was off).
+	SeriesEntries *[]SeriesEntry
 }
 
 // convertFieldsToOverrides extracts apply-path-only signals from the
@@ -168,4 +181,42 @@ func convertFieldsToOverrides(fields map[string]any) *applyOverrides {
 		out.FileNameSource = &v
 	}
 	return out
+}
+
+// extractSeriesEntries checks whether fields["series"] is an array of
+// objects (the multi-series format sent by the identify form). Returns
+// nil when the key is absent or is a string (handled by convertFieldsToMetadata).
+// Returns a non-nil pointer to an empty slice when the key is an empty array
+// (meaning "clear all series").
+func extractSeriesEntries(fields map[string]any) *[]SeriesEntry {
+	v, ok := fields["series"]
+	if !ok {
+		return nil
+	}
+	arr, ok := v.([]any)
+	if !ok {
+		return nil // scalar string — handled by convertFieldsToMetadata
+	}
+	entries := make([]SeriesEntry, 0, len(arr))
+	for _, item := range arr {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			continue
+		}
+		entry := SeriesEntry{Name: name}
+		if num, ok := m["number"].(float64); ok {
+			entry.Number = &num
+		}
+		if unit, ok := m["series_number_unit"].(string); ok {
+			if unit == models.SeriesNumberUnitVolume || unit == models.SeriesNumberUnitChapter {
+				entry.SeriesNumberUnit = &unit
+			}
+		}
+		entries = append(entries, entry)
+	}
+	return &entries
 }

--- a/pkg/plugins/handler_convert_test.go
+++ b/pkg/plugins/handler_convert_test.go
@@ -407,6 +407,93 @@ func TestConvertFieldsToMetadata_SeriesNumberUnitMissing(t *testing.T) {
 	assert.Nil(t, md.SeriesNumberUnit)
 }
 
+func TestExtractSeriesEntries_NilWhenAbsent(t *testing.T) {
+	t.Parallel()
+	got := extractSeriesEntries(map[string]any{"title": "Book"})
+	assert.Nil(t, got, "absent series key must yield nil")
+}
+
+func TestExtractSeriesEntries_NilWhenString(t *testing.T) {
+	t.Parallel()
+	got := extractSeriesEntries(map[string]any{"series": "My Series"})
+	assert.Nil(t, got, "scalar string must yield nil — handled by convertFieldsToMetadata")
+}
+
+func TestExtractSeriesEntries_EmptyArray(t *testing.T) {
+	t.Parallel()
+	got := extractSeriesEntries(map[string]any{"series": []any{}})
+	require.NotNil(t, got, "empty array must return non-nil pointer (meaning clear all)")
+	assert.Empty(t, *got)
+}
+
+func TestExtractSeriesEntries_SingleEntry(t *testing.T) {
+	t.Parallel()
+	got := extractSeriesEntries(map[string]any{
+		"series": []any{
+			map[string]any{"name": "Naruto", "number": 3.0, "series_number_unit": "volume"},
+		},
+	})
+	require.NotNil(t, got)
+	require.Len(t, *got, 1)
+	assert.Equal(t, "Naruto", (*got)[0].Name)
+	require.NotNil(t, (*got)[0].Number)
+	assert.InDelta(t, 3.0, *(*got)[0].Number, 0.001)
+	require.NotNil(t, (*got)[0].SeriesNumberUnit)
+	assert.Equal(t, "volume", *(*got)[0].SeriesNumberUnit)
+}
+
+func TestExtractSeriesEntries_MultipleEntries(t *testing.T) {
+	t.Parallel()
+	got := extractSeriesEntries(map[string]any{
+		"series": []any{
+			map[string]any{"name": "Series A", "number": 1.0},
+			map[string]any{"name": "Series B"},
+		},
+	})
+	require.NotNil(t, got)
+	require.Len(t, *got, 2)
+	assert.Equal(t, "Series A", (*got)[0].Name)
+	assert.Equal(t, "Series B", (*got)[1].Name)
+	assert.Nil(t, (*got)[1].Number)
+	assert.Nil(t, (*got)[1].SeriesNumberUnit)
+}
+
+func TestExtractSeriesEntries_SkipsEmptyNames(t *testing.T) {
+	t.Parallel()
+	got := extractSeriesEntries(map[string]any{
+		"series": []any{
+			map[string]any{"name": ""},
+			map[string]any{"name": "Valid"},
+		},
+	})
+	require.NotNil(t, got)
+	require.Len(t, *got, 1)
+	assert.Equal(t, "Valid", (*got)[0].Name)
+}
+
+func TestExtractSeriesEntries_InvalidUnit(t *testing.T) {
+	t.Parallel()
+	got := extractSeriesEntries(map[string]any{
+		"series": []any{
+			map[string]any{"name": "S", "series_number_unit": "bogus"},
+		},
+	})
+	require.NotNil(t, got)
+	require.Len(t, *got, 1)
+	assert.Nil(t, (*got)[0].SeriesNumberUnit, "invalid unit must be dropped")
+}
+
+func TestConvertFieldsToMetadata_SeriesArrayDoesNotSetScalar(t *testing.T) {
+	t.Parallel()
+	fields := map[string]any{
+		"series": []any{
+			map[string]any{"name": "My Series"},
+		},
+	}
+	md := convertFieldsToMetadata(fields)
+	assert.Empty(t, md.Series, "array format must not populate the scalar Series field")
+}
+
 func TestConvertFieldsToOverrides_NilWhenAbsent(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -156,7 +156,7 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 			return errors.Wrap(err, "failed to delete series")
 		}
 
-		newSeriesIDs := make(map[int]struct{})
+		newSeries := make(map[int]*models.Series)
 
 		if multiSeries {
 			for i, entry := range *overrides.SeriesEntries {
@@ -179,7 +179,7 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				if err := h.enrich.relStore.CreateBookSeries(ctx, bs); err != nil {
 					log.Warn("failed to create book series", logger.Data{"error": err.Error()})
 				}
-				newSeriesIDs[seriesRecord.ID] = struct{}{}
+				newSeries[seriesRecord.ID] = seriesRecord
 			}
 		} else {
 			seriesRecord, sErr := h.enrich.relStore.FindOrCreateSeries(ctx, md.Series, book.LibraryID, pluginSource)
@@ -194,25 +194,21 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				}); err != nil {
 					log.Warn("failed to create book series", logger.Data{"error": err.Error()})
 				}
-				newSeriesIDs[seriesRecord.ID] = struct{}{}
+				newSeries[seriesRecord.ID] = seriesRecord
 			}
 		}
 
 		if h.enrich.searchIndexer != nil {
-			for id := range newSeriesIDs {
+			for id, rec := range newSeries {
 				_, stillAttached := oldSeries[id]
 				if !stillAttached || seriesAggregateMayBeStale {
-					rec, ok := oldSeries[id]
-					if !ok {
-						rec = &models.Series{ID: id}
-					}
 					if err := h.enrich.searchIndexer.IndexSeries(ctx, rec); err != nil {
 						log.Warn("failed to update search index for series", logger.Data{"series_id": id, "error": err.Error()})
 					}
 				}
 			}
 			for oldID, oldSer := range oldSeries {
-				if _, kept := newSeriesIDs[oldID]; kept {
+				if _, kept := newSeries[oldID]; kept {
 					continue
 				}
 				if err := h.enrich.searchIndexer.IndexSeries(ctx, oldSer); err != nil {

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -187,10 +187,11 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				log.Warn("failed to find/create series", logger.Data{"name": md.Series, "error": sErr.Error()})
 			} else {
 				if err := h.enrich.relStore.CreateBookSeries(ctx, &models.BookSeries{
-					BookID:       book.ID,
-					SeriesID:     seriesRecord.ID,
-					SeriesNumber: md.SeriesNumber,
-					SortOrder:    1,
+					BookID:           book.ID,
+					SeriesID:         seriesRecord.ID,
+					SeriesNumber:     md.SeriesNumber,
+					SeriesNumberUnit: md.SeriesNumberUnit,
+					SortOrder:        1,
 				}); err != nil {
 					log.Warn("failed to create book series", logger.Data{"error": err.Error()})
 				}

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -143,13 +143,9 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 		}
 	}
 
-	// Series
-	if md.Series != "" {
-		// Capture old series before delete so we can re-index any that get
-		// detached — their series_fts.book_titles / book_authors aggregate
-		// columns must stop listing this book. Holding the *models.Series
-		// pointers from book.BookSeries lets us re-index without an extra
-		// DB round-trip.
+	// Series — multi-entry path (identify form) takes precedence over scalar (plugins).
+	multiSeries := overrides != nil && overrides.SeriesEntries != nil
+	if multiSeries || md.Series != "" {
 		oldSeries := make(map[int]*models.Series, len(book.BookSeries))
 		for _, bs := range book.BookSeries {
 			if bs.Series != nil {
@@ -159,42 +155,68 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 		if err := h.enrich.relStore.DeleteBookSeries(ctx, book.ID); err != nil {
 			return errors.Wrap(err, "failed to delete series")
 		}
-		seriesRecord, sErr := h.enrich.relStore.FindOrCreateSeries(ctx, md.Series, book.LibraryID, pluginSource)
-		if sErr != nil {
-			log.Warn("failed to find/create series", logger.Data{"name": md.Series, "error": sErr.Error()})
-		} else {
-			if err := h.enrich.relStore.CreateBookSeries(ctx, &models.BookSeries{
-				BookID:       book.ID,
-				SeriesID:     seriesRecord.ID,
-				SeriesNumber: md.SeriesNumber,
-				SortOrder:    1,
-			}); err != nil {
-				log.Warn("failed to create book series", logger.Data{"error": err.Error()})
+
+		newSeriesIDs := make(map[int]struct{})
+
+		if multiSeries {
+			for i, entry := range *overrides.SeriesEntries {
+				seriesRecord, sErr := h.enrich.relStore.FindOrCreateSeries(ctx, entry.Name, book.LibraryID, pluginSource)
+				if sErr != nil {
+					log.Warn("failed to find/create series", logger.Data{"name": entry.Name, "error": sErr.Error()})
+					continue
+				}
+				bs := &models.BookSeries{
+					BookID:    book.ID,
+					SeriesID:  seriesRecord.ID,
+					SortOrder: i + 1,
+				}
+				if entry.Number != nil {
+					bs.SeriesNumber = entry.Number
+				}
+				if entry.SeriesNumberUnit != nil {
+					bs.SeriesNumberUnit = entry.SeriesNumberUnit
+				}
+				if err := h.enrich.relStore.CreateBookSeries(ctx, bs); err != nil {
+					log.Warn("failed to create book series", logger.Data{"error": err.Error()})
+				}
+				newSeriesIDs[seriesRecord.ID] = struct{}{}
 			}
-			// Re-index series whose attachment to this book actually
-			// changed: the new series (if it wasn't already attached,
-			// covering both newly-created series and freshly-attached
-			// existing series), and every old series that's no longer
-			// attached. Additionally re-index the still-attached series
-			// when book.title or book.authors changed during this apply
-			// — series_fts.book_titles / book_authors are aggregate
-			// columns that would otherwise go stale. Index after
-			// CreateBookSeries so the aggregate reflects the just-
-			// attached book.
-			if h.enrich.searchIndexer != nil {
-				_, stillAttached := oldSeries[seriesRecord.ID]
+		} else {
+			seriesRecord, sErr := h.enrich.relStore.FindOrCreateSeries(ctx, md.Series, book.LibraryID, pluginSource)
+			if sErr != nil {
+				log.Warn("failed to find/create series", logger.Data{"name": md.Series, "error": sErr.Error()})
+			} else {
+				if err := h.enrich.relStore.CreateBookSeries(ctx, &models.BookSeries{
+					BookID:       book.ID,
+					SeriesID:     seriesRecord.ID,
+					SeriesNumber: md.SeriesNumber,
+					SortOrder:    1,
+				}); err != nil {
+					log.Warn("failed to create book series", logger.Data{"error": err.Error()})
+				}
+				newSeriesIDs[seriesRecord.ID] = struct{}{}
+			}
+		}
+
+		if h.enrich.searchIndexer != nil {
+			for id := range newSeriesIDs {
+				_, stillAttached := oldSeries[id]
 				if !stillAttached || seriesAggregateMayBeStale {
-					if err := h.enrich.searchIndexer.IndexSeries(ctx, seriesRecord); err != nil {
-						log.Warn("failed to update search index for series", logger.Data{"series_id": seriesRecord.ID, "error": err.Error()})
+					rec, ok := oldSeries[id]
+					if !ok {
+						rec = &models.Series{ID: id}
+					}
+					if err := h.enrich.searchIndexer.IndexSeries(ctx, rec); err != nil {
+						log.Warn("failed to update search index for series", logger.Data{"series_id": id, "error": err.Error()})
 					}
 				}
-				for oldID, oldSer := range oldSeries {
-					if oldID == seriesRecord.ID {
-						continue
-					}
-					if err := h.enrich.searchIndexer.IndexSeries(ctx, oldSer); err != nil {
-						log.Warn("failed to update search index for detached series", logger.Data{"series_id": oldID, "error": err.Error()})
-					}
+			}
+			for oldID, oldSer := range oldSeries {
+				if _, kept := newSeriesIDs[oldID]; kept {
+					continue
+				}
+				if err := h.enrich.searchIndexer.IndexSeries(ctx, oldSer); err != nil {
+					log.Warn("failed to update search index for detached series", logger.Data{"series_id": oldID, "error": err.Error()})
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Extracts shared entity-search adapter hooks (`useSeriesSearch`, `useGenreSearch`, `useTagSearch`, etc.) so BookEditDialog, FileEditDialog, and IdentifyReviewForm all share the same search-with-counts pattern
- Upgrades `MultiSelectCombobox` to a hook-based API with internal search state, entity counts in dropdowns and chips, and "In your library" group headings in `EntityCombobox`
- Upgrades the identify review form's series field from a single-entry scalar to a full `SortableEntityList` with drag-to-reorder, per-entry number/unit inputs — matching BookEditDialog. The backend plugin-apply path accepts both the new array format and the existing scalar format for backward compatibility with plugins

## Test plan
- Open the identify dialog for a book, verify the series field shows as a sortable list (not a single combobox + number input)
- Add multiple series entries, reorder them, set numbers and units, then apply — verify the book's series list updates correctly
- Remove all series entries and apply — verify series are cleared
- Identify a book that already has multiple series — verify existing entries populate correctly
- Verify genres, tags, publishers, narrators comboboxes in all three edit dialogs (BookEditDialog, FileEditDialog, IdentifyReviewForm) show entity counts in dropdowns and chips
- Verify the "In your library" group heading appears in EntityCombobox results