### PR TITLE
[Backend] Alias-aware FindOrCreate resolution

### DIFF
--- a/pkg/aliases/service.go
+++ b/pkg/aliases/service.go
@@ -24,6 +24,22 @@ type ResourceConfig struct {
 	ResourceTable string
 }
 
+// FindResourceIDByAlias looks up a resource ID by checking alias names (case-insensitive).
+// Returns the resource ID if found, or sql.ErrNoRows if no alias matches.
+func FindResourceIDByAlias(ctx context.Context, db bun.IDB, cfg ResourceConfig, name string, libraryID int) (int, error) {
+	var resourceID int
+	err := db.NewSelect().
+		TableExpr(cfg.AliasTable).
+		Column(cfg.ResourceFK).
+		Where("LOWER(name) = LOWER(?) AND library_id = ?", name, libraryID).
+		Limit(1).
+		Scan(ctx, &resourceID)
+	if err != nil {
+		return 0, err
+	}
+	return resourceID, nil
+}
+
 func (svc *Service) ListAliases(ctx context.Context, cfg ResourceConfig, resourceID int) ([]string, error) {
 	var names []string
 	err := svc.db.NewSelect().

--- a/pkg/genres/service.go
+++ b/pkg/genres/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
@@ -98,6 +99,11 @@ func (svc *Service) FindOrCreateGenre(ctx context.Context, name string, libraryI
 	}
 	if !errors.Is(err, errcodes.NotFound("Genre")) {
 		return nil, err
+	}
+
+	// Check aliases
+	if resourceID, aliasErr := aliases.FindResourceIDByAlias(ctx, svc.db, aliases.GenreConfig, name, libraryID); aliasErr == nil {
+		return svc.RetrieveGenre(ctx, RetrieveGenreOptions{ID: &resourceID})
 	}
 
 	// Create new genre

--- a/pkg/genres/service_test.go
+++ b/pkg/genres/service_test.go
@@ -1,0 +1,191 @@
+package genres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func setupTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func createTestLibrary(t *testing.T, db *bun.DB) *models.Library {
+	t.Helper()
+	lib := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(context.Background())
+	require.NoError(t, err)
+	return lib
+}
+
+func TestFindOrCreateGenre_PrimaryNameMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	// Create a genre directly
+	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
+	err := svc.CreateGenre(ctx, genre)
+	require.NoError(t, err)
+
+	// FindOrCreate with the same name should return the existing genre
+	found, err := svc.FindOrCreateGenre(ctx, "Science Fiction", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, genre.ID, found.ID)
+	assert.Equal(t, "Science Fiction", found.Name)
+}
+
+func TestFindOrCreateGenre_PrimaryNameMatch_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
+	err := svc.CreateGenre(ctx, genre)
+	require.NoError(t, err)
+
+	// FindOrCreate with different case should return the existing genre
+	found, err := svc.FindOrCreateGenre(ctx, "science fiction", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, genre.ID, found.ID)
+}
+
+func TestFindOrCreateGenre_AliasMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	// Create a genre and add an alias
+	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
+	err := svc.CreateGenre(ctx, genre)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO genre_aliases (created_at, genre_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), genre.ID, "Sci-Fi", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	// FindOrCreate with the alias name should return the canonical genre
+	found, err := svc.FindOrCreateGenre(ctx, "Sci-Fi", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, genre.ID, found.ID)
+	assert.Equal(t, "Science Fiction", found.Name)
+}
+
+func TestFindOrCreateGenre_AliasMatch_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
+	err := svc.CreateGenre(ctx, genre)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO genre_aliases (created_at, genre_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), genre.ID, "Sci-Fi", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	// Case-insensitive alias match
+	found, err := svc.FindOrCreateGenre(ctx, "SCI-FI", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, genre.ID, found.ID)
+}
+
+func TestFindOrCreateGenre_NoMatch_CreatesNew(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	// FindOrCreate with a name that doesn't match any primary or alias
+	found, err := svc.FindOrCreateGenre(ctx, "Mystery", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Mystery", found.Name)
+	assert.Equal(t, lib.ID, found.LibraryID)
+
+	// Verify it was actually created
+	retrieved, err := svc.RetrieveGenre(ctx, RetrieveGenreOptions{ID: &found.ID})
+	require.NoError(t, err)
+	assert.Equal(t, "Mystery", retrieved.Name)
+}
+
+func TestFindOrCreateGenre_AliasMatch_LibraryScoped(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib1 := createTestLibrary(t, db)
+	lib2 := &models.Library{
+		Name:                     "Other Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib2).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create genre with alias in lib1
+	genre := &models.Genre{LibraryID: lib1.ID, Name: "Science Fiction"}
+	err = svc.CreateGenre(ctx, genre)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO genre_aliases (created_at, genre_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), genre.ID, "Sci-Fi", lib1.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	// FindOrCreate in lib2 with the alias name should NOT match lib1's alias
+	found, err := svc.FindOrCreateGenre(ctx, "Sci-Fi", lib2.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, genre.ID, found.ID, "Should not match alias from different library")
+	assert.Equal(t, "Sci-Fi", found.Name)
+	assert.Equal(t, lib2.ID, found.LibraryID)
+}

--- a/pkg/imprints/service.go
+++ b/pkg/imprints/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
@@ -98,6 +99,11 @@ func (svc *Service) FindOrCreateImprint(ctx context.Context, name string, librar
 	}
 	if !errors.Is(err, errcodes.NotFound("Imprint")) {
 		return nil, err
+	}
+
+	// Check aliases
+	if resourceID, aliasErr := aliases.FindResourceIDByAlias(ctx, svc.db, aliases.ImprintConfig, name, libraryID); aliasErr == nil {
+		return svc.RetrieveImprint(ctx, RetrieveImprintOptions{ID: &resourceID})
 	}
 
 	// Create new imprint

--- a/pkg/imprints/service_test.go
+++ b/pkg/imprints/service_test.go
@@ -1,0 +1,104 @@
+package imprints
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func setupTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func createTestLibrary(t *testing.T, db *bun.DB) *models.Library {
+	t.Helper()
+	lib := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(context.Background())
+	require.NoError(t, err)
+	return lib
+}
+
+func TestFindOrCreateImprint_PrimaryNameMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	imp := &models.Imprint{LibraryID: lib.ID, Name: "Vintage Books"}
+	err := svc.CreateImprint(ctx, imp)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreateImprint(ctx, "Vintage Books", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, imp.ID, found.ID)
+}
+
+func TestFindOrCreateImprint_AliasMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	imp := &models.Imprint{LibraryID: lib.ID, Name: "Vintage Books"}
+	err := svc.CreateImprint(ctx, imp)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO imprint_aliases (created_at, imprint_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), imp.ID, "Vintage", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreateImprint(ctx, "Vintage", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, imp.ID, found.ID)
+	assert.Equal(t, "Vintage Books", found.Name)
+}
+
+func TestFindOrCreateImprint_NoMatch_CreatesNew(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	found, err := svc.FindOrCreateImprint(ctx, "Tor Books", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Tor Books", found.Name)
+	assert.Equal(t, lib.ID, found.LibraryID)
+}

--- a/pkg/people/service.go
+++ b/pkg/people/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/sortname"
@@ -112,6 +113,11 @@ func (svc *Service) FindOrCreatePerson(ctx context.Context, name string, library
 	}
 	if !errors.Is(err, errcodes.NotFound("Person")) {
 		return nil, err
+	}
+
+	// Check aliases
+	if resourceID, aliasErr := aliases.FindResourceIDByAlias(ctx, svc.db, aliases.PersonConfig, name, libraryID); aliasErr == nil {
+		return svc.RetrievePerson(ctx, RetrievePersonOptions{ID: &resourceID})
 	}
 
 	// Create new person

--- a/pkg/people/service_test.go
+++ b/pkg/people/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/errcodes"
@@ -149,4 +150,87 @@ func TestRetrievePerson_LibraryScoping(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, errcodes.NotFound("Person")),
 		"expected NotFound when person ID belongs to a different library, got: %v", err)
