### PR TITLE
[CI] Separate read/write dirs in gotestsplit run (-junit-out flag)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
           name: gotest-timings-shard-${{ matrix.shard }}
           path: .gotest-timings-fresh/
           retention-days: 1
+          # Dot-prefixed dir; without this flag upload-artifact uploads zero files.
           include-hidden-files: true
+          # Catch go test crashing before any junit is written.
           if-no-files-found: error
 
   consolidate-test-timings:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,42 +45,23 @@ jobs:
           restore-keys: |
             gotest-timings-${{ github.ref }}-
             gotest-timings-refs/heads/master-
-      - name: Compute shard index
-        # Export the zero-based shard index so the upload step can glob just
-        # this shard's fresh junit files. Done in its own step because env vars
-        # written via $GITHUB_ENV are only visible to subsequent steps.
+      - name: Run tests
         env:
           SHARD: ${{ matrix.shard }}
-        run: echo "SHARD_INDEX=$((SHARD - 1))" >> $GITHUB_ENV
-      - name: Run tests
         run: |
           go run ./tools/gotestsplit run \
             -junit-dir=.gotest-timings \
-            -total=12 -index=$SHARD_INDEX \
+            -junit-out=.gotest-timings-fresh \
+            -total=12 -index=$((SHARD - 1)) \
             ./pkg/... -- -race
       - name: Upload shard JUnit
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: gotest-timings-shard-${{ matrix.shard }}
-          # Upload ONLY the files this shard wrote, not the entire restored
-          # cache directory. Each shard writes junit-${SHARD_INDEX}-*.xml; the
-          # rest of the dir is the previous run's junit files (untouched by
-          # this shard, since it only ran its own slice). If we upload
-          # everything, the consolidator's merge-multiple sees N versions of
-          # every filename and the "winner" is whichever artifact downloads
-          # last — so old data can silently overwrite fresh data in the
-          # saved cache.
-          # SHARD_INDEX is set via $GITHUB_ENV in the "Compute shard index"
-          # step above, then read here through the env expression context.
-          path: .gotest-timings/junit-${{ env.SHARD_INDEX }}-*.xml
+          path: .gotest-timings-fresh/
           retention-days: 1
-          # The path is under a dot-prefixed dir; without this flag
-          # upload-artifact treats the whole tree as hidden and uploads zero
-          # files.
           include-hidden-files: true
-          # If `go test` failed before any junit was written this catches it
-          # loudly, instead of silently shrinking the cache on the next run.
           if-no-files-found: error
 
   consolidate-test-timings:

--- a/tools/gotestsplit/CLAUDE.md
+++ b/tools/gotestsplit/CLAUDE.md
@@ -9,30 +9,26 @@ Bin-packs Go tests across N CI shards by **measured per-test wallclock**, not te
 Subcommands:
 - `simulate -junit-dir=DIR [-min=N] [-max=N]` — read JUnit history, project per-shard wallclock and CI cost across a range of N. Used for picking shard count.
 - `plan -junit-dir=DIR -total=N -index=I [-detail] PKG...` — print the assignment for one shard. Useful for debugging "why is shard 3 slow?".
-- `run -junit-dir=DIR -total=N -index=I PKG... [-- go-test-args]` — plan + exec `go test` per chunk + emit JUnit XML for next run.
+- `run -junit-dir=DIR [-junit-out=DIR] -total=N -index=I PKG... [-- go-test-args]` — plan + exec `go test` per chunk + emit JUnit XML. `-junit-dir` is the read-only history input; `-junit-out` (defaults to `-junit-dir`) is where fresh XML is written.
 
 ## Architecture cheatsheet
 
 - `pack.go` — pure `Pack(history, packages, N) [][]Item` function. Used by all three subcommands so simulate/plan/run agree. Smart-chunks any package whose wallclock estimate exceeds `ideal * 0.8` where `ideal = total / N`. Within a chunked package, tests are LPT-distributed by per-test duration.
 - `junit.go` — reads a directory of JUnit XML files into `History` (`map[pkg]map[test]float64`). Top-level tests only; subtests skipped (`-run` regex targets parents).
 - `discover.go` — wraps `go test -list .` to enumerate top-level tests per package.
-- `run.go` — execs `go test` per Item: whole-package items batched into one invocation, chunks each get their own `-run` regex invocation. Streams output and parses it via `go-junit-report/v2` to write `junit-{shard}-{seq}.xml`.
+- `run.go` — execs `go test` per Item: whole-package items batched into one invocation, chunks each get their own `-run` regex invocation. Streams output and parses it via `go-junit-report/v2` to write `junit-{shard}-{seq}.xml` into `-junit-out` (separate from the `-junit-dir` read path).
 
 ## Cache strategy in CI
 
 `.github/workflows/ci.yml`'s `test` job uses **restore-only** cache (`actions/cache/restore@v5`) with a key shared across all shards (`gotest-timings-${{ github.ref }}-${{ github.sha }}`).
 
