### PR TITLE
[Fix] Apply-all counter ignores Changed/All filter in identify review

### DIFF
--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -972,23 +972,10 @@ export function IdentifyReviewForm({
     [bookVisibleKeys, fileVisibleKeys],
   );
 
-  // Per-section counts use visible keys (consistent with what the section
-  // checkbox toggles). Global counts use all applicable keys (consistent with
-  // what actually gets applied).
-  const bookVisibleSelectedCount = bookVisibleKeys.filter(
-    (k) => decisions[k],
-  ).length;
-  const fileVisibleSelectedCount = fileVisibleKeys.filter(
-    (k) => decisions[k],
-  ).length;
-  const bookSelectedCount = bookApplicableKeys.filter(
-    (k) => decisions[k],
-  ).length;
-  const fileSelectedCount = fileApplicableKeys.filter(
-    (k) => decisions[k],
-  ).length;
+  const bookSelectedCount = bookVisibleKeys.filter((k) => decisions[k]).length;
+  const fileSelectedCount = fileVisibleKeys.filter((k) => decisions[k]).length;
   const totalSelected = bookSelectedCount + fileSelectedCount;
-  const totalApplicable = allApplicableKeys.length;
+  const totalApplicable = allVisibleKeys.length;
 
   const bookCheckboxState = aggregateDecisions(
     bookVisibleKeys.map((k) => decisions[k]),
@@ -1308,7 +1295,7 @@ export function IdentifyReviewForm({
               label="BOOK"
               onCheckedChange={(v) => setSectionDecisions(bookVisibleKeys, v)}
               onToggleCollapse={() => setBookCollapsed((c) => !c)}
-              selectedCount={bookVisibleSelectedCount}
+              selectedCount={bookSelectedCount}
               totalCount={bookVisibleKeys.length}
             />
             {!bookCollapsed && (
@@ -1648,7 +1635,7 @@ export function IdentifyReviewForm({
               label="FILE"
               onCheckedChange={(v) => setSectionDecisions(fileVisibleKeys, v)}
               onToggleCollapse={() => setFileCollapsed((c) => !c)}
-              selectedCount={fileVisibleSelectedCount}
+              selectedCount={fileSelectedCount}
               totalCount={fileVisibleKeys.length}
             />
             {!fileCollapsed && (

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -975,7 +975,7 @@ export function IdentifyReviewForm({
   const bookSelectedCount = bookVisibleKeys.filter((k) => decisions[k]).length;
   const fileSelectedCount = fileVisibleKeys.filter((k) => decisions[k]).length;
   const totalSelected = bookSelectedCount + fileSelectedCount;
-  const totalApplicable = allVisibleKeys.length;
+  const totalVisible = allVisibleKeys.length;
 
   const bookCheckboxState = aggregateDecisions(
     bookVisibleKeys.map((k) => decisions[k]),
@@ -1250,7 +1250,7 @@ export function IdentifyReviewForm({
         <span className="text-xs font-medium">Apply all</span>
         <span className="whitespace-nowrap text-[11.5px] tabular-nums text-muted-foreground">
           <span className="font-semibold text-foreground">{totalSelected}</span>{" "}
-          of {totalApplicable} selected
+          of {totalVisible} selected
         </span>
         <div className="ml-auto flex items-center gap-1 rounded-md bg-background p-0.5">
           <button


### PR DESCRIPTION
## Summary
- The global "Apply all — X of Y selected" counter in the identify review form always counted against all applicable fields (e.g., 16), ignoring the Changed/All filter toggle
- Section-level banners already used visible keys correctly; now the global counter does too
- Eliminated duplicate `bookVisibleSelectedCount`/`fileVisibleSelectedCount` variables that computed the same values after the fix

## Test plan
- Run identify on a book where only some fields changed (e.g., via Goodreads Enricher)
- Toggle to "Changed" mode — the "Apply all" counter should show "X of Y" where Y = number of changed fields, not total fields
- Toggle to "All" mode — counter should show total applicable fields
- Toggle individual field checkboxes and verify the X count updates correctly in both modes
- Verify section-level banners (BOOK, FILE) still show correct counts