### PR TITLE
[CI] Prune stale JUnit files in gotestsplit consolidator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
       - run: mise lint
 
   test:
-    name: Go Test (${{ matrix.shard }}/${{ env.SHARD_TOTAL }})
+    # Keep this N in sync with env.SHARD_TOTAL (env not available in name).
+    name: Go Test (${{ matrix.shard }}/12)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [master]
   workflow_call:
 
+env:
+  SHARD_TOTAL: 12
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -21,7 +24,7 @@ jobs:
       - run: mise lint
 
   test:
-    name: Go Test (${{ matrix.shard }}/12)
+    name: Go Test (${{ matrix.shard }}/${{ env.SHARD_TOTAL }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -52,7 +55,7 @@ jobs:
           go run ./tools/gotestsplit run \
             -junit-dir=.gotest-timings \
             -junit-out=.gotest-timings-fresh \
-            -total=12 -index=$((SHARD - 1)) \
+            -total=$SHARD_TOTAL -index=$((SHARD - 1)) \
             ./pkg/... -- -race
       - name: Upload shard JUnit
         if: always()
@@ -92,6 +95,7 @@ jobs:
           merge-multiple: true
       - uses: actions/checkout@v6
         with:
+          clean: false
           sparse-checkout: |
             tools/gotestsplit
             go.mod
@@ -100,8 +104,10 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Prune stale junit files
-        run: go run ./tools/gotestsplit prune -junit-dir=.gotest-timings -total=12
+        run: go run ./tools/gotestsplit prune -junit-dir=.gotest-timings -total=$SHARD_TOTAL
       - name: Report cache size
+        # Visibility check — a sudden drop beyond what prune removes means
+        # the merge-race bug or fresh-only upload assumption regressed.
         run: |
           echo "junit files: $(find .gotest-timings -name 'junit-*.xml' | wc -l)"
           du -sh .gotest-timings || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
           path: .gotest-timings
           pattern: gotest-timings-shard-*
           merge-multiple: true
+      # Must come AFTER cache restore + artifact download so clean: false
+      # preserves the assembled .gotest-timings directory.
       - uses: actions/checkout@v6
         with:
           clean: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,18 @@ jobs:
           path: .gotest-timings
           pattern: gotest-timings-shard-*
           merge-multiple: true
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            tools/gotestsplit
+            go.mod
+            go.sum
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Prune stale junit files
+        run: go run ./tools/gotestsplit prune -junit-dir=.gotest-timings -total=12
       - name: Report cache size
-        # Visibility check — a sudden drop in file count means the merge-race
-        # bug or the fresh-only upload assumption regressed.
         run: |
           echo "junit files: $(find .gotest-timings -name 'junit-*.xml' | wc -l)"
           du -sh .gotest-timings || true

--- a/tools/gotestsplit/CLAUDE.md
+++ b/tools/gotestsplit/CLAUDE.md
@@ -115,8 +115,9 @@ In 2026-04, N=12 was settled on as the best cost/value balance: typical slowest 
 ### Step 6: Pick the N and update CI
 
 Edit `.github/workflows/ci.yml`:
-- `env.SHARD_TOTAL: N` at the workflow level (the matrix, run step, job name, and prune step all reference this)
+- `env.SHARD_TOTAL: N` at the workflow level (the run step and prune step reference `$SHARD_TOTAL`)
 - `matrix.shard: [1, 2, ..., N]`
+- `name: Go Test (${{ matrix.shard }}/N)` (cosmetic; `env` is not available in the `name` context)
 
 Commit + push. The first run after the change is the contaminated one (Pack uses old-N cache for new-N split); subsequent runs are clean.
 

--- a/tools/gotestsplit/CLAUDE.md
+++ b/tools/gotestsplit/CLAUDE.md
@@ -10,6 +10,7 @@ Subcommands:
 - `simulate -junit-dir=DIR [-min=N] [-max=N]` — read JUnit history, project per-shard wallclock and CI cost across a range of N. Used for picking shard count.
 - `plan -junit-dir=DIR -total=N -index=I [-detail] PKG...` — print the assignment for one shard. Useful for debugging "why is shard 3 slow?".
 - `run -junit-dir=DIR [-junit-out=DIR] -total=N -index=I PKG... [-- go-test-args]` — plan + exec `go test` per chunk + emit JUnit XML. `-junit-dir` is the read-only history input; `-junit-out` (defaults to `-junit-dir`) is where fresh XML is written.
+- `prune -junit-dir=DIR -total=N` — delete orphan `junit-{shard}-{seq}.xml` files where `shard >= N`. Run by the CI consolidator to keep the cache tidy after shard count changes.
 
 ## Architecture cheatsheet
 
@@ -126,7 +127,7 @@ Commit + push. The first run after the change is the contaminated one (Pack uses
 - **`gh run view <run-id>` returns "still in progress" until the entire workflow completes** — for partial logs of an in-progress run, view individual jobs via the GHA web UI.
 - **`actions/cache/restore@v5` and `actions/cache/save@v5` are separate actions** from `actions/cache@v5`; we use the split form so only the consolidator saves. Don't replace with the unified form — concurrent saves race and only one shard's data wins.
 - **`gh pr checks` shows checks for the latest commit on the PR**, so monitors that scope by PR (not run-id) will break if a new commit is pushed mid-monitor. Scope monitors to a specific `RUN_ID` (`gh run view $RUN_ID --json jobs`).
-- **The cache is never pruned** — `junit-N-K.xml` files outlive the run that wrote them, so when shard count or chunk count drops, leftover files persist. `ReadHistory` merges them by lexical order with later wins, which is mostly harmless (durations drift, packing is stable) but means the cache grows unboundedly and can carry stale (pkg, test) entries for tests that have been renamed or removed. Live with it until cache size or stale data causes pain; the planned mitigation is a `prune` step in the consolidator.
+- **The consolidator prunes orphan shard files** — `prune -junit-dir=DIR -total=N` deletes any `junit-{shard}-{seq}.xml` where `shard >= N`. This runs automatically in the `consolidate-test-timings` job before saving the cache, so changing the shard count doesn't leave stale files behind. Dead-test entries within valid shard files are not pruned (live tests overwrite them via later-wins merging, so the impact is negligible).
 - **Re-running CI on the same SHA fails the consolidator's `Save consolidated cache` step** — `actions/cache/save@v5` keys are immutable per (repo, key), and the key includes `github.sha`. The first attempt's save succeeded; the re-run's save sees the key already exists and exits non-zero. This is harmless — the previous attempt's consolidated cache is still there, and subsequent commits restore it via the `gotest-timings-${{ github.ref }}-` fallback prefix — but the red ✗ on the Save step in re-runs is expected, not a regression. Don't add `github.run_attempt` to the key to "fix" it; that fragments the cache pointlessly.
 
 ## Pull-out plan (future)

--- a/tools/gotestsplit/CLAUDE.md
+++ b/tools/gotestsplit/CLAUDE.md
@@ -115,9 +115,8 @@ In 2026-04, N=12 was settled on as the best cost/value balance: typical slowest 
 ### Step 6: Pick the N and update CI
 
 Edit `.github/workflows/ci.yml`:
+- `env.SHARD_TOTAL: N` at the workflow level (the matrix, run step, job name, and prune step all reference this)
 - `matrix.shard: [1, 2, ..., N]`
-- `-total=N` in the `Run tests` step
-- `name: Go Test (${{ matrix.shard }}/N)` (cosmetic, but the job name is what shows up in the PR check list)
 
 Commit + push. The first run after the change is the contaminated one (Pack uses old-N cache for new-N split); subsequent runs are clean.
 

--- a/tools/gotestsplit/main.go
+++ b/tools/gotestsplit/main.go
@@ -33,6 +33,8 @@ func run(ctx context.Context, argv []string, stdout, stderr io.Writer) error {
 		return cmdPlan(ctx, argv[1:], stdout, stderr)
 	case "run":
 		return cmdRun(ctx, argv[1:], stdout, stderr)
+	case "prune":
+		return cmdPrune(ctx, argv[1:], stdout, stderr)
 	case "-h", "--help", "help":
 		printUsage(stdout)
 		return nil
@@ -49,5 +51,6 @@ Usage:
   gotestsplit simulate -junit-dir=<dir> [-min=N] [-max=N]
   gotestsplit plan -junit-dir=<dir> -total=N -index=I [-detail] <pkg>...
   gotestsplit run -junit-dir=<dir> [-junit-out=<dir>] -total=N -index=I <pkg>... [-- go-test-args]
+  gotestsplit prune -junit-dir=<dir> -total=N
   gotestsplit [-junit-out=<dir>] -total=N -index=I <pkg>... [-- go-test-args]   # shortcut for "run"`)
 }

--- a/tools/gotestsplit/prune.go
+++ b/tools/gotestsplit/prune.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+)
+
+var (
+	errPruneFlagsInvalid = errors.New("prune requires -junit-dir and -total>0")
+	junitFileRE          = regexp.MustCompile(`^junit-(\d+)-(\d+)\.xml$`)
+)
+
+func cmdPrune(_ context.Context, argv []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("prune", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	junitDir := fs.String("junit-dir", "", "directory of JUnit XML files to prune (required)")
+	total := fs.Int("total", 0, "current total number of shards (required)")
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+	if *junitDir == "" || *total <= 0 {
+		return errPruneFlagsInvalid
+	}
+
+	entries, err := os.ReadDir(*junitDir)
+	if err != nil {
+		return err
+	}
+
+	var deleted int
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		m := junitFileRE.FindStringSubmatch(e.Name())
+		if m == nil {
+			continue
+		}
+		shard, _ := strconv.Atoi(m[1])
+		if shard < *total {
+			continue
+		}
+		path := filepath.Join(*junitDir, e.Name())
+		if err := os.Remove(path); err != nil {
+			fmt.Fprintf(stderr, "warning: failed to remove %s: %v\n", e.Name(), err)
+			continue
+		}
+		fmt.Fprintf(stdout, "pruned %s (shard %d >= total %d)\n", e.Name(), shard, *total)
+		deleted++
+	}
+
+	if deleted == 0 {
+		fmt.Fprintln(stderr, "prune: nothing to delete")
+	} else {
+		fmt.Fprintf(stderr, "prune: deleted %d stale file(s)\n", deleted)
+	}
+	return nil
+}

--- a/tools/gotestsplit/prune.go
+++ b/tools/gotestsplit/prune.go
@@ -30,6 +30,10 @@ func cmdPrune(_ context.Context, argv []string, stdout, stderr io.Writer) error 
 	}
 
 	entries, err := os.ReadDir(*junitDir)
+	if errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintln(stderr, "prune: directory does not exist, nothing to do")
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/tools/gotestsplit/prune_test.go
+++ b/tools/gotestsplit/prune_test.go
@@ -105,6 +105,20 @@ func TestCmdPrune_NothingToDelete(t *testing.T) {
 	}
 }
 