+}
+
+func TestFindOrCreatePerson_PrimaryNameMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(ctx)
+	require.NoError(t, err)
+
+	person := &models.Person{
+		LibraryID:      lib.ID,
+		Name:           "Brandon Sanderson",
+		SortName:       "Sanderson, Brandon",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreatePerson(ctx, "Brandon Sanderson", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, person.ID, found.ID)
+}
+
+func TestFindOrCreatePerson_AliasMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(ctx)
+	require.NoError(t, err)
+
+	person := &models.Person{
+		LibraryID:      lib.ID,
+		Name:           "Robert Jordan",
+		SortName:       "Jordan, Robert",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO person_aliases (created_at, person_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), person.ID, "James Oliver Rigney Jr.", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreatePerson(ctx, "James Oliver Rigney Jr.", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, person.ID, found.ID)
+	assert.Equal(t, "Robert Jordan", found.Name)
+}
+
+func TestFindOrCreatePerson_NoMatch_CreatesNew(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(ctx)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreatePerson(ctx, "Terry Pratchett", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Terry Pratchett", found.Name)
+	assert.Equal(t, lib.ID, found.LibraryID)
 }

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
@@ -98,6 +99,11 @@ func (svc *Service) FindOrCreatePublisher(ctx context.Context, name string, libr
 	}
 	if !errors.Is(err, errcodes.NotFound("Publisher")) {
 		return nil, err
+	}
+
+	// Check aliases
+	if resourceID, aliasErr := aliases.FindResourceIDByAlias(ctx, svc.db, aliases.PublisherConfig, name, libraryID); aliasErr == nil {
+		return svc.RetrievePublisher(ctx, RetrievePublisherOptions{ID: &resourceID})
 	}
 
 	// Create new publisher

--- a/pkg/publishers/service_test.go
+++ b/pkg/publishers/service_test.go
@@ -1,0 +1,104 @@
+package publishers
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func setupTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func createTestLibrary(t *testing.T, db *bun.DB) *models.Library {
+	t.Helper()
+	lib := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(context.Background())
+	require.NoError(t, err)
+	return lib
+}
+
+func TestFindOrCreatePublisher_PrimaryNameMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	pub := &models.Publisher{LibraryID: lib.ID, Name: "Penguin Random House"}
+	err := svc.CreatePublisher(ctx, pub)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreatePublisher(ctx, "Penguin Random House", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, pub.ID, found.ID)
+}
+
+func TestFindOrCreatePublisher_AliasMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	pub := &models.Publisher{LibraryID: lib.ID, Name: "Penguin Random House"}
+	err := svc.CreatePublisher(ctx, pub)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO publisher_aliases (created_at, publisher_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), pub.ID, "PRH", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreatePublisher(ctx, "PRH", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, pub.ID, found.ID)
+	assert.Equal(t, "Penguin Random House", found.Name)
+}
+
+func TestFindOrCreatePublisher_NoMatch_CreatesNew(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	found, err := svc.FindOrCreatePublisher(ctx, "HarperCollins", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "HarperCollins", found.Name)
+	assert.Equal(t, lib.ID, found.LibraryID)
+}