-After tests, each shard uploads **only the junit files it wrote this run** (`.gotest-timings/junit-${SHARD_INDEX}-*.xml`) as a per-shard artifact (`gotest-timings-shard-N`). A separate `consolidate-test-timings` job (`needs: test`, `if: always()`) restores the previous cache, downloads all shard artifacts on top of it, and saves a single `actions/cache/save@v5` entry.
+After tests, each shard uploads the contents of its `-junit-out` directory (`.gotest-timings-fresh/`) as a per-shard artifact (`gotest-timings-shard-N`). Because `-junit-out` is separate from `-junit-dir`, only fresh files exist there — no filtering needed. A separate `consolidate-test-timings` job (`needs: test`, `if: always()`) restores the previous cache, downloads all shard artifacts on top of it, and saves a single `actions/cache/save@v5` entry.
 
 Three non-obvious requirements:
 
-1. **`include-hidden-files: true` on `actions/upload-artifact`** — `.gotest-timings/` starts with a dot; without this flag the action silently uploads zero files.
+1. **`include-hidden-files: true` on `actions/upload-artifact`** — `.gotest-timings-fresh/` starts with a dot; without this flag the action silently uploads zero files.
 2. **All shards must restore from the same cache** — each shard runs `Pack` independently. If shards see different histories, their plans diverge and tests can be missed or duplicated. The shared cache key + post-job consolidator together guarantee a single coherent input on the next run.
-3. **Uploads must be filtered to the shard's own filename prefix** — the upload path is `.gotest-timings/junit-${SHARD_INDEX}-*.xml`, never `.gotest-timings/`.
-
-   Why: each shard restores the full cache before testing, so its `.gotest-timings/` contains the previous run's `junit-*-*.xml` files for *every* shard plus the fresh files this shard just wrote. If the upload includes those previous-run files, the consolidator's `download-artifact` step (with `merge-multiple: true`) sees N versions of every filename and the "winner" per filename is whichever artifact downloads last — non-deterministic, so old data can silently overwrite fresh data in the saved cache. Filtering to the owned prefix gives the consolidator N disjoint sets of files.
-
-   The consolidator additionally restores the previous cache before downloading artifacts, so a shard that fails before writing any junit doesn't get its history dropped from the cache permanently.
+3. **Read and write directories must be separate** — `-junit-dir` (read) is the restored cache containing history from all shards; `-junit-out` (write) is a clean directory that only contains this run's fresh files. This separation means the upload step can grab the entire output directory without risk of re-uploading stale data from other shards. The consolidator additionally restores the previous cache before downloading artifacts, so a shard that fails before writing any junit doesn't get its history dropped from the cache permanently.
 
 If the cache is empty (cache miss), `Pack` falls back to count-based equal-count splitting (gotesplit's classic behavior) so first runs on a fresh branch behave like upstream gotesplit.
 

--- a/tools/gotestsplit/integration_test.go
+++ b/tools/gotestsplit/integration_test.go
@@ -68,3 +68,69 @@ func TestRun_ProducesJUnit_AndShardsAreRunnable(t *testing.T) {
 		t.Fatalf("second pass: %v\nstderr:\n%s", err, stderr.String())
 	}
 }