+func TestCmdPrune_MissingDirectory(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+
+	var stdout, stderr bytes.Buffer
+	err := cmdPrune(context.Background(), []string{"-junit-dir=" + dir, "-total=8"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("expected no error for missing directory, got: %v", err)
+	}
+	if !bytes.Contains(stderr.Bytes(), []byte("does not exist")) {
+		t.Errorf("expected stderr to mention missing directory, got: %s", stderr.String())
+	}
+}
+
 func TestCmdPrune_RequiresFlags(t *testing.T) {
 	t.Parallel()
 

--- a/tools/gotestsplit/prune_test.go
+++ b/tools/gotestsplit/prune_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestCmdPrune_DeletesOrphanShards(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Simulate a cache that was built when total=12, now we're pruning to total=8.
+	// Shard indices 0-7 should survive; 8-11 should be deleted.
+	files := map[string]bool{
+		"junit-0-1.xml":  true,  // keep: shard 0 < 8
+		"junit-0-2.xml":  true,  // keep: shard 0, second chunk
+		"junit-3-1.xml":  true,  // keep: shard 3 < 8
+		"junit-7-1.xml":  true,  // keep: shard 7 < 8 (boundary)
+		"junit-8-1.xml":  false, // delete: shard 8 >= 8
+		"junit-9-1.xml":  false, // delete: shard 9 >= 8
+		"junit-11-1.xml": false, // delete: shard 11 >= 8
+		"junit-11-2.xml": false, // delete: shard 11, second chunk
+		"other.xml":      true,  // keep: doesn't match junit pattern
+		"readme.txt":     true,  // keep: not even xml
+	}
+
+	for name := range files {
+		os.WriteFile(filepath.Join(dir, name), []byte("<testsuites/>"), 0o600)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := cmdPrune(context.Background(), []string{"-junit-dir=" + dir, "-total=8"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("cmdPrune: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	var remaining []string
+	for _, e := range entries {
+		remaining = append(remaining, e.Name())
+	}
+	sort.Strings(remaining)
+
+	var want []string
+	for name, keep := range files {
+		if keep {
+			want = append(want, name)
+		}
+	}
+	sort.Strings(want)
+
+	if len(remaining) != len(want) {
+		t.Fatalf("remaining files mismatch:\n got=%v\nwant=%v", remaining, want)
+	}
+	for i := range remaining {
+		if remaining[i] != want[i] {
+			t.Fatalf("remaining files mismatch:\n got=%v\nwant=%v", remaining, want)
+		}
+	}
+}
+
+func TestCmdPrune_ReportsDeletedFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	os.WriteFile(filepath.Join(dir, "junit-0-1.xml"), []byte("<testsuites/>"), 0o600)
+	os.WriteFile(filepath.Join(dir, "junit-5-1.xml"), []byte("<testsuites/>"), 0o600)
+
+	var stdout, stderr bytes.Buffer
+	err := cmdPrune(context.Background(), []string{"-junit-dir=" + dir, "-total=4"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("cmdPrune: %v", err)
+	}
+
+	out := stdout.String()
+	if out == "" {
+		t.Fatal("expected output reporting deleted files")
+	}
+	// Should mention the deleted file
+	if !bytes.Contains([]byte(out), []byte("junit-5-1.xml")) {
+		t.Errorf("expected output to mention junit-5-1.xml, got: %s", out)
+	}
+}
+
+func TestCmdPrune_NothingToDelete(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	os.WriteFile(filepath.Join(dir, "junit-0-1.xml"), []byte("<testsuites/>"), 0o600)
+	os.WriteFile(filepath.Join(dir, "junit-1-1.xml"), []byte("<testsuites/>"), 0o600)
+
+	var stdout, stderr bytes.Buffer
+	err := cmdPrune(context.Background(), []string{"-junit-dir=" + dir, "-total=4"}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("cmdPrune: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 files, got %d", len(entries))
+	}
+}
+
+func TestCmdPrune_RequiresFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"missing junit-dir", []string{"-total=8"}},
+		{"missing total", []string{"-junit-dir=/tmp"}},
+		{"total zero", []string{"-junit-dir=/tmp", "-total=0"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var stdout, stderr bytes.Buffer
+			err := cmdPrune(context.Background(), tt.args, &stdout, &stderr)
+			if err == nil {
+				t.Fatal("expected error for invalid flags")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `prune` subcommand to `tools/gotestsplit` that deletes orphan `junit-{shard}-{seq}.xml` files where the shard index >= the current total
- Wires the prune step into the `consolidate-test-timings` CI job, so changing shard count no longer leaves stale cache files behind
- Updates `tools/gotestsplit/CLAUDE.md` to document the new subcommand and replace the "cache is never pruned" gotcha

## Test plan
- Run `go test ./tools/gotestsplit/ -run TestCmdPrune -v` to verify the 4 new test cases pass (orphan deletion, output reporting, no-op, flag validation)
- Run `go test ./tools/gotestsplit/ -v` to verify no regressions in existing tests
- After merge, verify the `Prune stale junit files` step appears in the consolidator job and reports pruned files (or "nothing to delete" if cache is clean)