--- a/pkg/series/service.go
+++ b/pkg/series/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/sortname"
@@ -125,6 +126,21 @@ func (svc *Service) FindOrCreateSeries(ctx context.Context, name string, library
 	}
 	if !errors.Is(err, errcodes.NotFound("Series")) {
 		return nil, err
+	}
+
+	// Check aliases
+	if resourceID, aliasErr := aliases.FindResourceIDByAlias(ctx, svc.db, aliases.SeriesConfig, name, libraryID); aliasErr == nil {
+		s, retrieveErr := svc.RetrieveSeries(ctx, RetrieveSeriesOptions{ID: &resourceID})
+		if retrieveErr != nil {
+			return nil, retrieveErr
+		}
+		if models.GetDataSourcePriority(nameSource) < models.GetDataSourcePriority(s.NameSource) {
+			s.NameSource = nameSource
+			if updateErr := svc.UpdateSeries(ctx, s, UpdateSeriesOptions{Columns: []string{"name_source"}}); updateErr != nil {
+				return nil, updateErr
+			}
+		}
+		return s, nil
 	}
 
 	// Create new series

--- a/pkg/series/service_test.go
+++ b/pkg/series/service_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/appsettings"
@@ -472,4 +473,87 @@ func TestCleanupOrphanedSeries_ReturnsDeletedIDs(t *testing.T) {
 		Where("id = ?", keep.ID).Count(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, 1, count, "series with books must not be cleaned up")
+}
+
+func TestFindOrCreateSeries_PrimaryNameMatch(t *testing.T) {
+	t.Parallel()
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	s := &models.Series{
+		LibraryID:  library.ID,
+		Name:       "Harry Potter",
+		NameSource: models.DataSourceFilepath,
+		SortName:   "Harry Potter",
+	}
+	err = svc.CreateSeries(ctx, s)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreateSeries(ctx, "Harry Potter", library.ID, models.DataSourceFilepath)
+	require.NoError(t, err)
+	assert.Equal(t, s.ID, found.ID)
+}
+
+func TestFindOrCreateSeries_AliasMatch(t *testing.T) {
+	t.Parallel()
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	s := &models.Series{
+		LibraryID:  library.ID,
+		Name:       "A Song of Ice and Fire",
+		NameSource: models.DataSourceFilepath,
+		SortName:   "Song of Ice and Fire, A",
+	}
+	err = svc.CreateSeries(ctx, s)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO series_aliases (created_at, series_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), s.ID, "Game of Thrones", library.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreateSeries(ctx, "Game of Thrones", library.ID, models.DataSourceFilepath)
+	require.NoError(t, err)
+	assert.Equal(t, s.ID, found.ID)
+	assert.Equal(t, "A Song of Ice and Fire", found.Name)
+}
+
+func TestFindOrCreateSeries_NoMatch_CreatesNew(t *testing.T) {
+	t.Parallel()
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreateSeries(ctx, "The Wheel of Time", library.ID, models.DataSourceFilepath)
+	require.NoError(t, err)
+	assert.Equal(t, "The Wheel of Time", found.Name)
+	assert.Equal(t, library.ID, found.LibraryID)
 }

