### PR TITLE
[Backend] Scanner cache: pre-populate alias entries on first resolution

### DIFF
--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/joblogs"
@@ -368,6 +369,7 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 		// .pdf companion next to a .epub) and skip it instead of trying to
 		// recreate it as a main file and hitting UNIQUE(filepath, library_id).
 		cache := NewScanCache()
+		cache.SetAliasLister(NewAliasServiceAdapter(aliases.NewService(w.db)))
 		allFiles, err := w.bookService.ListAllFilesForLibrary(ctx, library.ID)
 		if err != nil {
 			jobLog.Warn("failed to pre-load files", logger.Data{"error": err.Error()})

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
-	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/joblogs"
@@ -369,7 +368,7 @@ func (w *Worker) ProcessScanJob(ctx context.Context, job *models.Job, jobLog *jo
 		// .pdf companion next to a .epub) and skip it instead of trying to
 		// recreate it as a main file and hitting UNIQUE(filepath, library_id).
 		cache := NewScanCache()
-		cache.SetAliasLister(NewAliasServiceAdapter(aliases.NewService(w.db)))
+		cache.SetAliasLister(NewAliasServiceAdapter(w.aliasService))
 		allFiles, err := w.bookService.ListAllFilesForLibrary(ctx, library.ID)
 		if err != nil {
 			jobLog.Warn("failed to pre-load files", logger.Data{"error": err.Error()})

--- a/pkg/worker/scan_cache.go
+++ b/pkg/worker/scan_cache.go
@@ -39,6 +39,17 @@ type ImprintFinder interface {
 	FindOrCreateImprint(ctx context.Context, name string, libraryID int) (*models.Imprint, error)
 }
 
+// AliasLister fetches alias names for resolved resources so the cache can
+// pre-populate entries for every name variant (canonical + aliases).
+type AliasLister interface {
+	ListPersonAliases(ctx context.Context, personID int) ([]string, error)
+	ListGenreAliases(ctx context.Context, genreID int) ([]string, error)
+	ListTagAliases(ctx context.Context, tagID int) ([]string, error)
+	ListSeriesAliases(ctx context.Context, seriesID int) ([]string, error)
+	ListPublisherAliases(ctx context.Context, publisherID int) ([]string, error)
+	ListImprintAliases(ctx context.Context, imprintID int) ([]string, error)
+}
+
 // ScanCache provides thread-safe caching for entity lookups during parallel file processing.
 // It uses sync.Map for cache storage and per-key mutexes to prevent duplicate concurrent DB calls.
 type ScanCache struct {
@@ -82,6 +93,8 @@ type ScanCache struct {
 	// after the scan (renaming folders back into the structured layout).
 	movedBookIDs map[int]struct{}
 
+	aliasLister AliasLister
+
 	// libraryRootPaths caches the library's root paths (from
 	// library.LibraryPaths) so syncBookFilepathAfterMove can enforce its
 	// "don't set Book.Filepath to a library root" guard without a DB
@@ -103,6 +116,12 @@ func NewScanCache() *ScanCache {
 	return &ScanCache{
 		knownFiles: make(map[string]*models.File),
 	}
+}
+
+// SetAliasLister configures alias lookup so that cache misses pre-populate
+// entries for the canonical name and every alias of the resolved resource.
+func (c *ScanCache) SetAliasLister(lister AliasLister) {
+	c.aliasLister = lister
 }
 
 // LoadKnownFiles populates the known files cache from a list of existing files.
@@ -128,6 +147,17 @@ func cacheKey(name string, libraryID int) string {
 func getMutex(mutexMap *sync.Map, key any) *sync.Mutex {
 	mu, _ := mutexMap.LoadOrStore(key, &sync.Mutex{})
 	return mu.(*sync.Mutex)
+}
+
+// populateAliasEntries stores the resource in the cache under its canonical name
+// and every alias name, so subsequent lookups for any variant are cache hits.
+func populateAliasEntries(cacheMap *sync.Map, canonicalName string, libraryID int, value any, aliasNames []string) {
+	canonKey := cacheKey(canonicalName, libraryID)
+	cacheMap.LoadOrStore(canonKey, value)
+	for _, alias := range aliasNames {
+		aliasKey := cacheKey(alias, libraryID)
+		cacheMap.LoadOrStore(aliasKey, value)
+	}
 }
 
 // GetOrCreatePerson retrieves a person from the cache or calls the service to find/create one.
@@ -158,6 +188,13 @@ func (c *ScanCache) GetOrCreatePerson(ctx context.Context, name string, libraryI
 
 	c.persons.Store(key, person)
 	c.personCount.Add(1)
+
+	if c.aliasLister != nil {
+		if aliasNames, err := c.aliasLister.ListPersonAliases(ctx, person.ID); err == nil {
+			populateAliasEntries(&c.persons, person.Name, libraryID, person, aliasNames)
+		}
+	}
+
 	return person, nil
 }
 
@@ -189,6 +226,13 @@ func (c *ScanCache) GetOrCreateGenre(ctx context.Context, name string, libraryID
 
 	c.genres.Store(key, genre)
 	c.genreCount.Add(1)
+
+	if c.aliasLister != nil {
+		if aliasNames, err := c.aliasLister.ListGenreAliases(ctx, genre.ID); err == nil {
+			populateAliasEntries(&c.genres, genre.Name, libraryID, genre, aliasNames)
+		}
+	}
+
 	return genre, nil
 }
 
@@ -220,6 +264,13 @@ func (c *ScanCache) GetOrCreateTag(ctx context.Context, name string, libraryID i
 
 	c.tags.Store(key, tag)
 	c.tagCount.Add(1)
+
+	if c.aliasLister != nil {
+		if aliasNames, err := c.aliasLister.ListTagAliases(ctx, tag.ID); err == nil {
+			populateAliasEntries(&c.tags, tag.Name, libraryID, tag, aliasNames)
+		}
+	}
+
 	return tag, nil
 }
 
@@ -251,6 +302,13 @@ func (c *ScanCache) GetOrCreateSeries(ctx context.Context, name string, libraryI
 
 	c.series.Store(key, series)
 	c.seriesCount.Add(1)
+
+	if c.aliasLister != nil {
+		if aliasNames, err := c.aliasLister.ListSeriesAliases(ctx, series.ID); err == nil {
+			populateAliasEntries(&c.series, series.Name, libraryID, series, aliasNames)
+		}
+	}
+
 	return series, nil
 }
 
@@ -302,6 +360,13 @@ func (c *ScanCache) GetOrCreatePublisher(ctx context.Context, name string, libra
 
 	c.publishers.Store(key, publisher)
 	c.publisherCount.Add(1)
+
+	if c.aliasLister != nil {
+		if aliasNames, err := c.aliasLister.ListPublisherAliases(ctx, publisher.ID); err == nil {
+			populateAliasEntries(&c.publishers, publisher.Name, libraryID, publisher, aliasNames)
+		}
+	}
+
 	return publisher, nil
 }
 
@@ -333,6 +398,13 @@ func (c *ScanCache) GetOrCreateImprint(ctx context.Context, name string, library
 
 	c.imprints.Store(key, imprint)
 	c.imprintCount.Add(1)
+
+	if c.aliasLister != nil {
+		if aliasNames, err := c.aliasLister.ListImprintAliases(ctx, imprint.ID); err == nil {
+			populateAliasEntries(&c.imprints, imprint.Name, libraryID, imprint, aliasNames)
+		}
+	}
+
 	return imprint, nil
 }
 

--- a/pkg/worker/scan_cache_aliases.go
+++ b/pkg/worker/scan_cache_aliases.go
@@ -1,0 +1,40 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/shishobooks/shisho/pkg/aliases"
+)
+
+// aliasServiceAdapter wraps aliases.Service to implement the AliasLister interface.
+type aliasServiceAdapter struct {
+	svc *aliases.Service
+}
+
+func NewAliasServiceAdapter(svc *aliases.Service) AliasLister {
+	return &aliasServiceAdapter{svc: svc}
+}
+
+func (a *aliasServiceAdapter) ListPersonAliases(ctx context.Context, personID int) ([]string, error) {
+	return a.svc.ListAliases(ctx, aliases.PersonConfig, personID)
+}
+
+func (a *aliasServiceAdapter) ListGenreAliases(ctx context.Context, genreID int) ([]string, error) {
+	return a.svc.ListAliases(ctx, aliases.GenreConfig, genreID)
+}
+
+func (a *aliasServiceAdapter) ListTagAliases(ctx context.Context, tagID int) ([]string, error) {
+	return a.svc.ListAliases(ctx, aliases.TagConfig, tagID)
+}
+
+func (a *aliasServiceAdapter) ListSeriesAliases(ctx context.Context, seriesID int) ([]string, error) {
+	return a.svc.ListAliases(ctx, aliases.SeriesConfig, seriesID)
+}
+
+func (a *aliasServiceAdapter) ListPublisherAliases(ctx context.Context, publisherID int) ([]string, error) {
+	return a.svc.ListAliases(ctx, aliases.PublisherConfig, publisherID)
+}
+
+func (a *aliasServiceAdapter) ListImprintAliases(ctx context.Context, imprintID int) ([]string, error) {
+	return a.svc.ListAliases(ctx, aliases.ImprintConfig, imprintID)
+}

--- a/pkg/worker/scan_cache_test.go
+++ b/pkg/worker/scan_cache_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -574,28 +575,24 @@ func TestScanCache_LockBook_DifferentBooks(t *testing.T) {
 
 // mockAliasLister implements AliasLister for testing alias pre-population.
 type mockAliasLister struct {
-	mu              sync.Mutex
-	personAliases   map[int][]string
-	genreAliases    map[int][]string
-	tagAliases      map[int][]string
-	seriesAliases   map[int][]string
-	publisherAlias  map[int][]string
-	imprintAliases  map[int][]string
-	personCallCount int
-	genreCallCount  int
+	mu               sync.Mutex
+	personAliases    map[int][]string
+	genreAliases     map[int][]string
+	tagAliases       map[int][]string
+	seriesAliases    map[int][]string
+	publisherAliases map[int][]string
+	imprintAliases   map[int][]string
 }
 
 func (m *mockAliasLister) ListPersonAliases(_ context.Context, personID int) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.personCallCount++
 	return m.personAliases[personID], nil
 }
 
 func (m *mockAliasLister) ListGenreAliases(_ context.Context, genreID int) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.genreCallCount++
 	return m.genreAliases[genreID], nil
 }
 
@@ -614,7 +611,7 @@ func (m *mockAliasLister) ListSeriesAliases(_ context.Context, seriesID int) ([]
 func (m *mockAliasLister) ListPublisherAliases(_ context.Context, publisherID int) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.publisherAlias[publisherID], nil
+	return m.publisherAliases[publisherID], nil
 }
 
 func (m *mockAliasLister) ListImprintAliases(_ context.Context, imprintID int) ([]string, error) {
@@ -763,7 +760,6 @@ func TestScanCache_AliasPrePopulation_DifferentLibraries(t *testing.T) {
 	personLib1 := &models.Person{ID: 1, Name: "Author", LibraryID: 1}
 	personLib2 := &models.Person{ID: 2, Name: "Author", LibraryID: 2}
 
-	callCount := 0
 	svc := &mockPersonFinder{
 		persons: map[string]*models.Person{
 			"Author|1": personLib1,
@@ -782,7 +778,6 @@ func TestScanCache_AliasPrePopulation_DifferentLibraries(t *testing.T) {
 	p1, err := cache.GetOrCreatePerson(ctx, "Author", 1, svc)
 	require.NoError(t, err)
 	assert.Equal(t, 1, p1.ID)
-	_ = callCount
 
 	// "Alias1" should hit cache for library 1
 	p2, err := cache.GetOrCreatePerson(ctx, "Alias1", 1, svc)
@@ -830,4 +825,50 @@ func TestScanCache_AliasPrePopulation_Concurrent(t *testing.T) {
 	// The service should only be called a small number of times
 	// (ideally 1, but concurrent first-access on different keys may cause a few)
 	assert.LessOrEqual(t, svc.CallCount(), 4, "service should be called at most once per unique name before pre-population kicks in")
+}
+
+// errorAliasLister always returns an error, simulating a DB failure.
+type errorAliasLister struct{}
+
+func (e *errorAliasLister) ListPersonAliases(context.Context, int) ([]string, error) {
+	return nil, errors.New("db error")
+}
+func (e *errorAliasLister) ListGenreAliases(context.Context, int) ([]string, error) {
+	return nil, errors.New("db error")
+}
+func (e *errorAliasLister) ListTagAliases(context.Context, int) ([]string, error) {
+	return nil, errors.New("db error")
+}
+func (e *errorAliasLister) ListSeriesAliases(context.Context, int) ([]string, error) {
+	return nil, errors.New("db error")
+}
+func (e *errorAliasLister) ListPublisherAliases(context.Context, int) ([]string, error) {
+	return nil, errors.New("db error")
+}
+func (e *errorAliasLister) ListImprintAliases(context.Context, int) ([]string, error) {
+	return nil, errors.New("db error")
+}
+
+func TestScanCache_AliasPrePopulation_ListError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cache := NewScanCache()
+
+	canonical := &models.Person{ID: 42, Name: "Joanne Rowling", LibraryID: 1}
+	svc := &aliasAwarePersonFinder{canonical: canonical}
+
+	cache.SetAliasLister(&errorAliasLister{})
+
+	// First lookup succeeds despite alias listing error
+	person1, err := cache.GetOrCreatePerson(ctx, "J.K. Rowling", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 42, person1.ID)
+	assert.Equal(t, 1, svc.CallCount())
+
+	// Canonical name is NOT pre-populated due to error, so it hits service
+	person2, err := cache.GetOrCreatePerson(ctx, "Joanne Rowling", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 42, person2.ID)
+	assert.Equal(t, 2, svc.CallCount(), "canonical name should hit service since alias listing failed")
 }

--- a/pkg/worker/scan_cache_test.go
+++ b/pkg/worker/scan_cache_test.go
@@ -571,3 +571,263 @@ func TestScanCache_LockBook_DifferentBooks(t *testing.T) {
 			"all goroutines for book %d should complete", i)
 	}
 }
+
+// mockAliasLister implements AliasLister for testing alias pre-population.
+type mockAliasLister struct {
+	mu              sync.Mutex
+	personAliases   map[int][]string
+	genreAliases    map[int][]string
+	tagAliases      map[int][]string
+	seriesAliases   map[int][]string
+	publisherAlias  map[int][]string
+	imprintAliases  map[int][]string
+	personCallCount int
+	genreCallCount  int
+}
+
+func (m *mockAliasLister) ListPersonAliases(_ context.Context, personID int) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.personCallCount++
+	return m.personAliases[personID], nil
+}
+
+func (m *mockAliasLister) ListGenreAliases(_ context.Context, genreID int) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.genreCallCount++
+	return m.genreAliases[genreID], nil
+}
+
+func (m *mockAliasLister) ListTagAliases(_ context.Context, tagID int) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tagAliases[tagID], nil
+}
+
+func (m *mockAliasLister) ListSeriesAliases(_ context.Context, seriesID int) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.seriesAliases[seriesID], nil
+}
+
+func (m *mockAliasLister) ListPublisherAliases(_ context.Context, publisherID int) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.publisherAlias[publisherID], nil
+}
+
+func (m *mockAliasLister) ListImprintAliases(_ context.Context, imprintID int) ([]string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.imprintAliases[imprintID], nil
+}
+
+// aliasAwarePersonFinder always resolves to a fixed canonical person,
+// simulating alias-aware FindOrCreate behavior.
+type aliasAwarePersonFinder struct {
+	mu        sync.Mutex
+	callCount int
+	canonical *models.Person
+}
+
+func (m *aliasAwarePersonFinder) FindOrCreatePerson(_ context.Context, _ string, _ int) (*models.Person, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callCount++
+	return m.canonical, nil
+}
+
+func (m *aliasAwarePersonFinder) CallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
+}
+
+// aliasAwareGenreFinder always resolves to a fixed canonical genre.
+type aliasAwareGenreFinder struct {
+	mu        sync.Mutex
+	callCount int
+	canonical *models.Genre
+}
+
+func (m *aliasAwareGenreFinder) FindOrCreateGenre(_ context.Context, _ string, _ int) (*models.Genre, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callCount++
+	return m.canonical, nil
+}
+
+func (m *aliasAwareGenreFinder) CallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
+}
+
+func TestScanCache_AliasPrePopulation_Person(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cache := NewScanCache()
+
+	canonical := &models.Person{ID: 42, Name: "Joanne Rowling", LibraryID: 1}
+	svc := &aliasAwarePersonFinder{canonical: canonical}
+
+	cache.SetAliasLister(&mockAliasLister{
+		personAliases: map[int][]string{
+			42: {"J.K. Rowling", "JK Rowling"},
+		},
+	})
+
+	// First lookup by alias — hits service
+	person1, err := cache.GetOrCreatePerson(ctx, "J.K. Rowling", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 42, person1.ID)
+	assert.Equal(t, "Joanne Rowling", person1.Name)
+	assert.Equal(t, 1, svc.CallCount())
+
+	// Lookup by canonical name — should hit cache, no service call
+	person2, err := cache.GetOrCreatePerson(ctx, "Joanne Rowling", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 42, person2.ID)
+	assert.Equal(t, 1, svc.CallCount(), "canonical name lookup should hit cache")
+
+	// Lookup by different alias — should hit cache, no service call
+	person3, err := cache.GetOrCreatePerson(ctx, "JK Rowling", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 42, person3.ID)
+	assert.Equal(t, 1, svc.CallCount(), "alias lookup should hit cache")
+}
+
+func TestScanCache_AliasPrePopulation_Genre(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cache := NewScanCache()
+
+	canonical := &models.Genre{ID: 10, Name: "Science Fiction", LibraryID: 1}
+	svc := &aliasAwareGenreFinder{canonical: canonical}
+
+	cache.SetAliasLister(&mockAliasLister{
+		genreAliases: map[int][]string{
+			10: {"Sci-Fi", "SF"},
+		},
+	})
+
+	// First lookup by alias — hits service
+	genre1, err := cache.GetOrCreateGenre(ctx, "Sci-Fi", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 10, genre1.ID)
+	assert.Equal(t, 1, svc.CallCount())
+
+	// Lookup by canonical name — cache hit
+	genre2, err := cache.GetOrCreateGenre(ctx, "Science Fiction", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 10, genre2.ID)
+	assert.Equal(t, 1, svc.CallCount(), "canonical name lookup should hit cache")
+
+	// Lookup by other alias — cache hit
+	genre3, err := cache.GetOrCreateGenre(ctx, "SF", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 10, genre3.ID)
+	assert.Equal(t, 1, svc.CallCount(), "alias lookup should hit cache")
+}
+
+func TestScanCache_AliasPrePopulation_NoAliasLister(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cache := NewScanCache()
+
+	canonical := &models.Person{ID: 1, Name: "Author", LibraryID: 1}
+	svc := &aliasAwarePersonFinder{canonical: canonical}
+
+	// No alias lister set — should still work, just no pre-population
+	person, err := cache.GetOrCreatePerson(ctx, "Author", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 1, person.ID)
+	assert.Equal(t, 1, svc.CallCount())
+
+	// Same name hits cache as before
+	_, err = cache.GetOrCreatePerson(ctx, "Author", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 1, svc.CallCount())
+}
+
+func TestScanCache_AliasPrePopulation_DifferentLibraries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cache := NewScanCache()
+
+	personLib1 := &models.Person{ID: 1, Name: "Author", LibraryID: 1}
+	personLib2 := &models.Person{ID: 2, Name: "Author", LibraryID: 2}
+
+	callCount := 0
+	svc := &mockPersonFinder{
+		persons: map[string]*models.Person{
+			"Author|1": personLib1,
+			"Author|2": personLib2,
+		},
+	}
+
+	cache.SetAliasLister(&mockAliasLister{
+		personAliases: map[int][]string{
+			1: {"Alias1"},
+			2: {"Alias2"},
+		},
+	})
+
+	// Resolve in library 1
+	p1, err := cache.GetOrCreatePerson(ctx, "Author", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 1, p1.ID)
+	_ = callCount
+
+	// "Alias1" should hit cache for library 1
+	p2, err := cache.GetOrCreatePerson(ctx, "Alias1", 1, svc)
+	require.NoError(t, err)
+	assert.Equal(t, 1, p2.ID, "alias should resolve to library 1 person")
+
+	// "Alias1" in library 2 should NOT hit the library-1 cache
+	p3, err := cache.GetOrCreatePerson(ctx, "Alias1", 2, svc)
+	require.NoError(t, err)
+	assert.NotEqual(t, 1, p3.ID, "alias in different library should not cross-contaminate")
+}
+
+func TestScanCache_AliasPrePopulation_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cache := NewScanCache()
+
+	canonical := &models.Person{ID: 42, Name: "Canonical", LibraryID: 1}
+	svc := &aliasAwarePersonFinder{canonical: canonical}
+
+	cache.SetAliasLister(&mockAliasLister{
+		personAliases: map[int][]string{
+			42: {"Alias1", "Alias2", "Alias3"},
+		},
+	})
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+	names := []string{"Canonical", "Alias1", "Alias2", "Alias3"}
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			name := names[idx%len(names)]
+			person, err := cache.GetOrCreatePerson(ctx, name, 1, svc)
+			assert.NoError(t, err)
+			assert.Equal(t, 42, person.ID)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// The service should only be called a small number of times
+	// (ideally 1, but concurrent first-access on different keys may cause a few)
+	assert.LessOrEqual(t, svc.CallCount(), 4, "service should be called at most once per unique name before pre-population kicks in")
+}

