### PR TITLE
[Frontend] Standardize styling on semantic design tokens

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -215,7 +215,7 @@ Tailwind breakpoints used in Shisho:
 ```tsx
 // Good - stacked layout
 <div className="flex flex-col gap-3 mb-6">
-  <h1 className="text-2xl md:text-3xl font-semibold">{title}</h1>
+  <h1 className="text-2xl font-semibold">{title}</h1>
   <div className="flex items-center gap-2">
     <Button size="sm" variant="outline">
       <Edit className="h-4 w-4 sm:mr-2" />
@@ -226,7 +226,7 @@ Tailwind breakpoints used in Shisho:
 
 // Bad - side-by-side causes layout issues
 <div className="flex items-start justify-between">
-  <h1 className="text-3xl">{title}</h1>
+  <h1 className="text-2xl font-semibold">{title}</h1>
   <Button>Edit</Button>
 </div>
 ```

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -849,7 +849,7 @@ All metadata detail pages (Series, Person, Genre, Tag) follow a consistent struc
 
 **Header Section:**
 ```tsx
-<div className="mb-8">
+<div className="mb-6 md:mb-8">
   <div className="flex items-start justify-between gap-4 mb-2">
     <h1 className="text-2xl font-semibold min-w-0 break-words">{name}</h1>
     <div className="flex gap-2 shrink-0">

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -10,6 +10,25 @@ This file documents frontend patterns and conventions specific to Shisho.
 - Vite for bundling
 - Radix UI primitives with shadcn/ui patterns
 
+## Design Tokens
+
+Use semantic color tokens exclusively. Never use hardcoded Tailwind colors (`dark:bg-neutral-*`, `dark:text-violet-*`, `text-gray-*`, `bg-neutral-*`). The CSS variables in the theme already handle dark mode — manual `dark:` color overrides cause drift.
+
+| Pattern | Classes |
+|---------|---------|
+| Page titles (all pages) | `text-2xl font-semibold` |
+| Dialog titles | `text-sm font-semibold` |
+| Page header margin | `mb-6 md:mb-8` |
+| Card/section padding | `p-4 md:p-6` |
+| Dialog body spacing | `space-y-6` |
+| Border radius (page components) | `rounded-md` (not `rounded-lg`) |
+| Hover backgrounds | `hover:bg-muted/50` |
+| Selected card | `border-primary bg-primary/5` + `border-transparent` when unselected |
+| Selected toggle chip | `border-primary bg-primary/5 text-primary` |
+| Inline warning | `rounded-md bg-destructive/10 border border-destructive/20 p-3` |
+| Danger zone section | `space-y-3 rounded-md border border-destructive/40 p-4 md:p-6` with `text-lg font-semibold text-destructive` title (see `PluginDangerZone.tsx`) |
+| Muted status badge | `bg-muted text-muted-foreground` |
+
 ## Architecture
 
 ### React Router (`app/router.tsx`)

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -219,7 +219,7 @@ For settings/admin pages with title, description, and action buttons:
 ```tsx
 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 md:mb-8">
   <div>
-    <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
+    <h1 className="text-2xl font-semibold mb-1 md:mb-2">
       Page Title
     </h1>
     <p className="text-sm md:text-base text-muted-foreground">
@@ -832,7 +832,7 @@ All metadata detail pages (Series, Person, Genre, Tag) follow a consistent struc
 ```tsx
 <div className="mb-8">
   <div className="flex items-start justify-between gap-4 mb-2">
-    <h1 className="text-3xl font-bold min-w-0 break-words">{name}</h1>
+    <h1 className="text-2xl font-semibold min-w-0 break-words">{name}</h1>
     <div className="flex gap-2 shrink-0">
       <Button onClick={() => setEditOpen(true)} size="sm" variant="outline">
         <Edit className="h-4 w-4 mr-2" />

--- a/app/components/files/FetchChaptersDialog.tsx
+++ b/app/components/files/FetchChaptersDialog.tsx
@@ -133,7 +133,7 @@ interface ErrorStageProps {
 
 const ErrorStage = ({ code, onRetry }: ErrorStageProps) => (
   <div className="space-y-4">
-    <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
+    <div className="rounded-md border border-destructive/20 bg-destructive/10 p-3">
       <p className="text-sm font-medium text-destructive">Lookup failed</p>
       <p className="mt-1 text-sm text-destructive/80">{errorMessage(code)}</p>
     </div>
@@ -219,7 +219,7 @@ const ResultStage = ({
 
       {/* Duration match / mismatch callout */}
       {!detection.withinTolerance ? (
-        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
+        <div className="rounded-md border border-destructive/20 bg-destructive/10 p-3">
           <p className="text-sm font-medium text-destructive">
             Duration differs by {formatDurationMs(diffMs)}. May be a different
             edition.
@@ -287,7 +287,7 @@ const ResultStage = ({
 
       {/* Overwrite warning */}
       {hasChanges && (
-        <div className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3">
+        <div className="rounded-md border border-destructive/20 bg-destructive/10 p-3">
           <p className="text-sm font-medium text-destructive">
             Unsaved changes will be overwritten
           </p>

--- a/app/components/layout/Sidebar.tsx
+++ b/app/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@ const NavItem = ({ item, collapsed }: NavItemProps) => {
         "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
         collapsed && "justify-center px-2",
         item.isActive
-          ? "bg-primary/10 text-primary dark:bg-violet-500/20 dark:text-violet-300"
+          ? "bg-primary/10 text-primary"
           : "text-muted-foreground hover:bg-muted hover:text-foreground",
       )}
       to={item.to}
@@ -73,7 +73,7 @@ const Sidebar = ({ items }: SidebarProps) => {
   return (
     <aside
       className={cn(
-        "sticky top-14 flex h-[calc(100vh-3.5rem)] shrink-0 flex-col border-r border-border bg-muted/30 transition-all duration-200 md:top-16 md:h-[calc(100vh-4rem)] dark:bg-neutral-900/50",
+        "sticky top-14 flex h-[calc(100vh-3.5rem)] shrink-0 flex-col border-r border-border bg-muted/30 transition-all duration-200 md:top-16 md:h-[calc(100vh-4rem)]",
         collapsed ? "w-14" : "w-48",
       )}
     >

--- a/app/components/layout/topNavClasses.ts
+++ b/app/components/layout/topNavClasses.ts
@@ -1,7 +1,7 @@
 import { cn } from "@/libraries/utils";
 
 export const TOP_NAV_WRAPPER = cn(
-  "sticky top-0 z-30 border-b border-border bg-background dark:bg-neutral-900",
+  "sticky top-0 z-30 border-b border-border bg-background",
 );
 export const TOP_NAV_INNER = cn("mx-auto max-w-7xl px-4 md:px-6");
 export const TOP_NAV_ROW = cn("flex h-14 items-center justify-between md:h-16");

--- a/app/components/library/AddToListDialog.tsx
+++ b/app/components/library/AddToListDialog.tsx
@@ -188,7 +188,7 @@ export const AddToListDialog = ({
             </DialogDescription>
           </DialogHeader>
 
-          <DialogBody className="space-y-4">
+          <DialogBody className="space-y-6">
             {/* Search */}
             <div className="relative">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -259,7 +259,7 @@ const BookItem = ({
           {(!coverLoaded || coverError) && (
             <CoverPlaceholder
               className={cn(
-                "absolute inset-0 rounded-sm border border-neutral-300 dark:border-neutral-600",
+                "absolute inset-0 rounded-sm border border-border",
                 isSelected && "ring-2 ring-primary ring-offset-1",
               )}
               variant={placeholderVariant}
@@ -270,7 +270,7 @@ const BookItem = ({
             <img
               alt={`${book.title} Cover`}
               className={cn(
-                "w-full h-full object-cover rounded-sm border-neutral-300 dark:border-neutral-600 border-1",
+                "w-full h-full object-cover rounded-sm border-border border-1",
                 !coverLoaded && "opacity-0",
                 isSelected && "ring-2 ring-primary ring-offset-1",
               )}
@@ -354,7 +354,7 @@ const BookItem = ({
           if (uniqueAuthors.length === 0) return null;
 
           return (
-            <div className="mt-1 text-xs line-clamp-2 text-neutral-500">
+            <div className="mt-1 text-xs line-clamp-2 text-muted-foreground">
               {uniqueAuthors.map((a, i) => (
                 <span key={a.personId}>
                   {a.hasPerson ? (

--- a/app/components/library/BookSelectionList.tsx
+++ b/app/components/library/BookSelectionList.tsx
@@ -117,8 +117,10 @@ function BookSelectionItem({ book, isSelected }: BookSelectionItemProps) {
   return (
     <label
       className={cn(
-        "flex items-start gap-3 p-2 rounded-md cursor-pointer transition-colors overflow-hidden",
-        isSelected ? "bg-primary/10" : "hover:bg-muted/50",
+        "flex items-start gap-3 p-2 rounded-md border cursor-pointer transition-colors overflow-hidden",
+        isSelected
+          ? "border-primary bg-primary/5"
+          : "border-transparent hover:bg-muted/50",
       )}
       htmlFor={`book-${book.id}`}
     >

--- a/app/components/library/BulkDownloadToast.tsx
+++ b/app/components/library/BulkDownloadToast.tsx
@@ -16,7 +16,7 @@ export const BulkDownloadToast = () => {
   const progressPercent = total > 0 ? Math.round((current / total) * 100) : 0;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 bg-background border rounded-lg shadow-lg p-4 w-80">
+    <div className="fixed bottom-4 right-4 z-50 bg-background border rounded-md shadow-lg p-4 w-80">
       <div className="flex items-start justify-between gap-2 mb-2">
         <div className="flex items-center gap-2 text-sm font-medium">
           {status === "completed" ? (

--- a/app/components/library/CoverGalleryTabs.tsx
+++ b/app/components/library/CoverGalleryTabs.tsx
@@ -173,7 +173,7 @@ function CoverGalleryTabs({
                   "px-2.5 py-1 text-xs font-medium rounded-full border cursor-pointer",
                   "transition-all duration-150",
                   file.id === selectedFileId
-                    ? "bg-primary border-primary text-primary-foreground"
+                    ? "border-primary bg-primary/5 text-primary"
                     : "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
                 )}
                 onClick={() => handleTabClick(file.id)}

--- a/app/components/library/CreateListDialog.tsx
+++ b/app/components/library/CreateListDialog.tsx
@@ -143,7 +143,7 @@ export function CreateListDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="space-y-4">
+        <DialogBody className="space-y-6">
           <div className="space-y-2">
             <Label htmlFor="list-name">Name</Label>
             <Input

--- a/app/components/library/DeleteConfirmationDialog.tsx
+++ b/app/components/library/DeleteConfirmationDialog.tsx
@@ -169,7 +169,7 @@ export function DeleteConfirmationDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="space-y-4 min-w-0">
+        <DialogBody className="space-y-6 min-w-0">
           {/* Warning banner */}
           <div className="bg-destructive/10 border border-destructive/20 rounded-md p-3 text-sm text-destructive break-words">
             This action cannot be undone. Files will be permanently deleted from

--- a/app/components/library/DeleteLibraryDialog.tsx
+++ b/app/components/library/DeleteLibraryDialog.tsx
@@ -64,7 +64,7 @@ export function DeleteLibraryDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="space-y-4 min-w-0">
+        <DialogBody className="space-y-6 min-w-0">
           <div className="bg-destructive/10 border border-destructive/20 rounded-md p-3 text-sm text-destructive break-words space-y-2">
             <p>This action is irreversible.</p>
             <p>Files on disk will not be deleted.</p>

--- a/app/components/library/FilterSheet.tsx
+++ b/app/components/library/FilterSheet.tsx
@@ -276,7 +276,7 @@ const FilterContent = ({
               className={cn(
                 "inline-flex h-8 items-center rounded-md border px-3 text-xs font-medium cursor-pointer transition-colors",
                 isSelected
-                  ? "border-primary bg-primary text-primary-foreground"
+                  ? "border-primary bg-primary/5 text-primary"
                   : "border-border bg-card hover:bg-accent",
               )}
               key={option.value}

--- a/app/components/library/GlobalSearch.tsx
+++ b/app/components/library/GlobalSearch.tsx
@@ -82,7 +82,7 @@ const SearchResultCover = ({
   return (
     <div
       className={cn(
-        "flex-shrink-0 bg-neutral-200 dark:bg-neutral-700 rounded overflow-hidden relative",
+        "flex-shrink-0 bg-muted rounded overflow-hidden relative",
         thumbnailClasses,
       )}
     >
@@ -326,9 +326,7 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
         <Link
           className={cn(
             "flex items-center gap-3 px-3 py-2 rounded-md",
-            selectedIndex === index
-              ? "bg-neutral-100 dark:bg-neutral-800"
-              : "hover:bg-neutral-100 dark:hover:bg-neutral-800",
+            selectedIndex === index ? "bg-muted" : "hover:bg-muted",
           )}
           key={`book-${book.id}`}
           onClick={handleResultClick}
@@ -372,9 +370,7 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
       <Link
         className={cn(
           "flex items-center gap-3 px-3 py-2 rounded-md",
-          selectedIndex === index
-            ? "bg-neutral-100 dark:bg-neutral-800"
-            : "hover:bg-neutral-100 dark:hover:bg-neutral-800",
+          selectedIndex === index ? "bg-muted" : "hover:bg-muted",
         )}
         key={`series-${series.id}`}
         onClick={handleResultClick}
@@ -414,9 +410,7 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
       <Link
         className={cn(
           "flex items-center gap-3 px-3 py-2 rounded-md",
-          selectedIndex === index
-            ? "bg-neutral-100 dark:bg-neutral-800"
-            : "hover:bg-neutral-100 dark:hover:bg-neutral-800",
+          selectedIndex === index ? "bg-muted" : "hover:bg-muted",
         )}
         key={`person-${person.id}`}
         onClick={handleResultClick}

--- a/app/components/library/GlobalSearch.tsx
+++ b/app/components/library/GlobalSearch.tsx
@@ -472,7 +472,7 @@ const GlobalSearch = ({ fullWidth = false, onClose }: GlobalSearchProps) => {
       {isOpen && debouncedQuery && (
         <div
           className={cn(
-            "bg-background border border-border rounded-lg shadow-lg z-50 max-h-96 overflow-y-auto",
+            "bg-background border border-border rounded-md shadow-lg z-50 max-h-96 overflow-y-auto",
             fullWidth
               ? "fixed left-4 right-4 top-28"
               : "absolute top-full mt-2 left-0 w-80",

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -196,7 +196,7 @@ export function IdentifyBookDialog({
         )}
 
         {step === "search" && (
-          <DialogBody className="space-y-4">
+          <DialogBody className="space-y-6">
             {/* File selector — only shown on the search step. The review step
                 scopes to the file already chosen here, so re-presenting the
                 picker would be misleading; switching files always means

--- a/app/components/library/LibraryListPicker.tsx
+++ b/app/components/library/LibraryListPicker.tsx
@@ -77,7 +77,7 @@ const LibraryListPicker = () => {
                     group relative flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm transition-colors cursor-pointer
                     ${
                       isActive
-                        ? "bg-primary/10 text-primary dark:bg-primary/15 dark:text-violet-300"
+                        ? "bg-primary/10 text-primary"
                         : "text-foreground hover:bg-accent"
                     }
                   `}
