### PR TITLE
[E2E] Fix flaky review-flag bulk-mark-reviewed test on Firefox

### DIFF
--- a/e2e/review-flag.spec.ts
+++ b/e2e/review-flag.spec.ts
@@ -220,14 +220,14 @@ test.describe("Review flag", () => {
       .click({ force: true });
 
     // The selection toolbar should appear showing 2 books.
-    await expect(page.getByText(/2 books/)).toBeVisible();
+    await expect(page.getByText("2 books", { exact: true })).toBeVisible();
 
     // Open the "More" popover and click "Mark reviewed".
     await page.getByRole("button", { name: /^More$/ }).click();
     await page.getByText("Mark reviewed").click();
 
     // Wait for the toolbar to dismiss (selection mode exits after bulk action).
-    await expect(page.getByText(/2 books/)).not.toBeVisible();
+    await expect(page.getByText("2 books", { exact: true })).not.toBeVisible();
 
     // The filtered view should now show neither book (they were marked reviewed).
     await expect(page.getByText("Bulk Book Alpha")).not.toBeVisible();


### PR DESCRIPTION
## Summary
- The `bulk mark reviewed via multi-select` test in `e2e/review-flag.spec.ts` was flaky on Firefox — `getByText(/2 books/)` matched both the selection toolbar and the Gallery pagination text ("Showing 1-2 of 2 books"), causing a Playwright strict mode violation
- Changed to `getByText("2 books", { exact: true })` so the locator only matches the toolbar's standalone text node

## Test plan
- Confirm the test passes on Firefox by checking CI
- Verify it still passes on Chromium