### PR TITLE
[Backend] Merge transfers source name and aliases

### DIFF
--- a/pkg/aliases/service.go
+++ b/pkg/aliases/service.go
@@ -130,6 +130,86 @@ func (svc *Service) RemoveAllAliases(ctx context.Context, cfg ResourceConfig, re
 	return errors.WithStack(err)
 }
 
+// TransferAliasesOnMerge reassigns the source resource's aliases to the target
+// and adds the source's primary name as a new alias of the target. Duplicates
+// (case-insensitive match against the target's primary name or existing aliases)
+// are silently left for CASCADE to clean up when the source is deleted.
+// Accepts bun.IDB so it works inside a transaction.
+func TransferAliasesOnMerge(ctx context.Context, db bun.IDB, cfg ResourceConfig, sourceID, targetID int) error {
+	var targetName string
+	err := db.NewSelect().
+		TableExpr(cfg.ResourceTable).
+		Column("name").
+		Where("id = ?", targetID).
+		Scan(ctx, &targetName)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	var targetAliases []string
+	err = db.NewSelect().
+		TableExpr(cfg.AliasTable).
+		Column("name").
+		Where(cfg.ResourceFK+" = ?", targetID).
+		Scan(ctx, &targetAliases)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	existing := make(map[string]bool, 1+len(targetAliases))
+	existing[strings.ToLower(targetName)] = true
+	for _, a := range targetAliases {
+		existing[strings.ToLower(a)] = true
+	}
+
+	var sourceAliases []string
+	err = db.NewSelect().
+		TableExpr(cfg.AliasTable).
+		Column("name").
+		Where(cfg.ResourceFK+" = ?", sourceID).
+		Scan(ctx, &sourceAliases)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	for _, name := range sourceAliases {
+		if existing[strings.ToLower(name)] {
+			continue
+		}
+		existing[strings.ToLower(name)] = true
+		_, err = db.NewRaw(
+			"UPDATE "+cfg.AliasTable+" SET "+cfg.ResourceFK+" = ? WHERE "+cfg.ResourceFK+" = ? AND LOWER(name) = LOWER(?)",
+			targetID, sourceID, name,
+		).Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	var sourceName string
+	var sourceLibraryID int
+	err = db.NewSelect().
+		TableExpr(cfg.ResourceTable).
+		Column("name", "library_id").
+		Where("id = ?", sourceID).
+		Scan(ctx, &sourceName, &sourceLibraryID)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if !existing[strings.ToLower(sourceName)] {
+		_, err = db.NewRaw(
+			"INSERT INTO "+cfg.AliasTable+" (created_at, "+cfg.ResourceFK+", name, library_id) VALUES (?, ?, ?, ?)",
+			time.Now(), targetID, sourceName, sourceLibraryID,
+		).Exec(ctx)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	return nil
+}
+
 func (svc *Service) SyncAliases(ctx context.Context, cfg ResourceConfig, resourceID int, libraryID int, desired []string) error {
 	current, err := svc.ListAliases(ctx, cfg, resourceID)
 	if err != nil {

--- a/pkg/aliases/service_test.go
+++ b/pkg/aliases/service_test.go
@@ -259,6 +259,110 @@ func TestAddAlias_DifferentLibrariesAllowed(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestTransferAliasesOnMerge_SourceNameBecomesAlias(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	lib := createTestLibrary(t, db)
+	target := createTestGenre(t, db, "Science Fiction", lib.ID)
+	source := createTestGenre(t, db, "Sci-Fi", lib.ID)
+
+	err := TransferAliasesOnMerge(ctx, db, GenreConfig, source.ID, target.ID)
+	require.NoError(t, err)
+
+	svc := NewService(db)
+	aliases, err := svc.ListAliases(ctx, GenreConfig, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Sci-Fi"}, aliases)
+}
+
+func TestTransferAliasesOnMerge_TransfersSourceAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	target := createTestGenre(t, db, "Science Fiction", lib.ID)
+	source := createTestGenre(t, db, "Sci-Fi", lib.ID)
+
+	// Add aliases to source
+	require.NoError(t, svc.AddAlias(ctx, GenreConfig, source.ID, "SF", lib.ID))
+	require.NoError(t, svc.AddAlias(ctx, GenreConfig, source.ID, "SciFi", lib.ID))
+
+	err := TransferAliasesOnMerge(ctx, db, GenreConfig, source.ID, target.ID)
+	require.NoError(t, err)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, target.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"Sci-Fi", "SF", "SciFi"}, aliases)
+}
+
+func TestTransferAliasesOnMerge_PreservesExistingTargetAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	target := createTestGenre(t, db, "Science Fiction", lib.ID)
+	source := createTestGenre(t, db, "Sci-Fi", lib.ID)
+
+	require.NoError(t, svc.AddAlias(ctx, GenreConfig, target.ID, "SF", lib.ID))
+
+	err := TransferAliasesOnMerge(ctx, db, GenreConfig, source.ID, target.ID)
+	require.NoError(t, err)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, target.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"SF", "Sci-Fi"}, aliases)
+}
+
+func TestTransferAliasesOnMerge_CascadeCleansUpRemainingSourceAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	target := createTestGenre(t, db, "Science Fiction", lib.ID)
+	source := createTestGenre(t, db, "Sci-Fi", lib.ID)
+
+	require.NoError(t, svc.AddAlias(ctx, GenreConfig, source.ID, "SF", lib.ID))
+
+	err := TransferAliasesOnMerge(ctx, db, GenreConfig, source.ID, target.ID)
+	require.NoError(t, err)
+
+	// Simulate what merge does: delete the source. Any remaining source
+	// aliases (none here since all were transferred) are cascade-deleted.
+	_, err = db.NewDelete().Model((*models.Genre)(nil)).Where("id = ?", source.ID).Exec(ctx)
+	require.NoError(t, err)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, target.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"Sci-Fi", "SF"}, aliases)
+}
+
+func TestTransferAliasesOnMerge_NoAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	lib := createTestLibrary(t, db)
+	target := createTestGenre(t, db, "Science Fiction", lib.ID)
+	source := createTestGenre(t, db, "Sci-Fi", lib.ID)
+
+	err := TransferAliasesOnMerge(ctx, db, GenreConfig, source.ID, target.ID)
+	require.NoError(t, err)
+
+	// Source name should still become an alias even when neither side had aliases
+	svc := NewService(db)
+	aliases, err := svc.ListAliases(ctx, GenreConfig, target.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Sci-Fi"}, aliases)
+}
+
 func TestAddAlias_ReturnsValidationError(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/genres/service.go
+++ b/pkg/genres/service.go
@@ -273,6 +273,10 @@ func (svc *Service) MergeGenres(ctx context.Context, targetID, sourceID int) err
 			return errors.WithStack(err)
 		}
 