+
+// TestRun_SeparateJunitOut verifies that -junit-out writes fresh XML into a
+// separate directory while -junit-dir is used only for reading history.
+func TestRun_SeparateJunitOut(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test")
+	}
+
+	readDir := t.TempDir()
+	writeDir := t.TempDir()
+	fixture, err := filepath.Abs("testdata/fixturemod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(fixture)
+
+	var stdout, stderr bytes.Buffer
+	err = cmdRun(context.Background(), []string{
+		"-junit-dir=" + readDir,
+		"-junit-out=" + writeDir,
+		"-total=2", "-index=0",
+		"./...",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run: %v\nstderr:\n%s", err, stderr.String())
+	}
+
+	// Fresh XML must land in writeDir, not readDir.
+	writeEntries, err := os.ReadDir(writeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var written int
+	for _, e := range writeEntries {
+		if strings.HasSuffix(e.Name(), ".xml") {
+			written++
+		}
+	}
+	if written == 0 {
+		t.Fatalf("no JUnit files in -junit-out dir %s", writeDir)
+	}
+
+	readEntries, err := os.ReadDir(readDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range readEntries {
+		if strings.HasSuffix(e.Name(), ".xml") {
+			t.Errorf("unexpected JUnit file in -junit-dir: %s", e.Name())
+		}
+	}
+
+	// Second run reads history from writeDir and writes to a new output dir.
+	writeDir2 := t.TempDir()
+	stdout.Reset()
+	stderr.Reset()
+	err = cmdRun(context.Background(), []string{
+		"-junit-dir=" + writeDir,
+		"-junit-out=" + writeDir2,
+		"-total=2", "-index=0",
+		"./...",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("second run: %v\nstderr:\n%s", err, stderr.String())
+	}
+}

--- a/tools/gotestsplit/integration_test.go
+++ b/tools/gotestsplit/integration_test.go
@@ -75,6 +75,7 @@ func TestRun_SeparateJunitOut(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration test")
 	}
+	// Cannot t.Parallel() — uses t.Chdir.
 
 	readDir := t.TempDir()
 	writeDir := t.TempDir()

--- a/tools/gotestsplit/main.go
+++ b/tools/gotestsplit/main.go
@@ -48,6 +48,6 @@ func printUsage(w io.Writer) {
 Usage:
   gotestsplit simulate -junit-dir=<dir> [-min=N] [-max=N]
   gotestsplit plan -junit-dir=<dir> -total=N -index=I [-detail] <pkg>...
-  gotestsplit run -junit-dir=<dir> -total=N -index=I <pkg>... [-- go-test-args]
-  gotestsplit -total=N -index=I <pkg>... [-- go-test-args]   # shortcut for "run"`)
+  gotestsplit run -junit-dir=<dir> [-junit-out=<dir>] -total=N -index=I <pkg>... [-- go-test-args]
+  gotestsplit [-junit-out=<dir>] -total=N -index=I <pkg>... [-- go-test-args]   # shortcut for "run"`)
 }

--- a/tools/gotestsplit/run.go
+++ b/tools/gotestsplit/run.go
@@ -26,7 +26,8 @@ var (
 func cmdRun(ctx context.Context, argv []string, stdout, stderr io.Writer) error {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	fs.SetOutput(stderr)
-	junitDir := fs.String("junit-dir", "", "directory to read prior JUnit XML from and write new XML to (required)")
+	junitDir := fs.String("junit-dir", "", "directory to read prior JUnit XML from (required)")
+	junitOut := fs.String("junit-out", "", "directory to write fresh JUnit XML to (defaults to -junit-dir)")
 	total := fs.Int("total", 0, "total number of shards (required)")
 	index := fs.Int("index", 0, "zero-based shard index")
 	if err := fs.Parse(argv); err != nil {
@@ -34,6 +35,9 @@ func cmdRun(ctx context.Context, argv []string, stdout, stderr io.Writer) error 
 	}
 	if *junitDir == "" || *total <= 0 || *index < 0 || *index >= *total {
 		return errRunFlagsInvalid
+	}
+	if *junitOut == "" {
+		*junitOut = *junitDir
 	}
 
 	args := fs.Args()
@@ -51,6 +55,11 @@ func cmdRun(ctx context.Context, argv []string, stdout, stderr io.Writer) error 
 
 	if err := os.MkdirAll(*junitDir, 0o755); err != nil {
 		return err
+	}
+	if *junitOut != *junitDir {
+		if err := os.MkdirAll(*junitOut, 0o755); err != nil {
+			return err
+		}
 	}
 	hist, err := ReadHistory(*junitDir)
 	if err != nil {
@@ -89,7 +98,7 @@ func cmdRun(ctx context.Context, argv []string, stdout, stderr io.Writer) error 
 			*index+1, *total, seq, strings.Join(goArgs, " "))
 		report, runErr := goTest(ctx, goArgs, stdout, stderr)
 		if report != nil {
-			path := filepath.Join(*junitDir,
+			path := filepath.Join(*junitOut,
 				fmt.Sprintf("junit-%d-%d.xml", *index, seq))
 			if werr := writeJUnit(path, *report); werr != nil {
 				fmt.Fprintf(stderr, "gotestsplit: failed to write %s: %v\n", path, werr)


### PR DESCRIPTION
## Summary
- Add `-junit-out` flag to `gotestsplit run` so fresh JUnit XML is written to a dedicated directory, keeping `-junit-dir` read-only
- Update CI workflow to use `-junit-out=.gotest-timings-fresh`, eliminating the `Compute shard index` step and filename-glob upload workaround
- Add integration test covering the split-dir case and update `tools/gotestsplit/CLAUDE.md`

## Test plan
- `go test ./tools/gotestsplit/ -count=1` passes (including the new `TestRun_SeparateJunitOut`)
- CI workflow uses the new flag and uploads the entire `-junit-out` directory cleanly
- Backward compat: omitting `-junit-out` defaults to `-junit-dir` (existing test `TestRun_ProducesJUnit_AndShardsAreRunnable` still passes unchanged)