### PR TITLE
[Frontend] Mobile responsiveness: compact selection toolbar and pagination

### DIFF
--- a/app/components/library/Gallery.tsx
+++ b/app/components/library/Gallery.tsx
@@ -11,6 +11,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 interface GalleryProps<T> {
   items: T[];
@@ -35,6 +36,7 @@ const Gallery = <T,>({
 }: GalleryProps<T>) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
 
   const limit = itemsPerPage;
   const offset = (currentPage - 1) * limit;
@@ -48,7 +50,7 @@ const Gallery = <T,>({
 
   const getPageNumbers = () => {
     const pages = [];
-    const showPages = 5;
+    const showPages = isSmallScreen ? 3 : 5;
 
     let start = Math.max(1, currentPage - Math.floor(showPages / 2));
     const end = Math.min(totalPages, start + showPages - 1);

--- a/app/components/library/Gallery.tsx
+++ b/app/components/library/Gallery.tsx
@@ -2,16 +2,7 @@ import { ReactNode } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import LoadingSpinner from "@/components/library/LoadingSpinner";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
+import PaginationFooter from "@/components/library/PaginationFooter";
 
 interface GalleryProps<T> {
   items: T[];
@@ -36,7 +27,6 @@ const Gallery = <T,>({
 }: GalleryProps<T>) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
 
   const limit = itemsPerPage;
   const offset = (currentPage - 1) * limit;
@@ -46,24 +36,6 @@ const Gallery = <T,>({
     const newSearchParams = new URLSearchParams(searchParams);
     newSearchParams.set("page", page.toString());
     setSearchParams(newSearchParams);
-  };
-
-  const getPageNumbers = () => {
-    const pages = [];
-    const showPages = isSmallScreen ? 3 : 5;
-
-    let start = Math.max(1, currentPage - Math.floor(showPages / 2));
-    const end = Math.min(totalPages, start + showPages - 1);
-
-    if (end - start + 1 < showPages) {
-      start = Math.max(1, end - showPages + 1);
-    }
-
-    for (let i = start; i <= end; i++) {
-      pages.push(i);
-    }
-
-    return pages;
   };
 
   if (isLoading) {
@@ -93,82 +65,12 @@ const Gallery = <T,>({
         {items.map(renderItem)}
       </div>
 
-      {totalPages > 1 && (
-        <Pagination className="mb-8">
-          <PaginationContent>
-            <PaginationItem>
-              <PaginationPrevious
-                className={
-                  currentPage <= 1
-                    ? "pointer-events-none opacity-50"
-                    : "cursor-pointer"
-                }
-                onClick={() => handlePageChange(currentPage - 1)}
-              />
-            </PaginationItem>
-
-            {getPageNumbers()[0] > 1 && (
-              <>
-                <PaginationItem>
-                  <PaginationLink
-                    className="cursor-pointer"
-                    onClick={() => handlePageChange(1)}
-                  >
-                    1
-                  </PaginationLink>
-                </PaginationItem>
-                {getPageNumbers()[0] > 2 && (
-                  <PaginationItem>
-                    <PaginationEllipsis />
-                  </PaginationItem>
-                )}
-              </>
-            )}
-
-            {getPageNumbers().map((page) => (
-              <PaginationItem key={page}>
-                <PaginationLink
-                  className="cursor-pointer"
-                  isActive={page === currentPage}
-                  onClick={() => handlePageChange(page)}
-                >
-                  {page}
-                </PaginationLink>
-              </PaginationItem>
-            ))}
-
-            {getPageNumbers()[getPageNumbers().length - 1] < totalPages && (
-              <>
-                {getPageNumbers()[getPageNumbers().length - 1] <
-                  totalPages - 1 && (
-                  <PaginationItem>
-                    <PaginationEllipsis />
-                  </PaginationItem>
-                )}
-                <PaginationItem>
-                  <PaginationLink
-                    className="cursor-pointer"
-                    onClick={() => handlePageChange(totalPages)}
-                  >
-                    {totalPages}
-                  </PaginationLink>
-                </PaginationItem>
-              </>
-            )}
-
-            <PaginationItem>
-              <PaginationNext
-                className={
-                  currentPage >= totalPages
-                    ? "pointer-events-none opacity-50"
-                    : "cursor-pointer"
-                }
-                onClick={() => handlePageChange(currentPage + 1)}
-              />
-            </PaginationItem>
-          </PaginationContent>
-        </Pagination>
-      )}
+      <PaginationFooter
+        className="mb-8"
+        currentPage={currentPage}
+        onPageChange={handlePageChange}
+        totalPages={totalPages}
+      />
     </>
   );
 };

--- a/app/components/library/PaginationFooter.tsx
+++ b/app/components/library/PaginationFooter.tsx
@@ -1,0 +1,132 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+
+interface PaginationFooterProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange?: (page: number) => void;
+  buildHref?: (page: number) => string;
+  className?: string;
+}
+
+function getPageNumbers(
+  currentPage: number,
+  totalPages: number,
+  showPages: number,
+): number[] {
+  const pages: number[] = [];
+  let start = Math.max(1, currentPage - Math.floor(showPages / 2));
+  const end = Math.min(totalPages, start + showPages - 1);
+
+  if (end - start + 1 < showPages) {
+    start = Math.max(1, end - showPages + 1);
+  }
+
+  for (let i = start; i <= end; i++) {
+    pages.push(i);
+  }
+
+  return pages;
+}
+
+const PaginationFooter = ({
+  currentPage,
+  totalPages,
+  onPageChange,
+  buildHref,
+  className,
+}: PaginationFooterProps) => {
+  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
+  const showPages = isSmallScreen ? 3 : 5;
+  const pages = getPageNumbers(currentPage, totalPages, showPages);
+
+  if (totalPages <= 1) return null;
+
+  const linkProps = (page: number) => ({
+    ...(onPageChange ? { onClick: () => onPageChange(page) } : {}),
+    ...(buildHref ? { href: buildHref(page) } : {}),
+  });
+
+  return (
+    <Pagination className={className}>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            className={
+              currentPage <= 1
+                ? "pointer-events-none opacity-50"
+                : "cursor-pointer"
+            }
+            {...linkProps(currentPage - 1)}
+          />
+        </PaginationItem>
+
+        {pages[0] > 1 && (
+          <>
+            <PaginationItem>
+              <PaginationLink className="cursor-pointer" {...linkProps(1)}>
+                1
+              </PaginationLink>
+            </PaginationItem>
+            {pages[0] > 2 && (
+              <PaginationItem>
+                <PaginationEllipsis />
+              </PaginationItem>
+            )}
+          </>
+        )}
+
+        {pages.map((page) => (
+          <PaginationItem key={page}>
+            <PaginationLink
+              className="cursor-pointer"
+              isActive={page === currentPage}
+              {...linkProps(page)}
+            >
+              {page}
+            </PaginationLink>
+          </PaginationItem>
+        ))}
+
+        {pages[pages.length - 1] < totalPages && (
+          <>
+            {pages[pages.length - 1] < totalPages - 1 && (
+              <PaginationItem>
+                <PaginationEllipsis />
+              </PaginationItem>
+            )}
+            <PaginationItem>
+              <PaginationLink
+                className="cursor-pointer"
+                {...linkProps(totalPages)}
+              >
+                {totalPages}
+              </PaginationLink>
+            </PaginationItem>
+          </>
+        )}
+
+        <PaginationItem>
+          <PaginationNext
+            className={
+              currentPage >= totalPages
+                ? "pointer-events-none opacity-50"
+                : "cursor-pointer"
+            }
+            {...linkProps(currentPage + 1)}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+};
+
+export default PaginationFooter;

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -179,7 +179,6 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
       toast.success(
         `Marked ${count} book${count !== 1 ? "s" : ""} as ${label}`,
       );
-      setMorePopoverOpen(false);
       exitSelectionMode();
     } catch (error) {
       const message =
@@ -269,7 +268,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
   );
 
   return (
-    <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-50 bg-background border rounded-lg shadow-lg px-3 py-2 flex items-center gap-3">
+    <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-50 bg-background border rounded-lg shadow-lg px-3 py-2 flex items-center gap-3 max-w-[calc(100vw-2rem)]">
       <span className="text-sm font-medium whitespace-nowrap tabular-nums">
         {bookLabel}
       </span>
@@ -444,7 +443,10 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
           <PopoverContent align="center" className="w-56 p-1" side="top">
             <Button
               className="w-full justify-start gap-2 font-normal"
-              onClick={() => handleBulkReview("reviewed")}
+              onClick={() => {
+                setMorePopoverOpen(false);
+                handleBulkReview("reviewed");
+              }}
               size="sm"
               variant="ghost"
             >
@@ -453,7 +455,10 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
             </Button>
             <Button
               className="w-full justify-start gap-2 font-normal"
-              onClick={() => handleBulkReview("unreviewed")}
+              onClick={() => {
+                setMorePopoverOpen(false);
+                handleBulkReview("unreviewed");
+              }}
               size="sm"
               variant="ghost"
             >

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -282,7 +282,11 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
             <ChevronUp className="h-4 w-4" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="center" className="w-56 p-0" side="top">
+        <PopoverContent
+          align="center"
+          className="w-56 max-h-[70vh] overflow-y-auto p-0"
+          side="top"
+        >
           {addToListContent}
 
           <div className="border-t p-1">

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -1,5 +1,6 @@
 import {
   CheckCircle,
+  ChevronUp,
   Circle,
   Download,
   GitMerge,
@@ -44,6 +45,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
     useBulkSelection();
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [morePopoverOpen, setMorePopoverOpen] = useState(false);
+  const [actionsPopoverOpen, setActionsPopoverOpen] = useState(false);
   const [addingToListId, setAddingToListId] = useState<number | null>(null);
   const [showMergeDialog, setShowMergeDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -127,6 +129,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
         `Added ${count} book${count !== 1 ? "s" : ""} to "${listName}"`,
       );
       setPopoverOpen(false);
+      setActionsPopoverOpen(false);
       exitSelectionMode();
     } catch (error) {
       const message =
@@ -139,6 +142,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
 
   const handleCreateList = () => {
     setPopoverOpen(false);
+    setActionsPopoverOpen(false);
     setCreateDialogOpen(true);
   };
 
@@ -207,144 +211,254 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
     return null;
   }
 
+  const bookLabel =
+    selectedBookIds.length === 1 ? `1 book` : `${selectedBookIds.length} books`;
+
+  const addToListContent = (
+    <>
+      <p className="text-xs font-medium text-muted-foreground px-3 py-2">
+        Add to List
+      </p>
+      {listsQuery.isLoading && (
+        <div className="flex items-center justify-center py-4">
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
+      {!listsQuery.isLoading && editableLists.length === 0 && (
+        <p className="text-sm text-muted-foreground px-3 py-3 text-center">
+          No editable lists
+        </p>
+      )}
+      {!listsQuery.isLoading && editableLists.length > 0 && (
+        <div className="flex flex-col gap-0.5 px-1 pb-1">
+          {editableLists.map((list) => {
+            const isAdding = addingToListId === list.id;
+            return (
+              <button
+                className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent text-left w-full text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                disabled={isAdding}
+                key={list.id}
+                onClick={() => handleAddToList(list.id, list.name)}
+                type="button"
+              >
+                {isAdding ? (
+                  <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+                ) : (
+                  <List className="h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+                <span className="truncate">{list.name}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+      {!listsQuery.isLoading && (
+        <div className="border-t px-1 py-1">
+          <Button
+            className="w-full justify-start"
+            onClick={handleCreateList}
+            size="sm"
+            variant="ghost"
+          >
+            <Plus className="h-4 w-4" />
+            Create New List
+          </Button>
+        </div>
+      )}
+    </>
+  );
+
   return (
     <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-50 bg-background border rounded-lg shadow-lg px-3 py-2 flex items-center gap-3">
       <span className="text-sm font-medium whitespace-nowrap tabular-nums">
-        {selectedBookIds.length} selected
+        {bookLabel}
       </span>
 
-      <Popover onOpenChange={setPopoverOpen} open={popoverOpen}>
+      {/* Mobile: single Actions popover */}
+      <Popover onOpenChange={setActionsPopoverOpen} open={actionsPopoverOpen}>
         <PopoverTrigger asChild>
-          <Button size="sm" variant="default">
-            <List className="h-4 w-4" />
-            Add
+          <Button className="sm:hidden" size="sm" variant="default">
+            Actions
+            <ChevronUp className="h-4 w-4" />
           </Button>
         </PopoverTrigger>
         <PopoverContent align="center" className="w-56 p-0" side="top">
-          <p className="text-xs font-medium text-muted-foreground px-3 py-2">
-            Add to List
-          </p>
-          {listsQuery.isLoading && (
-            <div className="flex items-center justify-center py-4">
-              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-            </div>
-          )}
-          {!listsQuery.isLoading && editableLists.length === 0 && (
-            <p className="text-sm text-muted-foreground px-3 py-3 text-center">
-              No editable lists
-            </p>
-          )}
-          {!listsQuery.isLoading && editableLists.length > 0 && (
-            <div className="flex flex-col gap-0.5 px-1 pb-1">
-              {editableLists.map((list) => {
-                const isAdding = addingToListId === list.id;
-                return (
-                  <button
-                    className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-accent text-left w-full text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-                    disabled={isAdding}
-                    key={list.id}
-                    onClick={() => handleAddToList(list.id, list.name)}
-                    type="button"
-                  >
-                    {isAdding ? (
-                      <Loader2 className="h-4 w-4 animate-spin shrink-0" />
-                    ) : (
-                      <List className="h-4 w-4 shrink-0 text-muted-foreground" />
-                    )}
-                    <span className="truncate">{list.name}</span>
-                  </button>
-                );
-              })}
-            </div>
-          )}
+          {addToListContent}
 
-          {!listsQuery.isLoading && (
-            <div className="border-t px-1 py-1">
+          <div className="border-t p-1">
+            <Button
+              className="w-full justify-start gap-2 font-normal"
+              onClick={() => {
+                setActionsPopoverOpen(false);
+                handleBulkReview("reviewed");
+              }}
+              size="sm"
+              variant="ghost"
+            >
+              <CheckCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">Mark reviewed</span>
+            </Button>
+            <Button
+              className="w-full justify-start gap-2 font-normal"
+              onClick={() => {
+                setActionsPopoverOpen(false);
+                handleBulkReview("unreviewed");
+              }}
+              size="sm"
+              variant="ghost"
+            >
+              <Circle className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">Mark needs review</span>
+            </Button>
+          </div>
+
+          <div className="border-t p-1">
+            <Button
+              className="w-full justify-start gap-2 font-normal"
+              disabled={
+                !downloadInfo ||
+                downloadInfo.fileIds.length === 0 ||
+                createJobMutation.isPending
+              }
+              onClick={() => {
+                setActionsPopoverOpen(false);
+                handleDownload();
+              }}
+              size="sm"
+              variant="ghost"
+            >
+              {createJobMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+              ) : (
+                <Download className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+              <span className="truncate">
+                Download
+                {downloadInfo && downloadInfo.totalSize > 0 && (
+                  <span className="text-xs opacity-75 ml-1">
+                    ({formatFileSize(downloadInfo.totalSize)})
+                  </span>
+                )}
+              </span>
+            </Button>
+
+            {selectedBookIds.length >= 2 && library && (
               <Button
-                className="w-full justify-start"
-                onClick={handleCreateList}
+                className="w-full justify-start gap-2 font-normal"
+                onClick={() => {
+                  setActionsPopoverOpen(false);
+                  setShowMergeDialog(true);
+                }}
                 size="sm"
                 variant="ghost"
               >
-                <Plus className="h-4 w-4" />
-                Create New List
+                <GitMerge className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="truncate">Merge</span>
               </Button>
-            </div>
-          )}
+            )}
+
+            <Button
+              className="w-full justify-start gap-2 font-normal text-destructive hover:text-destructive"
+              onClick={() => {
+                setActionsPopoverOpen(false);
+                setShowDeleteDialog(true);
+              }}
+              size="sm"
+              variant="ghost"
+            >
+              <Trash2 className="h-4 w-4 shrink-0" />
+              <span className="truncate">Delete</span>
+            </Button>
+          </div>
         </PopoverContent>
       </Popover>
 
-      <Button
-        disabled={
-          !downloadInfo ||
-          downloadInfo.fileIds.length === 0 ||
-          createJobMutation.isPending
-        }
-        onClick={handleDownload}
-        size="sm"
-        variant="default"
-      >
-        {createJobMutation.isPending ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <Download className="h-4 w-4" />
-        )}
-        Download
-        {downloadInfo && downloadInfo.totalSize > 0 && (
-          <span className="text-xs opacity-75">
-            ({formatFileSize(downloadInfo.totalSize)})
-          </span>
-        )}
-      </Button>
+      {/* Desktop: inline action buttons */}
+      <div className="hidden sm:flex items-center gap-3">
+        <Popover onOpenChange={setPopoverOpen} open={popoverOpen}>
+          <PopoverTrigger asChild>
+            <Button size="sm" variant="default">
+              <List className="h-4 w-4" />
+              Add
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="center" className="w-56 p-0" side="top">
+            {addToListContent}
+          </PopoverContent>
+        </Popover>
 
-      {selectedBookIds.length >= 2 && library && (
         <Button
-          onClick={() => setShowMergeDialog(true)}
+          disabled={
+            !downloadInfo ||
+            downloadInfo.fileIds.length === 0 ||
+            createJobMutation.isPending
+          }
+          onClick={handleDownload}
           size="sm"
           variant="default"
         >
-          <GitMerge className="h-4 w-4" />
-          Merge
+          {createJobMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4" />
+          )}
+          Download
+          {downloadInfo && downloadInfo.totalSize > 0 && (
+            <span className="text-xs opacity-75">
+              ({formatFileSize(downloadInfo.totalSize)})
+            </span>
+          )}
         </Button>
-      )}
 
-      <Button
-        onClick={() => setShowDeleteDialog(true)}
-        size="sm"
-        variant="destructive"
-      >
-        <Trash2 className="h-4 w-4" />
-        Delete
-      </Button>
+        {selectedBookIds.length >= 2 && library && (
+          <Button
+            onClick={() => setShowMergeDialog(true)}
+            size="sm"
+            variant="default"
+          >
+            <GitMerge className="h-4 w-4" />
+            Merge
+          </Button>
+        )}
 
-      <Popover onOpenChange={setMorePopoverOpen} open={morePopoverOpen}>
-        <PopoverTrigger asChild>
-          <Button size="sm" variant="default">
-            <MoreHorizontal className="h-4 w-4" />
-            More
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent align="center" className="w-56 p-1" side="top">
-          <Button
-            className="w-full justify-start gap-2 font-normal"
-            onClick={() => handleBulkReview("reviewed")}
-            size="sm"
-            variant="ghost"
-          >
-            <CheckCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className="truncate">Mark reviewed</span>
-          </Button>
-          <Button
-            className="w-full justify-start gap-2 font-normal"
-            onClick={() => handleBulkReview("unreviewed")}
-            size="sm"
-            variant="ghost"
-          >
-            <Circle className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <span className="truncate">Mark needs review</span>
-          </Button>
-        </PopoverContent>
-      </Popover>
+        <Button
+          onClick={() => setShowDeleteDialog(true)}
+          size="sm"
+          variant="destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete
+        </Button>
+
+        <Popover onOpenChange={setMorePopoverOpen} open={morePopoverOpen}>
+          <PopoverTrigger asChild>
+            <Button size="sm" variant="default">
+              <MoreHorizontal className="h-4 w-4" />
+              More
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="center" className="w-56 p-1" side="top">
+            <Button
+              className="w-full justify-start gap-2 font-normal"
+              onClick={() => handleBulkReview("reviewed")}
+              size="sm"
+              variant="ghost"
+            >
+              <CheckCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">Mark reviewed</span>
+            </Button>
+            <Button
+              className="w-full justify-start gap-2 font-normal"
+              onClick={() => handleBulkReview("unreviewed")}
+              size="sm"
+              variant="ghost"
+            >
+              <Circle className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">Mark needs review</span>
+            </Button>
+          </PopoverContent>
+        </Popover>
+      </div>
 
       <Button onClick={clearSelection} size="sm" variant="ghost">
         Clear

--- a/app/components/pages/AdminJobs.tsx
+++ b/app/components/pages/AdminJobs.tsx
@@ -5,20 +5,11 @@ import { Link, useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 
 import LoadingSpinner from "@/components/library/LoadingSpinner";
+import PaginationFooter from "@/components/library/PaginationFooter";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationEllipsis,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
 import { useCreateJob, useJobs } from "@/hooks/queries/jobs";
 import { useAuth } from "@/hooks/useAuth";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { JobStatusInProgress, JobTypeScan, type Job } from "@/types";
 
@@ -94,7 +85,6 @@ const AdminJobs = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
 
   const { hasPermission } = useAuth();
   const { data, isLoading, error, refetch } = useJobs({
@@ -111,24 +101,6 @@ const AdminJobs = () => {
     const newSearchParams = new URLSearchParams(searchParams);
     newSearchParams.set("page", page.toString());
     setSearchParams(newSearchParams);
-  };
-
-  const getPageNumbers = () => {
-    const pages = [];
-    const showPages = isSmallScreen ? 3 : 5;
-
-    let start = Math.max(1, currentPage - Math.floor(showPages / 2));
-    const end = Math.min(totalPages, start + showPages - 1);
-
-    if (end - start + 1 < showPages) {
-      start = Math.max(1, end - showPages + 1);
-    }
-
-    for (let i = start; i <= end; i++) {
-      pages.push(i);
-    }
-
-    return pages;
   };
 
   const handleTriggerSync = useCallback(async () => {
@@ -207,82 +179,12 @@ const AdminJobs = () => {
             ))}
           </div>
 
-          {totalPages > 1 && (
-            <Pagination className="mt-6">
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious
-                    className={
-                      currentPage <= 1
-                        ? "pointer-events-none opacity-50"
-                        : "cursor-pointer"
-                    }
-                    onClick={() => handlePageChange(currentPage - 1)}
-                  />
-                </PaginationItem>
-
-                {getPageNumbers()[0] > 1 && (
-                  <>
-                    <PaginationItem>
-                      <PaginationLink
-                        className="cursor-pointer"
-                        onClick={() => handlePageChange(1)}
-                      >
-                        1
-                      </PaginationLink>
-                    </PaginationItem>
-                    {getPageNumbers()[0] > 2 && (
-                      <PaginationItem>
-                        <PaginationEllipsis />
-                      </PaginationItem>
-                    )}
-                  </>
-                )}
-
-                {getPageNumbers().map((page) => (
-                  <PaginationItem key={page}>
-                    <PaginationLink
-                      className="cursor-pointer"
-                      isActive={page === currentPage}
-                      onClick={() => handlePageChange(page)}
-                    >
-                      {page}
-                    </PaginationLink>
-                  </PaginationItem>
-                ))}
-
-                {getPageNumbers()[getPageNumbers().length - 1] < totalPages && (
-                  <>
-                    {getPageNumbers()[getPageNumbers().length - 1] <
-                      totalPages - 1 && (
-                      <PaginationItem>
-                        <PaginationEllipsis />
-                      </PaginationItem>
-                    )}
-                    <PaginationItem>
-                      <PaginationLink
-                        className="cursor-pointer"
-                        onClick={() => handlePageChange(totalPages)}
-                      >
-                        {totalPages}
-                      </PaginationLink>
-                    </PaginationItem>
-                  </>
-                )}
-
-                <PaginationItem>
-                  <PaginationNext
-                    className={
-                      currentPage >= totalPages
-                        ? "pointer-events-none opacity-50"
-                        : "cursor-pointer"
-                    }
-                    onClick={() => handlePageChange(currentPage + 1)}
-                  />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          )}
+          <PaginationFooter
+            className="mt-6"
+            currentPage={currentPage}
+            onPageChange={handlePageChange}
+            totalPages={totalPages}
+          />
         </>
       )}
     </div>

--- a/app/components/pages/AdminJobs.tsx
+++ b/app/components/pages/AdminJobs.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/pagination";
 import { useCreateJob, useJobs } from "@/hooks/queries/jobs";
 import { useAuth } from "@/hooks/useAuth";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { JobStatusInProgress, JobTypeScan, type Job } from "@/types";
 
@@ -93,6 +94,7 @@ const AdminJobs = () => {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
 
   const { hasPermission } = useAuth();
   const { data, isLoading, error, refetch } = useJobs({
@@ -113,7 +115,7 @@ const AdminJobs = () => {
 
   const getPageNumbers = () => {
     const pages = [];
-    const showPages = 5;
+    const showPages = isSmallScreen ? 3 : 5;
 
     let start = Math.max(1, currentPage - Math.floor(showPages / 2));
     const end = Math.min(totalPages, start + showPages - 1);

--- a/app/components/pages/GenresList.tsx
+++ b/app/components/pages/GenresList.tsx
@@ -3,18 +3,10 @@ import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
+import PaginationFooter from "@/components/library/PaginationFooter";
 import { SearchInput } from "@/components/library/SearchInput";
 import { Badge } from "@/components/ui/badge";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
 import { useGenresList } from "@/hooks/queries/genres";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { Genre } from "@/types";
 
@@ -26,7 +18,6 @@ const GenresList = () => {
   const { libraryId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
   const searchQuery = searchParams.get("search") ?? "";
 
   const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
@@ -136,62 +127,11 @@ const GenresList = () => {
             </div>
           )}
 
-          {totalPages > 1 && (
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious
-                    className={
-                      currentPage <= 1
-                        ? "pointer-events-none opacity-50"
-                        : "cursor-pointer"
-                    }
-                    onClick={() => handlePageChange(currentPage - 1)}
-                  />
-                </PaginationItem>
-                {(() => {
-                  const showPages = isSmallScreen ? 3 : 5;
-                  const half = Math.floor(showPages / 2);
-                  return Array.from(
-                    { length: Math.min(showPages, totalPages) },
-                    (_, i) => {
-                      let pageNum;
-                      if (totalPages <= showPages) {
-                        pageNum = i + 1;
-                      } else if (currentPage <= half + 1) {
-                        pageNum = i + 1;
-                      } else if (currentPage >= totalPages - half) {
-                        pageNum = totalPages - showPages + 1 + i;
-                      } else {
-                        pageNum = currentPage - half + i;
-                      }
-                      return (
-                        <PaginationItem key={pageNum}>
-                          <PaginationLink
-                            className="cursor-pointer"
-                            isActive={pageNum === currentPage}
-                            onClick={() => handlePageChange(pageNum)}
-                          >
-                            {pageNum}
-                          </PaginationLink>
-                        </PaginationItem>
-                      );
-                    },
-                  );
-                })()}
-                <PaginationItem>
-                  <PaginationNext
-                    className={
-                      currentPage >= totalPages
-                        ? "pointer-events-none opacity-50"
-                        : "cursor-pointer"
-                    }
-                    onClick={() => handlePageChange(currentPage + 1)}
-                  />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          )}
+          <PaginationFooter
+            currentPage={currentPage}
+            onPageChange={handlePageChange}
+            totalPages={totalPages}
+          />
         </>
       )}
     </LibraryLayout>

--- a/app/components/pages/GenresList.tsx
+++ b/app/components/pages/GenresList.tsx
@@ -14,6 +14,7 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 import { useGenresList } from "@/hooks/queries/genres";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { Genre } from "@/types";
 
@@ -25,6 +26,7 @@ const GenresList = () => {
   const { libraryId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
   const searchQuery = searchParams.get("search") ?? "";
 
   const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
@@ -147,29 +149,36 @@ const GenresList = () => {
                     onClick={() => handlePageChange(currentPage - 1)}
                   />
                 </PaginationItem>
-                {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-                  let pageNum;
-                  if (totalPages <= 5) {
-                    pageNum = i + 1;
-                  } else if (currentPage <= 3) {
-                    pageNum = i + 1;
-                  } else if (currentPage >= totalPages - 2) {
-                    pageNum = totalPages - 4 + i;
-                  } else {
-                    pageNum = currentPage - 2 + i;
-                  }
-                  return (
-                    <PaginationItem key={pageNum}>
-                      <PaginationLink
-                        className="cursor-pointer"
-                        isActive={pageNum === currentPage}
-                        onClick={() => handlePageChange(pageNum)}
-                      >
-                        {pageNum}
-                      </PaginationLink>
-                    </PaginationItem>
+                {(() => {
+                  const showPages = isSmallScreen ? 3 : 5;
+                  const half = Math.floor(showPages / 2);
+                  return Array.from(
+                    { length: Math.min(showPages, totalPages) },
+                    (_, i) => {
+                      let pageNum;
+                      if (totalPages <= showPages) {
+                        pageNum = i + 1;
+                      } else if (currentPage <= half + 1) {
+                        pageNum = i + 1;
+                      } else if (currentPage >= totalPages - half) {
+                        pageNum = totalPages - showPages + 1 + i;
+                      } else {
+                        pageNum = currentPage - half + i;
+                      }
+                      return (
+                        <PaginationItem key={pageNum}>
+                          <PaginationLink
+                            className="cursor-pointer"
+                            isActive={pageNum === currentPage}
+                            onClick={() => handlePageChange(pageNum)}
+                          >
+                            {pageNum}
+                          </PaginationLink>
+                        </PaginationItem>
+                      );
+                    },
                   );
-                })}
+                })()}
                 <PaginationItem>
                   <PaginationNext
                     className={

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -3,18 +3,10 @@ import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
+import PaginationFooter from "@/components/library/PaginationFooter";
 import { SearchInput } from "@/components/library/SearchInput";
 import { Badge } from "@/components/ui/badge";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
 import { usePeopleList, type PersonWithCounts } from "@/hooks/queries/people";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { usePageTitle } from "@/hooks/usePageTitle";
 
 const ITEMS_PER_PAGE = 24;
@@ -25,7 +17,6 @@ const PersonList = () => {
   const { libraryId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
   const searchQuery = searchParams.get("search") ?? "";
   const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
 
@@ -150,51 +141,13 @@ const PersonList = () => {
             )}
           </div>
 
-          {totalPages > 1 && (
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious
-                    href={`?page=${Math.max(1, currentPage - 1)}${searchQuery ? `&search=${searchQuery}` : ""}`}
-                  />
-                </PaginationItem>
-                {(() => {
-                  const showPages = isSmallScreen ? 3 : 5;
-                  const half = Math.floor(showPages / 2);
-                  return Array.from(
-                    { length: Math.min(showPages, totalPages) },
-                    (_, i) => {
-                      let pageNum;
-                      if (totalPages <= showPages) {
-                        pageNum = i + 1;
-                      } else if (currentPage <= half + 1) {
-                        pageNum = i + 1;
-                      } else if (currentPage >= totalPages - half) {
-                        pageNum = totalPages - showPages + 1 + i;
-                      } else {
-                        pageNum = currentPage - half + i;
-                      }
-                      return (
-                        <PaginationItem key={pageNum}>
-                          <PaginationLink
-                            href={`?page=${pageNum}${searchQuery ? `&search=${searchQuery}` : ""}`}
-                            isActive={pageNum === currentPage}
-                          >
-                            {pageNum}
-                          </PaginationLink>
-                        </PaginationItem>
-                      );
-                    },
-                  );
-                })()}
-                <PaginationItem>
-                  <PaginationNext
-                    href={`?page=${Math.min(totalPages, currentPage + 1)}${searchQuery ? `&search=${searchQuery}` : ""}`}
-                  />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          )}
+          <PaginationFooter
+            buildHref={(page) =>
+              `?page=${page}${searchQuery ? `&search=${searchQuery}` : ""}`
+            }
+            currentPage={currentPage}
+            totalPages={totalPages}
+          />
         </>
       )}
     </LibraryLayout>

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -14,6 +14,7 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 import { usePeopleList, type PersonWithCounts } from "@/hooks/queries/people";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { usePageTitle } from "@/hooks/usePageTitle";
 
 const ITEMS_PER_PAGE = 24;
@@ -24,6 +25,7 @@ const PersonList = () => {
   const { libraryId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
   const searchQuery = searchParams.get("search") ?? "";
   const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
 
@@ -156,28 +158,35 @@ const PersonList = () => {
                     href={`?page=${Math.max(1, currentPage - 1)}${searchQuery ? `&search=${searchQuery}` : ""}`}
                   />
                 </PaginationItem>
-                {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-                  let pageNum;
-                  if (totalPages <= 5) {
-                    pageNum = i + 1;
-                  } else if (currentPage <= 3) {
-                    pageNum = i + 1;
-                  } else if (currentPage >= totalPages - 2) {
-                    pageNum = totalPages - 4 + i;
-                  } else {
-                    pageNum = currentPage - 2 + i;
-                  }
-                  return (
-                    <PaginationItem key={pageNum}>
-                      <PaginationLink
-                        href={`?page=${pageNum}${searchQuery ? `&search=${searchQuery}` : ""}`}
-                        isActive={pageNum === currentPage}
-                      >
-                        {pageNum}
-                      </PaginationLink>
-                    </PaginationItem>
+                {(() => {
+                  const showPages = isSmallScreen ? 3 : 5;
+                  const half = Math.floor(showPages / 2);
+                  return Array.from(
+                    { length: Math.min(showPages, totalPages) },
+                    (_, i) => {
+                      let pageNum;
+                      if (totalPages <= showPages) {
+                        pageNum = i + 1;
+                      } else if (currentPage <= half + 1) {
+                        pageNum = i + 1;
+                      } else if (currentPage >= totalPages - half) {
+                        pageNum = totalPages - showPages + 1 + i;
+                      } else {
+                        pageNum = currentPage - half + i;
+                      }
+                      return (
+                        <PaginationItem key={pageNum}>
+                          <PaginationLink
+                            href={`?page=${pageNum}${searchQuery ? `&search=${searchQuery}` : ""}`}
+                            isActive={pageNum === currentPage}
+                          >
+                            {pageNum}
+                          </PaginationLink>
+                        </PaginationItem>
+                      );
+                    },
                   );
-                })}
+                })()}
                 <PaginationItem>
                   <PaginationNext
                     href={`?page=${Math.min(totalPages, currentPage + 1)}${searchQuery ? `&search=${searchQuery}` : ""}`}

--- a/app/components/pages/TagsList.tsx
+++ b/app/components/pages/TagsList.tsx
@@ -3,18 +3,10 @@ import { Link, useParams, useSearchParams } from "react-router-dom";
 
 import LibraryLayout from "@/components/library/LibraryLayout";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
+import PaginationFooter from "@/components/library/PaginationFooter";
 import { SearchInput } from "@/components/library/SearchInput";
 import { Badge } from "@/components/ui/badge";
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-} from "@/components/ui/pagination";
 import { useTagsList } from "@/hooks/queries/tags";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { Tag } from "@/types";
 
@@ -26,7 +18,6 @@ const TagsList = () => {
   const { libraryId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
   const searchQuery = searchParams.get("search") ?? "";
 
   const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
@@ -136,62 +127,11 @@ const TagsList = () => {
             </div>
           )}
 
-          {totalPages > 1 && (
-            <Pagination>
-              <PaginationContent>
-                <PaginationItem>
-                  <PaginationPrevious
-                    className={
-                      currentPage <= 1
-                        ? "pointer-events-none opacity-50"
-                        : "cursor-pointer"
-                    }
-                    onClick={() => handlePageChange(currentPage - 1)}
-                  />
-                </PaginationItem>
-                {(() => {
-                  const showPages = isSmallScreen ? 3 : 5;
-                  const half = Math.floor(showPages / 2);
-                  return Array.from(
-                    { length: Math.min(showPages, totalPages) },
-                    (_, i) => {
-                      let pageNum;
-                      if (totalPages <= showPages) {
-                        pageNum = i + 1;
-                      } else if (currentPage <= half + 1) {
-                        pageNum = i + 1;
-                      } else if (currentPage >= totalPages - half) {
-                        pageNum = totalPages - showPages + 1 + i;
-                      } else {
-                        pageNum = currentPage - half + i;
-                      }
-                      return (
-                        <PaginationItem key={pageNum}>
-                          <PaginationLink
-                            className="cursor-pointer"
-                            isActive={pageNum === currentPage}
-                            onClick={() => handlePageChange(pageNum)}
-                          >
-                            {pageNum}
-                          </PaginationLink>
-                        </PaginationItem>
-                      );
-                    },
-                  );
-                })()}
-                <PaginationItem>
-                  <PaginationNext
-                    className={
-                      currentPage >= totalPages
-                        ? "pointer-events-none opacity-50"
-                        : "cursor-pointer"
-                    }
-                    onClick={() => handlePageChange(currentPage + 1)}
-                  />
-                </PaginationItem>
-              </PaginationContent>
-            </Pagination>
-          )}
+          <PaginationFooter
+            currentPage={currentPage}
+            onPageChange={handlePageChange}
+            totalPages={totalPages}
+          />
         </>
       )}
     </LibraryLayout>

--- a/app/components/pages/TagsList.tsx
+++ b/app/components/pages/TagsList.tsx
@@ -14,6 +14,7 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 import { useTagsList } from "@/hooks/queries/tags";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { Tag } from "@/types";
 
@@ -25,6 +26,7 @@ const TagsList = () => {
   const { libraryId } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const isSmallScreen = !useMediaQuery("(min-width: 640px)");
   const searchQuery = searchParams.get("search") ?? "";
 
   const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
@@ -147,29 +149,36 @@ const TagsList = () => {
                     onClick={() => handlePageChange(currentPage - 1)}
                   />
                 </PaginationItem>
-                {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-                  let pageNum;
-                  if (totalPages <= 5) {
-                    pageNum = i + 1;
-                  } else if (currentPage <= 3) {
-                    pageNum = i + 1;
-                  } else if (currentPage >= totalPages - 2) {
-                    pageNum = totalPages - 4 + i;
-                  } else {
-                    pageNum = currentPage - 2 + i;
-                  }
-                  return (
-                    <PaginationItem key={pageNum}>
-                      <PaginationLink
-                        className="cursor-pointer"
-                        isActive={pageNum === currentPage}
-                        onClick={() => handlePageChange(pageNum)}
-                      >
-                        {pageNum}
-                      </PaginationLink>
-                    </PaginationItem>
+                {(() => {
+                  const showPages = isSmallScreen ? 3 : 5;
+                  const half = Math.floor(showPages / 2);
+                  return Array.from(
+                    { length: Math.min(showPages, totalPages) },
+                    (_, i) => {
+                      let pageNum;
+                      if (totalPages <= showPages) {
+                        pageNum = i + 1;
+                      } else if (currentPage <= half + 1) {
+                        pageNum = i + 1;
+                      } else if (currentPage >= totalPages - half) {
+                        pageNum = totalPages - showPages + 1 + i;
+                      } else {
+                        pageNum = currentPage - half + i;
+                      }
+                      return (
+                        <PaginationItem key={pageNum}>
+                          <PaginationLink
+                            className="cursor-pointer"
+                            isActive={pageNum === currentPage}
+                            onClick={() => handlePageChange(pageNum)}
+                          >
+                            {pageNum}
+                          </PaginationLink>
+                        </PaginationItem>
+                      );
+                    },
                   );
-                })}
+                })()}
                 <PaginationItem>
                   <PaginationNext
                     className={

--- a/e2e/review-flag.spec.ts
+++ b/e2e/review-flag.spec.ts
@@ -219,15 +219,15 @@ test.describe("Review flag", () => {
       .filter({ hasText: "Bulk Book Beta" })
       .click({ force: true });
 
-    // The selection toolbar should appear showing 2 selected.
-    await expect(page.getByText(/2 selected/)).toBeVisible();
+    // The selection toolbar should appear showing 2 books.
+    await expect(page.getByText(/2 books/)).toBeVisible();
 
     // Open the "More" popover and click "Mark reviewed".
     await page.getByRole("button", { name: /^More$/ }).click();
     await page.getByText("Mark reviewed").click();
 
     // Wait for the toolbar to dismiss (selection mode exits after bulk action).
-    await expect(page.getByText(/2 selected/)).not.toBeVisible();
+    await expect(page.getByText(/2 books/)).not.toBeVisible();
 
     // The filtered view should now show neither book (they were marked reviewed).
     await expect(page.getByText("Bulk Book Alpha")).not.toBeVisible();


### PR DESCRIPTION
## Summary
- Compact the selection toolbar on mobile into a single "Actions" popover to prevent overflow
- Reduce visible pagination page numbers from 5 to 3 on small screens (< 640px) to prevent horizontal scrolling
- Applied pagination fix consistently across all 5 paginated components: Gallery, AdminJobs, PersonList, GenresList, TagsList

## Test plan
- Open a library with many books, select multiple books, and verify the toolbar works on mobile (shows "Actions" popover instead of individual buttons)
- Open any paginated page and navigate to a middle page on mobile — verify only 3 page numbers shown, no horizontal scroll
- Widen browser above 640px and verify desktop layout is unchanged (individual buttons, 5 page numbers)