### PR TITLE
[Fix] Replace native select with Radix UI Select in plugin config form

### DIFF
--- a/app/components/plugins/PluginConfigForm.test.tsx
+++ b/app/components/plugins/PluginConfigForm.test.tsx
@@ -129,7 +129,7 @@ describe("PluginConfigForm", () => {
     // Radix Select renders a trigger with role="combobox"
     expect(
       screen.getByRole("combobox", { name: /split mode/i }),
-    ).toBeInTheDocument();
+    ).toHaveTextContent("Colon");
     // No native <select> elements should exist
     expect(document.querySelector("select")).toBeNull();
   });

--- a/app/components/plugins/PluginConfigForm.test.tsx
+++ b/app/components/plugins/PluginConfigForm.test.tsx
@@ -40,8 +40,19 @@ vi.mock("@/hooks/queries/plugins", () => ({
           min: 1,
           max: 100,
         },
+        splitMode: {
+          type: "select",
+          label: "Split Mode",
+          description: "How to split subtitles",
+          required: false,
+          secret: false,
+          options: [
+            { value: "colon", label: "Colon" },
+            { value: "dash", label: "Dash" },
+          ],
+        },
       },
-      values: { apiKey: "", maxResults: 10 },
+      values: { apiKey: "", maxResults: 10, splitMode: "colon" },
       // Declare a field so the field-settings save path fires.
       declaredFields: ["title"],
       fieldSettings: { title: true },
@@ -104,10 +115,23 @@ describe("PluginConfigForm", () => {
         expect.objectContaining({
           scope: "shisho",
           id: "test",
-          config: expect.objectContaining({ apiKey: "sk-123" }),
+          config: expect.objectContaining({
+            apiKey: "sk-123",
+            splitMode: "colon",
+          }),
         }),
       );
     });
+  });
+
+  it("renders select fields using Radix Select, not native <select>", () => {
+    render(wrap(<PluginConfigForm canWrite={true} id="test" scope="shisho" />));
+    // Radix Select renders a trigger with role="combobox"
+    expect(
+      screen.getByRole("combobox", { name: /split mode/i }),
+    ).toBeInTheDocument();
+    // No native <select> elements should exist
+    expect(document.querySelector("select")).toBeNull();
   });
 
   it("hides Save button and disables inputs when canWrite is false", () => {
@@ -118,6 +142,9 @@ describe("PluginConfigForm", () => {
       screen.queryByRole("button", { name: /save/i }),
     ).not.toBeInTheDocument();
     expect(screen.getByLabelText(/api key/i)).toBeDisabled();
+    expect(
+      screen.getByRole("combobox", { name: /split mode/i }),
+    ).toBeDisabled();
   });
 
   // Regression test: when the field-settings save fails we must NOT reset

--- a/app/components/plugins/PluginConfigForm.tsx
+++ b/app/components/plugins/PluginConfigForm.tsx
@@ -217,8 +217,7 @@ export const PluginConfigForm = ({
           <Select
             disabled={!canWrite}
             onValueChange={handleChange}
-            // Radix Select doesn't accept "" as a valid item value
-            value={value || undefined}
+            value={value}
           >
             <SelectTrigger id={fieldId}>
               <SelectValue placeholder="Select..." />

--- a/app/components/plugins/PluginConfigForm.tsx
+++ b/app/components/plugins/PluginConfigForm.tsx
@@ -6,6 +6,13 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -207,20 +214,22 @@ export const PluginConfigForm = ({
             </span>
           </div>
         ) : field.type === "select" ? (
-          <select
-            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring md:text-sm disabled:cursor-not-allowed disabled:opacity-50"
+          <Select
             disabled={!canWrite}
-            id={fieldId}
-            onChange={(e) => handleChange(e.target.value)}
-            value={value}
+            onValueChange={handleChange}
+            value={value || undefined}
           >
-            <option value="">Select...</option>
-            {field.options?.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger id={fieldId}>
+              <SelectValue placeholder="Select..." />
+            </SelectTrigger>
+            <SelectContent>
+              {field.options?.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         ) : field.type === "textarea" ? (
           <Textarea
             disabled={!canWrite}

--- a/app/components/plugins/PluginConfigForm.tsx
+++ b/app/components/plugins/PluginConfigForm.tsx
@@ -217,6 +217,7 @@ export const PluginConfigForm = ({
           <Select
             disabled={!canWrite}
             onValueChange={handleChange}
+            // Radix Select doesn't accept "" as a valid item value
             value={value || undefined}
           >
             <SelectTrigger id={fieldId}>


### PR DESCRIPTION
## Summary
- Replaces the native HTML `<select>` in `PluginConfigForm` with the Radix UI `Select` component used throughout the app
- Fixes inconsistent dropdown arrow spacing and styling for select fields in plugin configuration
- Closes #195

## Test plan
- Open any plugin configuration page that has a select field (e.g., "Split Subtitle from Title")
- Verify the dropdown looks consistent with other selects in the app (proper ChevronDown icon, spacing, hover/focus states)
- Verify the select is disabled when the user lacks write permissions
- Verify changing a select value and saving works correctly