### PR TITLE
[CI] Fix consolidate test timings job losing artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
             go.mod
             go.sum
       - name: Restore previous test timing cache
+        # Preserves shard history when a shard fails before writing junit
+        # or upload-artifact fails — fresh artifacts overlay on top.
         uses: actions/cache/restore@v5
         with:
           path: .gotest-timings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,11 +76,13 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            tools/gotestsplit
+            go.mod
+            go.sum
       - name: Restore previous test timing cache
-        # Belt-and-suspenders alongside the fresh-only uploads above: if a
-        # shard fails before writing any junit (or upload-artifact fails),
-        # we still preserve that shard's prior history rather than dropping
-        # it from the cache permanently.
         uses: actions/cache/restore@v5
         with:
           path: .gotest-timings
@@ -94,15 +96,6 @@ jobs:
           path: .gotest-timings
           pattern: gotest-timings-shard-*
           merge-multiple: true
-      # Must come AFTER cache restore + artifact download so clean: false
-      # preserves the assembled .gotest-timings directory.
-      - uses: actions/checkout@v6
-        with:
-          clean: false
-          sparse-checkout: |
-            tools/gotestsplit
-            go.mod
-            go.sum
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod


### PR DESCRIPTION
## Summary
- `checkout@v6` unconditionally wipes the working directory when no `.git` exists, ignoring `clean: false`
- The consolidate job was downloading artifacts *before* checkout, so they got deleted
- Moved checkout to be the first step so cache restore and artifact download happen in an initialized workspace

## Test plan
- Push and verify the consolidate-test-timings job in CI now shows >0 junit files in the "Report cache size" step
- Verify the "Save consolidated cache" step succeeds without the "Path(s) specified...do(es) not exist" warning