### PR TITLE
[Fix] Show book counts for genres/tags beyond first 50 alphabetically

### DIFF
--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -30,8 +30,10 @@ import { Textarea } from "@/components/ui/textarea";
 import { useUpdateBook } from "@/hooks/queries/books";
 import {
   useAuthorSearch,
+  useGenreItemCounts,
   useGenreSearch,
   useSeriesSearch,
+  useTagItemCounts,
   useTagSearch,
   type NameWithBookCount,
 } from "@/hooks/queries/entity-search";
@@ -623,6 +625,9 @@ export function BookEditDialog({
               label="Genre"
               onChange={setGenres}
               placeholder="Add genres..."
+              useSelectedItemCounts={function useGenreCounts(v) {
+                return useGenreItemCounts(book.library_id, v);
+              }}
               values={genres}
             />
           </div>
@@ -642,6 +647,9 @@ export function BookEditDialog({
               label="Tag"
               onChange={setTags}
               placeholder="Add tags..."
+              useSelectedItemCounts={function useTagCounts(v) {
+                return useTagItemCounts(book.library_id, v);
+              }}
               values={tags}
             />
           </div>

--- a/app/components/library/IdentifyReviewForm.test.tsx
+++ b/app/components/library/IdentifyReviewForm.test.tsx
@@ -70,6 +70,8 @@ vi.mock("@/hooks/queries/entity-search", () => ({
   useImprintSearch: () => ({ data: [], isLoading: false }),
   useGenreSearch: () => ({ data: [], isLoading: false }),
   useTagSearch: () => ({ data: [], isLoading: false }),
+  useGenreItemCounts: () => new Map(),
+  useTagItemCounts: () => new Map(),
 }));
 
 vi.mock("@/libraries/api", async () => {

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -43,11 +43,13 @@ import {
 } from "@/components/ui/tooltip";
 import { getLanguageName } from "@/constants/languages";
 import {
+  useGenreItemCounts,
   useGenreSearch,
   useImprintSearch,
   usePeopleSearch,
   usePublisherSearch,
   useSeriesSearch,
+  useTagItemCounts,
   useTagSearch,
   type NameOption,
   type NameWithBookCount,
@@ -1568,6 +1570,9 @@ export function IdentifyReviewForm({
                     label="Genre"
                     onChange={setGenres}
                     placeholder="Add genres..."
+                    useSelectedItemCounts={function useGenreCounts(v) {
+                      return useGenreItemCounts(book.library_id, v);
+                    }}
                     values={genres}
                   />
                 </FieldRow>
@@ -1596,6 +1601,9 @@ export function IdentifyReviewForm({
                     label="Tag"
                     onChange={setTags}
                     placeholder="Add tags..."
+                    useSelectedItemCounts={function useTagCounts(v) {
+                      return useTagItemCounts(book.library_id, v);
+                    }}
                     values={tags}
                   />
                 </FieldRow>

--- a/app/components/ui/MultiSelectCombobox.test.tsx
+++ b/app/components/ui/MultiSelectCombobox.test.tsx
@@ -4,7 +4,16 @@ import { describe, expect, it, vi } from "vitest";
 
 import { MultiSelectCombobox } from "./MultiSelectCombobox";
 
+interface NameWithCount {
+  name: string;
+  book_count: number;
+}
+
 function makeHook(items: string[], isLoading = false) {
+  return () => ({ data: items, isLoading });
+}
+
+function makeCountHook(items: NameWithCount[], isLoading = false) {
   return () => ({ data: items, isLoading });
 }
 
@@ -114,5 +123,37 @@ describe("MultiSelectCombobox", () => {
     await user.click(screen.getByRole("combobox"));
     await user.type(screen.getByPlaceholderText(/Search genre/i), "Thriller");
     expect(screen.getByText(/Create new genre "Thriller"/)).toBeInTheDocument();
+  });
+
+  it("displays counts for selected values not in the initial hook results", () => {
+    const hookItems: NameWithCount[] = [
+      { name: "Adventure", book_count: 10 },
+      { name: "Fantasy", book_count: 5 },
+    ];
+
+    render(
+      <MultiSelectCombobox<NameWithCount>
+        getOptionCount={(g) => g.book_count}
+        getOptionLabel={(g) => g.name}
+        hook={makeCountHook(hookItems)}
+        label="Genre"
+        onChange={vi.fn()}
+        useSelectedItemCounts={() =>
+          new Map([
+            ["Young Adult", 22],
+            ["Science Fiction", 15],
+          ])
+        }
+        values={["Fantasy", "Young Adult", "Science Fiction"]}
+      />,
+    );
+
+    const chips = screen.getAllByTestId("ms-chip");
+    expect(chips[0]).toHaveTextContent("Fantasy");
+    expect(chips[0]).toHaveTextContent("(5)");
+    expect(chips[1]).toHaveTextContent("Young Adult");
+    expect(chips[1]).toHaveTextContent("(22)");
+    expect(chips[2]).toHaveTextContent("Science Fiction");
+    expect(chips[2]).toHaveTextContent("(15)");
   });
 });

--- a/app/components/ui/MultiSelectCombobox.tsx
+++ b/app/components/ui/MultiSelectCombobox.tsx
@@ -27,6 +27,7 @@ interface MultiSelectComboboxProps<T> {
   getOptionDescription?: (item: T) => string | undefined;
   getOptionCount?: (item: T) => number | undefined;
   placeholder?: string;
+  useSelectedItemCounts?: (values: string[]) => Map<string, number>;
 }
 
 export function MultiSelectCombobox<T>({
@@ -38,6 +39,7 @@ export function MultiSelectCombobox<T>({
   getOptionDescription,
   getOptionCount,
   placeholder,
+  useSelectedItemCounts,
 }: MultiSelectComboboxProps<T>) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -49,6 +51,15 @@ export function MultiSelectCombobox<T>({
     for (const item of items) {
       const c = getOptionCount(item);
       if (c != null) chipCounts.current.set(getOptionLabel(item), c);
+    }
+  }
+
+  const selectedCounts = useSelectedItemCounts?.(values);
+  if (selectedCounts) {
+    for (const [name, count] of selectedCounts) {
+      if (!chipCounts.current.has(name)) {
+        chipCounts.current.set(name, count);
+      }
     }
   }
 

--- a/app/components/ui/MultiSelectCombobox.tsx
+++ b/app/components/ui/MultiSelectCombobox.tsx
@@ -54,12 +54,13 @@ export function MultiSelectCombobox<T>({
     }
   }
 
-  const selectedCounts = useSelectedItemCounts?.(values);
+  const missingValues = values.filter((v) => !chipCounts.current.has(v));
+  const selectedCounts = useSelectedItemCounts
+    ? useSelectedItemCounts(missingValues)
+    : undefined;
   if (selectedCounts) {
     for (const [name, count] of selectedCounts) {
-      if (!chipCounts.current.has(name)) {
-        chipCounts.current.set(name, count);
-      }
+      chipCounts.current.set(name, count);
     }
   }
 

--- a/app/hooks/queries/entity-search.ts
+++ b/app/hooks/queries/entity-search.ts
@@ -1,11 +1,23 @@
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { API } from "@/libraries/api";
 import type { AuthorInput } from "@/types";
 
-import { useGenresList } from "./genres";
+import {
+  QueryKey as GenresQueryKey,
+  useGenresList,
+  type ListGenresData,
+} from "./genres";
 import { useImprintsList } from "./imprints";
 import { usePeopleList, type PersonWithCounts } from "./people";
 import { usePublishersList } from "./publishers";
 import { useSeriesList } from "./series";
-import { useTagsList } from "./tags";
+import {
+  QueryKey as TagsQueryKey,
+  useTagsList,
+  type ListTagsData,
+} from "./tags";
 
 interface NameOption {
   name: string;
@@ -155,4 +167,74 @@ export function useTagSearch(
     book_count: t.book_count,
   }));
   return { data: adapted, isLoading };
+}
+
+export function useGenreItemCounts(
+  libraryId: number | undefined,
+  values: string[],
+): Map<string, number> {
+  const results = useQueries({
+    queries: values.map((name) => ({
+      queryKey: [
+        GenresQueryKey.ListGenres,
+        { library_id: libraryId, search: name, limit: 1 },
+      ],
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        API.request<ListGenresData>(
+          "GET",
+          "/genres",
+          null,
+          { library_id: libraryId, search: name, limit: 1 },
+          signal,
+        ),
+      enabled: !!libraryId,
+      staleTime: 5 * 60 * 1000,
+    })),
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, number>();
+    for (let i = 0; i < results.length; i++) {
+      const genre = results[i].data?.genres.find(
+        (g) => g.name.toLowerCase() === values[i].toLowerCase(),
+      );
+      if (genre) map.set(values[i], genre.book_count);
+    }
+    return map;
+  }, [results, values]);
+}
+
+export function useTagItemCounts(
+  libraryId: number | undefined,
+  values: string[],
+): Map<string, number> {
+  const results = useQueries({
+    queries: values.map((name) => ({
+      queryKey: [
+        TagsQueryKey.ListTags,
+        { library_id: libraryId, search: name, limit: 1 },
+      ],
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        API.request<ListTagsData>(
+          "GET",
+          "/tags",
+          null,
+          { library_id: libraryId, search: name, limit: 1 },
+          signal,
+        ),
+      enabled: !!libraryId,
+      staleTime: 5 * 60 * 1000,
+    })),
+  });
+
+  return useMemo(() => {
+    const map = new Map<string, number>();
+    for (let i = 0; i < results.length; i++) {
+      const tag = results[i].data?.tags.find(
+        (t) => t.name.toLowerCase() === values[i].toLowerCase(),
+      );
+      if (tag) map.set(values[i], tag.book_count);
+    }
+    return map;
+  }, [results, values]);
 }

--- a/app/hooks/queries/entity-search.ts
+++ b/app/hooks/queries/entity-search.ts
@@ -177,14 +177,14 @@ export function useGenreItemCounts(
     queries: values.map((name) => ({
       queryKey: [
         GenresQueryKey.ListGenres,
-        { library_id: libraryId, search: name, limit: 1 },
+        { library_id: libraryId, search: name, limit: 5 },
       ],
       queryFn: ({ signal }: { signal: AbortSignal }) =>
         API.request<ListGenresData>(
           "GET",
           "/genres",
           null,
-          { library_id: libraryId, search: name, limit: 1 },
+          { library_id: libraryId, search: name, limit: 5 },
           signal,
         ),
       enabled: !!libraryId,
@@ -192,6 +192,7 @@ export function useGenreItemCounts(
     })),
   });
 
+  const dataKey = results.map((r) => r.dataUpdatedAt).join(",");
   return useMemo(() => {
     const map = new Map<string, number>();
     for (let i = 0; i < results.length; i++) {
@@ -201,7 +202,8 @@ export function useGenreItemCounts(
       if (genre) map.set(values[i], genre.book_count);
     }
     return map;
-  }, [results, values]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataKey, values]);
 }
 
 export function useTagItemCounts(
@@ -212,14 +214,14 @@ export function useTagItemCounts(
     queries: values.map((name) => ({
       queryKey: [
         TagsQueryKey.ListTags,
-        { library_id: libraryId, search: name, limit: 1 },
+        { library_id: libraryId, search: name, limit: 5 },
       ],
       queryFn: ({ signal }: { signal: AbortSignal }) =>
         API.request<ListTagsData>(
           "GET",
           "/tags",
           null,
-          { library_id: libraryId, search: name, limit: 1 },
+          { library_id: libraryId, search: name, limit: 5 },
           signal,
         ),
       enabled: !!libraryId,
@@ -227,6 +229,7 @@ export function useTagItemCounts(
     })),
   });
 
+  const dataKey = results.map((r) => r.dataUpdatedAt).join(",");
   return useMemo(() => {
     const map = new Map<string, number>();
     for (let i = 0; i < results.length; i++) {
@@ -236,5 +239,6 @@ export function useTagItemCounts(
       if (tag) map.set(values[i], tag.book_count);
     }
     return map;
-  }, [results, values]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataKey, values]);
 }

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -7,6 +7,7 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 | `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
 | `needs-info`               | `needs-info`         | Waiting on reporter for more information |
 | `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `in-progress`              | `in-progress`        | Currently being worked on by an agent    |
 | `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
 | `wontfix`                  | `wontfix`            | Will not be actioned                     |
 


### PR DESCRIPTION
Closes #198

## Summary
- Added `useSelectedItemCounts` optional prop to `MultiSelectCombobox` that fetches book counts for selected values missing from the initial 50-item API response
- Created `useGenreItemCounts` and `useTagItemCounts` hooks that use `useQueries` to individually search for each missing value's count via the existing search endpoint
- Wired the new hooks into `BookEditDialog` and `IdentifyReviewForm`

## Test plan
- Unit test verifies that selected values not in the initial hook results still display their counts when `useSelectedItemCounts` is provided
- Open BookEditDialog for a book with genres/tags past the 50th alphabetically (e.g., "Young Adult", "Science Fiction" in a library with >50 genres) and confirm all badges show counts
- Confirm the dropdown search-as-you-type still works with the 50-item limit
- Run `pnpm lint:types` — no type errors