--- a/pkg/tags/service.go
+++ b/pkg/tags/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/uptrace/bun"
@@ -98,6 +99,11 @@ func (svc *Service) FindOrCreateTag(ctx context.Context, name string, libraryID 
 	}
 	if !errors.Is(err, errcodes.NotFound("Tag")) {
 		return nil, err
+	}
+
+	// Check aliases
+	if resourceID, aliasErr := aliases.FindResourceIDByAlias(ctx, svc.db, aliases.TagConfig, name, libraryID); aliasErr == nil {
+		return svc.RetrieveTag(ctx, RetrieveTagOptions{ID: &resourceID})
 	}
 
 	// Create new tag

--- a/pkg/tags/service_test.go
+++ b/pkg/tags/service_test.go
@@ -1,0 +1,104 @@
+package tags
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func setupTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func createTestLibrary(t *testing.T, db *bun.DB) *models.Library {
+	t.Helper()
+	lib := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(context.Background())
+	require.NoError(t, err)
+	return lib
+}
+
+func TestFindOrCreateTag_PrimaryNameMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	tag := &models.Tag{LibraryID: lib.ID, Name: "Fantasy"}
+	err := svc.CreateTag(ctx, tag)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreateTag(ctx, "Fantasy", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tag.ID, found.ID)
+}
+
+func TestFindOrCreateTag_AliasMatch(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	tag := &models.Tag{LibraryID: lib.ID, Name: "Science Fiction"}
+	err := svc.CreateTag(ctx, tag)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO tag_aliases (created_at, tag_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), tag.ID, "Sci-Fi", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	found, err := svc.FindOrCreateTag(ctx, "Sci-Fi", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, tag.ID, found.ID)
+	assert.Equal(t, "Science Fiction", found.Name)
+}
+
+func TestFindOrCreateTag_NoMatch_CreatesNew(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	found, err := svc.FindOrCreateTag(ctx, "Horror", lib.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Horror", found.Name)
+	assert.Equal(t, lib.ID, found.LibraryID)
+}


### PR DESCRIPTION
Closes #201

## Summary
- Adds `FindResourceIDByAlias` helper to the `pkg/aliases` package that performs a case-insensitive alias lookup by name and library
- Modifies `FindOrCreate` in all six resource services (genres, tags, series, people, publishers, imprints) to check aliases after a primary name miss
- Lookup order: primary name (case-insensitive) → aliases (case-insensitive) → create new resource
- When an alias matches, the canonical resource is returned silently — no signature change
- Scanner, plugin persist handler, and sidecar flows become alias-aware automatically since they all call `FindOrCreate`

## Test plan
- Service-level tests for all 6 resource types: primary name match, alias match (case-insensitive), no match → create
- Library scoping test: alias in library A doesn't match in library B
- Race condition handling still works (UNIQUE constraint retry)
- Full `mise check:quiet` passes (lint, Go tests, JS lint, JS tests)
- Worker tests pass (main caller of FindOrCreate)