+		if err := aliases.TransferAliasesOnMerge(ctx, tx, aliases.GenreConfig, sourceID, targetID); err != nil {
+			return err
+		}
+
 		// Delete the source genre
 		_, err = tx.NewDelete().
 			Model((*models.Genre)(nil)).

--- a/pkg/imprints/service.go
+++ b/pkg/imprints/service.go
@@ -261,6 +261,10 @@ func (svc *Service) MergeImprints(ctx context.Context, targetID, sourceID int) e
 			return errors.WithStack(err)
 		}
 
+		if err := aliases.TransferAliasesOnMerge(ctx, tx, aliases.ImprintConfig, sourceID, targetID); err != nil {
+			return err
+		}
+
 		// Delete the source imprint
 		_, err = tx.NewDelete().
 			Model((*models.Imprint)(nil)).

--- a/pkg/people/service.go
+++ b/pkg/people/service.go
@@ -325,6 +325,10 @@ func (svc *Service) MergePeople(ctx context.Context, targetID, sourceID int) err
 			return errors.WithStack(err)
 		}
 
+		if err := aliases.TransferAliasesOnMerge(ctx, tx, aliases.PersonConfig, sourceID, targetID); err != nil {
+			return err
+		}
+
 		// Delete the source person
 		_, err = tx.NewDelete().
 			Model((*models.Person)(nil)).

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -261,6 +261,10 @@ func (svc *Service) MergePublishers(ctx context.Context, targetID, sourceID int)
 			return errors.WithStack(err)
 		}
 
+		if err := aliases.TransferAliasesOnMerge(ctx, tx, aliases.PublisherConfig, sourceID, targetID); err != nil {
+			return err
+		}
+
 		// Delete the source publisher
 		_, err = tx.NewDelete().
 			Model((*models.Publisher)(nil)).

--- a/pkg/series/service.go
+++ b/pkg/series/service.go
@@ -300,6 +300,10 @@ func (svc *Service) MergeSeries(ctx context.Context, targetID, sourceID int) ([]
 			return errors.WithStack(err)
 		}
 
+		if err := aliases.TransferAliasesOnMerge(ctx, tx, aliases.SeriesConfig, sourceID, targetID); err != nil {
+			return err
+		}
+
 		// Delete the source series
 		_, err = tx.NewDelete().
 			Model((*models.Series)(nil)).

--- a/pkg/tags/service.go
+++ b/pkg/tags/service.go
@@ -273,6 +273,10 @@ func (svc *Service) MergeTags(ctx context.Context, targetID, sourceID int) error
 			return errors.WithStack(err)
 		}
 
+		if err := aliases.TransferAliasesOnMerge(ctx, tx, aliases.TagConfig, sourceID, targetID); err != nil {
+			return err
+		}
+
 		// Delete the source tag
 		_, err = tx.NewDelete().
 			Model((*models.Tag)(nil)).


### PR DESCRIPTION
Closes #203

## Summary
- Added `TransferAliasesOnMerge` function to the aliases package that reassigns source aliases to the target via UPDATE (avoiding UNIQUE constraint violations) and inserts the source's primary name as a new alias of the target
- Wired the function into all six merge methods (genres, tags, series, people, publishers, imprints) inside their existing transactions, before the source deletion step
- Case-insensitive duplicates against the target's name or existing aliases are silently skipped; any remaining source aliases are cleaned up via ON DELETE CASCADE when the source is deleted

## Test plan
- Unit tests for TransferAliasesOnMerge covering: source name becomes alias, source aliases transfer, existing target aliases preserved, cascade cleanup after source deletion, no-aliases baseline
- Existing merge tests (series reindex, books merge integration) continue to pass
- All Go tests pass with coverage, zero lint issues