### PR TITLE
[Backend] Auto-add old name as alias when renaming resources

### DIFF
--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -170,7 +170,8 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
-		// Simple rename
+		// Simple rename — capture old name before mutation
+		oldName := genre.Name
 		genre.Name = newName
 		opts := UpdateGenreOptions{Columns: []string{"name"}}
 		err = h.genreService.UpdateGenre(ctx, genre, opts)
@@ -178,6 +179,12 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 		nameChanged = true
+
+		log := logger.FromContext(ctx)
+		_ = h.aliasService.RemoveAlias(ctx, aliases.GenreConfig, id, newName)
+		if err := h.aliasService.AddAlias(ctx, aliases.GenreConfig, id, oldName, genre.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"genre_id": id, "old_name": oldName, "error": err.Error()})
+		}
 	}
 
 	// Sync aliases if provided

--- a/pkg/genres/handlers_test.go
+++ b/pkg/genres/handlers_test.go
@@ -1,0 +1,132 @@
+package genres
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func newTestEcho(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	return e
+}
+
+func newTestHandler(t *testing.T, db *bun.DB) *handler {
+	t.Helper()
+	return &handler{
+		genreService:  NewService(db),
+		aliasService:  aliases.NewService(db),
+		searchService: search.NewService(db),
+	}
+}
+
+func patchGenre(t *testing.T, h *handler, genreID int, payload UpdateGenrePayload) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	e := newTestEcho(t)
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(genreID))
+
+	err = h.update(c)
+	if err != nil {
+		e.HTTPErrorHandler(err, c)
+	}
+	return rec
+}
+
+func TestUpdateGenre_RenameAddsOldNameAsAlias(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(t, db)
+
+	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
+	require.NoError(t, h.genreService.CreateGenre(ctx, genre))
+
+	newName := "Sci-Fi"
+	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &newName})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.Contains(t, aliasList, "Science Fiction")
+}
+
+func TestUpdateGenre_RenameWithPreExistingAlias_NoDuplicate(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(t, db)
+
+	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
+	require.NoError(t, h.genreService.CreateGenre(ctx, genre))
+
+	// Pre-add "Science Fiction" as an alias manually (simulate user adding it before rename)
+	_, err := db.NewRaw(
+		"INSERT INTO genre_aliases (created_at, genre_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), genre.ID, "SF", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	newName := "Sci-Fi"
+	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &newName})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.Contains(t, aliasList, "Science Fiction", "old name should be added as alias")
+	assert.Contains(t, aliasList, "SF", "existing alias should be preserved")
+}
+
+func TestUpdateGenre_RenameBackToOriginalName(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(t, db)
+
+	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
+	require.NoError(t, h.genreService.CreateGenre(ctx, genre))
+
+	// First rename: "Science Fiction" → "Sci-Fi"
+	newName := "Sci-Fi"
+	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &newName})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Second rename back: "Sci-Fi" → "Science Fiction"
+	originalName := "Science Fiction"
+	rec = patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &originalName})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.Contains(t, aliasList, "Sci-Fi", "previous name should be an alias")
+	assert.NotContains(t, aliasList, "Science Fiction", "alias matching new primary name should be removed")
+}

--- a/pkg/genres/handlers_test.go
+++ b/pkg/genres/handlers_test.go
@@ -78,7 +78,7 @@ func TestUpdateGenre_RenameAddsOldNameAsAlias(t *testing.T) {
 	assert.Contains(t, aliasList, "Science Fiction")
 }
 
-func TestUpdateGenre_RenameWithPreExistingAlias_NoDuplicate(t *testing.T) {
+func TestUpdateGenre_RenamePreservesExistingAliases(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	ctx := context.Background()
@@ -88,7 +88,6 @@ func TestUpdateGenre_RenameWithPreExistingAlias_NoDuplicate(t *testing.T) {
 	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
 	require.NoError(t, h.genreService.CreateGenre(ctx, genre))
 
-	// Pre-add "Science Fiction" as an alias manually (simulate user adding it before rename)
 	_, err := db.NewRaw(
 		"INSERT INTO genre_aliases (created_at, genre_id, name, library_id) VALUES (?, ?, ?, ?)",
 		time.Now(), genre.ID, "SF", lib.ID,
@@ -103,6 +102,29 @@ func TestUpdateGenre_RenameWithPreExistingAlias_NoDuplicate(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, aliasList, "Science Fiction", "old name should be added as alias")
 	assert.Contains(t, aliasList, "SF", "existing alias should be preserved")
+}
+
+func TestUpdateGenre_SequentialRenames_NoDuplicateAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(t, db)
+
+	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
+	require.NoError(t, h.genreService.CreateGenre(ctx, genre))
+
+	nameB := "Sci-Fi"
+	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &nameB})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	nameC := "SF"
+	rec = patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &nameC})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"Science Fiction", "Sci-Fi"}, aliasList)
 }
 
 func TestUpdateGenre_RenameBackToOriginalName(t *testing.T) {

--- a/pkg/imprints/handlers.go
+++ b/pkg/imprints/handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -151,11 +152,18 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
+		oldName := imprint.Name
 		imprint.Name = newName
 		opts := UpdateImprintOptions{Columns: []string{"name"}}
 		err = h.imprintService.UpdateImprint(ctx, imprint, opts)
 		if err != nil {
 			return errors.WithStack(err)
+		}
+
+		log := logger.FromContext(ctx)
+		_ = h.aliasService.RemoveAlias(ctx, aliases.ImprintConfig, id, newName)
+		if err := h.aliasService.AddAlias(ctx, aliases.ImprintConfig, id, oldName, imprint.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"imprint_id": id, "old_name": oldName, "error": err.Error()})
 		}
 	}
 

