### PR TITLE
Alias schema, model, and CRUD API

### DIFF
--- a/.sandcastle/.env.example
+++ b/.sandcastle/.env.example
@@ -1,0 +1,5 @@
+# Anthropic API key
+# If you want to use your Claude subscription instead of an API key, see https://github.com/mattpocock/sandcastle/issues/191
+ANTHROPIC_API_KEY=
+# GitHub personal access token
+GH_TOKEN=

--- a/.sandcastle/.gitignore
+++ b/.sandcastle/.gitignore
@@ -1,0 +1,3 @@
+.env
+logs/
+worktrees/

--- a/.sandcastle/CODING_STANDARDS.md
+++ b/.sandcastle/CODING_STANDARDS.md
@@ -1,0 +1,133 @@
+# Coding Standards
+
+## Style
+
+### Go (Backend)
+
+- **Formatting**: All Go files formatted with `goimports` (auto-managed by golangci-lint formatter)
+- **Naming**: PascalCase for exported identifiers, camelCase for unexported
+- **JSON fields**: Always `snake_case` in struct tags (`json:"created_at"`)
+- **Error wrapping**: Use `github.com/pkg/errors` for stack traces (`errors.WithStack`, `errors.Wrap`)
+- **Imports**: Grouped as stdlib, external, internal (enforced by goimports)
+- **Comments**: Minimal — only when the "why" isn't obvious. No function-level doc comments unless exported API
+- **Constants**: Group related constants with `const ( ... )` blocks; use `//tygo:emit` for TypeScript union type generation
+
+### TypeScript / React (Frontend)
+
+- **Formatting**: Prettier with trailing commas (`"always-multiline"`)
+- **Import order**: Builtins → third-party → `@/` aliases → relative (enforced by `@ianvs/prettier-plugin-sort-imports`)
+- **JSX props**: Sorted alphabetically (`react/jsx-sort-props` ESLint rule)
+- **Naming**: PascalCase for components and types, camelCase for functions and variables
+- **Class composition**: Always use `cn()` from `@/libraries/utils` — never template literals for dynamic classNames
+- **Exports**: Prefer named exports; `allowConstantExport` is enabled for react-refresh
+- **No default exports** except for page components used in router lazy-loading
+- **Type imports**: Use `import type { ... }` for type-only imports
+
+### Shared
+
+- **No comments explaining "what"** — code should be self-documenting via naming
+- **No task/ticket references in code** — those belong in commit messages and PRs
+- **Trailing commas** in multiline structures (enforced in both Go and TS)
+
+## Testing
+
+### Go Tests
+
+- **Framework**: Standard `testing` package with `testify/assert` and `testify/require`
+- **Parallelism**: Always add `t.Parallel()` as the first line in new test functions, except when tests share global state (config, shared plugin managers)
+- **Environment**: Tests run with `TZ=America/Chicago CI=true`
+- **TDD required**: Red-Green-Refactor — write the failing test first, then implement
+- **Test files**: Named `*_test.go` colocated with source
+
+### Frontend Tests
+
+- **Unit/Component**: Vitest + React Testing Library, colocated as `*.test.ts(x)`
+- **Fake timers**: Enabled globally; use `userEvent.setup({ advanceTimers: vi.advanceTimersByTime })`
+- **E2E**: Playwright with per-browser database isolation (Chromium + Firefox)
+- **Test independence**: Each E2E test file sets up its own preconditions via `beforeAll`
+
+### General Testing Principles
+
+- Tests for all major functionality (workers, file parsers, complex handlers)
+- No mocking of databases in integration tests — use real SQLite
+- E2E tests use test-only API endpoints (`ENVIRONMENT=test`) for setup/teardown
+
+## Architecture
+
+### Backend Structure
+
+Each domain package (`pkg/{domain}/`) contains:
+- `handlers.go` — HTTP request/response, binds params, calls service
+- `routes.go` — Echo route registration and middleware wiring
+- `service.go` — Business logic and database operations
+- `validators.go` — Request/response payload structs with validation tags
+
+### Key Conventions
+
+- **Request binding must use structs** — never bind directly to slices (the custom binder uses mold/validator which require struct targets)
+- **Bun table aliases in queries** — use single-letter aliases (`b` for books, `f` for files) not full table names
+- **Context propagation** — pass `context.Context` through all service calls; check `ctx.Err()` before expensive operations
+- **Error handling** — use `pkg/errcodes` for typed HTTP errors (`NotFound`, `Forbidden`, `BadRequest`, `Conflict`)
+- **Permissions on all routes** — every route must consider RBAC and library access checks
+
+### Frontend Structure
+
+- **Pages**: `app/components/pages/` — top-level route components
+- **Components**: `app/components/` — reusable UI components
+- **Hooks**: `app/hooks/queries/` — Tanstack Query wrappers per domain
+- **API client**: `app/libraries/api.ts` — single `ShishoAPI` class with typed methods
+- **Types**: Auto-generated from Go via tygo into `app/types/generated/`
+
+### Key Conventions
+
+- **Semantic color tokens only** — never hardcoded Tailwind colors; CSS variables handle dark mode
+- **`cursor-pointer` on all interactive elements** — checkboxes, selects, tabs, dropdowns, buttons
+- **Unsaved changes protection** — all create/edit forms must use `FormDialog` or `useUnsavedChanges`
+- **Tabbed navigation must be URL-synced** — tabs are deep-linked via route params, never local state alone
+- **Page titles required** — all pages use `usePageTitle` hook for browser tab titles
+- **Server-side search** — never rely on client-side filtering (list endpoints max at 50 items)
+- **Cover image cache-busting** — append `?v=${cacheKey}` using `query.dataUpdatedAt`
+- **Cross-resource invalidation** — mutations on metadata entities must also invalidate book queries
+
+### Database
+
+- **ORM**: Bun with SQLite
+- **Table names**: Always plural (`books`, `persons`, `files`)
+- **Foreign keys**: Always specify `ON DELETE CASCADE` or `ON DELETE SET NULL` — never leave implicit
+- **Indexes**: Required on WHERE clause columns and FK referencing columns
+- **FTS cleanup**: CASCADE doesn't remove FTS entries — callers must explicitly clean up search indexes
+- **Migrations**: Created via `mise db:migrate:create <name>`, rolled back via `mise db:rollback`
+
+### API Design
+
+- **All payloads use `snake_case`** field names
+- **List endpoints**: Max 50 items per request, support `limit`/`offset`/`search` params
+- **Validation**: Struct tags (`validate:"required,min=1,max=200"`) with trim via `mod:"trim"`
+- **Error responses**: `{ "error": { "message": "...", "code": "snake_case_code" } }` with appropriate HTTP status
+
+## Code Quality
+
+### Linting (Go)
+
+Enforced linters include: `errcheck`, `govet`, `staticcheck`, `gosec`, `ineffassign`, `unused`, `revive`, `exhaustive`, `bodyclose`, `noctx`, `perfsprint`. Full list in `.golangci.yml`.
+
+### Linting (Frontend)
+
+- ESLint with TypeScript strict rules (`@typescript-eslint/recommended`)
+- React hooks rules (exhaustive deps enforced, `set-state-in-effect` disabled)
+- Prettier for formatting (with Tailwind class sorting plugin)
+- Zero warnings policy (`--max-warnings 0`)
+
+### Git Conventions
+
+- **Commit format**: `[Category] Description` (e.g., `[Fix] Resolve race condition in job worker`)
+- **Categories**: `[Frontend]`, `[Backend]`, `[Feature]`/`[Feat]`, `[Fix]`, `[Docs]`/`[Doc]`, `[Test]`/`[E2E]`, `[CI]`/`[CD]`
+- **Commit messages**: Focus on "why", not "what"
+- **One concern per commit** — don't mix features with unrelated cleanup
+
+### Security
+
+- No command injection, XSS, SQL injection (OWASP top 10 awareness)
+- Session-based auth for frontend API routes, Basic Auth for OPDS, API key auth for eReader
+- Never store secrets in code or commit `.env` files
+- `gosec` linter catches common Go security issues