@@ -89,7 +89,7 @@ const LibraryListPicker = () => {
                       flex h-7 w-7 shrink-0 items-center justify-center rounded-md
                       ${
                         isActive
-                          ? "bg-primary text-primary-foreground dark:bg-violet-400 dark:text-neutral-900"
+                          ? "bg-primary text-primary-foreground"
                           : "bg-muted text-muted-foreground group-hover:bg-muted/80"
                       }
                     `}
@@ -100,7 +100,7 @@ const LibraryListPicker = () => {
                     {library.name}
                   </span>
                   {isActive && (
-                    <Check className="h-4 w-4 shrink-0 text-primary dark:text-violet-300" />
+                    <Check className="h-4 w-4 shrink-0 text-primary" />
                   )}
                 </button>
               );
@@ -128,7 +128,7 @@ const LibraryListPicker = () => {
                       group relative flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm transition-colors
                       ${
                         isActive
-                          ? "bg-primary/10 text-primary dark:bg-primary/15 dark:text-violet-300"
+                          ? "bg-primary/10 text-primary"
                           : "text-foreground hover:bg-accent/50"
                       }
                     `}
@@ -140,7 +140,7 @@ const LibraryListPicker = () => {
                         flex h-7 w-7 shrink-0 items-center justify-center rounded-md
                         ${
                           isActive
-                            ? "bg-primary text-primary-foreground dark:bg-violet-400 dark:text-neutral-900"
+                            ? "bg-primary text-primary-foreground"
                             : "bg-background text-muted-foreground group-hover:bg-background/80"
                         }
                       `}
@@ -153,13 +153,13 @@ const LibraryListPicker = () => {
                     <span
                       className={`
                         shrink-0 tabular-nums text-xs
-                        ${isActive ? "text-primary/70 dark:text-violet-300/70" : "text-muted-foreground"}
+                        ${isActive ? "text-primary/70" : "text-muted-foreground"}
                       `}
                     >
                       {list.book_count}
                     </span>
                     {isActive && (
-                      <Check className="h-4 w-4 shrink-0 text-primary dark:text-violet-300" />
+                      <Check className="h-4 w-4 shrink-0 text-primary" />
                     )}
                   </Link>
                 );

--- a/app/components/library/LoadingSpinner.tsx
+++ b/app/components/library/LoadingSpinner.tsx
@@ -3,7 +3,7 @@ const LoadingSpinner = () => {
     <div className="flex justify-center py-8" role="status">
       <svg
         aria-hidden="true"
-        className="w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-primary dark:fill-violet-300"
+        className="w-8 h-8 text-muted-foreground/20 animate-spin fill-primary"
         fill="none"
         viewBox="0 0 100 101"
         xmlns="http://www.w3.org/2000/svg"

--- a/app/components/library/LogViewer.tsx
+++ b/app/components/library/LogViewer.tsx
@@ -18,7 +18,7 @@ export interface LogViewerEntry {
 }
 
 const levelColors: Record<string, string> = {
-  debug: "bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400",
+  debug: "bg-muted text-muted-foreground",
   info: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
   warn: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400",
   error: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
@@ -174,7 +174,7 @@ const LogViewer = ({
   return (
     <div className="relative">
       <div
-        className={`overflow-y-auto border border-border rounded-md bg-muted/20 dark:bg-neutral-950/50 ${className}`}
+        className={`overflow-y-auto border border-border rounded-md bg-muted/20 ${className}`}
         onScroll={handleScroll}
         ref={scrollRef}
       >

--- a/app/components/library/Logo.tsx
+++ b/app/components/library/Logo.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/libraries/utils";
 
 const ShelfIcon = ({ className }: { className?: string }) => (
   <svg
-    className={cn("text-primary dark:text-violet-300", className)}
+    className={cn("text-primary", className)}
     fill="none"
     viewBox="0 0 48 48"
     xmlns="http://www.w3.org/2000/svg"
@@ -65,7 +65,7 @@ const Logo = ({ asLink = false, className, size = "md" }: LogoProps) => {
         Shisho
         <span
           className={cn(
-            "align-super font-normal text-primary dark:text-violet-300 ml-0.5",
+            "align-super font-normal text-primary ml-0.5",
             superscriptSizeClasses[size],
           )}
         >

--- a/app/components/library/MergeBooksDialog.tsx
+++ b/app/components/library/MergeBooksDialog.tsx
@@ -152,7 +152,7 @@ export function MergeBooksDialog({
 
         {bookQueryError && (
           <DialogBody>
-            <div className="flex items-start gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+            <div className="flex items-start gap-3 p-3 rounded-md bg-destructive/10 border border-destructive/20">
               <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
               <div className="text-sm">
                 <p className="font-medium text-destructive">
@@ -256,7 +256,7 @@ export function MergeBooksDialog({
             <>
               <DialogBody className="space-y-4">
                 {/* Warning banner */}
-                <div className="flex items-start gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+                <div className="flex items-start gap-3 p-3 rounded-md bg-destructive/10 border border-destructive/20">
                   <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
                   <div className="text-sm">
                     <p className="font-medium text-destructive">
@@ -273,7 +273,7 @@ export function MergeBooksDialog({
 
                 {/* Summary */}
                 <div className="space-y-3">
-                  <div className="p-3 rounded-lg border bg-card">
+                  <div className="p-3 rounded-md border bg-card">
                     <div className="text-sm text-muted-foreground mb-1">
                       Target book
                     </div>

--- a/app/components/library/MergeBooksDialog.tsx
+++ b/app/components/library/MergeBooksDialog.tsx
@@ -168,7 +168,7 @@ export function MergeBooksDialog({
 
         {!isLoadingBooks && !bookQueryError && step === "select" && (
           <>
-            <DialogBody className="space-y-4">
+            <DialogBody className="space-y-6">
               <div className="space-y-2">
                 <Label>Select target book</Label>
                 <p className="text-sm text-muted-foreground">
@@ -254,7 +254,7 @@ export function MergeBooksDialog({
           step === "confirm" &&
           targetBook && (
             <>
-              <DialogBody className="space-y-4">
+              <DialogBody className="space-y-6">
                 {/* Warning banner */}
                 <div className="flex items-start gap-3 p-3 rounded-md bg-destructive/10 border border-destructive/20">
                   <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />

--- a/app/components/library/MergeBooksDialog.tsx
+++ b/app/components/library/MergeBooksDialog.tsx
@@ -188,8 +188,10 @@ export function MergeBooksDialog({
                     return (
                       <label
                         className={cn(
-                          "flex items-start gap-3 p-2 rounded-md cursor-pointer transition-colors",
-                          isSelected ? "bg-primary/10" : "hover:bg-muted/50",
+                          "flex items-start gap-3 p-2 rounded-md border cursor-pointer transition-colors",
+                          isSelected
+                            ? "border-primary bg-primary/5"
+                            : "border-transparent hover:bg-muted/50",
                         )}
                         htmlFor={`book-${book.id}`}
                         key={book.id}

--- a/app/components/library/MergeIntoDialog.tsx
+++ b/app/components/library/MergeIntoDialog.tsx
@@ -89,7 +89,7 @@ export function MergeIntoDialog({
         </DialogHeader>
 
         <DialogBody className="space-y-4">
-          <div className="flex items-start gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+          <div className="flex items-start gap-3 p-3 rounded-md bg-destructive/10 border border-destructive/20">
             <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
             <div className="text-sm">
               <p className="font-medium text-destructive">

--- a/app/components/library/MergeIntoDialog.tsx
+++ b/app/components/library/MergeIntoDialog.tsx
@@ -88,7 +88,7 @@ export function MergeIntoDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="space-y-4">
+        <DialogBody className="space-y-6">
           <div className="flex items-start gap-3 p-3 rounded-md bg-destructive/10 border border-destructive/20">
             <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
             <div className="text-sm">

--- a/app/components/library/MetadataEditDialog.tsx
+++ b/app/components/library/MetadataEditDialog.tsx
@@ -157,7 +157,7 @@ export function MetadataEditDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="space-y-4">
+        <DialogBody className="space-y-6">
           <div className="space-y-2">
             <Label htmlFor="name">Name</Label>
             <Input

--- a/app/components/library/MobileDrawer.tsx
+++ b/app/components/library/MobileDrawer.tsx
@@ -35,7 +35,7 @@ const NavItem = ({ to, icon, label, isActive, onClick }: NavItemProps) => (
     className={cn(
       "flex items-center gap-4 px-4 py-3.5 text-base font-medium transition-colors active:bg-muted/50",
       isActive
-        ? "bg-primary/10 text-primary dark:bg-violet-500/20 dark:text-violet-300"
+        ? "bg-primary/10 text-primary"
         : "text-foreground hover:bg-muted",
     )}
     onClick={onClick}
@@ -154,7 +154,7 @@ const MobileDrawer = () => {
       <aside
         aria-label="Mobile navigation"
         className={cn(
-          "fixed inset-y-0 left-0 z-50 w-72 bg-background dark:bg-neutral-900 shadow-2xl transition-transform duration-300 ease-out md:hidden flex flex-col",
+          "fixed inset-y-0 left-0 z-50 w-72 bg-background shadow-2xl transition-transform duration-300 ease-out md:hidden flex flex-col",
           isOpen ? "translate-x-0" : "-translate-x-full",
         )}
       >
@@ -225,7 +225,7 @@ const MobileDrawer = () => {
                           className={cn(
                             "flex items-center gap-3 w-full px-6 py-2.5 text-left transition-colors",
                             isActive
-                              ? "bg-primary/10 text-primary dark:bg-violet-500/20 dark:text-violet-300"
+                              ? "bg-primary/10 text-primary"
                               : "hover:bg-muted",
                           )}
                           key={library.id}
@@ -254,7 +254,7 @@ const MobileDrawer = () => {
                           className={cn(
                             "flex items-center gap-3 w-full px-6 py-2.5 text-left transition-colors",
                             isActive
-                              ? "bg-primary/10 text-primary dark:bg-violet-500/20 dark:text-violet-300"
+                              ? "bg-primary/10 text-primary"
                               : "hover:bg-muted",
                           )}
                           key={list.id}
@@ -266,7 +266,7 @@ const MobileDrawer = () => {
                             className={cn(
                               "shrink-0 tabular-nums text-xs",
                               isActive
-                                ? "text-primary/70 dark:text-violet-300/70"
+                                ? "text-primary/70"
                                 : "text-muted-foreground",
                             )}
                           >

--- a/app/components/library/MoveFilesDialog.tsx
+++ b/app/components/library/MoveFilesDialog.tsx
@@ -95,7 +95,7 @@ export function MoveFilesDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="space-y-4">
+        <DialogBody className="space-y-6">
           {willDeleteBook ? (
             <div className="flex items-start gap-3 p-3 rounded-md bg-destructive/10 border border-destructive/20">
               <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />

--- a/app/components/library/MoveFilesDialog.tsx
+++ b/app/components/library/MoveFilesDialog.tsx
@@ -97,7 +97,7 @@ export function MoveFilesDialog({
 
         <DialogBody className="space-y-4">
           {willDeleteBook ? (
-            <div className="flex items-start gap-3 p-3 rounded-lg bg-destructive/10 border border-destructive/20">
+            <div className="flex items-start gap-3 p-3 rounded-md bg-destructive/10 border border-destructive/20">
               <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
               <div className="text-sm">
                 <p className="font-medium text-destructive">
@@ -107,7 +107,7 @@ export function MoveFilesDialog({
               </div>
             </div>
           ) : (
-            <div className="flex items-start gap-3 p-3 rounded-lg bg-muted/50 border">
+            <div className="flex items-start gap-3 p-3 rounded-md bg-muted/50 border">
               <Info className="h-5 w-5 text-muted-foreground shrink-0 mt-0.5" />
               <p className="text-sm text-muted-foreground">{warningMessage}</p>
             </div>

--- a/app/components/library/MoveToPositionDialog.tsx
+++ b/app/components/library/MoveToPositionDialog.tsx
@@ -68,7 +68,7 @@ export const MoveToPositionDialog = ({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="space-y-4">
+        <DialogBody className="space-y-6">
           <div className="space-y-2">
             <Label htmlFor="position">Position (1-{totalBooks})</Label>
             <Input

--- a/app/components/library/RescanDialog.tsx
+++ b/app/components/library/RescanDialog.tsx
@@ -82,7 +82,7 @@ export function RescanDialog({
           >
             {modes.map((mode) => (
               <Label
-                className="flex items-start gap-3 rounded-lg border p-3 cursor-pointer has-[[data-state=checked]]:border-primary"
+                className="flex items-start gap-3 rounded-md border p-3 cursor-pointer has-[[data-state=checked]]:border-primary"
                 htmlFor={`rescan-${entityType}-${mode.value}`}
                 key={mode.value}
               >

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -268,7 +268,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
   );
 
   return (
-    <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-50 bg-background border rounded-lg shadow-lg px-3 py-2 flex items-center gap-3 max-w-[calc(100vw-2rem)]">
+    <div className="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-50 bg-background border rounded-md shadow-lg px-3 py-2 flex items-center gap-3 max-w-[calc(100vw-2rem)]">
       <span className="text-sm font-medium whitespace-nowrap tabular-nums">
         {bookLabel}
       </span>

--- a/app/components/pages/AdminCache.tsx
+++ b/app/components/pages/AdminCache.tsx
@@ -64,9 +64,7 @@ const AdminCache = () => {
   return (
     <div>
       <div className="mb-6 md:mb-8">
-        <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
-          Cache
-        </h1>
+        <h1 className="text-2xl font-semibold mb-1 md:mb-2">Cache</h1>
         <p className="text-sm md:text-base text-muted-foreground">
           Inspect and clear server caches. Content will be regenerated on next
           access.

--- a/app/components/pages/AdminJobs.tsx
+++ b/app/components/pages/AdminJobs.tsx
@@ -26,7 +26,7 @@ const getStatusColor = (status: string) => {
     case "failed":
       return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400";
     default:
-      return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400";
+      return "bg-muted text-muted-foreground";
   }
 };
 

--- a/app/components/pages/AdminJobs.tsx
+++ b/app/components/pages/AdminJobs.tsx
@@ -135,7 +135,7 @@ const AdminJobs = () => {
     <div>
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 md:mb-8">
         <div>
-          <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
+          <h1 className="text-2xl font-semibold mb-1 md:mb-2">
             Background Jobs
           </h1>
           <p className="text-sm md:text-base text-muted-foreground">

--- a/app/components/pages/AdminLibraries.tsx
+++ b/app/components/pages/AdminLibraries.tsx
@@ -96,9 +96,7 @@ const AdminLibraries = () => {
     <div>
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 md:mb-8">
         <div>
-          <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
-            Libraries
-          </h1>
+          <h1 className="text-2xl font-semibold mb-1 md:mb-2">Libraries</h1>
           <p className="text-sm md:text-base text-muted-foreground">
             Manage your media libraries and their settings.
           </p>

--- a/app/components/pages/AdminLogs.tsx
+++ b/app/components/pages/AdminLogs.tsx
@@ -55,9 +55,7 @@ const AdminLogs = () => {
   return (
     <div className="flex flex-col h-[calc(100vh-12rem)]">
       <div className="mb-4">
-        <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
-          Server Logs
-        </h1>
+        <h1 className="text-2xl font-semibold mb-1 md:mb-2">Server Logs</h1>
         <p className="text-sm md:text-base text-muted-foreground">
           Real-time server logs from the current session.
         </p>

--- a/app/components/pages/AdminReviewCriteria.tsx
+++ b/app/components/pages/AdminReviewCriteria.tsx
@@ -232,9 +232,7 @@ const AdminReviewCriteria = () => {
 
   const pageHeader = (
     <div className="mb-6 md:mb-8">
-      <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
-        Review Criteria
-      </h1>
+      <h1 className="text-2xl font-semibold mb-1 md:mb-2">Review Criteria</h1>
       <p className="text-sm md:text-base text-muted-foreground">
         Choose which metadata fields must be present for a book to be considered
         reviewed.

--- a/app/components/pages/AdminSettings.tsx
+++ b/app/components/pages/AdminSettings.tsx
@@ -69,9 +69,7 @@ const AdminSettings = () => {
   return (
     <div>
       <div className="mb-6 md:mb-8">
-        <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
-          Server Settings
-        </h1>
+        <h1 className="text-2xl font-semibold mb-1 md:mb-2">Server Settings</h1>
         <p className="text-sm md:text-base text-muted-foreground">
           Current system configuration. Settings can be changed via the config
           file or environment variables.

--- a/app/components/pages/AdminUsers.tsx
+++ b/app/components/pages/AdminUsers.tsx
@@ -130,9 +130,7 @@ const AdminUsers = () => {
       <div>
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 md:mb-8">
           <div>
-            <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
-              Users
-            </h1>
+            <h1 className="text-2xl font-semibold mb-1 md:mb-2">Users</h1>
             <p className="text-sm md:text-base text-muted-foreground">
               Manage user accounts and permissions.
             </p>
@@ -166,9 +164,7 @@ const AdminUsers = () => {
       <div>
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 md:mb-8">
           <div>
-            <h2 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
-              Roles
-            </h2>
+            <h2 className="text-2xl font-semibold mb-1 md:mb-2">Roles</h2>
             <p className="text-sm md:text-base text-muted-foreground">
               Define roles with custom permissions.
             </p>

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1243,7 +1243,7 @@ const BookDetail = () => {
                   {book.book_series.map((bs) => (
                     <div className="flex items-center gap-2" key={bs.id}>
                       <Link
-                        className="text-sm font-medium text-primary hover:text-primary/80 hover:underline dark:text-violet-300 dark:hover:text-violet-400"
+                        className="text-sm font-medium text-primary hover:text-primary/80 hover:underline"
                         to={`/libraries/${libraryId}/series/${bs.series_id}`}
                       >
                         {bs.series?.name ?? "Unknown Series"}

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1566,7 +1566,7 @@ const BookDetail = () => {
 
       {/* File selection action bar */}
       {selectedFileIds.size > 0 && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-background border rounded-lg shadow-lg p-3 flex items-center gap-3 z-50">
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-background border rounded-md shadow-lg p-3 flex items-center gap-3 z-50">
           <span className="text-sm text-muted-foreground">
             {selectedFileIds.size} file
             {selectedFileIds.size !== 1 ? "s" : ""} selected

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1098,9 +1098,7 @@ const BookDetail = () => {
         <div className="lg:col-span-2 space-y-4 md:space-y-6">
           <div>
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-2">
-              <h1 className="text-2xl md:text-3xl font-semibold">
-                {book.title}
-              </h1>
+              <h1 className="text-2xl font-semibold">{book.title}</h1>
               {/*
                 The relative wrapper exists so AddToListPopover can be opened
                 from the dropdown menu's "Add to list" item: its trigger is an

--- a/app/components/pages/CreateLibrary.tsx
+++ b/app/components/pages/CreateLibrary.tsx
@@ -165,14 +165,14 @@ const CreateLibrary = () => {
     <div>
       <TopNav />
       <div className="max-w-7xl w-full mx-auto px-6 py-8">
-        <div className="mb-8">
+        <div className="mb-6 md:mb-8">
           <h1 className="text-2xl font-semibold mb-2">Create Library</h1>
           <p className="text-muted-foreground">
             Create a new library to organize your book collection
           </p>
         </div>
 
-        <div className="max-w-2xl space-y-6 border border-border rounded-md p-6">
+        <div className="max-w-2xl space-y-6 border border-border rounded-md p-4 md:p-6">
           {/* Library Name */}
           <div className="space-y-2">
             <Label htmlFor="library-name">Library Name</Label>

--- a/app/components/pages/CreateUser.tsx
+++ b/app/components/pages/CreateUser.tsx
@@ -149,12 +149,12 @@ const CreateUser = () => {
 
   return (
     <div>
-      <div className="mb-8">
+      <div className="mb-6 md:mb-8">
         <h1 className="text-2xl font-semibold mb-2">Create User</h1>
         <p className="text-muted-foreground">Add a new user to the system</p>
       </div>
 
-      <div className="max-w-2xl space-y-6 border border-border rounded-md p-6">
+      <div className="max-w-2xl space-y-6 border border-border rounded-md p-4 md:p-6">
         {/* Basic Info */}
         <div className="space-y-4">
           <h2 className="text-lg font-medium">Account Information</h2>

--- a/app/components/pages/FileDetail.tsx
+++ b/app/components/pages/FileDetail.tsx
@@ -188,7 +188,7 @@ const FileDetail = () => {
 
       {/* File title with Edit/Save/Cancel buttons */}
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-6">
-        <h1 className="text-2xl md:text-3xl font-semibold">{filename}</h1>
+        <h1 className="text-2xl font-semibold">{filename}</h1>
         <div className="flex items-center gap-2 shrink-0">
           {/* Read button for CBZ, EPUB, and PDF files */}
           {(file.file_type === FileTypeCBZ ||

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -173,7 +173,7 @@ const GenreDetail = () => {
       {/* Genre Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-3xl font-bold min-w-0 break-words">
+          <h1 className="text-2xl font-semibold min-w-0 break-words">
             {genre.name}
           </h1>
           <div className="flex gap-2 shrink-0">

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -171,7 +171,7 @@ const GenreDetail = () => {
       />
 
       {/* Genre Header */}
-      <div className="mb-8">
+      <div className="mb-6 md:mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
           <h1 className="text-2xl font-semibold min-w-0 break-words">
             {genre.name}

--- a/app/components/pages/GenresList.tsx
+++ b/app/components/pages/GenresList.tsx
@@ -75,7 +75,7 @@ const GenresList = () => {
 
     return (
       <Link
-        className="flex items-center justify-between p-3 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+        className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
         key={genre.id}
         to={`/libraries/${libraryId}/genres/${genre.id}`}
       >

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -606,11 +606,11 @@ const HomeContent = () => {
           </div>
           <div className="flex-1" />
           {isSelectionMode ? (
-            <Button onClick={exitSelectionMode} variant="outline">
+            <Button onClick={exitSelectionMode} size="sm" variant="outline">
               Cancel
             </Button>
           ) : (
-            <Button onClick={enterSelectionMode} variant="outline">
+            <Button onClick={enterSelectionMode} size="sm" variant="outline">
               <CheckSquare className="h-4 w-4" />
               Select
             </Button>

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -123,7 +123,7 @@ const ImprintDetail = () => {
       {/* Imprint Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-3xl font-bold min-w-0 break-words">
+          <h1 className="text-2xl font-semibold min-w-0 break-words">
             {imprint.name}
           </h1>
           <div className="flex gap-2 shrink-0">

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -121,7 +121,7 @@ const ImprintDetail = () => {
       />
 
       {/* Imprint Header */}
-      <div className="mb-8">
+      <div className="mb-6 md:mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
           <h1 className="text-2xl font-semibold min-w-0 break-words">
             {imprint.name}

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -169,7 +169,7 @@ const ImprintDetail = () => {
             <div className="space-y-3">
               {imprintFilesQuery.data.map((file) => (
                 <div
-                  className="border-l-4 border-l-primary dark:border-l-violet-300 pl-4 py-2"
+                  className="border-l-4 border-l-primary pl-4 py-2"
                   key={file.id}
                 >
                   <div className="flex items-center justify-between gap-4">

--- a/app/components/pages/ImprintsList.tsx
+++ b/app/components/pages/ImprintsList.tsx
@@ -73,7 +73,7 @@ const ImprintsList = () => {
 
     return (
       <Link
-        className="flex items-center justify-between p-3 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+        className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
         key={imprint.id}
         to={`/libraries/${libraryId}/imprints/${imprint.id}`}
       >

--- a/app/components/pages/JobDetail.tsx
+++ b/app/components/pages/JobDetail.tsx
@@ -35,7 +35,7 @@ const getLevelColor = (level: string) => {
     case JobLogLevelFatal:
       return "bg-red-700/30 text-red-300";
     default:
-      return "bg-gray-500/20 text-gray-400";
+      return "bg-muted text-muted-foreground";
   }
 };
 
@@ -50,7 +50,7 @@ const getStatusColor = (status: string) => {
     case "failed":
       return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400";
     default:
-      return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400";
+      return "bg-muted text-muted-foreground";
   }
 };
 

--- a/app/components/pages/LibrarySettings.tsx
+++ b/app/components/pages/LibrarySettings.tsx
@@ -422,9 +422,9 @@ const LibrarySettings = () => {
 
       {canDeleteLibrary && libraryQuery.data && (
         <>
-          <section className="max-w-2xl mt-8 border border-destructive/40 rounded-md p-4 md:p-6">
-            <h2 className="text-base md:text-lg font-semibold text-destructive mb-1">
-              Danger Zone
+          <section className="max-w-2xl mt-8 space-y-3 rounded-md border border-destructive/40 p-4 md:p-6">
+            <h2 className="text-lg font-semibold text-destructive">
+              Danger zone
             </h2>
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-2">
               <div className="min-w-0">

--- a/app/components/pages/LibrarySettings.tsx
+++ b/app/components/pages/LibrarySettings.tsx
@@ -247,14 +247,14 @@ const LibrarySettings = () => {
 
   return (
     <LibraryLayout>
-      <div className="mb-8">
+      <div className="mb-6 md:mb-8">
         <h1 className="text-2xl font-semibold mb-2">Library Settings</h1>
         <p className="text-muted-foreground">
           Manage library name, paths, and scanning behavior
         </p>
       </div>
 
-      <div className="max-w-2xl space-y-6 border border-border rounded-md p-6">
+      <div className="max-w-2xl space-y-6 border border-border rounded-md p-4 md:p-6">
         {/* Library Name */}
         <div className="space-y-2">
           <Label htmlFor="library-name">Library Name</Label>

--- a/app/components/pages/LibrarySettings.tsx
+++ b/app/components/pages/LibrarySettings.tsx
@@ -426,7 +426,7 @@ const LibrarySettings = () => {
             <h2 className="text-lg font-semibold text-destructive">
               Danger zone
             </h2>
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mt-2">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <div className="min-w-0">
                 <p className="font-medium">Delete this library</p>
                 <p className="text-sm text-muted-foreground">

--- a/app/components/pages/ListDetail.tsx
+++ b/app/components/pages/ListDetail.tsx
@@ -215,7 +215,7 @@ const ListDetail = () => {
         {/* List Header */}
         <div className="mb-6 md:mb-8">
           <div className="flex flex-col gap-3 mb-2">
-            <h1 className="text-2xl md:text-3xl font-bold min-w-0 break-words">
+            <h1 className="text-2xl font-semibold min-w-0 break-words">
               {list.name}
             </h1>
             <div className="flex gap-2">

--- a/app/components/pages/ListDetail.tsx
+++ b/app/components/pages/ListDetail.tsx
@@ -191,9 +191,7 @@ const ListDetail = () => {
         <TopNav />
         <div className="max-w-7xl w-full mx-auto px-4 md:px-6 py-4 md:py-8">
           <div className="text-center">
-            <h1 className="text-xl md:text-2xl font-semibold mb-4">
-              List Not Found
-            </h1>
+            <h1 className="text-2xl font-semibold mb-4">List Not Found</h1>
             <p className="text-muted-foreground">
               The list you're looking for doesn't exist or may have been
               removed.

--- a/app/components/pages/ListsIndex.tsx
+++ b/app/components/pages/ListsIndex.tsx
@@ -66,7 +66,7 @@ const ListsIndex = () => {
 
     return (
       <Link
-        className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 p-3 md:p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors"
+        className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 p-3 md:p-4 rounded-md border bg-card hover:bg-muted/50 transition-colors"
         key={list.id}
         to={`/lists/${list.id}`}
       >
@@ -93,7 +93,7 @@ const ListsIndex = () => {
   const renderTemplateCard = (template: ListTemplate) => {
     return (
       <button
-        className="flex flex-col items-start gap-2 p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors text-left cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        className="flex flex-col items-start gap-2 p-4 rounded-md border bg-card hover:bg-muted/50 transition-colors text-left cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         disabled={createFromTemplateMutation.isPending}
         key={template.name}
         onClick={() => handleCreateFromTemplate(template)}

--- a/app/components/pages/ListsIndex.tsx
+++ b/app/components/pages/ListsIndex.tsx
@@ -113,9 +113,7 @@ const ListsIndex = () => {
       <div className="max-w-3xl w-full mx-auto px-4 md:px-6 py-4 md:py-8">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 md:mb-8">
           <div>
-            <h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
-              Lists
-            </h1>
+            <h1 className="text-2xl font-semibold mb-1 md:mb-2">Lists</h1>
             <p className="text-sm md:text-base text-muted-foreground">
               Organize your books into custom collections
             </p>

--- a/app/components/pages/ListsIndex.tsx
+++ b/app/components/pages/ListsIndex.tsx
@@ -66,7 +66,7 @@ const ListsIndex = () => {
 
     return (
       <Link
-        className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 p-3 md:p-4 rounded-lg border bg-card hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
+        className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4 p-3 md:p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors"
         key={list.id}
         to={`/lists/${list.id}`}
       >
@@ -93,7 +93,7 @@ const ListsIndex = () => {
   const renderTemplateCard = (template: ListTemplate) => {
     return (
       <button
-        className="flex flex-col items-start gap-2 p-4 rounded-lg border bg-card hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors text-left cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        className="flex flex-col items-start gap-2 p-4 rounded-lg border bg-card hover:bg-muted/50 transition-colors text-left cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
         disabled={createFromTemplateMutation.isPending}
         key={template.name}
         onClick={() => handleCreateFromTemplate(template)}

--- a/app/components/pages/Login.tsx
+++ b/app/components/pages/Login.tsx
@@ -69,7 +69,7 @@ const Login = () => {
     <div className="min-h-dvh flex items-center justify-center bg-background px-4 py-8">
       <Toaster richColors />
       <div className="w-full max-w-md">
-        <div className="flex flex-col items-center mb-8">
+        <div className="flex flex-col items-center mb-6 md:mb-8">
           <Logo className="mb-2" size="lg" />
           <p className="text-muted-foreground text-center">
             Sign in to access your library

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -183,7 +183,7 @@ const PersonDetail = () => {
       />
 
       {/* Person Header */}
-      <div className="mb-8">
+      <div className="mb-6 md:mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
           <h1 className="text-2xl font-semibold min-w-0 break-words">
             {person.name}

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -280,7 +280,7 @@ const PersonDetail = () => {
             <div className="space-y-2">
               {narratedFilesQuery.data.map((file) => (
                 <Link
-                  className="flex items-center justify-between p-4 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-lg border border-border hover:bg-muted/50 transition-colors"
                   key={file.id}
                   to={`/libraries/${libraryId}/books/${file.book_id}`}
                 >

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -280,7 +280,7 @@ const PersonDetail = () => {
             <div className="space-y-2">
               {narratedFilesQuery.data.map((file) => (
                 <Link
-                  className="flex items-center justify-between p-4 rounded-lg border border-border hover:bg-muted/50 transition-colors"
+                  className="flex items-center justify-between p-4 rounded-md border border-border hover:bg-muted/50 transition-colors"
                   key={file.id}
                   to={`/libraries/${libraryId}/books/${file.book_id}`}
                 >

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -185,7 +185,7 @@ const PersonDetail = () => {
       {/* Person Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-3xl font-bold min-w-0 break-words">
+          <h1 className="text-2xl font-semibold min-w-0 break-words">
             {person.name}
           </h1>
           <div className="flex gap-2 shrink-0">

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -66,7 +66,7 @@ const PersonList = () => {
 
     return (
       <Link
-        className="flex items-center justify-between p-4 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
+        className="flex items-center justify-between p-4 rounded-lg border border-border hover:bg-muted/50 transition-colors"
         key={person.id}
         to={`/libraries/${libraryId}/people/${person.id}`}
       >

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -66,7 +66,7 @@ const PersonList = () => {
 
     return (
       <Link
-        className="flex items-center justify-between p-4 rounded-lg border border-border hover:bg-muted/50 transition-colors"
+        className="flex items-center justify-between p-4 rounded-md border border-border hover:bg-muted/50 transition-colors"
         key={person.id}
         to={`/libraries/${libraryId}/people/${person.id}`}
       >

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -121,7 +121,7 @@ const PublisherDetail = () => {
       />
 
       {/* Publisher Header */}
-      <div className="mb-8">
+      <div className="mb-6 md:mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
           <h1 className="text-2xl font-semibold min-w-0 break-words">
             {publisher.name}

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -169,7 +169,7 @@ const PublisherDetail = () => {
             <div className="space-y-3">
               {publisherFilesQuery.data.map((file) => (
                 <div
-                  className="border-l-4 border-l-primary dark:border-l-violet-300 pl-4 py-2"
+                  className="border-l-4 border-l-primary pl-4 py-2"
                   key={file.id}
                 >
                   <div className="flex items-center justify-between gap-4">

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -123,7 +123,7 @@ const PublisherDetail = () => {
       {/* Publisher Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-3xl font-bold min-w-0 break-words">
+          <h1 className="text-2xl font-semibold min-w-0 break-words">
             {publisher.name}
           </h1>
           <div className="flex gap-2 shrink-0">

--- a/app/components/pages/PublishersList.tsx
+++ b/app/components/pages/PublishersList.tsx
@@ -73,7 +73,7 @@ const PublishersList = () => {
 
     return (
       <Link
-        className="flex items-center justify-between p-3 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+        className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
         key={publisher.id}
         to={`/libraries/${libraryId}/publishers/${publisher.id}`}
       >

--- a/app/components/pages/SecuritySettings.tsx
+++ b/app/components/pages/SecuritySettings.tsx
@@ -173,7 +173,7 @@ const SecuritySettings = () => {
 
         <div className="max-w-2xl space-y-6">
           {/* Password Change */}
-          <div className="rounded-md border border-border p-6">
+          <div className="rounded-md border border-border p-4 md:p-6">
             <h2 className="mb-4 text-lg font-semibold">Change Password</h2>
             <div className="space-y-4">
               <div className="space-y-2">
@@ -249,7 +249,7 @@ function EReaderSection() {
   );
 
   return (
-    <div className="rounded-md border border-border p-6">
+    <div className="rounded-md border border-border p-4 md:p-6">
       <div className="mb-4 flex items-start justify-between">
         <div>
           <h2 className="text-lg font-semibold">eReader Browser Access</h2>
@@ -506,7 +506,7 @@ function KoboSyncSection() {
   );
 
   return (
-    <div className="rounded-md border border-border p-6">
+    <div className="rounded-md border border-border p-4 md:p-6">
       <div className="mb-4 flex items-start justify-between">
         <div>
           <h2 className="text-lg font-semibold">Kobo Wireless Sync</h2>

--- a/app/components/pages/SecuritySettings.tsx
+++ b/app/components/pages/SecuritySettings.tsx
@@ -109,7 +109,7 @@ const SecuritySettings = () => {
     return (
       <div className="min-h-dvh flex items-center justify-center bg-background px-4 py-8">
         <div className="w-full max-w-md">
-          <div className="flex flex-col items-center mb-8">
+          <div className="flex flex-col items-center mb-6 md:mb-8">
             <Logo className="mb-2" size="lg" />
             <h1 className="text-xl font-semibold mb-1">
               Password Reset Required
@@ -164,7 +164,7 @@ const SecuritySettings = () => {
     <div>
       <TopNav />
       <div className="mx-auto w-full max-w-7xl px-6 py-8">
-        <div className="mb-8">
+        <div className="mb-6 md:mb-8">
           <h1 className="mb-2 text-2xl font-semibold">Security Settings</h1>
           <p className="text-muted-foreground">
             Manage your password and API keys
@@ -466,7 +466,7 @@ function EReaderSetupDialog({
         {generateShortUrl.isPending ? (
           <DialogBody>Generating URL...</DialogBody>
         ) : shortUrl ? (
-          <DialogBody className="space-y-4">
+          <DialogBody className="space-y-6">
             <div className="flex gap-2">
               <Input
                 className="font-mono"
@@ -735,7 +735,7 @@ function KoboSetupDialog({
             Configure your Kobo device to sync books wirelessly from Shisho.
           </DialogDescription>
         </DialogHeader>
-        <DialogBody className="space-y-4">
+        <DialogBody className="space-y-6">
           {/* Scope Selection */}
           <div className="space-y-3">
             <Label>Sync Scope</Label>

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -176,7 +176,7 @@ const SeriesDetail = () => {
       {/* Series Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-3xl font-bold min-w-0 break-words">
+          <h1 className="text-2xl font-semibold min-w-0 break-words">
             {series.name}
           </h1>
           <div className="flex gap-2 shrink-0">

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -174,7 +174,7 @@ const SeriesDetail = () => {
       />
 
       {/* Series Header */}
-      <div className="mb-8">
+      <div className="mb-6 md:mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
           <h1 className="text-2xl font-semibold min-w-0 break-words">
             {series.name}

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -90,9 +90,7 @@ const SeriesCard = ({
           {/* Placeholder shown until image loads or on error */}
           {(!coverLoaded || coverError) && (
             <CoverPlaceholder
-              className={cn(
-                "absolute inset-0 rounded-sm border border-neutral-300 dark:border-neutral-600",
-              )}
+              className={cn("absolute inset-0 rounded-sm border border-border")}
               variant={isAudiobook ? "audiobook" : "book"}
             />
           )}
@@ -101,7 +99,7 @@ const SeriesCard = ({
             <img
               alt={`${seriesItem.name} Cover`}
               className={cn(
-                "w-full h-full object-cover rounded-sm border-neutral-300 dark:border-neutral-600 border-1",
+                "w-full h-full object-cover rounded-sm border-border border-1",
                 !coverLoaded && "opacity-0",
               )}
               onError={() => setCoverError(true)}
@@ -125,7 +123,7 @@ const SeriesCard = ({
           <TooltipContent>{seriesItem.name}</TooltipContent>
         </Tooltip>
       </Link>
-      <div className="mt-1 text-xs line-clamp-1 text-neutral-500 dark:text-neutral-500">
+      <div className="mt-1 text-xs line-clamp-1 text-muted-foreground">
         <Badge className="text-xs" variant="secondary">
           {bookCount} book{bookCount !== 1 ? "s" : ""}
         </Badge>

--- a/app/components/pages/Setup.tsx
+++ b/app/components/pages/Setup.tsx
@@ -159,7 +159,7 @@ const Setup = () => {
     <div className="min-h-screen flex items-center justify-center bg-background">
       <Toaster richColors />
       <div className="w-full max-w-md p-8">
-        <div className="flex flex-col items-center mb-8">
+        <div className="flex flex-col items-center mb-6 md:mb-8">
           <Logo className="mb-2" size="lg" />
           <h1 className="text-xl font-semibold mb-1">Welcome!</h1>
           <p className="text-muted-foreground text-center">

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -171,7 +171,7 @@ const TagDetail = () => {
       />
 
       {/* Tag Header */}
-      <div className="mb-8">
+      <div className="mb-6 md:mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
           <h1 className="text-2xl font-semibold min-w-0 break-words">
             {tag.name}

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -173,7 +173,9 @@ const TagDetail = () => {
       {/* Tag Header */}
       <div className="mb-8">
         <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-3xl font-bold min-w-0 break-words">{tag.name}</h1>
+          <h1 className="text-2xl font-semibold min-w-0 break-words">
+            {tag.name}
+          </h1>
           <div className="flex gap-2 shrink-0">
             <Button
               onClick={() => setEditOpen(true)}

--- a/app/components/pages/TagsList.tsx
+++ b/app/components/pages/TagsList.tsx
@@ -75,7 +75,7 @@ const TagsList = () => {
 
     return (
       <Link
-        className="flex items-center justify-between p-3 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+        className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
         key={tag.id}
         to={`/libraries/${libraryId}/tags/${tag.id}`}
       >

--- a/app/components/pages/UserDetail.tsx
+++ b/app/components/pages/UserDetail.tsx
@@ -267,7 +267,7 @@ const UserDetail = () => {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-6 md:mb-8">
         <div className="flex items-center gap-4">
           <h1 className="text-2xl font-semibold">{user.username}</h1>
           <div className="flex items-center gap-2">
@@ -280,7 +280,7 @@ const UserDetail = () => {
         </div>
       </div>
 
-      <div className="max-w-2xl space-y-6 border border-border rounded-md p-6">
+      <div className="max-w-2xl space-y-6 border border-border rounded-md p-4 md:p-6">
         {/* Basic Info */}
         <div className="space-y-4">
           <h2 className="text-lg font-medium">Basic Information</h2>
@@ -449,7 +449,7 @@ const UserDetail = () => {
                 : "Enter a new password for this user."}
             </DialogDescription>
           </DialogHeader>
-          <DialogBody className="space-y-4">
+          <DialogBody className="space-y-6">
             {isSelf && (
               <div className="space-y-2">
                 <Label htmlFor="current-password">Current Password</Label>

--- a/app/components/pages/UserSettings.tsx
+++ b/app/components/pages/UserSettings.tsx
@@ -127,7 +127,7 @@ const UserSettings = () => {
           </div>
 
           {/* Security Settings Link */}
-          <div className="rounded-md border border-border p-6">
+          <div className="rounded-md border border-border p-4 md:p-6">
             <div className="flex items-center justify-between">
               <div>
                 <h2 className="text-lg font-semibold">Security</h2>

--- a/app/components/pages/UserSettings.tsx
+++ b/app/components/pages/UserSettings.tsx
@@ -71,7 +71,7 @@ const UserSettings = () => {
     <div>
       <TopNav />
       <div className="max-w-7xl w-full mx-auto px-6 py-8">
-        <div className="mb-8">
+        <div className="mb-6 md:mb-8">
           <h1 className="text-2xl font-semibold mb-2">User Settings</h1>
           <p className="text-muted-foreground">
             Manage your account preferences
@@ -80,7 +80,7 @@ const UserSettings = () => {
 
         <div className="max-w-2xl space-y-6">
           {/* Theme Settings */}
-          <div className="border border-border rounded-md p-6">
+          <div className="border border-border rounded-md p-4 md:p-6">
             <h2 className="text-lg font-semibold mb-4">Appearance</h2>
             <div className="space-y-3">
               <ThemeOption

--- a/app/components/plugins/CapabilitiesWarning.tsx
+++ b/app/components/plugins/CapabilitiesWarning.tsx
@@ -50,7 +50,7 @@ export const CapabilitiesWarning = ({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="space-y-4">
+        <DialogBody className="space-y-6">
           {rows.length > 0 && (
             <div className="space-y-2">
               {rows.map((def) => (

--- a/docs/superpowers/plans/2026-05-02-style-audit.md
+++ b/docs/superpowers/plans/2026-05-02-style-audit.md
@@ -1,0 +1,811 @@
+# Style Consistency Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> Check the project's root CLAUDE.md and any relevant subdirectory CLAUDE.md files for rules that apply to your work.
+
+**Goal:** Standardize all frontend styling on patterns established by the Identify review form — semantic color tokens, consistent spacing, uniform selection states, and matching border radii.
+
+**Architecture:** Pure CSS class replacements across ~30 files. No behavioral changes, no new components. Every change swaps hardcoded/inconsistent Tailwind classes for the project's semantic design tokens.
+
+**Tech Stack:** React, TailwindCSS, shadcn/ui
+
+**Reference patterns:**
+- Page titles: `text-2xl font-semibold`
+- Dialog titles: `text-sm font-semibold`
+- Selection: `border-primary bg-primary/5` (cards), `border-primary bg-primary/5 text-primary` (toggle chips)
+- Inline warnings: `rounded-md bg-destructive/10 border border-destructive/20 p-3`
+- Page danger zones: Match `PluginDangerZone.tsx` — `space-y-3 rounded-md border border-destructive/40 p-4 md:p-6` with title `text-lg font-semibold text-destructive`
+- Dialog body spacing: `space-y-6`
+- Card/section padding: `p-4 md:p-6`
+- Page header margin: `mb-6 md:mb-8`
+- Border radius (page components): `rounded-md`
+- Hover backgrounds: `hover:bg-muted/50`
+
+---
+
+### Task 1: Hardcoded colors — Layout, Navigation, Logo, Spinner
+
+These files use `dark:bg-neutral-*`, `dark:text-violet-*`, or `text-gray-*` instead of semantic tokens. The dark mode primary CSS variable (`oklch(0.8 0.15 280)`) already produces the same violet shade, making these overrides redundant.
+
+**Files:**
+- Modify: `app/components/layout/topNavClasses.ts:4`
+- Modify: `app/components/layout/Sidebar.tsx:35,76`
+- Modify: `app/components/library/MobileDrawer.tsx:38,157,228,257,269`
+- Modify: `app/components/library/Logo.tsx:7,68`
+- Modify: `app/components/library/LoadingSpinner.tsx:6`
+
+- [ ] **Step 1: Fix topNavClasses.ts**
+
+Line 4 — remove `dark:bg-neutral-900`:
+```ts
+// Before
+"sticky top-0 z-30 border-b border-border bg-background dark:bg-neutral-900"
+// After
+"sticky top-0 z-30 border-b border-border bg-background"
+```
+
+- [ ] **Step 2: Fix Sidebar.tsx**
+
+Line 35 — NavItem active state, remove violet overrides:
+```tsx
+// Before
+? "bg-primary/10 text-primary dark:bg-violet-500/20 dark:text-violet-300"
+// After
+? "bg-primary/10 text-primary"
+```
+
+Line 76 — sidebar container, remove dark neutral override:
+```tsx
+// Before
+"sticky top-14 flex h-[calc(100vh-3.5rem)] shrink-0 flex-col border-r border-border bg-muted/30 transition-all duration-200 md:top-16 md:h-[calc(100vh-4rem)] dark:bg-neutral-900/50",
+// After
+"sticky top-14 flex h-[calc(100vh-3.5rem)] shrink-0 flex-col border-r border-border bg-muted/30 transition-all duration-200 md:top-16 md:h-[calc(100vh-4rem)]",
+```
+
+- [ ] **Step 3: Fix MobileDrawer.tsx**
+
+Line 38 — nav item active (same pattern as Sidebar):
+```tsx
+// Before
+? "bg-primary/10 text-primary dark:bg-violet-500/20 dark:text-violet-300"
+// After
+? "bg-primary/10 text-primary"
+```
+
+Line 157 — drawer container background:
+```tsx
+// Before
+dark:bg-neutral-900
+// After
+(remove, keep bg-background or bg-muted/30 only — check the full class string)
+```
+
+Lines 228, 257 — nav active states (same replacement as line 38).
+
+Line 269 — count text:
+```tsx
+// Before
+? "text-primary/70 dark:text-violet-300/70"
+// After
+? "text-primary/70"
+```
+
+- [ ] **Step 4: Fix Logo.tsx**
+
+Line 7:
+```tsx
+// Before
+className={cn("text-primary dark:text-violet-300", className)}
+// After
+className={cn("text-primary", className)}
+```
+
+Line 68:
+```tsx
+// Before
+"align-super font-normal text-primary dark:text-violet-300 ml-0.5",
+// After
+"align-super font-normal text-primary ml-0.5",
+```
+
+- [ ] **Step 5: Fix LoadingSpinner.tsx**
+
+Line 6:
+```tsx
+// Before
+className="w-8 h-8 text-gray-200 animate-spin dark:text-gray-600 fill-primary dark:fill-violet-300"
+// After
+className="w-8 h-8 text-muted-foreground/20 animate-spin fill-primary"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/components/layout/topNavClasses.ts app/components/layout/Sidebar.tsx app/components/library/MobileDrawer.tsx app/components/library/Logo.tsx app/components/library/LoadingSpinner.tsx
+git commit -m "[Frontend] Replace hardcoded colors with semantic tokens in layout and navigation"
+```
+
+---
+
+### Task 2: Hardcoded colors — GlobalSearch, LibraryListPicker
+
+**Files:**
+- Modify: `app/components/library/GlobalSearch.tsx:85,330,331,376,377,418,419`
+- Modify: `app/components/library/LibraryListPicker.tsx:80,92,103,131,143,156,162`
+
+- [ ] **Step 1: Fix GlobalSearch.tsx**
+
+Line 85 — keyboard shortcut badge:
+```tsx
+// Before
+bg-neutral-200 dark:bg-neutral-700
+// After
+bg-muted
+```
+
+Lines 330-331, 376-377, 418-419 — search result group backgrounds (3 pairs):
+```tsx
+// Before
+bg-neutral-100 dark:bg-neutral-800
+// After
+bg-muted
+```
+
+- [ ] **Step 2: Fix LibraryListPicker.tsx**
+
+Line 80 — library row active:
+```tsx
+// Before
+? "bg-primary/10 text-primary dark:bg-primary/15 dark:text-violet-300"
+// After
+? "bg-primary/10 text-primary"
+```
+
+Line 92 — library icon active:
+```tsx
+// Before
+? "bg-primary text-primary-foreground dark:bg-violet-400 dark:text-neutral-900"
+// After
+? "bg-primary text-primary-foreground"
+```
+
+Line 103 — check icon:
+```tsx
+// Before
+<Check className="h-4 w-4 shrink-0 text-primary dark:text-violet-300" />
+// After
+<Check className="h-4 w-4 shrink-0 text-primary" />
+```
+
+Line 131 — list row active (same as line 80 pattern):
+```tsx
+// Before
+? "bg-primary/10 text-primary dark:bg-primary/15 dark:text-violet-300"
+// After
+? "bg-primary/10 text-primary"
+```
+
+Line 143 — list icon active (same as line 92 pattern):
+```tsx
+// Before
+? "bg-primary text-primary-foreground dark:bg-violet-400 dark:text-neutral-900"
+// After
+? "bg-primary text-primary-foreground"
+```
+
+Line 156 — list count text:
+```tsx
+// Before
+${isActive ? "text-primary/70 dark:text-violet-300/70" : "text-muted-foreground"}
+// After
+${isActive ? "text-primary/70" : "text-muted-foreground"}
+```
+
+Line 162 — check icon (same as line 103):
+```tsx
+// Before
+<Check className="h-4 w-4 shrink-0 text-primary dark:text-violet-300" />
+// After
+<Check className="h-4 w-4 shrink-0 text-primary" />
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/library/GlobalSearch.tsx app/components/library/LibraryListPicker.tsx
+git commit -m "[Frontend] Replace hardcoded colors with semantic tokens in search and picker"
+```
+
+---
+
+### Task 3: Hardcoded colors — Entity list pages & detail pages
+
+**Files:**
+- Modify: `app/components/pages/GenresList.tsx:78`
+- Modify: `app/components/pages/TagsList.tsx:78`
+- Modify: `app/components/pages/ImprintsList.tsx:76`
+- Modify: `app/components/pages/PublishersList.tsx:76`
+- Modify: `app/components/pages/PersonList.tsx:69`
+- Modify: `app/components/pages/SeriesList.tsx:94,104,128`
+- Modify: `app/components/pages/ListsIndex.tsx:69,96`
+- Modify: `app/components/pages/PersonDetail.tsx:283`
+- Modify: `app/components/pages/ImprintDetail.tsx:172`
+- Modify: `app/components/pages/PublisherDetail.tsx:172`
+- Modify: `app/components/pages/BookDetail.tsx:1246`
+- Modify: `app/components/library/BookItem.tsx:262,273,357`
+
+- [ ] **Step 1: Fix entity list page hover backgrounds**
+
+All follow the same pattern — replace hardcoded hover with semantic token:
+
+GenresList.tsx:78, TagsList.tsx:78, ImprintsList.tsx:76, PublishersList.tsx:76:
+```tsx
+// Before
+hover:bg-neutral-100 dark:hover:bg-neutral-800
+// After
+hover:bg-muted/50
+```
+
+PersonList.tsx:69, ListsIndex.tsx:69,96, PersonDetail.tsx:283:
+```tsx
+// Before
+hover:bg-neutral-50 dark:hover:bg-neutral-800
+// After
+hover:bg-muted/50
+```
+
+- [ ] **Step 2: Fix entity list page borders**
+
+PersonList.tsx:69, PersonDetail.tsx:283:
+```tsx
+// Before
+border-neutral-200 dark:border-neutral-700
+// After
+border-border
+```
+
+SeriesList.tsx:94,104:
+```tsx
+// Before
+border-neutral-300 dark:border-neutral-600
+// After
+border-border
+```
+
+BookItem.tsx:262,273:
+```tsx
+// Before
+border-neutral-300 dark:border-neutral-600
+// After
+border-border
+```
+
+- [ ] **Step 3: Fix hardcoded text colors**
+
+SeriesList.tsx:128:
+```tsx
+// Before
+text-neutral-500 dark:text-neutral-500
+// After
+text-muted-foreground
+```
+
+BookItem.tsx:357:
+```tsx
+// Before
+text-neutral-500
+// After
+text-muted-foreground
+```
+
+- [ ] **Step 4: Fix violet overrides in detail pages**
+
+ImprintDetail.tsx:172 and PublisherDetail.tsx:172:
+```tsx
+// Before
+className="border-l-4 border-l-primary dark:border-l-violet-300 pl-4 py-2"
+// After
+className="border-l-4 border-l-primary pl-4 py-2"
+```
+
+BookDetail.tsx:1246 — author link:
+```tsx
+// Before
+className="text-sm font-medium text-primary hover:text-primary/80 hover:underline dark:text-violet-300 dark:hover:text-violet-400"
+// After
+className="text-sm font-medium text-primary hover:text-primary/80 hover:underline"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/pages/GenresList.tsx app/components/pages/TagsList.tsx app/components/pages/ImprintsList.tsx app/components/pages/PublishersList.tsx app/components/pages/PersonList.tsx app/components/pages/SeriesList.tsx app/components/pages/ListsIndex.tsx app/components/pages/PersonDetail.tsx app/components/pages/ImprintDetail.tsx app/components/pages/PublisherDetail.tsx app/components/pages/BookDetail.tsx app/components/library/BookItem.tsx
+git commit -m "[Frontend] Replace hardcoded colors with semantic tokens in list and detail pages"
+```
+
+---
+
+### Task 4: Hardcoded colors — Job & log components
+
+**Files:**
+- Modify: `app/components/pages/AdminJobs.tsx:29`
+- Modify: `app/components/pages/JobDetail.tsx:38,53`
+- Modify: `app/components/library/LogViewer.tsx:21,177`
+
+- [ ] **Step 1: Fix AdminJobs.tsx**
+
+Line 29 — job status badge "queued"/"cancelled" color (gray):
+```tsx
+// Before
+bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400
+// After
+bg-muted text-muted-foreground
+```
+
+- [ ] **Step 2: Fix JobDetail.tsx**
+
+Line 38 — log level "trace" color:
+```tsx
+// Before
+bg-gray-500/20 text-gray-400
+// After
+bg-muted text-muted-foreground
+```
+
+Line 53 — log level "info" badge:
+```tsx
+// Before
+bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400
+// After
+bg-muted text-muted-foreground
+```
+
+- [ ] **Step 3: Fix LogViewer.tsx**
+
+Line 21 — log level TRACE:
+```tsx
+// Before
+bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-400
+// After
+bg-muted text-muted-foreground
+```
+
+Line 177 — log viewer container dark bg:
+```tsx
+// Before
+dark:bg-neutral-950/50
+// After
+(remove the dark override, keep only the base background class)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/pages/AdminJobs.tsx app/components/pages/JobDetail.tsx app/components/library/LogViewer.tsx
+git commit -m "[Frontend] Replace hardcoded gray colors with semantic tokens in job and log components"
+```
+
+---
+
+### Task 5: Page titles — Standardize to `text-2xl font-semibold`
+
+Three groups need changing:
+1. Entity detail pages: `text-3xl font-bold` → `text-2xl font-semibold`
+2. Admin pages: `text-xl md:text-2xl font-semibold` → `text-2xl font-semibold`
+3. Book/File/List detail: `text-2xl md:text-3xl font-semibold/font-bold` → `text-2xl font-semibold`
+
+**Files:**
+- Modify: `app/components/pages/GenreDetail.tsx:176`
+- Modify: `app/components/pages/ImprintDetail.tsx:126`
+- Modify: `app/components/pages/PersonDetail.tsx:188`
+- Modify: `app/components/pages/PublisherDetail.tsx:126`
+- Modify: `app/components/pages/SeriesDetail.tsx:179`
+- Modify: `app/components/pages/TagDetail.tsx:176`
+- Modify: `app/components/pages/AdminCache.tsx:67`
+- Modify: `app/components/pages/AdminJobs.tsx:138`
+- Modify: `app/components/pages/AdminLibraries.tsx:99`
+- Modify: `app/components/pages/AdminLogs.tsx:58`
+- Modify: `app/components/pages/AdminUsers.tsx:133`
+- Modify: `app/components/pages/AdminSettings.tsx:72`
+- Modify: `app/components/pages/ListsIndex.tsx:116`
+- Modify: `app/components/pages/BookDetail.tsx:1101`
+- Modify: `app/components/pages/FileDetail.tsx:191`
+- Modify: `app/components/pages/ListDetail.tsx:218`
+
+- [ ] **Step 1: Fix entity detail page titles**
+
+GenreDetail.tsx:176, ImprintDetail.tsx:126, PersonDetail.tsx:188, PublisherDetail.tsx:126, SeriesDetail.tsx:179, TagDetail.tsx:176:
+```tsx
+// Before
+<h1 className="text-3xl font-bold min-w-0 break-words">
+// After
+<h1 className="text-2xl font-semibold min-w-0 break-words">
+```
+
+- [ ] **Step 2: Fix admin page titles**
+
+AdminCache.tsx:67, AdminJobs.tsx:138, AdminLibraries.tsx:99, AdminLogs.tsx:58, AdminUsers.tsx:133, AdminSettings.tsx:72, ListsIndex.tsx:116:
+```tsx
+// Before
+<h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
+// After
+<h1 className="text-2xl font-semibold mb-1 md:mb-2">
+```
+
+- [ ] **Step 3: Fix book/file/list detail titles**
+
+BookDetail.tsx:1101, FileDetail.tsx:191:
+```tsx
+// Before
+<h1 className="text-2xl md:text-3xl font-semibold">
+// After
+<h1 className="text-2xl font-semibold">
+```
+
+ListDetail.tsx:218:
+```tsx
+// Before
+<h1 className="text-2xl md:text-3xl font-bold min-w-0 break-words">
+// After
+<h1 className="text-2xl font-semibold min-w-0 break-words">
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/pages/GenreDetail.tsx app/components/pages/ImprintDetail.tsx app/components/pages/PersonDetail.tsx app/components/pages/PublisherDetail.tsx app/components/pages/SeriesDetail.tsx app/components/pages/TagDetail.tsx app/components/pages/AdminCache.tsx app/components/pages/AdminJobs.tsx app/components/pages/AdminLibraries.tsx app/components/pages/AdminLogs.tsx app/components/pages/AdminUsers.tsx app/components/pages/AdminSettings.tsx app/components/pages/ListsIndex.tsx app/components/pages/BookDetail.tsx app/components/pages/FileDetail.tsx app/components/pages/ListDetail.tsx
+git commit -m "[Frontend] Standardize all page titles to text-2xl font-semibold"
+```
+
+---
+
+### Task 6: Selection states — Standardize to `border-primary bg-primary/5`
+
+Four components need updating. Checkboxes (BookItem, BookDetail) and image-ring selections (PagePicker) are intentionally different patterns and should NOT change.
+
+**Files:**
+- Modify: `app/components/library/BookSelectionList.tsx:119-122`
+- Modify: `app/components/library/MergeBooksDialog.tsx:190-193`
+- Modify: `app/components/library/FilterSheet.tsx:276-281`
+- Modify: `app/components/library/CoverGalleryTabs.tsx:172-177`
+
+- [ ] **Step 1: Fix BookSelectionList.tsx**
+
+Lines 119-122 — add border to base, use `border-primary bg-primary/5` when selected:
+```tsx
+// Before
+className={cn(
+  "flex items-start gap-3 p-2 rounded-md cursor-pointer transition-colors overflow-hidden",
+  isSelected ? "bg-primary/10" : "hover:bg-muted/50",
+)}
+// After
+className={cn(
+  "flex items-start gap-3 p-2 rounded-md border cursor-pointer transition-colors overflow-hidden",
+  isSelected ? "border-primary bg-primary/5" : "border-transparent hover:bg-muted/50",
+)}
+```
+
+- [ ] **Step 2: Fix MergeBooksDialog.tsx**
+
+Lines 190-193 — same pattern as BookSelectionList:
+```tsx
+// Before
+className={cn(
+  "flex items-start gap-3 p-2 rounded-md cursor-pointer transition-colors",
+  isSelected ? "bg-primary/10" : "hover:bg-muted/50",
+)}
+// After
+className={cn(
+  "flex items-start gap-3 p-2 rounded-md border cursor-pointer transition-colors",
+  isSelected ? "border-primary bg-primary/5" : "border-transparent hover:bg-muted/50",
+)}
+```
+
+- [ ] **Step 3: Fix FilterSheet.tsx**
+
+Lines 276-281 — change from solid fill to subtle highlight:
+```tsx
+// Before
+isSelected
+  ? "border-primary bg-primary text-primary-foreground"
+  : "border-border bg-card hover:bg-accent",
+// After
+isSelected
+  ? "border-primary bg-primary/5 text-primary"
+  : "border-border bg-card hover:bg-accent",
+```
+
+- [ ] **Step 4: Fix CoverGalleryTabs.tsx**
+
+Lines 172-177 — change pill tabs from solid fill to subtle highlight:
+```tsx
+// Before
+file.id === selectedFileId
+  ? "bg-primary border-primary text-primary-foreground"
+  : "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
+// After
+file.id === selectedFileId
+  ? "border-primary bg-primary/5 text-primary"
+  : "border-border text-muted-foreground hover:bg-accent hover:text-foreground",
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/components/library/BookSelectionList.tsx app/components/library/MergeBooksDialog.tsx app/components/library/FilterSheet.tsx app/components/library/CoverGalleryTabs.tsx
+git commit -m "[Frontend] Standardize card selection states to border-primary bg-primary/5"
+```
+
+---
+
+### Task 7: Border radius + Warning cards + Danger zones
+
+Fix `rounded-lg` → `rounded-md` in page components, standardize inline warning cards to `rounded-md bg-destructive/10 border border-destructive/20 p-3`, and align LibrarySettings danger zone to PluginDangerZone.
+
+**Files (border radius):**
+- Modify: `app/components/library/MoveFilesDialog.tsx:100,110`
+- Modify: `app/components/library/MergeBooksDialog.tsx:155,257`
+- Modify: `app/components/library/MergeIntoDialog.tsx:92`
+- Modify: `app/components/library/SelectionToolbar.tsx:271`
+- Modify: `app/components/library/BulkDownloadToast.tsx:19`
+- Modify: `app/components/library/GlobalSearch.tsx:481`
+- Modify: `app/components/library/RescanDialog.tsx:85`
+- Modify: `app/components/pages/BookDetail.tsx:1571`
+- Modify: `app/components/pages/ListsIndex.tsx:69`
+
+**Files (warning cards):**
+- Modify: `app/components/files/FetchChaptersDialog.tsx:136,222,290`
+- Modify: `app/components/library/DeleteConfirmationDialog.tsx:174`
+- Modify: `app/components/library/DeleteLibraryDialog.tsx:68`
+
+**Files (danger zone):**
+- Modify: `app/components/pages/LibrarySettings.tsx:425-428`
+
+- [ ] **Step 1: Fix rounded-lg → rounded-md**
+
+In each file, find `rounded-lg` and replace with `rounded-md`. These are in card/container elements, not the dialog/sheet primitives:
+
+MoveFilesDialog.tsx:100 — `rounded-lg` → `rounded-md`
+MoveFilesDialog.tsx:110 — `rounded-lg` → `rounded-md`
+MergeBooksDialog.tsx:155 — `rounded-lg` → `rounded-md`
+MergeBooksDialog.tsx:257 — `rounded-lg` → `rounded-md`
+MergeIntoDialog.tsx:92 — `rounded-lg` → `rounded-md`
+SelectionToolbar.tsx:271 — `rounded-lg` → `rounded-md`
+BulkDownloadToast.tsx:19 — `rounded-lg` → `rounded-md`
+GlobalSearch.tsx:481 — `rounded-lg` → `rounded-md`
+RescanDialog.tsx:85 — `rounded-lg` → `rounded-md`
+BookDetail.tsx:1571 — `rounded-lg` → `rounded-md`
+ListsIndex.tsx:69 — `rounded-lg` → `rounded-md`
+
+- [ ] **Step 2: Standardize inline warning cards**
+
+FetchChaptersDialog.tsx lines 136, 222, 290 — border opacity `/50` → `/20`, padding `px-4 py-3` → `p-3`:
+```tsx
+// Before
+className="rounded-md border border-destructive/50 bg-destructive/10 px-4 py-3"
+// After
+className="rounded-md border border-destructive/20 bg-destructive/10 p-3"
+```
+
+DeleteConfirmationDialog.tsx:174 — already `rounded-md` and `p-3`, just fix border opacity (already `/20`, verify):
+```tsx
+// Verify it matches: rounded-md bg-destructive/10 border border-destructive/20 p-3
+```
+
+DeleteLibraryDialog.tsx:68 — already `rounded-md` and `p-3`, verify border opacity (already `/20`, verify):
+```tsx
+// Verify it matches: rounded-md bg-destructive/10 border border-destructive/20 p-3
+```
+
+- [ ] **Step 3: Fix LibrarySettings danger zone to match PluginDangerZone**
+
+LibrarySettings.tsx:425-428:
+```tsx
+// Before
+<section className="max-w-2xl mt-8 border border-destructive/40 rounded-md p-4 md:p-6">
+  <h2 className="text-base md:text-lg font-semibold text-destructive mb-1">
+    Danger Zone
+  </h2>
+// After
+<section className="max-w-2xl mt-8 space-y-3 rounded-md border border-destructive/40 p-4 md:p-6">
+  <h2 className="text-lg font-semibold text-destructive">
+    Danger zone
+  </h2>
+```
+
+Key changes: add `space-y-3`, remove responsive `text-base md:text-lg` → flat `text-lg`, remove `mb-1` (spacing handled by `space-y-3`), lowercase "zone".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/library/MoveFilesDialog.tsx app/components/library/MergeBooksDialog.tsx app/components/library/MergeIntoDialog.tsx app/components/library/SelectionToolbar.tsx app/components/library/BulkDownloadToast.tsx app/components/library/GlobalSearch.tsx app/components/library/RescanDialog.tsx app/components/pages/BookDetail.tsx app/components/pages/ListsIndex.tsx app/components/files/FetchChaptersDialog.tsx app/components/library/DeleteConfirmationDialog.tsx app/components/library/DeleteLibraryDialog.tsx app/components/pages/LibrarySettings.tsx
+git commit -m "[Frontend] Standardize border radius, warning cards, and danger zone styling"
+```
+
+---
+
+### Task 8: Spacing — Dialog bodies, card padding, page header margins
+
+**Files (DialogBody space-y-4 → space-y-6):**
+- Modify: `app/components/plugins/CapabilitiesWarning.tsx:53`
+- Modify: `app/components/library/MoveToPositionDialog.tsx:71`
+- Modify: `app/components/library/MetadataEditDialog.tsx:160`
+- Modify: `app/components/library/MoveFilesDialog.tsx:98`
+- Modify: `app/components/library/CreateListDialog.tsx:146`
+- Modify: `app/components/library/IdentifyBookDialog.tsx:199`
+- Modify: `app/components/library/DeleteConfirmationDialog.tsx:172`
+- Modify: `app/components/library/AddToListDialog.tsx:191`
+- Modify: `app/components/library/DeleteLibraryDialog.tsx:67`
+- Modify: `app/components/library/MergeIntoDialog.tsx:91`
+- Modify: `app/components/library/MergeBooksDialog.tsx:171,255`
+- Modify: `app/components/pages/SecuritySettings.tsx:469,738`
+- Modify: `app/components/pages/UserDetail.tsx:452`
+
+**Files (flat p-6 → p-4 md:p-6):**
+- Modify: `app/components/pages/LibrarySettings.tsx:257`
+- Modify: `app/components/pages/CreateLibrary.tsx:175`
+- Modify: `app/components/pages/UserSettings.tsx:83`
+- Modify: `app/components/pages/UserDetail.tsx:283`
+- Modify: `app/components/pages/CreateUser.tsx:157`
+
+**Files (flat mb-8 → mb-6 md:mb-8):**
+- Modify: `app/components/pages/LibrarySettings.tsx:250`
+- Modify: `app/components/pages/CreateLibrary.tsx:168`
+- Modify: `app/components/pages/CreateUser.tsx:152`
+- Modify: `app/components/pages/UserSettings.tsx:74`
+- Modify: `app/components/pages/SecuritySettings.tsx:167`
+- Modify: `app/components/pages/UserDetail.tsx:270`
+- Modify: `app/components/pages/SeriesDetail.tsx:177`
+- Modify: `app/components/pages/ImprintDetail.tsx:124`
+- Modify: `app/components/pages/GenreDetail.tsx:174`
+- Modify: `app/components/pages/TagDetail.tsx:174`
+- Modify: `app/components/pages/PublisherDetail.tsx:124`
+- Modify: `app/components/pages/PersonDetail.tsx:186`
+- Modify: `app/components/pages/Login.tsx:72`
+- Modify: `app/components/pages/Setup.tsx:162`
+
+- [ ] **Step 1: Fix all DialogBody space-y-4 → space-y-6**
+
+In every file listed above, replace `space-y-4` with `space-y-6` on the `<DialogBody>` className. Where the className has additional classes (e.g., `"space-y-4 min-w-0"`), only replace `space-y-4` → `space-y-6`.
+
+- [ ] **Step 2: Fix flat p-6 → p-4 md:p-6**
+
+LibrarySettings.tsx:257:
+```tsx
+// Before: "max-w-2xl space-y-6 border border-border rounded-md p-6"
+// After:  "max-w-2xl space-y-6 border border-border rounded-md p-4 md:p-6"
+```
+
+CreateLibrary.tsx:175:
+```tsx
+// Before: "max-w-2xl space-y-6 border border-border rounded-md p-6"
+// After:  "max-w-2xl space-y-6 border border-border rounded-md p-4 md:p-6"
+```
+
+UserSettings.tsx:83:
+```tsx
+// Before: "border border-border rounded-md p-6"
+// After:  "border border-border rounded-md p-4 md:p-6"
+```
+
+UserDetail.tsx:283:
+```tsx
+// Before: "max-w-2xl space-y-6 border border-border rounded-md p-6"
+// After:  "max-w-2xl space-y-6 border border-border rounded-md p-4 md:p-6"
+```
+
+CreateUser.tsx:157:
+```tsx
+// Before: "max-w-2xl space-y-6 border border-border rounded-md p-6"
+// After:  "max-w-2xl space-y-6 border border-border rounded-md p-4 md:p-6"
+```
+
+- [ ] **Step 3: Fix flat mb-8 → mb-6 md:mb-8**
+
+In every file listed above, find the page header `<div>` with `mb-8` and replace with `mb-6 md:mb-8`. Be careful to preserve other classes on the same element (e.g., `"flex flex-col items-center mb-8"` → `"flex flex-col items-center mb-6 md:mb-8"`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/components/plugins/CapabilitiesWarning.tsx app/components/library/MoveToPositionDialog.tsx app/components/library/MetadataEditDialog.tsx app/components/library/MoveFilesDialog.tsx app/components/library/CreateListDialog.tsx app/components/library/IdentifyBookDialog.tsx app/components/library/DeleteConfirmationDialog.tsx app/components/library/AddToListDialog.tsx app/components/library/DeleteLibraryDialog.tsx app/components/library/MergeIntoDialog.tsx app/components/library/MergeBooksDialog.tsx app/components/pages/SecuritySettings.tsx app/components/pages/UserDetail.tsx app/components/pages/LibrarySettings.tsx app/components/pages/CreateLibrary.tsx app/components/pages/UserSettings.tsx app/components/pages/CreateUser.tsx app/components/pages/SeriesDetail.tsx app/components/pages/ImprintDetail.tsx app/components/pages/GenreDetail.tsx app/components/pages/TagDetail.tsx app/components/pages/PublisherDetail.tsx app/components/pages/PersonDetail.tsx app/components/pages/Login.tsx app/components/pages/Setup.tsx
+git commit -m "[Frontend] Standardize dialog body, card padding, and page header spacing"
+```
+
+---
+
+### Task 9: Gallery select button + CLAUDE.md docs
+
+**Files:**
+- Modify: `app/components/pages/Home.tsx:608-617`
+- Modify: `app/CLAUDE.md`
+
+- [ ] **Step 1: Update gallery select button to size="sm"**
+
+Home.tsx lines 608-617 — add `size="sm"` to both the Select and Cancel buttons:
+```tsx
+// Before
+<Button onClick={exitSelectionMode} variant="outline">
+  Cancel
+</Button>
+// After
+<Button onClick={exitSelectionMode} size="sm" variant="outline">
+  Cancel
+</Button>
+
+// Before
+<Button onClick={enterSelectionMode} variant="outline">
+  <CheckSquare className="h-4 w-4" />
+  Select
+</Button>
+// After
+<Button onClick={enterSelectionMode} size="sm" variant="outline">
+  <CheckSquare className="h-4 w-4" />
+  Select
+</Button>
+```
+
+Keep the button in its current position (right side of toolbar).
+
+- [ ] **Step 2: Update app/CLAUDE.md patterns**
+
+Update the "Detail Page Patterns" section header example:
+```tsx
+// Before
+<h1 className="text-3xl font-bold min-w-0 break-words">{name}</h1>
+// After
+<h1 className="text-2xl font-semibold min-w-0 break-words">{name}</h1>
+```
+
+Update the "Admin Page Headers" section example:
+```tsx
+// Before
+<h1 className="text-xl md:text-2xl font-semibold mb-1 md:mb-2">
+// After
+<h1 className="text-2xl font-semibold mb-1 md:mb-2">
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/components/pages/Home.tsx app/CLAUDE.md
+git commit -m "[Frontend] Update gallery select button size and sync CLAUDE.md patterns"
+```
+
+---
+
+### Task 10: Verify
+
+- [ ] **Step 1: Run JS lint to verify no syntax/type issues**
+
+```bash
+mise lint:js
+```
+
+Expected: All checks pass.
+
+- [ ] **Step 2: Run unit tests**
+
+```bash
+mise test:unit
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Visual spot-check in browser**
+
+Start the dev server with `mise start` and verify:
+- Sidebar, top nav, and mobile drawer look correct in both light and dark mode
+- Entity detail page titles are visually consistent across Genre, Series, Person, etc.
+- Admin page titles are consistent
+- Book detail, file detail, list detail titles match
+- Filter, sort, size, and select buttons on the gallery page are the same size
+- Filter chips in FilterSheet use subtle highlight instead of solid fill
+- Cover gallery tabs use subtle highlight
+- BookSelectionList and MergeBooksDialog selection states show border + light background
+- Warning cards in dialogs have consistent rounded corners and border opacity
+- LibrarySettings danger zone matches PluginDangerZone
+- Dialog body spacing is consistent
+- Card sections have responsive padding
+- GlobalSearch dropdown uses semantic background colors
+- LoadingSpinner looks correct in both themes


### PR DESCRIPTION
## Summary
- Replace all hardcoded Tailwind colors (`dark:bg-neutral-*`, `dark:text-violet-*`, `text-gray-*`, `bg-neutral-*`) with semantic tokens (`bg-muted`, `text-primary`, `text-muted-foreground`, etc.) across layout, navigation, search, list/detail pages, and job/log components
- Standardize page titles to `text-2xl font-semibold`, selection states to `border-primary bg-primary/5`, border radius to `rounded-md`, dialog body spacing to `space-y-6`, card padding to `p-4 md:p-6`, and page header margins to `mb-6 md:mb-8`
- Align warning cards to `rounded-md bg-destructive/10 border border-destructive/20 p-3` and LibrarySettings danger zone to match PluginDangerZone pattern
- Add `size="sm"` to gallery Select/Cancel buttons for consistency with Filter/Sort/Size buttons
- Add Design Tokens reference section to `app/CLAUDE.md` to prevent drift

## Test plan
- Verify sidebar, top nav, and mobile drawer render correctly in both light and dark mode
- Check entity detail page titles (Genre, Series, Person, etc.) are visually uniform at `text-2xl font-semibold`
- Confirm admin page titles match across Cache, Jobs, Libraries, Logs, Users, Settings
- Open FilterSheet and verify chips use subtle highlight (`bg-primary/5`) instead of solid fill
- Open BookSelectionList and MergeBooksDialog — selected items should show `border-primary` border with light background
- Check warning cards in FetchChaptersDialog, DeleteConfirmationDialog, DeleteLibraryDialog for consistent border opacity and padding
- Compare LibrarySettings danger zone with PluginDangerZone — should match
- Verify dialog body spacing is consistent across dialogs
- Confirm GlobalSearch dropdown, LoadingSpinner, and cover placeholders use semantic colors
- Run `mise lint:js` and `mise test:unit` — both pass