--- a/pkg/people/handlers.go
+++ b/pkg/people/handlers.go
@@ -164,7 +164,9 @@ func (h *handler) update(c echo.Context) error {
 	opts := UpdatePersonOptions{Columns: []string{}}
 	nameChanged := false
 
+	var oldName string
 	if params.Name != nil && *params.Name != person.Name {
+		oldName = person.Name
 		nameChanged = true
 		person.Name = *params.Name
 		// Regenerate sort name when name changes (unless sort_name_source is manual)
@@ -193,6 +195,14 @@ func (h *handler) update(c echo.Context) error {
 	err = h.personService.UpdatePerson(ctx, person, opts)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	if nameChanged {
+		log := logger.FromContext(ctx)
+		_ = h.aliasService.RemoveAlias(ctx, aliases.PersonConfig, id, person.Name)
+		if err := h.aliasService.AddAlias(ctx, aliases.PersonConfig, id, oldName, person.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"person_id": id, "old_name": oldName, "error": err.Error()})
+		}
 	}
 
 	// Sync aliases if provided

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -151,11 +152,18 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
+		oldName := publisher.Name
 		publisher.Name = newName
 		opts := UpdatePublisherOptions{Columns: []string{"name"}}
 		err = h.publisherService.UpdatePublisher(ctx, publisher, opts)
 		if err != nil {
 			return errors.WithStack(err)
+		}
+
+		log := logger.FromContext(ctx)
+		_ = h.aliasService.RemoveAlias(ctx, aliases.PublisherConfig, id, newName)
+		if err := h.aliasService.AddAlias(ctx, aliases.PublisherConfig, id, oldName, publisher.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"publisher_id": id, "old_name": oldName, "error": err.Error()})
 		}
 	}
 

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -146,7 +146,11 @@ func (h *handler) update(c echo.Context) error {
 	// Keep track of what's been changed
 	opts := UpdateSeriesOptions{Columns: []string{}}
 
+	var oldName string
+	nameChanged := false
 	if params.Name != nil && *params.Name != series.Name {
+		oldName = series.Name
+		nameChanged = true
 		series.Name = *params.Name
 		series.NameSource = models.DataSourceManual
 		opts.Columns = append(opts.Columns, "name", "name_source")
@@ -180,6 +184,14 @@ func (h *handler) update(c echo.Context) error {
 	err = h.seriesService.UpdateSeries(ctx, series, opts)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	if nameChanged {
+		log := logger.FromContext(ctx)
+		_ = h.aliasService.RemoveAlias(ctx, aliases.SeriesConfig, id, series.Name)
+		if err := h.aliasService.AddAlias(ctx, aliases.SeriesConfig, id, oldName, series.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"series_id": id, "old_name": oldName, "error": err.Error()})
+		}
 	}
 
 	// Sync aliases if provided

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -161,6 +161,7 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
+		oldName := tag.Name
 		tag.Name = newName
 		opts := UpdateTagOptions{Columns: []string{"name"}}
 		err = h.tagService.UpdateTag(ctx, tag, opts)
@@ -168,6 +169,12 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 		nameChanged = true
+
+		log := logger.FromContext(ctx)
+		_ = h.aliasService.RemoveAlias(ctx, aliases.TagConfig, id, newName)
+		if err := h.aliasService.AddAlias(ctx, aliases.TagConfig, id, oldName, tag.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"tag_id": id, "old_name": oldName, "error": err.Error()})
+		}
 	}
 
 	if params.Aliases != nil {


### PR DESCRIPTION
Closes #204

## Summary
- When any of the six resource types (genre, tag, series, person, publisher, imprint) is renamed via its update handler, the old name is automatically added as an alias
- If the old name already exists as an alias, the operation is silently skipped (no duplicate)
- If an alias matches the new primary name (e.g. renaming back to a previous name), it is cleaned up to avoid data inconsistency
- Handler tests cover: rename adds alias, rename with pre-existing alias, rename back to original name

## Test plan
- Handler tests for all three rename-alias scenarios pass (genres)
- All Go tests pass (`mise test`)
- Go lint clean (`mise lint`)
- Full `mise check:quiet` passes