--- a/pkg/worker/testhelpers_test.go
+++ b/pkg/worker/testhelpers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/robinjoseph08/golib/logger"
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/chapters"
@@ -111,6 +112,7 @@ func newTestContext(t *testing.T) *testContext {
 		config:             cfg,
 		log:                logger.New(),
 		db:                 db,
+		aliasService:       aliases.NewService(db),
 		bookService:        bookService,
 		chapterService:     chapterService,
 		libraryService:     libraryService,
@@ -333,6 +335,7 @@ func newTestContextWithSearchService(t *testing.T) *testContext {
 		config:             cfg,
 		log:                logger.New(),
 		db:                 db,
+		aliasService:       aliases.NewService(db),
 		bookService:        bookService,
 		chapterService:     chapterService,
 		libraryService:     libraryService,

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/chapters"
@@ -45,6 +46,7 @@ type Worker struct {
 
 	processFuncs map[string]func(ctx context.Context, job *models.Job, jobLog *joblogs.JobLogger) error
 
+	aliasService       *aliases.Service
 	bookService        *books.Service
 	chapterService     *chapters.Service
 	genreService       *genres.Service
@@ -90,6 +92,7 @@ type Worker struct {
 }
 
 func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Broker, dlCache *downloadcache.Cache) *Worker {
+	aliasService := aliases.NewService(db)
 	appSettingsService := appsettings.NewService(db)
 	bookService := books.NewService(db).WithAppSettings(appSettingsService)
 	chapterService := chapters.NewService(db)
@@ -116,6 +119,7 @@ func New(cfg *config.Config, db *bun.DB, pm *plugins.Manager, broker *events.Bro
 		ctx:    ctx,
 		cancel: cancel,
 
+		aliasService:       aliasService,
 		appSettingsService: appSettingsService,
 		bookService:        bookService,
 		chapterService:     chapterService,


### PR DESCRIPTION
Closes #202

## Summary
- When a resource is resolved for the first time during a scan, the cache now fetches all aliases and populates entries for the canonical name AND every alias, all pointing to the same resource
- Adds `AliasLister` interface and adapter wrapping `aliases.Service` to keep the cache decoupled from the aliases package
- Subsequent lookups for any name variant (primary or alias) hit the cache without a DB roundtrip

## Test plan
- Unit tests verify alias pre-population for persons and genres (resolve via alias, then lookup canonical and other aliases — all cache hits)
- Test for graceful degradation when no alias lister is configured
- Test that different libraries don't cross-contaminate alias cache entries
- Concurrent access test verifies thread safety with alias pre-population
- All existing scan cache tests continue to pass