### PR TITLE
[Fix] Fix Prettier formatting in CODING_STANDARDS.md

### DIFF
--- a/.sandcastle/CODING_STANDARDS.md
+++ b/.sandcastle/CODING_STANDARDS.md
@@ -57,6 +57,7 @@
 ### Backend Structure
 
 Each domain package (`pkg/{domain}/`) contains:
+
 - `handlers.go` — HTTP request/response, binds params, calls service
 - `routes.go` — Echo route registration and middleware wiring
 - `service.go` — Business logic and database operations


### PR DESCRIPTION
## Summary
- Fix Prettier formatting issue in `.sandcastle/CODING_STANDARDS.md` — adds required blank line after heading before list

## Test plan
- `pnpm lint:prettier` passes cleanly