--- a/.sandcastle/Dockerfile
+++ b/.sandcastle/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:22-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+  git \
+  curl \
+  jq \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+  | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+  | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && apt-get update && apt-get install -y gh \
+  && rm -rf /var/lib/apt/lists/*
+
+# Rename the base image's "node" user (UID 1000) to "agent".
+# This keeps UID 1000 so that --userns=keep-id (Podman) and
+# --user 1000:1000 (Docker) map to the correct home directory owner.
+RUN usermod -d /home/agent -m -l agent node
+USER agent
+
+# Install Claude Code CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Add Claude to PATH
+ENV PATH="/home/agent/.local/bin:$PATH"
+
+WORKDIR /home/agent
+
+# In worktree sandbox mode, Sandcastle bind-mounts the git worktree at /home/agent/workspace
+# and overrides the working directory to /home/agent/workspace at container start.
+# Structure your Dockerfile so that /home/agent/workspace can serve as the project root.
+ENTRYPOINT ["sleep", "infinity"]

--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -1,0 +1,66 @@
+# TASK
+
+Fix issue {{TASK_ID}}: {{ISSUE_TITLE}}
+
+Pull in the issue using `gh issue view <ID>`. If it has a parent PRD, pull that in too.
+
+Only work on the issue specified.
+
+Work on branch {{BRANCH}}. Make commits and run tests.
+
+# CONTEXT
+
+Here are the last 10 commits:
+
+<recent-commits>
+
+!`git log -n 10 --format="%H%n%ad%n%B---" --date=short`
+
+</recent-commits>
+
+# EXPLORATION
+
+Explore the repo and fill your context window with relevant information that will allow you to complete the task.
+
+Pay extra attention to test files that touch the relevant parts of the code.
+
+# EXECUTION
+
+If applicable, use RGR to complete the task.
+
+1. RED: write one test
+2. GREEN: write the implementation to pass that test
+3. REPEAT until done
+4. REFACTOR the code
+
+# FEEDBACK LOOPS
+
+Before committing, run `mise check:quiet` to ensure the linter and tests pass.
+
+# COMMIT
+
+Make a git commit. The commit message must:
+
+1. Follow the commit convention of the repo
+2. Include task completed + PRD reference
+3. Key decisions made
+4. Files changed
+5. Blockers or notes for next iteration
+
+Keep it concise.
+
+# THE PULL REQUEST
+
+Push up the commit to GitHub. If there's no pull request for this branch, create one.
+
+Make sure to reference the issue in the PR.
+
+If the task is complete, prefix the issue with "Closes " so that the merging of the PR will auto-close the issue.
+
+# OUTPUT
+
+Once the task is fully complete, output <promise>COMPLETE</promise>.
+
+# FINAL RULES
+
+ONLY WORK ON A SINGLE TASK.

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -1,0 +1,222 @@
+// Parallel Planner with Review — four-phase orchestration loop
+//
+// This template drives a multi-phase workflow:
+//   Phase 1 (Plan):             An opus agent analyzes open issues, builds a
+//                               dependency graph, and outputs a <plan> JSON
+//                               listing unblocked issues with branch names.
+//   Phase 2 (Execute + Review): For each issue, a sandbox is created via
+//                               createSandbox(). The implementer runs first
+//                               (100 iterations). If it produces commits, a
+//                               reviewer runs in the same sandbox on the same
+//                               branch (1 iteration). All issue pipelines run
+//                               concurrently via Promise.allSettled().
+//   Phase 3 (Merge):            A single agent merges all completed branches
+//                               into the current branch.
+//
+// The outer loop repeats up to MAX_ITERATIONS times so that newly unblocked
+// issues are picked up after each round of merges.
+//
+// Usage:
+//   npx tsx .sandcastle/main.ts
+// Or add to package.json:
+//   "scripts": { "sandcastle": "npx tsx .sandcastle/main.ts" }
+
+import * as sandcastle from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// Maximum number of plan→execute→merge cycles before stopping.
+// Raise this if your backlog is large; lower it for a quick smoke-test run.
+const MAX_ITERATIONS = 10;
+
+// Hooks run inside the sandbox before the agent starts each iteration.
+// npm install ensures the sandbox always has fresh dependencies.
+const hooks = {
+  sandbox: { onSandboxReady: [{ command: "mise setup" }] },
+};
+
+// Copy node_modules from the host into the worktree before each sandbox
+// starts. Avoids a full npm install from scratch; the hook above handles
+// platform-specific binaries and any packages added since the last copy.
+const copyToWorktree = ["node_modules"];
+
+// ---------------------------------------------------------------------------
+// Main loop
+// ---------------------------------------------------------------------------
+
+for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
+  console.log(`\n=== Iteration ${iteration}/${MAX_ITERATIONS} ===\n`);
+
+  // -------------------------------------------------------------------------
+  // Phase 1: Plan
+  //
+  // The planning agent (opus, for deeper reasoning) reads the open issue list,
+  // builds a dependency graph, and selects the issues that can be worked in
+  // parallel right now (i.e., no blocking dependencies on other open issues).
+  //
+  // It outputs a <plan> JSON block — we parse that to drive Phase 2.
+  // -------------------------------------------------------------------------
+  const plan = await sandcastle.run({
+    hooks,
+    sandbox: docker(),
+    name: "planner",
+    // One iteration is enough: the planner just needs to read and reason,
+    // not write code.
+    maxIterations: 1,
+    // Opus for planning: dependency analysis benefits from deeper reasoning.
+    agent: sandcastle.claudeCode("claude-opus-4-6"),
+    promptFile: "./.sandcastle/plan-prompt.md",
+  });
+
+  // Extract the <plan>…</plan> block from the agent's stdout.
+  const planMatch = plan.stdout.match(/<plan>([\s\S]*?)<\/plan>/);
+  if (!planMatch) {
+    throw new Error(
+      "Planning agent did not produce a <plan> tag.\n\n" + plan.stdout,
+    );
+  }
+
+  // The plan JSON contains an array of issues, each with id, title, branch.
+  const { issues } = JSON.parse(planMatch[1]!) as {
+    issues: { id: string; title: string; branch: string }[];
+  };
+
+  if (issues.length === 0) {
+    // No unblocked work — either everything is done or everything is blocked.
+    console.log("No unblocked issues to work on. Exiting.");
+    break;
+  }
+
+  console.log(
+    `Planning complete. ${issues.length} issue(s) to work in parallel:`,
+  );
+  for (const issue of issues) {
+    console.log(`  ${issue.id}: ${issue.title} → ${issue.branch}`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Phase 2: Execute + Review
+  //
+  // For each issue, create a sandbox via createSandbox() so the implementer
+  // and reviewer share the same sandbox instance per branch. The implementer
+  // runs first; if it produces commits, the reviewer runs in the same sandbox.
+  //
+  // Promise.allSettled means one failing pipeline doesn't cancel the others.
+  // -------------------------------------------------------------------------
+
+  const settled = await Promise.allSettled(
+    issues.map(async (issue) => {
+      const sandbox = await sandcastle.createSandbox({
+        branch: issue.branch,
+        sandbox: docker(),
+        hooks,
+        copyToWorktree,
+      });
+
+      try {
+        // Run the implementer
+        const implement = await sandbox.run({
+          name: "implementer",
+          maxIterations: 100,
+          agent: sandcastle.claudeCode("claude-opus-4-6"),
+          promptFile: "./.sandcastle/implement-prompt.md",
+          promptArgs: {
+            TASK_ID: issue.id,
+            ISSUE_TITLE: issue.title,
+            BRANCH: issue.branch,
+          },
+        });
+
+        // Only review if the implementer produced commits
+        if (implement.commits.length > 0) {
+          const review = await sandbox.run({
+            name: "reviewer",
+            maxIterations: 10,
+            agent: sandcastle.claudeCode("claude-opus-4-6"),
+            promptFile: "./.sandcastle/review-prompt.md",
+            promptArgs: {
+              BRANCH: issue.branch,
+            },
+          });
+
+          // Merge commits from both runs so the merge phase sees all of them.
+          // Each sandbox.run() only returns commits from its own run.
+          return {
+            ...review,
+            commits: [...implement.commits, ...review.commits],
+          };
+        }
+
+        return implement;
+      } finally {
+        await sandbox.close();
+      }
+    }),
+  );
+
+  // Log any agents that threw (network error, sandbox crash, etc.).
+  for (const [i, outcome] of settled.entries()) {
+    if (outcome.status === "rejected") {
+      console.error(
+        `  ✗ ${issues[i]!.id} (${issues[i]!.branch}) failed: ${outcome.reason}`,
+      );
+    }
+  }
+
+  // Only pass branches that actually produced commits to the merge phase.
+  // An agent that ran successfully but made no commits has nothing to merge.
+  const completedIssues = settled
+    .map((outcome, i) => ({ outcome, issue: issues[i]! }))
+    .filter(
+      (entry) =>
+        entry.outcome.status === "fulfilled" &&
+        entry.outcome.value.commits.length > 0,
+    )
+    .map((entry) => entry.issue);
+
+  const completedBranches = completedIssues.map((i) => i.branch);
+
+  console.log(
+    `\nExecution complete. ${completedBranches.length} branch(es) with commits:`,
+  );
+  for (const branch of completedBranches) {
+    console.log(`  ${branch}`);
+  }
+
+  if (completedBranches.length === 0) {
+    // All agents ran but none made commits — nothing to merge this cycle.
+    console.log("No commits produced. Nothing to merge.");
+    continue;
+  }
+
+  // -------------------------------------------------------------------------
+  // Phase 3: Merge
+  //
+  // One agent merges all completed branches into the current branch,
+  // resolving any conflicts and running tests to confirm everything works.
+  //
+  // The {{BRANCHES}} and {{ISSUES}} prompt arguments are lists that the agent
+  // uses to know which branches to merge and which issues to close.
+  // -------------------------------------------------------------------------
+  await sandcastle.run({
+    hooks,
+    sandbox: docker(),
+    name: "merger",
+    maxIterations: 1,
+    agent: sandcastle.claudeCode("claude-opus-4-6"),
+    promptFile: "./.sandcastle/merge-prompt.md",
+    promptArgs: {
+      // A markdown list of branch names, one per line.
+      BRANCHES: completedBranches.map((b) => `- ${b}`).join("\n"),
+      // A markdown list of issue IDs and titles, one per line.
+      ISSUES: completedIssues.map((i) => `- ${i.id}: ${i.title}`).join("\n"),
+    },
+  });
+
+  console.log("\nBranches merged.");
+}
+
+console.log("\nAll done.");

--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -1,0 +1,26 @@
+# TASK
+
+Merge the following branches into the current branch:
+
+{{BRANCHES}}
+
+For each branch:
+
+1. Run `git merge <branch> --no-edit`
+2. If there are merge conflicts, resolve them intelligently by reading both sides and choosing the correct resolution
+3. After resolving conflicts, run `npm run typecheck` and `npm run test` to verify everything works
+4. If tests fail, fix the issues before proceeding to the next branch
+
+After all branches are merged, make a single commit summarizing the merge.
+
+# CLOSE ISSUES
+
+For each branch that was merged, close its issue using the following command:
+
+`gh issue close <ID> --comment "Completed by Sandcastle"`
+
+Here are all the issues:
+
+{{ISSUES}}
+
+Once you've merged everything you can, output <promise>COMPLETE</promise>.

--- a/.sandcastle/plan-prompt.md
+++ b/.sandcastle/plan-prompt.md
@@ -1,0 +1,33 @@
+# ISSUES
+
+Here are the open issues in the repo:
+
+<issues-json>
+
+!`gh issue list --state open --label Sandcastle --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+
+</issues-json>
+
+# TASK
+
+Analyze the open issues and build a dependency graph. For each issue, determine whether it **blocks** or **is blocked by** any other open issue.
+
+An issue B is **blocked by** issue A if:
+
+- B requires code or infrastructure that A introduces
+- B and A modify overlapping files or modules, making concurrent work likely to produce merge conflicts
+- B's requirements depend on a decision or API shape that A will establish
+
+An issue is **unblocked** if it has zero blocking dependencies on other open issues.
+
+For each unblocked issue, assign a branch name using the format `sandcastle/issue-{id}-{slug}`.
+
+# OUTPUT
+
+Output your plan as a JSON object wrapped in `<plan>` tags:
+
+<plan>
+{"issues": [{"id": "42", "title": "Fix auth bug", "branch": "sandcastle/issue-42-fix-auth-bug"}]}
+</plan>
+
+Include only unblocked issues. If every issue is blocked, include the single highest-priority candidate (the one with the fewest or weakest dependencies).

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -1,0 +1,53 @@
+# TASK
+
+Review the code changes on branch `{{BRANCH}}` and improve code clarity, consistency, and maintainability while preserving exact functionality.
+
+# CONTEXT
+
+## Branch diff
+
+!`git diff {{SOURCE_BRANCH}}...{{BRANCH}}`
+
+## Commits on this branch
+
+!`git log {{SOURCE_BRANCH}}..{{BRANCH}} --oneline`
+
+# REVIEW PROCESS
+
+1. **Understand the change**: Read the diff and commits above to understand the intent.
+
+2. **Analyze for improvements**: Look for opportunities to:
+   - Reduce unnecessary complexity and nesting
+   - Eliminate redundant code and abstractions
+   - Improve readability through clear variable and function names
+   - Consolidate related logic
+   - Remove unnecessary comments that describe obvious code
+   - Avoid nested ternary operators - prefer switch statements or if/else chains
+   - Choose clarity over brevity - explicit code is often better than overly compact code
+
+3. **Check correctness**:
+   - Does the implementation match the intent? Are edge cases handled?
+   - Are new/changed behaviours covered by tests?
+   - Are there unsafe casts, `any` types, or unchecked assumptions?
+   - Does the change introduce injection vulnerabilities, credential leaks, or other security issues?
+
+4. **Maintain balance**: Avoid over-simplification that could:
+   - Reduce code clarity or maintainability
+   - Create overly clever solutions that are hard to understand
+   - Combine too many concerns into single functions or components
+   - Remove helpful abstractions that improve code organization
+   - Make the code harder to debug or extend
+
+5. **Apply project standards**: Follow the coding standards defined in @.sandcastle/CODING_STANDARDS.md
+
+6. **Preserve functionality**: Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
+
+# EXECUTION
+
+If you find improvements to make:
+
+1. Make the changes directly on this branch
+2. Run tests and type checking to ensure nothing is broken
+3. Commit describing the refinements
+
+If the code is already clean and well-structured, output <promise>COMPLETE</promise>.

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
+    "@ai-hero/sandcastle": "^0.5.7",
     "@eslint/js": "^9.39.2",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
     "@playwright/test": "^1.59.1",

--- a/pkg/aliases/configs.go
+++ b/pkg/aliases/configs.go
@@ -1,0 +1,34 @@
+package aliases
+
+var (
+	GenreConfig = ResourceConfig{
+		AliasTable:    "genre_aliases",
+		ResourceFK:    "genre_id",
+		ResourceTable: "genres",
+	}
+	TagConfig = ResourceConfig{
+		AliasTable:    "tag_aliases",
+		ResourceFK:    "tag_id",
+		ResourceTable: "tags",
+	}
+	SeriesConfig = ResourceConfig{
+		AliasTable:    "series_aliases",
+		ResourceFK:    "series_id",
+		ResourceTable: "series",
+	}
+	PersonConfig = ResourceConfig{
+		AliasTable:    "person_aliases",
+		ResourceFK:    "person_id",
+		ResourceTable: "persons",
+	}
+	PublisherConfig = ResourceConfig{
+		AliasTable:    "publisher_aliases",
+		ResourceFK:    "publisher_id",
+		ResourceTable: "publishers",
+	}
+	ImprintConfig = ResourceConfig{
+		AliasTable:    "imprint_aliases",
+		ResourceFK:    "imprint_id",
+		ResourceTable: "imprints",
+	}
+)

--- a/pkg/aliases/service.go
+++ b/pkg/aliases/service.go
@@ -35,6 +35,9 @@ func (svc *Service) ListAliases(ctx context.Context, cfg ResourceConfig, resourc
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if names == nil {
+		return []string{}, nil
+	}
 	return names, nil
 }
 
@@ -44,7 +47,6 @@ func (svc *Service) AddAlias(ctx context.Context, cfg ResourceConfig, resourceID
 		return errcodes.ValidationError("Alias name cannot be empty")
 	}
 
-	// Check if alias matches the resource's own primary name
 	var primaryName string
 	err := svc.db.NewSelect().
 		TableExpr(cfg.ResourceTable).
@@ -58,7 +60,6 @@ func (svc *Service) AddAlias(ctx context.Context, cfg ResourceConfig, resourceID
 		return errcodes.ValidationError("Alias cannot match the resource's own name")
 	}
 
-	// Check if alias duplicates another resource's primary name (same type + library)
 	var conflictCount int
 	conflictCount, err = svc.db.NewSelect().
 		TableExpr(cfg.ResourceTable).
@@ -71,7 +72,6 @@ func (svc *Service) AddAlias(ctx context.Context, cfg ResourceConfig, resourceID
 		return errcodes.ValidationError("Alias conflicts with an existing name")
 	}
 
-	// Check if alias duplicates an existing alias (same type + library)
 	var aliasCount int
 	aliasCount, err = svc.db.NewSelect().
 		TableExpr(cfg.AliasTable).
@@ -130,7 +130,6 @@ func (svc *Service) SyncAliases(ctx context.Context, cfg ResourceConfig, resourc
 		desiredSet[strings.ToLower(strings.TrimSpace(a))] = true
 	}
 
-	// Remove aliases not in desired
 	for _, a := range current {
 		if !desiredSet[strings.ToLower(a)] {
 			if err := svc.RemoveAlias(ctx, cfg, resourceID, a); err != nil {
@@ -139,7 +138,6 @@ func (svc *Service) SyncAliases(ctx context.Context, cfg ResourceConfig, resourc
 		}
 	}
 
-	// Add aliases in desired but not in current
 	for _, a := range desired {
 		trimmed := strings.TrimSpace(a)
 		if trimmed == "" {

--- a/pkg/aliases/service.go
+++ b/pkg/aliases/service.go
@@ -1,0 +1,156 @@
+package aliases
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/uptrace/bun"
+)
+
+type Service struct {
+	db *bun.DB
+}
+
+func NewService(db *bun.DB) *Service {
+	return &Service{db: db}
+}
+
+type ResourceConfig struct {
+	AliasTable    string
+	ResourceFK    string
+	ResourceTable string
+}
+
+func (svc *Service) ListAliases(ctx context.Context, cfg ResourceConfig, resourceID int) ([]string, error) {
+	var names []string
+	err := svc.db.NewSelect().
+		TableExpr(cfg.AliasTable).
+		Column("name").
+		Where(cfg.ResourceFK+" = ?", resourceID).
+		Order("name ASC").
+		Scan(ctx, &names)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return names, nil
+}
+
+func (svc *Service) AddAlias(ctx context.Context, cfg ResourceConfig, resourceID int, name string, libraryID int) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errcodes.ValidationError("Alias name cannot be empty")
+	}
+
+	// Check if alias matches the resource's own primary name
+	var primaryName string
+	err := svc.db.NewSelect().
+		TableExpr(cfg.ResourceTable).
+		Column("name").
+		Where("id = ?", resourceID).
+		Scan(ctx, &primaryName)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if strings.EqualFold(name, primaryName) {
+		return errcodes.ValidationError("Alias cannot match the resource's own name")
+	}
+
+	// Check if alias duplicates another resource's primary name (same type + library)
+	var conflictCount int
+	conflictCount, err = svc.db.NewSelect().
+		TableExpr(cfg.ResourceTable).
+		Where("LOWER(name) = LOWER(?) AND library_id = ?", name, libraryID).
+		Count(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if conflictCount > 0 {
+		return errcodes.ValidationError("Alias conflicts with an existing name")
+	}
+
+	// Check if alias duplicates an existing alias (same type + library)
+	var aliasCount int
+	aliasCount, err = svc.db.NewSelect().
+		TableExpr(cfg.AliasTable).
+		Where("LOWER(name) = LOWER(?) AND library_id = ?", name, libraryID).
+		Count(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if aliasCount > 0 {
+		return errcodes.ValidationError("Alias conflicts with an existing alias")
+	}
+
+	_, err = svc.db.NewRaw(
+		"INSERT INTO "+cfg.AliasTable+" (created_at, "+cfg.ResourceFK+", name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), resourceID, name, libraryID,
+	).Exec(ctx)
+	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint") {
+			return errcodes.ValidationError("Alias conflicts with an existing alias")
+		}
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+func (svc *Service) RemoveAlias(ctx context.Context, cfg ResourceConfig, resourceID int, name string) error {
+	_, err := svc.db.NewDelete().
+		TableExpr(cfg.AliasTable).
+		Where(cfg.ResourceFK+" = ? AND LOWER(name) = LOWER(?)", resourceID, name).
+		Exec(ctx)
+	return errors.WithStack(err)
+}
+
+func (svc *Service) RemoveAllAliases(ctx context.Context, cfg ResourceConfig, resourceID int) error {
+	_, err := svc.db.NewDelete().
+		TableExpr(cfg.AliasTable).
+		Where(cfg.ResourceFK+" = ?", resourceID).
+		Exec(ctx)
+	return errors.WithStack(err)
+}
+
+func (svc *Service) SyncAliases(ctx context.Context, cfg ResourceConfig, resourceID int, libraryID int, desired []string) error {
+	current, err := svc.ListAliases(ctx, cfg, resourceID)
+	if err != nil {
+		return err
+	}
+
+	currentSet := make(map[string]bool, len(current))
+	for _, a := range current {
+		currentSet[strings.ToLower(a)] = true
+	}
+
+	desiredSet := make(map[string]bool, len(desired))
+	for _, a := range desired {
+		desiredSet[strings.ToLower(strings.TrimSpace(a))] = true
+	}
+
+	// Remove aliases not in desired
+	for _, a := range current {
+		if !desiredSet[strings.ToLower(a)] {
+			if err := svc.RemoveAlias(ctx, cfg, resourceID, a); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Add aliases in desired but not in current
+	for _, a := range desired {
+		trimmed := strings.TrimSpace(a)
+		if trimmed == "" {
+			continue
+		}
+		if !currentSet[strings.ToLower(trimmed)] {
+			if err := svc.AddAlias(ctx, cfg, resourceID, trimmed, libraryID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/aliases/service_test.go
+++ b/pkg/aliases/service_test.go
@@ -169,6 +169,7 @@ func TestListAliases_Empty(t *testing.T) {
 
 	aliases, err := svc.ListAliases(ctx, GenreConfig, genre.ID)
 	require.NoError(t, err)
+	assert.NotNil(t, aliases)
 	assert.Empty(t, aliases)
 }
 
@@ -258,7 +259,6 @@ func TestAddAlias_DifferentLibrariesAllowed(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// Verify the error type is a validation error (422).
 func TestAddAlias_ReturnsValidationError(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/aliases/service_test.go
+++ b/pkg/aliases/service_test.go
@@ -1,0 +1,278 @@
+package aliases
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func setupTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func createTestLibrary(t *testing.T, db *bun.DB) *models.Library {
+	t.Helper()
+	lib := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(context.Background())
+	require.NoError(t, err)
+	return lib
+}
+
+func createTestGenre(t *testing.T, db *bun.DB, name string, libraryID int) *models.Genre {
+	t.Helper()
+	g := &models.Genre{
+		LibraryID: libraryID,
+		Name:      name,
+	}
+	_, err := db.NewInsert().Model(g).Exec(context.Background())
+	require.NoError(t, err)
+	return g
+}
+
+func TestAddAlias(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+
+	err := svc.AddAlias(ctx, GenreConfig, genre.ID, "Sci-Fi", lib.ID)
+	require.NoError(t, err)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Sci-Fi"}, aliases)
+}
+
+func TestAddAlias_RejectsEmpty(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+
+	err := svc.AddAlias(ctx, GenreConfig, genre.ID, "  ", lib.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestAddAlias_RejectsDuplicatePrimaryName(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+
+	err := svc.AddAlias(ctx, GenreConfig, genre.ID, "science fiction", lib.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resource's own name")
+}
+
+func TestAddAlias_RejectsConflictWithOtherPrimaryName(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+	createTestGenre(t, db, "Fantasy", lib.ID)
+
+	err := svc.AddAlias(ctx, GenreConfig, genre.ID, "fantasy", lib.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "existing name")
+}
+
+func TestAddAlias_RejectsConflictWithExistingAlias(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre1 := createTestGenre(t, db, "Science Fiction", lib.ID)
+	genre2 := createTestGenre(t, db, "Fantasy", lib.ID)
+
+	err := svc.AddAlias(ctx, GenreConfig, genre1.ID, "SF", lib.ID)
+	require.NoError(t, err)
+
+	// Try adding same alias (case-insensitive) to another genre
+	err = svc.AddAlias(ctx, GenreConfig, genre2.ID, "sf", lib.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "existing alias")
+}
+
+func TestRemoveAlias(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+
+	err := svc.AddAlias(ctx, GenreConfig, genre.ID, "Sci-Fi", lib.ID)
+	require.NoError(t, err)
+
+	err = svc.RemoveAlias(ctx, GenreConfig, genre.ID, "Sci-Fi")
+	require.NoError(t, err)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.Empty(t, aliases)
+}
+
+func TestListAliases_Empty(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.Empty(t, aliases)
+}
+
+func TestSyncAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+
+	// Add initial aliases
+	err := svc.AddAlias(ctx, GenreConfig, genre.ID, "Sci-Fi", lib.ID)
+	require.NoError(t, err)
+	err = svc.AddAlias(ctx, GenreConfig, genre.ID, "SF", lib.ID)
+	require.NoError(t, err)
+
+	// Sync: keep SF, remove Sci-Fi, add SciFi
+	err = svc.SyncAliases(ctx, GenreConfig, genre.ID, lib.ID, []string{"SF", "SciFi"})
+	require.NoError(t, err)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"SF", "SciFi"}, aliases)
+}
+
+func TestSyncAliases_RejectsConflict(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+	createTestGenre(t, db, "Fantasy", lib.ID)
+
+	err := svc.SyncAliases(ctx, GenreConfig, genre.ID, lib.ID, []string{"fantasy"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "existing name")
+}
+
+func TestAddAlias_CascadeDeletesOnParentRemoval(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+
+	err := svc.AddAlias(ctx, GenreConfig, genre.ID, "Sci-Fi", lib.ID)
+	require.NoError(t, err)
+
+	// Delete the genre - aliases should cascade
+	_, err = db.NewDelete().Model((*models.Genre)(nil)).Where("id = ?", genre.ID).Exec(ctx)
+	require.NoError(t, err)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.Empty(t, aliases)
+}
+
+func TestAddAlias_DifferentLibrariesAllowed(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib1 := createTestLibrary(t, db)
+	lib2 := &models.Library{
+		Name:                     "Second Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib2).Exec(ctx)
+	require.NoError(t, err)
+
+	genre1 := createTestGenre(t, db, "Science Fiction", lib1.ID)
+	genre2 := createTestGenre(t, db, "Science Fiction", lib2.ID)
+
+	err = svc.AddAlias(ctx, GenreConfig, genre1.ID, "Sci-Fi", lib1.ID)
+	require.NoError(t, err)
+
+	// Same alias name in different library should succeed
+	err = svc.AddAlias(ctx, GenreConfig, genre2.ID, "Sci-Fi", lib2.ID)
+	require.NoError(t, err)
+}
+
+// Verify the error type is a validation error (422).
+func TestAddAlias_ReturnsValidationError(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+	createTestGenre(t, db, "Fantasy", lib.ID)
+
+	err := svc.AddAlias(ctx, GenreConfig, genre.ID, "Fantasy", lib.ID)
+	require.Error(t, err)
+
+	var validationErr *errcodes.Error
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, 422, validationErr.HTTPCode)
+}

--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -53,7 +53,7 @@ func (h *handler) retrieve(c echo.Context) error {
 		*models.Genre
 		BookCount int      `json:"book_count"`
 		Aliases   []string `json:"aliases"`
-	}{genre, bookCount, ensureSlice(aliasList)}
+	}{genre, bookCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -96,7 +96,7 @@ func (h *handler) list(c echo.Context) error {
 	for i, g := range genres {
 		bookCount, _ := h.genreService.GetBookCount(ctx, g.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.GenreConfig, g.ID)
-		result[i] = GenreWithCount{g, bookCount, ensureSlice(aliasList)}
+		result[i] = GenreWithCount{g, bookCount, aliasList}
 	}
 
 	response := map[string]any{
@@ -166,7 +166,7 @@ func (h *handler) update(c echo.Context) error {
 				*models.Genre
 				BookCount int      `json:"book_count"`
 				Aliases   []string `json:"aliases"`
-			}{existing, bookCount, ensureSlice(aliasList)}
+			}{existing, bookCount, aliasList}
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
@@ -206,7 +206,7 @@ func (h *handler) update(c echo.Context) error {
 		*models.Genre
 		BookCount int      `json:"book_count"`
 		Aliases   []string `json:"aliases"`
-	}{genre, bookCount, ensureSlice(aliasList)}
+	}{genre, bookCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -317,11 +317,4 @@ func (h *handler) deleteGenre(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
-}
-
-func ensureSlice(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
 }

--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/search"
@@ -15,6 +16,7 @@ import (
 
 type handler struct {
 	genreService  *Service
+	aliasService  *aliases.Service
 	searchService *search.Service
 }
 
@@ -45,10 +47,13 @@ func (h *handler) retrieve(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.GenreConfig, id)
+
 	response := struct {
 		*models.Genre
-		BookCount int `json:"book_count"`
-	}{genre, bookCount}
+		BookCount int      `json:"book_count"`
+		Aliases   []string `json:"aliases"`
+	}{genre, bookCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -81,15 +86,17 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Augment with book counts
+	// Augment with book counts and aliases
 	type GenreWithCount struct {
 		*models.Genre
-		BookCount int `json:"book_count"`
+		BookCount int      `json:"book_count"`
+		Aliases   []string `json:"aliases"`
 	}
 	result := make([]GenreWithCount, len(genres))
 	for i, g := range genres {
 		bookCount, _ := h.genreService.GetBookCount(ctx, g.ID)
-		result[i] = GenreWithCount{g, bookCount}
+		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.GenreConfig, g.ID)
+		result[i] = GenreWithCount{g, bookCount, ensureSlice(aliasList)}
 	}
 
 	response := map[string]any{
@@ -127,72 +134,79 @@ func (h *handler) update(c echo.Context) error {
 		}
 	}
 
-	if params.Name == nil || *params.Name == genre.Name {
-		// No change, just return current
-		bookCount, _ := h.genreService.GetBookCount(ctx, id)
-		response := struct {
-			*models.Genre
-			BookCount int `json:"book_count"`
-		}{genre, bookCount}
-		return errors.WithStack(c.JSON(http.StatusOK, response))
-	}
+	nameChanged := false
+	if params.Name != nil && *params.Name != genre.Name {
+		newName := strings.TrimSpace(*params.Name)
+		if newName == "" {
+			return errcodes.ValidationError("Genre name cannot be empty")
+		}
 
-	newName := strings.TrimSpace(*params.Name)
-	if newName == "" {
-		return errcodes.ValidationError("Genre name cannot be empty")
-	}
+		// Check if a genre with the new name already exists (case-insensitive)
+		existing, err := h.genreService.RetrieveGenre(ctx, RetrieveGenreOptions{
+			Name:      &newName,
+			LibraryID: &genre.LibraryID,
+		})
+		if err == nil && existing.ID != id {
+			// Merge into existing genre
+			err = h.genreService.MergeGenres(ctx, existing.ID, id)
+			if err != nil {
+				return errors.WithStack(err)
+			}
 
-	// Check if a genre with the new name already exists (case-insensitive)
-	existing, err := h.genreService.RetrieveGenre(ctx, RetrieveGenreOptions{
-		Name:      &newName,
-		LibraryID: &genre.LibraryID,
-	})
-	if err == nil && existing.ID != id {
-		// Merge into existing genre
-		err = h.genreService.MergeGenres(ctx, existing.ID, id)
+			// Remove merged genre from FTS index
+			log := logger.FromContext(ctx)
+			if err := h.searchService.DeleteFromGenreIndex(ctx, id); err != nil {
+				log.Warn("failed to remove merged genre from search index", logger.Data{"genre_id": id, "error": err.Error()})
+			}
+
+			// Return the target genre
+			bookCount, _ := h.genreService.GetBookCount(ctx, existing.ID)
+			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.GenreConfig, existing.ID)
+			response := struct {
+				*models.Genre
+				BookCount int      `json:"book_count"`
+				Aliases   []string `json:"aliases"`
+			}{existing, bookCount, ensureSlice(aliasList)}
+			return errors.WithStack(c.JSON(http.StatusOK, response))
+		}
+
+		// Simple rename
+		genre.Name = newName
+		opts := UpdateGenreOptions{Columns: []string{"name"}}
+		err = h.genreService.UpdateGenre(ctx, genre, opts)
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		nameChanged = true
+	}
 
-		// Remove merged genre from FTS index
-		log := logger.FromContext(ctx)
-		if err := h.searchService.DeleteFromGenreIndex(ctx, id); err != nil {
-			log.Warn("failed to remove merged genre from search index", logger.Data{"genre_id": id, "error": err.Error()})
+	// Sync aliases if provided
+	if params.Aliases != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.GenreConfig, id, genre.LibraryID, params.Aliases); err != nil {
+			return errors.WithStack(err)
 		}
-
-		// Return the target genre
-		bookCount, _ := h.genreService.GetBookCount(ctx, existing.ID)
-		response := struct {
-			*models.Genre
-			BookCount int `json:"book_count"`
-		}{existing, bookCount}
-		return errors.WithStack(c.JSON(http.StatusOK, response))
 	}
 
-	// Simple rename
-	genre.Name = newName
-	opts := UpdateGenreOptions{Columns: []string{"name"}}
-	err = h.genreService.UpdateGenre(ctx, genre, opts)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	// Reload and update FTS index
+	// Reload
 	genre, err = h.genreService.RetrieveGenre(ctx, RetrieveGenreOptions{ID: &id})
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	log := logger.FromContext(ctx)
-	if err := h.searchService.IndexGenre(ctx, genre); err != nil {
-		log.Warn("failed to update search index for genre", logger.Data{"genre_id": genre.ID, "error": err.Error()})
+	if nameChanged {
+		log := logger.FromContext(ctx)
+		if err := h.searchService.IndexGenre(ctx, genre); err != nil {
+			log.Warn("failed to update search index for genre", logger.Data{"genre_id": genre.ID, "error": err.Error()})
+		}
 	}
 
 	bookCount, _ := h.genreService.GetBookCount(ctx, id)
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.GenreConfig, id)
 	response := struct {
 		*models.Genre
-		BookCount int `json:"book_count"`
-	}{genre, bookCount}
+		BookCount int      `json:"book_count"`
+		Aliases   []string `json:"aliases"`
+	}{genre, bookCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -303,4 +317,11 @@ func (h *handler) deleteGenre(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func ensureSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }

--- a/pkg/genres/routes.go
+++ b/pkg/genres/routes.go
@@ -2,6 +2,7 @@ package genres
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/search"
@@ -11,10 +12,12 @@ import (
 // RegisterRoutesWithGroup registers genre routes on a pre-configured group.
 func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware) {
 	genreService := NewService(db)
+	aliasService := aliases.NewService(db)
 	searchService := search.NewService(db)
 
 	h := &handler{
 		genreService:  genreService,
+		aliasService:  aliasService,
 		searchService: searchService,
 	}
 

--- a/pkg/genres/validators.go
+++ b/pkg/genres/validators.go
@@ -8,7 +8,8 @@ type ListGenresQuery struct {
 }
 
 type UpdateGenrePayload struct {
-	Name *string `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
+	Name    *string  `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
+	Aliases []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`
 }
 
 type MergeGenresPayload struct {

--- a/pkg/imprints/handlers.go
+++ b/pkg/imprints/handlers.go
@@ -48,7 +48,7 @@ func (h *handler) retrieve(c echo.Context) error {
 		*models.Imprint
 		FileCount int      `json:"file_count"`
 		Aliases   []string `json:"aliases"`
-	}{imprint, fileCount, ensureSlice(aliasList)}
+	}{imprint, fileCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -89,7 +89,7 @@ func (h *handler) list(c echo.Context) error {
 	for i, imp := range imprints {
 		fileCount, _ := h.imprintService.GetFileCount(ctx, imp.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.ImprintConfig, imp.ID)
-		result[i] = ImprintWithCount{imp, fileCount, ensureSlice(aliasList)}
+		result[i] = ImprintWithCount{imp, fileCount, aliasList}
 	}
 
 	response := map[string]any{
@@ -147,7 +147,7 @@ func (h *handler) update(c echo.Context) error {
 				*models.Imprint
 				FileCount int      `json:"file_count"`
 				Aliases   []string `json:"aliases"`
-			}{existing, fileCount, ensureSlice(aliasList)}
+			}{existing, fileCount, aliasList}
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
@@ -176,7 +176,7 @@ func (h *handler) update(c echo.Context) error {
 		*models.Imprint
 		FileCount int      `json:"file_count"`
 		Aliases   []string `json:"aliases"`
-	}{imprint, fileCount, ensureSlice(aliasList)}
+	}{imprint, fileCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -268,11 +268,4 @@ func (h *handler) deleteImprint(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
-}
-
-func ensureSlice(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
 }

--- a/pkg/imprints/handlers.go
+++ b/pkg/imprints/handlers.go
@@ -7,12 +7,14 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
 type handler struct {
 	imprintService *Service
+	aliasService   *aliases.Service
 }
 
 func (h *handler) retrieve(c echo.Context) error {
@@ -29,23 +31,24 @@ func (h *handler) retrieve(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(imprint.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
 		}
 	}
 
-	// Get file count
 	fileCount, err := h.imprintService.GetFileCount(ctx, id)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.ImprintConfig, id)
+
 	response := struct {
 		*models.Imprint
-		FileCount int `json:"file_count"`
-	}{imprint, fileCount}
+		FileCount int      `json:"file_count"`
+		Aliases   []string `json:"aliases"`
+	}{imprint, fileCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -65,7 +68,6 @@ func (h *handler) list(c echo.Context) error {
 		Search:    params.Search,
 	}
 
-	// Filter by user's library access if user is in context
 	if user, ok := c.Get("user").(*models.User); ok {
 		libraryIDs := user.GetAccessibleLibraryIDs()
 		if libraryIDs != nil {
@@ -78,15 +80,16 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Augment with file counts
 	type ImprintWithCount struct {
 		*models.Imprint
-		FileCount int `json:"file_count"`
+		FileCount int      `json:"file_count"`
+		Aliases   []string `json:"aliases"`
 	}
 	result := make([]ImprintWithCount, len(imprints))
 	for i, imp := range imprints {
 		fileCount, _ := h.imprintService.GetFileCount(ctx, imp.ID)
-		result[i] = ImprintWithCount{imp, fileCount}
+		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.ImprintConfig, imp.ID)
+		result[i] = ImprintWithCount{imp, fileCount, ensureSlice(aliasList)}
 	}
 
 	response := map[string]any{
@@ -109,7 +112,6 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Fetch the imprint
 	imprint, err := h.imprintService.RetrieveImprint(ctx, RetrieveImprintOptions{
 		ID: &id,
 	})
@@ -117,68 +119,64 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(imprint.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
 		}
 	}
 
-	if params.Name == nil || *params.Name == imprint.Name {
-		// No change, just return current
-		fileCount, _ := h.imprintService.GetFileCount(ctx, id)
-		response := struct {
-			*models.Imprint
-			FileCount int `json:"file_count"`
-		}{imprint, fileCount}
-		return errors.WithStack(c.JSON(http.StatusOK, response))
-	}
+	if params.Name != nil && *params.Name != imprint.Name {
+		newName := strings.TrimSpace(*params.Name)
+		if newName == "" {
+			return errcodes.ValidationError("Imprint name cannot be empty")
+		}
 
-	newName := strings.TrimSpace(*params.Name)
-	if newName == "" {
-		return errcodes.ValidationError("Imprint name cannot be empty")
-	}
+		existing, err := h.imprintService.RetrieveImprint(ctx, RetrieveImprintOptions{
+			Name:      &newName,
+			LibraryID: &imprint.LibraryID,
+		})
+		if err == nil && existing.ID != id {
+			err = h.imprintService.MergeImprints(ctx, existing.ID, id)
+			if err != nil {
+				return errors.WithStack(err)
+			}
 
-	// Check if an imprint with the new name already exists (case-insensitive)
-	existing, err := h.imprintService.RetrieveImprint(ctx, RetrieveImprintOptions{
-		Name:      &newName,
-		LibraryID: &imprint.LibraryID,
-	})
-	if err == nil && existing.ID != id {
-		// Merge into existing imprint
-		err = h.imprintService.MergeImprints(ctx, existing.ID, id)
+			fileCount, _ := h.imprintService.GetFileCount(ctx, existing.ID)
+			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.ImprintConfig, existing.ID)
+			response := struct {
+				*models.Imprint
+				FileCount int      `json:"file_count"`
+				Aliases   []string `json:"aliases"`
+			}{existing, fileCount, ensureSlice(aliasList)}
+			return errors.WithStack(c.JSON(http.StatusOK, response))
+		}
+
+		imprint.Name = newName
+		opts := UpdateImprintOptions{Columns: []string{"name"}}
+		err = h.imprintService.UpdateImprint(ctx, imprint, opts)
 		if err != nil {
 			return errors.WithStack(err)
 		}
-
-		// Return the target imprint
-		fileCount, _ := h.imprintService.GetFileCount(ctx, existing.ID)
-		response := struct {
-			*models.Imprint
-			FileCount int `json:"file_count"`
-		}{existing, fileCount}
-		return errors.WithStack(c.JSON(http.StatusOK, response))
 	}
 
-	// Simple rename
-	imprint.Name = newName
-	opts := UpdateImprintOptions{Columns: []string{"name"}}
-	err = h.imprintService.UpdateImprint(ctx, imprint, opts)
-	if err != nil {
-		return errors.WithStack(err)
+	if params.Aliases != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.ImprintConfig, id, imprint.LibraryID, params.Aliases); err != nil {
+			return errors.WithStack(err)
+		}
 	}
 
-	// Reload
 	imprint, err = h.imprintService.RetrieveImprint(ctx, RetrieveImprintOptions{ID: &id})
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
 	fileCount, _ := h.imprintService.GetFileCount(ctx, id)
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.ImprintConfig, id)
 	response := struct {
 		*models.Imprint
-		FileCount int `json:"file_count"`
-	}{imprint, fileCount}
+		FileCount int      `json:"file_count"`
+		Aliases   []string `json:"aliases"`
+	}{imprint, fileCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -190,7 +188,6 @@ func (h *handler) files(c echo.Context) error {
 		return errcodes.NotFound("Imprint")
 	}
 
-	// Fetch the imprint to check library access
 	imprint, err := h.imprintService.RetrieveImprint(ctx, RetrieveImprintOptions{
 		ID: &id,
 	})
@@ -198,7 +195,6 @@ func (h *handler) files(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(imprint.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
@@ -225,7 +221,6 @@ func (h *handler) merge(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Fetch the target imprint to check library access
 	imprint, err := h.imprintService.RetrieveImprint(ctx, RetrieveImprintOptions{
 		ID: &id,
 	})
@@ -233,14 +228,12 @@ func (h *handler) merge(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(imprint.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
 		}
 	}
 
-	// Merge source imprint into target (this) imprint
 	err = h.imprintService.MergeImprints(ctx, id, params.SourceID)
 	if err != nil {
 		return errors.WithStack(err)
@@ -256,7 +249,6 @@ func (h *handler) deleteImprint(c echo.Context) error {
 		return errcodes.NotFound("Imprint")
 	}
 
-	// Fetch the imprint to check library access
 	imprint, err := h.imprintService.RetrieveImprint(ctx, RetrieveImprintOptions{
 		ID: &id,
 	})
@@ -264,7 +256,6 @@ func (h *handler) deleteImprint(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(imprint.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
@@ -277,4 +268,11 @@ func (h *handler) deleteImprint(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func ensureSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }

--- a/pkg/imprints/routes.go
+++ b/pkg/imprints/routes.go
@@ -2,6 +2,7 @@ package imprints
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
@@ -10,9 +11,11 @@ import (
 // RegisterRoutesWithGroup registers imprint routes on a pre-configured group.
 func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware) {
 	imprintService := NewService(db)
+	aliasService := aliases.NewService(db)
 
 	h := &handler{
 		imprintService: imprintService,
+		aliasService:   aliasService,
 	}
 
 	g.GET("", h.list)

--- a/pkg/imprints/validators.go
+++ b/pkg/imprints/validators.go
@@ -8,7 +8,8 @@ type ListImprintsQuery struct {
 }
 
 type UpdateImprintPayload struct {
-	Name *string `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
+	Name    *string  `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
+	Aliases []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`
 }
 
 type MergeImprintsPayload struct {

--- a/pkg/migrations/20260503000000_create_alias_tables.go
+++ b/pkg/migrations/20260503000000_create_alias_tables.go
@@ -10,31 +10,23 @@ import (
 func init() {
 	up := func(_ context.Context, db *bun.DB) error {
 		tables := []struct {
-			name string
-			fk   string
+			name   string
+			fk     string
+			parent string
 		}{
-			{"genre_aliases", "genre_id"},
-			{"tag_aliases", "tag_id"},
-			{"series_aliases", "series_id"},
-			{"person_aliases", "person_id"},
-			{"publisher_aliases", "publisher_id"},
-			{"imprint_aliases", "imprint_id"},
-		}
-
-		parentTables := map[string]string{
-			"genre_id":     "genres",
-			"tag_id":       "tags",
-			"series_id":    "series",
-			"person_id":    "persons",
-			"publisher_id": "publishers",
-			"imprint_id":   "imprints",
+			{"genre_aliases", "genre_id", "genres"},
+			{"tag_aliases", "tag_id", "tags"},
+			{"series_aliases", "series_id", "series"},
+			{"person_aliases", "person_id", "persons"},
+			{"publisher_aliases", "publisher_id", "publishers"},
+			{"imprint_aliases", "imprint_id", "imprints"},
 		}
 
 		for _, t := range tables {
 			create := `CREATE TABLE ` + t.name + ` (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
 				created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				` + t.fk + ` INTEGER NOT NULL REFERENCES ` + parentTables[t.fk] + `(id) ON DELETE CASCADE,
+				` + t.fk + ` INTEGER NOT NULL REFERENCES ` + t.parent + `(id) ON DELETE CASCADE,
 				name TEXT NOT NULL,
 				library_id INTEGER NOT NULL REFERENCES libraries(id) ON DELETE CASCADE
 			)`

--- a/pkg/migrations/20260503000000_create_alias_tables.go
+++ b/pkg/migrations/20260503000000_create_alias_tables.go
@@ -1,0 +1,72 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		tables := []struct {
+			name string
+			fk   string
+		}{
+			{"genre_aliases", "genre_id"},
+			{"tag_aliases", "tag_id"},
+			{"series_aliases", "series_id"},
+			{"person_aliases", "person_id"},
+			{"publisher_aliases", "publisher_id"},
+			{"imprint_aliases", "imprint_id"},
+		}
+
+		parentTables := map[string]string{
+			"genre_id":     "genres",
+			"tag_id":       "tags",
+			"series_id":    "series",
+			"person_id":    "persons",
+			"publisher_id": "publishers",
+			"imprint_id":   "imprints",
+		}
+
+		for _, t := range tables {
+			create := `CREATE TABLE ` + t.name + ` (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				` + t.fk + ` INTEGER NOT NULL REFERENCES ` + parentTables[t.fk] + `(id) ON DELETE CASCADE,
+				name TEXT NOT NULL,
+				library_id INTEGER NOT NULL REFERENCES libraries(id) ON DELETE CASCADE
+			)`
+			if _, err := db.Exec(create); err != nil {
+				return errors.Wrapf(err, "creating table %s", t.name)
+			}
+
+			idx := `CREATE UNIQUE INDEX ux_` + t.name + `_name_library_id ON ` + t.name + ` (name COLLATE NOCASE, library_id)`
+			if _, err := db.Exec(idx); err != nil {
+				return errors.Wrapf(err, "creating unique index on %s", t.name)
+			}
+		}
+
+		return nil
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		tables := []string{
+			"imprint_aliases",
+			"publisher_aliases",
+			"person_aliases",
+			"series_aliases",
+			"tag_aliases",
+			"genre_aliases",
+		}
+		for _, t := range tables {
+			if _, err := db.Exec("DROP TABLE IF EXISTS " + t); err != nil {
+				return errors.Wrapf(err, "dropping table %s", t)
+			}
+		}
+		return nil
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/alias.go
+++ b/pkg/models/alias.go
@@ -1,0 +1,67 @@
+package models
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type GenreAlias struct {
+	bun.BaseModel `bun:"table:genre_aliases,alias:ga" tstype:"-"`
+
+	ID        int       `bun:",pk,nullzero" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	GenreID   int       `bun:",nullzero" json:"genre_id"`
+	Name      string    `bun:",nullzero" json:"name"`
+	LibraryID int       `bun:",nullzero" json:"library_id"`
+}
+
+type TagAlias struct {
+	bun.BaseModel `bun:"table:tag_aliases,alias:ta" tstype:"-"`
+
+	ID        int       `bun:",pk,nullzero" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	TagID     int       `bun:",nullzero" json:"tag_id"`
+	Name      string    `bun:",nullzero" json:"name"`
+	LibraryID int       `bun:",nullzero" json:"library_id"`
+}
+
+type SeriesAlias struct {
+	bun.BaseModel `bun:"table:series_aliases,alias:sa" tstype:"-"`
+
+	ID        int       `bun:",pk,nullzero" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	SeriesID  int       `bun:",nullzero" json:"series_id"`
+	Name      string    `bun:",nullzero" json:"name"`
+	LibraryID int       `bun:",nullzero" json:"library_id"`
+}
+
+type PersonAlias struct {
+	bun.BaseModel `bun:"table:person_aliases,alias:pa" tstype:"-"`
+
+	ID        int       `bun:",pk,nullzero" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	PersonID  int       `bun:",nullzero" json:"person_id"`
+	Name      string    `bun:",nullzero" json:"name"`
+	LibraryID int       `bun:",nullzero" json:"library_id"`
+}
+
+type PublisherAlias struct {
+	bun.BaseModel `bun:"table:publisher_aliases,alias:puba" tstype:"-"`
+
+	ID          int       `bun:",pk,nullzero" json:"id"`
+	CreatedAt   time.Time `json:"created_at"`
+	PublisherID int       `bun:",nullzero" json:"publisher_id"`
+	Name        string    `bun:",nullzero" json:"name"`
+	LibraryID   int       `bun:",nullzero" json:"library_id"`
+}
+
+type ImprintAlias struct {
+	bun.BaseModel `bun:"table:imprint_aliases,alias:impa" tstype:"-"`
+
+	ID        int       `bun:",pk,nullzero" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	ImprintID int       `bun:",nullzero" json:"imprint_id"`
+	Name      string    `bun:",nullzero" json:"name"`
+	LibraryID int       `bun:",nullzero" json:"library_id"`
+}

--- a/pkg/models/genre.go
+++ b/pkg/models/genre.go
@@ -9,12 +9,13 @@ import (
 type Genre struct {
 	bun.BaseModel `bun:"table:genres,alias:g" tstype:"-"`
 
-	ID        int       `bun:",pk,nullzero" json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	LibraryID int       `bun:",nullzero" json:"library_id"`
-	Name      string    `bun:",nullzero" json:"name"`
-	BookCount int       `bun:",scanonly" json:"book_count"`
+	ID        int           `bun:",pk,nullzero" json:"id"`
+	CreatedAt time.Time     `json:"created_at"`
+	UpdatedAt time.Time     `json:"updated_at"`
+	LibraryID int           `bun:",nullzero" json:"library_id"`
+	Name      string        `bun:",nullzero" json:"name"`
+	Aliases   []*GenreAlias `bun:"rel:has-many,join:id=genre_id" json:"aliases" tstype:"GenreAlias[]"`
+	BookCount int           `bun:",scanonly" json:"book_count"`
 }
 
 type BookGenre struct {

--- a/pkg/models/imprint.go
+++ b/pkg/models/imprint.go
@@ -9,10 +9,11 @@ import (
 type Imprint struct {
 	bun.BaseModel `bun:"table:imprints,alias:imp" tstype:"-"`
 
-	ID        int       `bun:",pk,nullzero" json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	LibraryID int       `bun:",nullzero" json:"library_id"`
-	Name      string    `bun:",nullzero" json:"name"`
-	FileCount int       `bun:",scanonly" json:"file_count"`
+	ID        int             `bun:",pk,nullzero" json:"id"`
+	CreatedAt time.Time       `json:"created_at"`
+	UpdatedAt time.Time       `json:"updated_at"`
+	LibraryID int             `bun:",nullzero" json:"library_id"`
+	Name      string          `bun:",nullzero" json:"name"`
+	Aliases   []*ImprintAlias `bun:"rel:has-many,join:id=imprint_id" json:"aliases" tstype:"ImprintAlias[]"`
+	FileCount int             `bun:",scanonly" json:"file_count"`
 }

--- a/pkg/models/person.go
+++ b/pkg/models/person.go
@@ -9,13 +9,14 @@ import (
 type Person struct {
 	bun.BaseModel `bun:"table:persons,alias:p" tstype:"-"`
 
-	ID             int       `bun:",pk,nullzero" json:"id"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
-	LibraryID      int       `bun:",nullzero" json:"library_id"`
-	Name           string    `bun:",nullzero" json:"name"`
-	SortName       string    `bun:",notnull" json:"sort_name"`
-	SortNameSource string    `bun:",notnull" json:"sort_name_source" tstype:"DataSource"`
+	ID             int            `bun:",pk,nullzero" json:"id"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
+	LibraryID      int            `bun:",nullzero" json:"library_id"`
+	Name           string         `bun:",nullzero" json:"name"`
+	SortName       string         `bun:",notnull" json:"sort_name"`
+	SortNameSource string         `bun:",notnull" json:"sort_name_source" tstype:"DataSource"`
+	Aliases        []*PersonAlias `bun:"rel:has-many,join:id=person_id" json:"aliases" tstype:"PersonAlias[]"`
 }
 
 // Author role constants for CBZ ComicInfo.xml creator types.

--- a/pkg/models/publisher.go
+++ b/pkg/models/publisher.go
@@ -9,10 +9,11 @@ import (
 type Publisher struct {
 	bun.BaseModel `bun:"table:publishers,alias:pub" tstype:"-"`
 
-	ID        int       `bun:",pk,nullzero" json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	LibraryID int       `bun:",nullzero" json:"library_id"`
-	Name      string    `bun:",nullzero" json:"name"`
-	FileCount int       `bun:",scanonly" json:"file_count"`
+	ID        int               `bun:",pk,nullzero" json:"id"`
+	CreatedAt time.Time         `json:"created_at"`
+	UpdatedAt time.Time         `json:"updated_at"`
+	LibraryID int               `bun:",nullzero" json:"library_id"`
+	Name      string            `bun:",nullzero" json:"name"`
+	Aliases   []*PublisherAlias `bun:"rel:has-many,join:id=publisher_id" json:"aliases" tstype:"PublisherAlias[]"`
+	FileCount int               `bun:",scanonly" json:"file_count"`
 }

--- a/pkg/models/series.go
+++ b/pkg/models/series.go
@@ -15,19 +15,20 @@ const (
 type Series struct {
 	bun.BaseModel `bun:"table:series,alias:s" tstype:"-"`
 
-	ID                 int           `bun:",pk,nullzero" json:"id"`
-	CreatedAt          time.Time     `json:"created_at"`
-	UpdatedAt          time.Time     `json:"updated_at"`
-	LibraryID          int           `bun:",nullzero" json:"library_id"`
-	Library            *Library      `bun:"rel:belongs-to" json:"library,omitempty" tstype:"Library"`
-	Name               string        `bun:",nullzero" json:"name"`
-	NameSource         string        `bun:",nullzero" json:"name_source" tstype:"DataSource"`
-	SortName           string        `bun:",notnull" json:"sort_name"`
-	SortNameSource     string        `bun:",notnull" json:"sort_name_source" tstype:"DataSource"`
-	Description        *string       `json:"description,omitempty"`
-	CoverImageFilename *string       `json:"cover_image_filename,omitempty"`
-	BookSeries         []*BookSeries `bun:"rel:has-many" json:"book_series,omitempty" tstype:"BookSeries[]"`
-	BookCount          int           `bun:",scanonly" json:"book_count"`
+	ID                 int            `bun:",pk,nullzero" json:"id"`
+	CreatedAt          time.Time      `json:"created_at"`
+	UpdatedAt          time.Time      `json:"updated_at"`
+	LibraryID          int            `bun:",nullzero" json:"library_id"`
+	Library            *Library       `bun:"rel:belongs-to" json:"library,omitempty" tstype:"Library"`
+	Name               string         `bun:",nullzero" json:"name"`
+	NameSource         string         `bun:",nullzero" json:"name_source" tstype:"DataSource"`
+	SortName           string         `bun:",notnull" json:"sort_name"`
+	SortNameSource     string         `bun:",notnull" json:"sort_name_source" tstype:"DataSource"`
+	Description        *string        `json:"description,omitempty"`
+	CoverImageFilename *string        `json:"cover_image_filename,omitempty"`
+	Aliases            []*SeriesAlias `bun:"rel:has-many,join:id=series_id" json:"aliases" tstype:"SeriesAlias[]"`
+	BookSeries         []*BookSeries  `bun:"rel:has-many" json:"book_series,omitempty" tstype:"BookSeries[]"`
+	BookCount          int            `bun:",scanonly" json:"book_count"`
 }
 
 type BookSeries struct {

--- a/pkg/models/tag.go
+++ b/pkg/models/tag.go
@@ -9,12 +9,13 @@ import (
 type Tag struct {
 	bun.BaseModel `bun:"table:tags,alias:t" tstype:"-"`
 
-	ID        int       `bun:",pk,nullzero" json:"id"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	LibraryID int       `bun:",nullzero" json:"library_id"`
-	Name      string    `bun:",nullzero" json:"name"`
-	BookCount int       `bun:",scanonly" json:"book_count"`
+	ID        int         `bun:",pk,nullzero" json:"id"`
+	CreatedAt time.Time   `json:"created_at"`
+	UpdatedAt time.Time   `json:"updated_at"`
+	LibraryID int         `bun:",nullzero" json:"library_id"`
+	Name      string      `bun:",nullzero" json:"name"`
+	Aliases   []*TagAlias `bun:"rel:has-many,join:id=tag_id" json:"aliases" tstype:"TagAlias[]"`
+	BookCount int         `bun:",scanonly" json:"book_count"`
 }
 
 type BookTag struct {

--- a/pkg/people/handlers.go
+++ b/pkg/people/handlers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/search"
@@ -32,6 +33,7 @@ type FileOrganizer interface {
 
 type handler struct {
 	personService *Service
+	aliasService  *aliases.Service
 	searchService *search.Service
 	fileOrganizer FileOrganizer // optional, can be nil if not configured
 }
@@ -68,11 +70,14 @@ func (h *handler) retrieve(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PersonConfig, id)
+
 	response := struct {
 		*models.Person
-		AuthoredBookCount int `json:"authored_book_count"`
-		NarratedFileCount int `json:"narrated_file_count"`
-	}{person, authoredCount, narratedCount}
+		AuthoredBookCount int      `json:"authored_book_count"`
+		NarratedFileCount int      `json:"narrated_file_count"`
+		Aliases           []string `json:"aliases"`
+	}{person, authoredCount, narratedCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -105,17 +110,19 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Augment with counts
+	// Augment with counts and aliases
 	type PersonWithCounts struct {
 		*models.Person
-		AuthoredBookCount int `json:"authored_book_count"`
-		NarratedFileCount int `json:"narrated_file_count"`
+		AuthoredBookCount int      `json:"authored_book_count"`
+		NarratedFileCount int      `json:"narrated_file_count"`
+		Aliases           []string `json:"aliases"`
 	}
 	result := make([]PersonWithCounts, len(people))
 	for i, p := range people {
 		authoredCount, _ := h.personService.GetAuthoredBookCount(ctx, p.ID)
 		narratedCount, _ := h.personService.GetNarratedFileCount(ctx, p.ID)
-		result[i] = PersonWithCounts{p, authoredCount, narratedCount}
+		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PersonConfig, p.ID)
+		result[i] = PersonWithCounts{p, authoredCount, narratedCount, ensureSlice(aliasList)}
 	}
 
 	response := map[string]interface{}{
@@ -188,6 +195,13 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	// Sync aliases if provided
+	if params.Aliases != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.PersonConfig, id, person.LibraryID, params.Aliases); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
 	// Reload the model
 	person, err = h.personService.RetrievePerson(ctx, RetrievePersonOptions{
 		ID: &id,
@@ -256,12 +270,14 @@ func (h *handler) update(c echo.Context) error {
 	// Get counts
 	authoredCount, _ := h.personService.GetAuthoredBookCount(ctx, id)
 	narratedCount, _ := h.personService.GetNarratedFileCount(ctx, id)
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PersonConfig, id)
 
 	response := struct {
 		*models.Person
-		AuthoredBookCount int `json:"authored_book_count"`
-		NarratedFileCount int `json:"narrated_file_count"`
-	}{person, authoredCount, narratedCount}
+		AuthoredBookCount int      `json:"authored_book_count"`
+		NarratedFileCount int      `json:"narrated_file_count"`
+		Aliases           []string `json:"aliases"`
+	}{person, authoredCount, narratedCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -402,4 +418,11 @@ func (h *handler) deletePerson(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func ensureSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }

--- a/pkg/people/handlers.go
+++ b/pkg/people/handlers.go
@@ -77,7 +77,7 @@ func (h *handler) retrieve(c echo.Context) error {
 		AuthoredBookCount int      `json:"authored_book_count"`
 		NarratedFileCount int      `json:"narrated_file_count"`
 		Aliases           []string `json:"aliases"`
-	}{person, authoredCount, narratedCount, ensureSlice(aliasList)}
+	}{person, authoredCount, narratedCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -122,7 +122,7 @@ func (h *handler) list(c echo.Context) error {
 		authoredCount, _ := h.personService.GetAuthoredBookCount(ctx, p.ID)
 		narratedCount, _ := h.personService.GetNarratedFileCount(ctx, p.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PersonConfig, p.ID)
-		result[i] = PersonWithCounts{p, authoredCount, narratedCount, ensureSlice(aliasList)}
+		result[i] = PersonWithCounts{p, authoredCount, narratedCount, aliasList}
 	}
 
 	response := map[string]interface{}{
@@ -277,7 +277,7 @@ func (h *handler) update(c echo.Context) error {
 		AuthoredBookCount int      `json:"authored_book_count"`
 		NarratedFileCount int      `json:"narrated_file_count"`
 		Aliases           []string `json:"aliases"`
-	}{person, authoredCount, narratedCount, ensureSlice(aliasList)}
+	}{person, authoredCount, narratedCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -418,11 +418,4 @@ func (h *handler) deletePerson(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
-}
-
-func ensureSlice(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
 }

--- a/pkg/people/routes.go
+++ b/pkg/people/routes.go
@@ -2,6 +2,7 @@ package people
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/search"
@@ -12,10 +13,12 @@ import (
 // fileOrganizer is optional and can be nil if file organization on person name change is not needed.
 func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware, fileOrganizer FileOrganizer) {
 	personService := NewService(db)
+	aliasService := aliases.NewService(db)
 	searchService := search.NewService(db)
 
 	h := &handler{
 		personService: personService,
+		aliasService:  aliasService,
 		searchService: searchService,
 		fileOrganizer: fileOrganizer,
 	}

--- a/pkg/people/validators.go
+++ b/pkg/people/validators.go
@@ -8,8 +8,9 @@ type ListPeopleQuery struct {
 }
 
 type UpdatePersonPayload struct {
-	Name     *string `json:"name,omitempty" validate:"omitempty,max=300"`
-	SortName *string `json:"sort_name,omitempty" validate:"omitempty,max=300"`
+	Name     *string  `json:"name,omitempty" validate:"omitempty,max=300"`
+	SortName *string  `json:"sort_name,omitempty" validate:"omitempty,max=300"`
+	Aliases  []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`
 }
 
 type MergePeoplePayload struct {

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -48,7 +48,7 @@ func (h *handler) retrieve(c echo.Context) error {
 		*models.Publisher
 		FileCount int      `json:"file_count"`
 		Aliases   []string `json:"aliases"`
-	}{publisher, fileCount, ensureSlice(aliasList)}
+	}{publisher, fileCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -89,7 +89,7 @@ func (h *handler) list(c echo.Context) error {
 	for i, p := range publishers {
 		fileCount, _ := h.publisherService.GetFileCount(ctx, p.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PublisherConfig, p.ID)
-		result[i] = PublisherWithCount{p, fileCount, ensureSlice(aliasList)}
+		result[i] = PublisherWithCount{p, fileCount, aliasList}
 	}
 
 	response := map[string]any{
@@ -147,7 +147,7 @@ func (h *handler) update(c echo.Context) error {
 				*models.Publisher
 				FileCount int      `json:"file_count"`
 				Aliases   []string `json:"aliases"`
-			}{existing, fileCount, ensureSlice(aliasList)}
+			}{existing, fileCount, aliasList}
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
@@ -176,7 +176,7 @@ func (h *handler) update(c echo.Context) error {
 		*models.Publisher
 		FileCount int      `json:"file_count"`
 		Aliases   []string `json:"aliases"`
-	}{publisher, fileCount, ensureSlice(aliasList)}
+	}{publisher, fileCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -268,11 +268,4 @@ func (h *handler) deletePublisher(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
-}
-
-func ensureSlice(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
 }

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -7,12 +7,14 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
 type handler struct {
 	publisherService *Service
+	aliasService     *aliases.Service
 }
 
 func (h *handler) retrieve(c echo.Context) error {
@@ -29,23 +31,24 @@ func (h *handler) retrieve(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(publisher.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
 		}
 	}
 
-	// Get file count
 	fileCount, err := h.publisherService.GetFileCount(ctx, id)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PublisherConfig, id)
+
 	response := struct {
 		*models.Publisher
-		FileCount int `json:"file_count"`
-	}{publisher, fileCount}
+		FileCount int      `json:"file_count"`
+		Aliases   []string `json:"aliases"`
+	}{publisher, fileCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -65,7 +68,6 @@ func (h *handler) list(c echo.Context) error {
 		Search:    params.Search,
 	}
 
-	// Filter by user's library access if user is in context
 	if user, ok := c.Get("user").(*models.User); ok {
 		libraryIDs := user.GetAccessibleLibraryIDs()
 		if libraryIDs != nil {
@@ -78,15 +80,16 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Augment with file counts
 	type PublisherWithCount struct {
 		*models.Publisher
-		FileCount int `json:"file_count"`
+		FileCount int      `json:"file_count"`
+		Aliases   []string `json:"aliases"`
 	}
 	result := make([]PublisherWithCount, len(publishers))
 	for i, p := range publishers {
 		fileCount, _ := h.publisherService.GetFileCount(ctx, p.ID)
-		result[i] = PublisherWithCount{p, fileCount}
+		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PublisherConfig, p.ID)
+		result[i] = PublisherWithCount{p, fileCount, ensureSlice(aliasList)}
 	}
 
 	response := map[string]any{
@@ -109,7 +112,6 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Fetch the publisher
 	publisher, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{
 		ID: &id,
 	})
@@ -117,68 +119,64 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(publisher.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
 		}
 	}
 
-	if params.Name == nil || *params.Name == publisher.Name {
-		// No change, just return current
-		fileCount, _ := h.publisherService.GetFileCount(ctx, id)
-		response := struct {
-			*models.Publisher
-			FileCount int `json:"file_count"`
-		}{publisher, fileCount}
-		return errors.WithStack(c.JSON(http.StatusOK, response))
-	}
+	if params.Name != nil && *params.Name != publisher.Name {
+		newName := strings.TrimSpace(*params.Name)
+		if newName == "" {
+			return errcodes.ValidationError("Publisher name cannot be empty")
+		}
 
-	newName := strings.TrimSpace(*params.Name)
-	if newName == "" {
-		return errcodes.ValidationError("Publisher name cannot be empty")
-	}
+		existing, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{
+			Name:      &newName,
+			LibraryID: &publisher.LibraryID,
+		})
+		if err == nil && existing.ID != id {
+			err = h.publisherService.MergePublishers(ctx, existing.ID, id)
+			if err != nil {
+				return errors.WithStack(err)
+			}
 
-	// Check if a publisher with the new name already exists (case-insensitive)
-	existing, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{
-		Name:      &newName,
-		LibraryID: &publisher.LibraryID,
-	})
-	if err == nil && existing.ID != id {
-		// Merge into existing publisher
-		err = h.publisherService.MergePublishers(ctx, existing.ID, id)
+			fileCount, _ := h.publisherService.GetFileCount(ctx, existing.ID)
+			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PublisherConfig, existing.ID)
+			response := struct {
+				*models.Publisher
+				FileCount int      `json:"file_count"`
+				Aliases   []string `json:"aliases"`
+			}{existing, fileCount, ensureSlice(aliasList)}
+			return errors.WithStack(c.JSON(http.StatusOK, response))
+		}
+
+		publisher.Name = newName
+		opts := UpdatePublisherOptions{Columns: []string{"name"}}
+		err = h.publisherService.UpdatePublisher(ctx, publisher, opts)
 		if err != nil {
 			return errors.WithStack(err)
 		}
-
-		// Return the target publisher
-		fileCount, _ := h.publisherService.GetFileCount(ctx, existing.ID)
-		response := struct {
-			*models.Publisher
-			FileCount int `json:"file_count"`
-		}{existing, fileCount}
-		return errors.WithStack(c.JSON(http.StatusOK, response))
 	}
 
-	// Simple rename
-	publisher.Name = newName
-	opts := UpdatePublisherOptions{Columns: []string{"name"}}
-	err = h.publisherService.UpdatePublisher(ctx, publisher, opts)
-	if err != nil {
-		return errors.WithStack(err)
+	if params.Aliases != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.PublisherConfig, id, publisher.LibraryID, params.Aliases); err != nil {
+			return errors.WithStack(err)
+		}
 	}
 
-	// Reload
 	publisher, err = h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{ID: &id})
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
 	fileCount, _ := h.publisherService.GetFileCount(ctx, id)
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PublisherConfig, id)
 	response := struct {
 		*models.Publisher
-		FileCount int `json:"file_count"`
-	}{publisher, fileCount}
+		FileCount int      `json:"file_count"`
+		Aliases   []string `json:"aliases"`
+	}{publisher, fileCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -190,7 +188,6 @@ func (h *handler) files(c echo.Context) error {
 		return errcodes.NotFound("Publisher")
 	}
 
-	// Fetch the publisher to check library access
 	publisher, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{
 		ID: &id,
 	})
@@ -198,7 +195,6 @@ func (h *handler) files(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(publisher.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
@@ -225,7 +221,6 @@ func (h *handler) merge(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Fetch the target publisher to check library access
 	publisher, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{
 		ID: &id,
 	})
@@ -233,14 +228,12 @@ func (h *handler) merge(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(publisher.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
 		}
 	}
 
-	// Merge source publisher into target (this) publisher
 	err = h.publisherService.MergePublishers(ctx, id, params.SourceID)
 	if err != nil {
 		return errors.WithStack(err)
@@ -256,7 +249,6 @@ func (h *handler) deletePublisher(c echo.Context) error {
 		return errcodes.NotFound("Publisher")
 	}
 
-	// Fetch the publisher to check library access
 	publisher, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{
 		ID: &id,
 	})
@@ -264,7 +256,6 @@ func (h *handler) deletePublisher(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(publisher.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
@@ -277,4 +268,11 @@ func (h *handler) deletePublisher(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func ensureSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }

--- a/pkg/publishers/routes.go
+++ b/pkg/publishers/routes.go
@@ -2,6 +2,7 @@ package publishers
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
@@ -10,9 +11,11 @@ import (
 // RegisterRoutesWithGroup registers publisher routes on a pre-configured group.
 func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware) {
 	publisherService := NewService(db)
+	aliasService := aliases.NewService(db)
 
 	h := &handler{
 		publisherService: publisherService,
+		aliasService:     aliasService,
 	}
 
 	g.GET("", h.list)

--- a/pkg/publishers/validators.go
+++ b/pkg/publishers/validators.go
@@ -8,7 +8,8 @@ type ListPublishersQuery struct {
 }
 
 type UpdatePublisherPayload struct {
-	Name *string `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
+	Name    *string  `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
+	Aliases []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`
 }
 
 type MergePublishersPayload struct {

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -62,7 +62,7 @@ func (h *handler) retrieve(c echo.Context) error {
 		*models.Series
 		BookCount int      `json:"book_count"`
 		Aliases   []string `json:"aliases"`
-	}{series, bookCount, ensureSlice(aliasList)}
+	}{series, bookCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -105,7 +105,7 @@ func (h *handler) list(c echo.Context) error {
 	for i, s := range seriesList {
 		count, _ := h.seriesService.GetSeriesBookCount(ctx, s.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.SeriesConfig, s.ID)
-		result[i] = SeriesWithCount{s, count, ensureSlice(aliasList)}
+		result[i] = SeriesWithCount{s, count, aliasList}
 	}
 
 	response := map[string]interface{}{
@@ -211,7 +211,7 @@ func (h *handler) update(c echo.Context) error {
 		*models.Series
 		BookCount int      `json:"book_count"`
 		Aliases   []string `json:"aliases"`
-	}{series, bookCount, ensureSlice(aliasList)}
+	}{series, bookCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -447,11 +447,4 @@ func (h *handler) deleteSeries(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
-}
-
-func ensureSlice(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
 }

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/covers"
 	"github.com/shishobooks/shisho/pkg/errcodes"
@@ -22,6 +23,7 @@ import (
 
 type handler struct {
 	seriesService  *Service
+	aliasService   *aliases.Service
 	bookService    *books.Service
 	libraryService *libraries.Service
 	searchService  *search.Service
@@ -54,10 +56,13 @@ func (h *handler) retrieve(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.SeriesConfig, id)
+
 	response := struct {
 		*models.Series
-		BookCount int `json:"book_count"`
-	}{series, bookCount}
+		BookCount int      `json:"book_count"`
+		Aliases   []string `json:"aliases"`
+	}{series, bookCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -90,15 +95,17 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Augment with book counts
+	// Augment with book counts and aliases
 	type SeriesWithCount struct {
 		*models.Series
-		BookCount int `json:"book_count"`
+		BookCount int      `json:"book_count"`
+		Aliases   []string `json:"aliases"`
 	}
 	result := make([]SeriesWithCount, len(seriesList))
 	for i, s := range seriesList {
 		count, _ := h.seriesService.GetSeriesBookCount(ctx, s.ID)
-		result[i] = SeriesWithCount{s, count}
+		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.SeriesConfig, s.ID)
+		result[i] = SeriesWithCount{s, count, ensureSlice(aliasList)}
 	}
 
 	response := map[string]interface{}{
@@ -175,6 +182,13 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	// Sync aliases if provided
+	if params.Aliases != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.SeriesConfig, id, series.LibraryID, params.Aliases); err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
 	// Reload the model
 	series, err = h.seriesService.RetrieveSeries(ctx, RetrieveSeriesOptions{
 		ID: &id,
@@ -191,11 +205,13 @@ func (h *handler) update(c echo.Context) error {
 
 	// Get book count
 	bookCount, _ := h.seriesService.GetSeriesBookCount(ctx, id)
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.SeriesConfig, id)
 
 	response := struct {
 		*models.Series
-		BookCount int `json:"book_count"`
-	}{series, bookCount}
+		BookCount int      `json:"book_count"`
+		Aliases   []string `json:"aliases"`
+	}{series, bookCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -431,4 +447,11 @@ func (h *handler) deleteSeries(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func ensureSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }

--- a/pkg/series/routes.go
+++ b/pkg/series/routes.go
@@ -2,6 +2,7 @@ package series
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/books"
@@ -14,12 +15,14 @@ import (
 // RegisterRoutesWithGroup registers series routes on a pre-configured group.
 func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware, appSettingsSvc *appsettings.Service) {
 	seriesService := NewService(db)
+	aliasService := aliases.NewService(db)
 	bookService := books.NewService(db).WithAppSettings(appSettingsSvc)
 	libraryService := libraries.NewService(db)
 	searchService := search.NewService(db)
 
 	h := &handler{
 		seriesService:  seriesService,
+		aliasService:   aliasService,
 		bookService:    bookService,
 		libraryService: libraryService,
 		searchService:  searchService,

--- a/pkg/series/validators.go
+++ b/pkg/series/validators.go
@@ -8,9 +8,10 @@ type ListSeriesQuery struct {
 }
 
 type UpdateSeriesPayload struct {
-	Name        *string `json:"name,omitempty" validate:"omitempty,max=300"`
-	SortName    *string `json:"sort_name,omitempty" validate:"omitempty,max=300"`
-	Description *string `json:"description,omitempty" validate:"omitempty,max=2000"`
+	Name        *string  `json:"name,omitempty" validate:"omitempty,max=300"`
+	SortName    *string  `json:"sort_name,omitempty" validate:"omitempty,max=300"`
+	Description *string  `json:"description,omitempty" validate:"omitempty,max=2000"`
+	Aliases     []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`
 }
 
 type MergeSeriesPayload struct {

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/search"
@@ -15,6 +16,7 @@ import (
 
 type handler struct {
 	tagService    *Service
+	aliasService  *aliases.Service
 	searchService *search.Service
 }
 
@@ -39,16 +41,18 @@ func (h *handler) retrieve(c echo.Context) error {
 		}
 	}
 
-	// Get book count
 	bookCount, err := h.tagService.GetBookCount(ctx, id)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, id)
+
 	response := struct {
 		*models.Tag
-		BookCount int `json:"book_count"`
-	}{tag, bookCount}
+		BookCount int      `json:"book_count"`
+		Aliases   []string `json:"aliases"`
+	}{tag, bookCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -68,7 +72,6 @@ func (h *handler) list(c echo.Context) error {
 		Search:    params.Search,
 	}
 
-	// Filter by user's library access if user is in context
 	if user, ok := c.Get("user").(*models.User); ok {
 		libraryIDs := user.GetAccessibleLibraryIDs()
 		if libraryIDs != nil {
@@ -81,15 +84,16 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Augment with book counts
 	type TagWithCount struct {
 		*models.Tag
-		BookCount int `json:"book_count"`
+		BookCount int      `json:"book_count"`
+		Aliases   []string `json:"aliases"`
 	}
 	result := make([]TagWithCount, len(tags))
 	for i, t := range tags {
 		bookCount, _ := h.tagService.GetBookCount(ctx, t.ID)
-		result[i] = TagWithCount{t, bookCount}
+		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, t.ID)
+		result[i] = TagWithCount{t, bookCount, ensureSlice(aliasList)}
 	}
 
 	response := map[string]any{
@@ -112,7 +116,6 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Fetch the tag
 	tag, err := h.tagService.RetrieveTag(ctx, RetrieveTagOptions{
 		ID: &id,
 	})
@@ -120,79 +123,78 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(tag.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
 		}
 	}
 
-	if params.Name == nil || *params.Name == tag.Name {
-		// No change, just return current
-		bookCount, _ := h.tagService.GetBookCount(ctx, id)
-		response := struct {
-			*models.Tag
-			BookCount int `json:"book_count"`
-		}{tag, bookCount}
-		return errors.WithStack(c.JSON(http.StatusOK, response))
-	}
+	nameChanged := false
+	if params.Name != nil && *params.Name != tag.Name {
+		newName := strings.TrimSpace(*params.Name)
+		if newName == "" {
+			return errcodes.ValidationError("Tag name cannot be empty")
+		}
 
-	newName := strings.TrimSpace(*params.Name)
-	if newName == "" {
-		return errcodes.ValidationError("Tag name cannot be empty")
-	}
+		existing, err := h.tagService.RetrieveTag(ctx, RetrieveTagOptions{
+			Name:      &newName,
+			LibraryID: &tag.LibraryID,
+		})
+		if err == nil && existing.ID != id {
+			err = h.tagService.MergeTags(ctx, existing.ID, id)
+			if err != nil {
+				return errors.WithStack(err)
+			}
 
-	// Check if a tag with the new name already exists (case-insensitive)
-	existing, err := h.tagService.RetrieveTag(ctx, RetrieveTagOptions{
-		Name:      &newName,
-		LibraryID: &tag.LibraryID,
-	})
-	if err == nil && existing.ID != id {
-		// Merge into existing tag
-		err = h.tagService.MergeTags(ctx, existing.ID, id)
+			log := logger.FromContext(ctx)
+			if err := h.searchService.DeleteFromTagIndex(ctx, id); err != nil {
+				log.Warn("failed to remove merged tag from search index", logger.Data{"tag_id": id, "error": err.Error()})
+			}
+
+			bookCount, _ := h.tagService.GetBookCount(ctx, existing.ID)
+			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, existing.ID)
+			response := struct {
+				*models.Tag
+				BookCount int      `json:"book_count"`
+				Aliases   []string `json:"aliases"`
+			}{existing, bookCount, ensureSlice(aliasList)}
+			return errors.WithStack(c.JSON(http.StatusOK, response))
+		}
+
+		tag.Name = newName
+		opts := UpdateTagOptions{Columns: []string{"name"}}
+		err = h.tagService.UpdateTag(ctx, tag, opts)
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		nameChanged = true
+	}
 
-		// Remove merged tag from FTS index
-		log := logger.FromContext(ctx)
-		if err := h.searchService.DeleteFromTagIndex(ctx, id); err != nil {
-			log.Warn("failed to remove merged tag from search index", logger.Data{"tag_id": id, "error": err.Error()})
+	if params.Aliases != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.TagConfig, id, tag.LibraryID, params.Aliases); err != nil {
+			return errors.WithStack(err)
 		}
-
-		// Return the target tag
-		bookCount, _ := h.tagService.GetBookCount(ctx, existing.ID)
-		response := struct {
-			*models.Tag
-			BookCount int `json:"book_count"`
-		}{existing, bookCount}
-		return errors.WithStack(c.JSON(http.StatusOK, response))
 	}
 
-	// Simple rename
-	tag.Name = newName
-	opts := UpdateTagOptions{Columns: []string{"name"}}
-	err = h.tagService.UpdateTag(ctx, tag, opts)
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	// Reload and update FTS index
 	tag, err = h.tagService.RetrieveTag(ctx, RetrieveTagOptions{ID: &id})
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	log := logger.FromContext(ctx)
-	if err := h.searchService.IndexTag(ctx, tag); err != nil {
-		log.Warn("failed to update search index for tag", logger.Data{"tag_id": tag.ID, "error": err.Error()})
+	if nameChanged {
+		log := logger.FromContext(ctx)
+		if err := h.searchService.IndexTag(ctx, tag); err != nil {
+			log.Warn("failed to update search index for tag", logger.Data{"tag_id": tag.ID, "error": err.Error()})
+		}
 	}
 
 	bookCount, _ := h.tagService.GetBookCount(ctx, id)
+	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, id)
 	response := struct {
 		*models.Tag
-		BookCount int `json:"book_count"`
-	}{tag, bookCount}
+		BookCount int      `json:"book_count"`
+		Aliases   []string `json:"aliases"`
+	}{tag, bookCount, ensureSlice(aliasList)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -204,7 +206,6 @@ func (h *handler) books(c echo.Context) error {
 		return errcodes.NotFound("Tag")
 	}
 
-	// Fetch the tag to check library access
 	tag, err := h.tagService.RetrieveTag(ctx, RetrieveTagOptions{
 		ID: &id,
 	})
@@ -212,7 +213,6 @@ func (h *handler) books(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(tag.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
@@ -239,7 +239,6 @@ func (h *handler) merge(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Fetch the target tag to check library access
 	tag, err := h.tagService.RetrieveTag(ctx, RetrieveTagOptions{
 		ID: &id,
 	})
@@ -247,20 +246,17 @@ func (h *handler) merge(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(tag.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
 		}
 	}
 
-	// Merge source tag into target (this) tag
 	err = h.tagService.MergeTags(ctx, id, params.SourceID)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	// Remove the merged (source) tag from FTS index
 	log := logger.FromContext(ctx)
 	if err := h.searchService.DeleteFromTagIndex(ctx, params.SourceID); err != nil {
 		log.Warn("failed to remove merged tag from search index", logger.Data{"tag_id": params.SourceID, "error": err.Error()})
@@ -276,7 +272,6 @@ func (h *handler) deleteTag(c echo.Context) error {
 		return errcodes.NotFound("Tag")
 	}
 
-	// Fetch the tag to check library access
 	tag, err := h.tagService.RetrieveTag(ctx, RetrieveTagOptions{
 		ID: &id,
 	})
@@ -284,7 +279,6 @@ func (h *handler) deleteTag(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Check library access
 	if user, ok := c.Get("user").(*models.User); ok {
 		if !user.HasLibraryAccess(tag.LibraryID) {
 			return errcodes.Forbidden("You don't have access to this library")
@@ -296,11 +290,17 @@ func (h *handler) deleteTag(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Remove from FTS index
 	log := logger.FromContext(ctx)
 	if err := h.searchService.DeleteFromTagIndex(ctx, id); err != nil {
 		log.Warn("failed to remove tag from search index", logger.Data{"tag_id": id, "error": err.Error()})
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+func ensureSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -52,7 +52,7 @@ func (h *handler) retrieve(c echo.Context) error {
 		*models.Tag
 		BookCount int      `json:"book_count"`
 		Aliases   []string `json:"aliases"`
-	}{tag, bookCount, ensureSlice(aliasList)}
+	}{tag, bookCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -93,7 +93,7 @@ func (h *handler) list(c echo.Context) error {
 	for i, t := range tags {
 		bookCount, _ := h.tagService.GetBookCount(ctx, t.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, t.ID)
-		result[i] = TagWithCount{t, bookCount, ensureSlice(aliasList)}
+		result[i] = TagWithCount{t, bookCount, aliasList}
 	}
 
 	response := map[string]any{
@@ -157,7 +157,7 @@ func (h *handler) update(c echo.Context) error {
 				*models.Tag
 				BookCount int      `json:"book_count"`
 				Aliases   []string `json:"aliases"`
-			}{existing, bookCount, ensureSlice(aliasList)}
+			}{existing, bookCount, aliasList}
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
@@ -194,7 +194,7 @@ func (h *handler) update(c echo.Context) error {
 		*models.Tag
 		BookCount int      `json:"book_count"`
 		Aliases   []string `json:"aliases"`
-	}{tag, bookCount, ensureSlice(aliasList)}
+	}{tag, bookCount, aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -296,11 +296,4 @@ func (h *handler) deleteTag(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
-}
-
-func ensureSlice(s []string) []string {
-	if s == nil {
-		return []string{}
-	}
-	return s
 }

--- a/pkg/tags/routes.go
+++ b/pkg/tags/routes.go
@@ -2,6 +2,7 @@ package tags
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/search"
@@ -11,10 +12,12 @@ import (
 // RegisterRoutesWithGroup registers tag routes on a pre-configured group.
 func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware) {
 	tagService := NewService(db)
+	aliasService := aliases.NewService(db)
 	searchService := search.NewService(db)
 
 	h := &handler{
 		tagService:    tagService,
+		aliasService:  aliasService,
 		searchService: searchService,
 	}
 

--- a/pkg/tags/validators.go
+++ b/pkg/tags/validators.go
@@ -8,7 +8,8 @@ type ListTagsQuery struct {
 }
 
 type UpdateTagPayload struct {
-	Name *string `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
+	Name    *string  `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
+	Aliases []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`
 }
 
 type MergeTagsPayload struct {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
     devDependencies:
+      '@ai-hero/sandcastle':
+        specifier: ^0.5.7
+        version: 0.5.7(@effect/cluster@0.57.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/typeclass@0.39.0(effect@3.21.2))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.4
@@ -283,6 +286,18 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@ai-hero/sandcastle@0.5.7':
+    resolution: {integrity: sha512-5ZznDx9LQCdOYooL+INx6+35tH44Lb/7+BYUmgWPuBXy5YD7pt14GgMHMWbx3NtSYot7VcBMrgj7UpAQmpRrDA==}
+    hasBin: true
+    peerDependencies:
+      '@daytona/sdk': ^0.164.0
+      '@vercel/sandbox': '>=1.0.0'
+    peerDependenciesMeta:
+      '@daytona/sdk':
+        optional: true
+      '@vercel/sandbox':
+        optional: true
 
   '@algolia/abtesting@1.18.0':
     resolution: {integrity: sha512-8siuLG+FIns1AjZ/g2SDVwHz9S+ObacDQISEJvS8XsNei1zl3FXqfqQrBpmrG7ACWCyesXHbicMJtvRbg00FEw==}
@@ -970,6 +985,14 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
+  '@clack/core@1.3.0':
+    resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.3.0':
+    resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==}
+    engines: {node: '>= 20.12.0'}
+
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -1550,6 +1573,97 @@ packages:
     resolution: {integrity: sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==}
     engines: {node: '>=20.0'}
 
+  '@effect/cli@0.74.0':
+    resolution: {integrity: sha512-vjMJWJWQ2zMRVcZJj2ZGr7vFgVoX6lsCuqAsNiN2ndWZAidkEJ6g1Euuib2V2nTXeWvRyd3FY2Fw2UvX48Uenw==}
+    peerDependencies:
+      '@effect/platform': ^0.95.0
+      '@effect/printer': ^0.48.0
+      '@effect/printer-ansi': ^0.48.0
+      effect: ^3.20.0
+
+  '@effect/cluster@0.57.0':
+    resolution: {integrity: sha512-VjZoZ4hmgDb0GtGjktypTk/nArA3ntsXU2O9vOBzDjJLRKVBt7IS0/cllHrHwK5Jxkfz86B2k+Prw4/+nrLFlw==}
+    peerDependencies:
+      '@effect/platform': ^0.95.0
+      '@effect/rpc': ^0.74.0
+      '@effect/sql': ^0.50.0
+      '@effect/workflow': ^0.17.0
+      effect: ^3.20.0
+
+  '@effect/experimental@0.59.0':
+    resolution: {integrity: sha512-XqdBpIH5VLlkRxKlyPYp8TAYUeBPjoWYgtrxDebDab14K4kkrpkHk0ZsmmOiQUZ+LY5veRn/PBSogXor9gtPqg==}
+    peerDependencies:
+      '@effect/platform': ^0.95.0
+      effect: ^3.20.0
+      ioredis: ^5
+      lmdb: ^3
+    peerDependenciesMeta:
+      ioredis:
+        optional: true
+      lmdb:
+        optional: true
+
+  '@effect/platform-node-shared@0.58.0':
+    resolution: {integrity: sha512-kl8ejYM1xvjRlk+4/R1YzB6A3E3hVWY4jIfEl21uu4S43V0S15gHvcur7iMIEXfJTX1a25EKF+Buef+Yv5wZZQ==}
+    peerDependencies:
+      '@effect/cluster': ^0.57.0
+      '@effect/platform': ^0.95.0
+      '@effect/rpc': ^0.74.0
+      '@effect/sql': ^0.50.0
+      effect: ^3.20.0
+
+  '@effect/platform-node@0.105.0':
+    resolution: {integrity: sha512-6JxOLqLJMm+m1ZQavIb75S7YJ4fRvrDaYUZ4rqv2IMq5ZK9HVaU/LeejE9tip9zAG9yNM/6mn183iiIV/xge5w==}
+    peerDependencies:
+      '@effect/cluster': ^0.57.0
+      '@effect/platform': ^0.95.0
+      '@effect/rpc': ^0.74.0
+      '@effect/sql': ^0.50.0
+      effect: ^3.20.0
+
+  '@effect/platform@0.95.0':
+    resolution: {integrity: sha512-WDlRiWRSWlmhCPq09bvAofK0qr5vM4yNklXjoJdZHmugKRRTpN/Okn3ODnjgM/Kb/4hjMrRyrsUeH/Brieq7KA==}
+    peerDependencies:
+      effect: ^3.20.0
+
+  '@effect/printer-ansi@0.48.0':
+    resolution: {integrity: sha512-CzQ5kiomjR9DZ6LPfKAaWmys6JU65c2Q/VQcTKRK4RfaDWeTAehpAVmgOIyKSPkcr9XBhjo2cJx4xyZ4E5nN7g==}
+    peerDependencies:
+      '@effect/typeclass': ^0.39.0
+      effect: ^3.20.0
+
+  '@effect/printer@0.48.0':
+    resolution: {integrity: sha512-f/+QVyqACuLkoB+HDDX2XxloslmgMDL+C6ecHBV0cB0zJzJmLCOybwOkRcCI2xJ/DWHEIpoRyvq+Bfdza0AIrA==}
+    peerDependencies:
+      '@effect/typeclass': ^0.39.0
+      effect: ^3.20.0
+
+  '@effect/rpc@0.74.0':
+    resolution: {integrity: sha512-EV/cHQqJxLtY+RTlPlVQU1KyTzml1wFne+Sh91RacGRRVh6uTm4UdhRh9TNtbYHD4rM9yD3T6zqUgKr0AH8MvQ==}
+    peerDependencies:
+      '@effect/platform': ^0.95.0
+      effect: ^3.20.0
+
+  '@effect/sql@0.50.0':
+    resolution: {integrity: sha512-sOTzsC+ICASgSmX1RITYo6ut7ZbkX+hMG6YagJEyhtptxco9MgSflpF/ix/L92haJ+YTS5Zur/Dm2bDNfVes4w==}
+    peerDependencies:
+      '@effect/experimental': ^0.59.0
+      '@effect/platform': ^0.95.0
+      effect: ^3.20.0
+
+  '@effect/typeclass@0.39.0':
+    resolution: {integrity: sha512-V8qGpm4BTMS4pW9e7aCdxC0sy/TYsdxmnpWtokkNWnggZ6kvh1Psp3AfUuuZLyNmUk4T+lYB/ItEsga/+hryig==}
+    peerDependencies:
+      effect: ^3.20.0
+
+  '@effect/workflow@0.17.0':
+    resolution: {integrity: sha512-JiayvFTTMrp36P0cVFcgu6Nb7ZJxQv+FRqs3DPORkVAcCZlWOKa3KyuYebN3qZbRsmLzS7cxuC8BAeMuqb+WaQ==}
+    peerDependencies:
+      '@effect/experimental': ^0.59.0
+      '@effect/platform': ^0.95.0
+      '@effect/rpc': ^0.74.0
+      effect: ^3.20.0
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -1999,6 +2113,36 @@ packages:
   '@module-federation/webpack-bundler-runtime@0.22.0':
     resolution: {integrity: sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+
   '@napi-rs/wasm-runtime@1.0.7':
     resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
 
@@ -2029,6 +2173,94 @@ packages:
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
 
   '@peculiar/asn1-cms@2.7.0':
     resolution: {integrity: sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==}
@@ -4370,6 +4602,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.21.2:
+    resolution: {integrity: sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==}
+
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
@@ -4625,6 +4860,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4638,8 +4877,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
@@ -4692,6 +4940,9 @@ packages:
   find-cache-dir@4.0.0:
     resolution: {integrity: sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==}
     engines: {node: '>=14.16'}
+
+  find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -5091,6 +5342,10 @@ packages:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
 
+  ini@4.1.3:
+    resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -5437,6 +5692,9 @@ packages:
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  kubernetes-types@1.30.0:
+    resolution: {integrity: sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==}
 
   latest-version@7.0.0:
     resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
@@ -5864,6 +6122,11 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -5910,9 +6173,19 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.12:
+    resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
+
   multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
     hasBin: true
+
+  multipasta@0.2.7:
+    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -5941,6 +6214,9 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
@@ -5948,6 +6224,10 @@ packages:
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
@@ -6697,6 +6977,9 @@ packages:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
     engines: {node: '>=12.20'}
 
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
   pvtsutils@1.3.6:
     resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
 
@@ -7436,6 +7719,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  toml@3.0.0:
+    resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -7649,6 +7935,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -7974,6 +8264,23 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@ai-hero/sandcastle@0.5.7(@effect/cluster@0.57.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/typeclass@0.39.0(effect@3.21.2))':
+    dependencies:
+      '@clack/prompts': 1.3.0
+      '@effect/cli': 0.74.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/printer-ansi@0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.95.0(effect@3.21.2)
+      '@effect/platform-node': 0.105.0(@effect/cluster@0.57.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer': 0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
+    transitivePeerDependencies:
+      - '@effect/cluster'
+      - '@effect/rpc'
+      - '@effect/sql'
+      - '@effect/typeclass'
+      - bufferutil
+      - utf-8-validate
 
   '@algolia/abtesting@1.18.0':
     dependencies:
@@ -8890,6 +9197,18 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@clack/core@1.3.0':
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.3.0':
+    dependencies:
+      '@clack/core': 1.3.0
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
 
   '@colors/colors@1.5.0':
     optional: true
@@ -10050,6 +10369,102 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@effect/cli@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/printer-ansi@0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/platform': 0.95.0(effect@3.21.2)
+      '@effect/printer': 0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/printer-ansi': 0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
+      ini: 4.1.3
+      toml: 3.0.0
+      yaml: 2.8.3
+
+  '@effect/cluster@0.57.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/platform': 0.95.0(effect@3.21.2)
+      '@effect/rpc': 0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/workflow': 0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
+      kubernetes-types: 1.30.0
+
+  '@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/platform': 0.95.0(effect@3.21.2)
+      effect: 3.21.2
+      uuid: 11.1.1
+
+  '@effect/platform-node-shared@0.58.0(@effect/cluster@0.57.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/cluster': 0.57.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.95.0(effect@3.21.2)
+      '@effect/rpc': 0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
+      '@parcel/watcher': 2.5.6
+      effect: 3.21.2
+      multipasta: 0.2.7
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform-node@0.105.0(@effect/cluster@0.57.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/cluster': 0.57.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.95.0(effect@3.21.2)
+      '@effect/platform-node-shared': 0.58.0(@effect/cluster@0.57.0(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
+      '@effect/rpc': 0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/sql': 0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
+      mime: 3.0.0
+      undici: 7.25.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@effect/platform@0.95.0(effect@3.21.2)':
+    dependencies:
+      effect: 3.21.2
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.12
+      multipasta: 0.2.7
+
+  '@effect/printer-ansi@0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/printer': 0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/typeclass': 0.39.0(effect@3.21.2)
+      effect: 3.21.2
+
+  '@effect/printer@0.48.0(@effect/typeclass@0.39.0(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/typeclass': 0.39.0(effect@3.21.2)
+      effect: 3.21.2
+
+  '@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/platform': 0.95.0(effect@3.21.2)
+      effect: 3.21.2
+      msgpackr: 1.11.12
+
+  '@effect/sql@0.50.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/experimental': 0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.95.0(effect@3.21.2)
+      effect: 3.21.2
+      uuid: 11.1.1
+
+  '@effect/typeclass@0.39.0(effect@3.21.2)':
+    dependencies:
+      effect: 3.21.2
+
+  '@effect/workflow@0.17.0(@effect/experimental@0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.95.0(effect@3.21.2))(@effect/rpc@0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)':
+    dependencies:
+      '@effect/experimental': 0.59.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
+      '@effect/platform': 0.95.0(effect@3.21.2)
+      '@effect/rpc': 0.74.0(@effect/platform@0.95.0(effect@3.21.2))(effect@3.21.2)
+      effect: 3.21.2
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -10469,6 +10884,24 @@ snapshots:
       '@module-federation/runtime': 0.22.0
       '@module-federation/sdk': 0.22.0
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
+
   '@napi-rs/wasm-runtime@1.0.7':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -10500,6 +10933,66 @@ snapshots:
       fastq: 1.20.1
 
   '@oxc-project/types@0.127.0': {}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.4
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
 
   '@peculiar/asn1-cms@2.7.0':
     dependencies:
@@ -12945,6 +13438,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effect@3.21.2:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   electron-to-chromium@1.5.349: {}
 
   emoji-regex@8.0.0: {}
@@ -13360,6 +13858,10 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -13374,7 +13876,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.1.5:
     dependencies:
@@ -13437,6 +13949,8 @@ snapshots:
     dependencies:
       common-path-prefix: 3.0.0
       pkg-dir: 7.0.0
+
+  find-my-way-ts@0.1.6: {}
 
   find-up@5.0.0:
     dependencies:
@@ -13915,6 +14429,8 @@ snapshots:
 
   ini@2.0.0: {}
 
+  ini@4.1.3: {}
+
   inline-style-parser@0.2.7: {}
 
   internal-slot@1.1.0:
@@ -14252,6 +14768,8 @@ snapshots:
   kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
+
+  kubernetes-types@1.30.0: {}
 
   latest-version@7.0.0:
     dependencies:
@@ -14939,6 +15457,8 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mime@3.0.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-response@3.1.0: {}
@@ -14971,10 +15491,28 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.12:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   multicast-dns@7.2.5:
     dependencies:
       dns-packet: 5.6.1
       thunky: 1.1.0
+
+  multipasta@0.2.7: {}
 
   nanoid@3.3.11: {}
 
@@ -14993,6 +15531,8 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
+  node-addon-api@7.1.1: {}
+
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -15006,6 +15546,11 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.38: {}
 
@@ -15761,6 +16306,8 @@ snapshots:
   pupa@3.3.0:
     dependencies:
       escape-goat: 4.0.0
+
+  pure-rand@6.1.0: {}
 
   pvtsutils@1.3.6:
     dependencies:
@@ -16668,6 +17215,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  toml@3.0.0: {}
+
   totalist@3.0.1: {}
 
   tough-cookie@6.0.1:
@@ -16892,6 +17441,8 @@ snapshots:
   utility-types@3.11.0: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.1: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
## Summary

- Creates six alias tables (`genre_aliases`, `tag_aliases`, `series_aliases`, `person_aliases`, `publisher_aliases`, `imprint_aliases`) with FKs (`ON DELETE CASCADE`) and unique indexes on `(name COLLATE NOCASE, library_id)`
- Adds Go model structs for each alias type and `Aliases` has-many relations on all six parent resource models
- Implements shared alias service (`pkg/aliases/`) with add, remove, list, and sync methods including uniqueness validation against primary names and existing aliases (case-insensitive, scoped to resource type + library)
- Updates GET list and detail endpoints for all six resource types to include `"aliases": [...]` in responses
- Updates PATCH endpoints for all six resource types to accept an `aliases` array — the server diffs against current state to determine adds/removes
- Runs `mise tygo` to generate TypeScript types with the aliases field
- Includes 12 service-level tests covering alias CRUD, uniqueness validation, cascade deletion, and cross-library isolation

Closes #200

## Test plan

- [ ] Run `mise lint test` — all Go lints and tests pass
- [ ] Run `mise lint:js` — TypeScript types check, ESLint passes
- [ ] Run `mise db:rollback && mise db:migrate` — migration applies and rolls back cleanly
- [ ] Verify `GET /genres` returns `aliases: []` for genres with no aliases
- [ ] Verify `PATCH /genres/:id` with `{"aliases": ["Sci-Fi"]}` adds the alias, and subsequent GET returns it
- [ ] Verify adding a duplicate alias (case-insensitive) returns 422
- [ ] Verify adding an alias that matches a primary name returns 422
- [ ] Verify deleting a resource cascades to its aliases