### PR TITLE
[Backend] Include aliases in FTS indexes and LIKE search

### DIFF
--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -193,7 +193,7 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	if nameChanged {
+	if nameChanged || params.Aliases != nil {
 		log := logger.FromContext(ctx)
 		if err := h.searchService.IndexGenre(ctx, genre); err != nil {
 			log.Warn("failed to update search index for genre", logger.Data{"genre_id": genre.ID, "error": err.Error()})

--- a/pkg/imprints/service.go
+++ b/pkg/imprints/service.go
@@ -152,10 +152,10 @@ func (svc *Service) listImprintsWithTotal(ctx context.Context, opts ListImprints
 	if len(opts.LibraryIDs) > 0 {
 		q = q.Where("imp.library_id IN (?)", bun.List(opts.LibraryIDs))
 	}
-	// Search using LIKE (no FTS for imprints)
+	// Search using LIKE (no FTS for imprints) — also matches alias names
 	if opts.Search != nil && *opts.Search != "" {
 		search := "%" + strings.ToLower(*opts.Search) + "%"
-		q = q.Where("LOWER(imp.name) LIKE ?", search)
+		q = q.Where("(LOWER(imp.name) LIKE ? OR imp.id IN (SELECT imprint_id FROM imprint_aliases WHERE LOWER(name) LIKE ? AND library_id = imp.library_id))", search, search)
 	}
 	if opts.Limit != nil {
 		q = q.Limit(*opts.Limit)

--- a/pkg/imprints/service_test.go
+++ b/pkg/imprints/service_test.go
@@ -102,3 +102,31 @@ func TestFindOrCreateImprint_NoMatch_CreatesNew(t *testing.T) {
 	assert.Equal(t, "Tor Books", found.Name)
 	assert.Equal(t, lib.ID, found.LibraryID)
 }
+
+func TestListImprints_SearchMatchesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	imp := &models.Imprint{LibraryID: lib.ID, Name: "Vintage Books"}
+	err := svc.CreateImprint(ctx, imp)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO imprint_aliases (created_at, imprint_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), imp.ID, "Vintage Classics", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	search := "Vintage Classics"
+	results, err := svc.ListImprints(ctx, ListImprintsOptions{
+		LibraryID: &lib.ID,
+		Search:    &search,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1, "Should find imprint by alias 'Vintage Classics'")
+	assert.Equal(t, "Vintage Books", results[0].Name)
+}

--- a/pkg/people/handlers.go
+++ b/pkg/people/handlers.go
@@ -196,10 +196,12 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	// Sync aliases if provided
+	aliasesChanged := false
 	if params.Aliases != nil {
 		if err := h.aliasService.SyncAliases(ctx, aliases.PersonConfig, id, person.LibraryID, params.Aliases); err != nil {
 			return errors.WithStack(err)
 		}
+		aliasesChanged = true
 	}
 
 	// Reload the model
@@ -214,6 +216,34 @@ func (h *handler) update(c echo.Context) error {
 	log := logger.FromContext(ctx)
 	if err := h.searchService.IndexPerson(ctx, person); err != nil {
 		log.Warn("failed to update search index for person", logger.Data{"person_id": person.ID, "error": err.Error()})
+	}
+
+	// Re-index associated books when aliases change (books_fts includes author/narrator aliases)
+	if aliasesChanged {
+		authoredBooks, err := h.personService.GetAuthoredBooks(ctx, id)
+		if err != nil {
+			log.Warn("failed to get authored books for FTS reindex after alias change", logger.Data{"person_id": id, "error": err.Error()})
+		} else {
+			for _, book := range authoredBooks {
+				if err := h.searchService.ReindexBookByID(ctx, book.ID); err != nil {
+					log.Warn("failed to reindex book after person alias change", logger.Data{"person_id": id, "book_id": book.ID, "error": err.Error()})
+				}
+			}
+		}
+		narratedFiles, err := h.personService.GetNarratedFiles(ctx, id)
+		if err != nil {
+			log.Warn("failed to get narrated files for FTS reindex after alias change", logger.Data{"person_id": id, "error": err.Error()})
+		} else {
+			reindexedBooks := make(map[int]bool)
+			for _, file := range narratedFiles {
+				if !reindexedBooks[file.BookID] {
+					reindexedBooks[file.BookID] = true
+					if err := h.searchService.ReindexBookByID(ctx, file.BookID); err != nil {
+						log.Warn("failed to reindex book after narrator alias change", logger.Data{"person_id": id, "book_id": file.BookID, "error": err.Error()})
+					}
+				}
+			}
+		}
 	}
 
 	// If name changed and file organizer is configured, reorganize associated files

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -152,10 +152,10 @@ func (svc *Service) listPublishersWithTotal(ctx context.Context, opts ListPublis
 	if len(opts.LibraryIDs) > 0 {
 		q = q.Where("pub.library_id IN (?)", bun.List(opts.LibraryIDs))
 	}
-	// Search using LIKE (no FTS for publishers)
+	// Search using LIKE (no FTS for publishers) — also matches alias names
 	if opts.Search != nil && *opts.Search != "" {
 		search := "%" + strings.ToLower(*opts.Search) + "%"
-		q = q.Where("LOWER(pub.name) LIKE ?", search)
+		q = q.Where("(LOWER(pub.name) LIKE ? OR pub.id IN (SELECT publisher_id FROM publisher_aliases WHERE LOWER(name) LIKE ? AND library_id = pub.library_id))", search, search)
 	}
 	if opts.Limit != nil {
 		q = q.Limit(*opts.Limit)

--- a/pkg/publishers/service_test.go
+++ b/pkg/publishers/service_test.go
@@ -102,3 +102,31 @@ func TestFindOrCreatePublisher_NoMatch_CreatesNew(t *testing.T) {
 	assert.Equal(t, "HarperCollins", found.Name)
 	assert.Equal(t, lib.ID, found.LibraryID)
 }
+
+func TestListPublishers_SearchMatchesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	pub := &models.Publisher{LibraryID: lib.ID, Name: "Penguin Random House"}
+	err := svc.CreatePublisher(ctx, pub)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO publisher_aliases (created_at, publisher_id, name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), pub.ID, "PRH", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	search := "PRH"
+	results, err := svc.ListPublishers(ctx, ListPublishersOptions{
+		LibraryID: &lib.ID,
+		Search:    &search,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1, "Should find publisher by alias 'PRH'")
+	assert.Equal(t, "Penguin Random House", results[0].Name)
+}

--- a/pkg/search/service.go
+++ b/pkg/search/service.go
@@ -273,12 +273,13 @@ func (svc *Service) searchSeriesInternal(ctx context.Context, ftsQuery string, l
 	results := []SeriesSearchResult{}
 
 	err := svc.db.NewSelect().
-		TableExpr("series_fts").
-		ColumnExpr("series_id AS id, library_id, name").
-		ColumnExpr("(SELECT COUNT(*) FROM book_series WHERE series_id = series_fts.series_id) AS book_count").
+		TableExpr("series_fts sf").
+		Join("JOIN series s ON s.id = sf.series_id").
+		ColumnExpr("sf.series_id AS id, sf.library_id, s.name").
+		ColumnExpr("(SELECT COUNT(*) FROM book_series WHERE series_id = sf.series_id) AS book_count").
 		Where("series_fts MATCH ?", ftsQuery).
-		Where("library_id = ?", libraryID).
-		Order("rank").
+		Where("sf.library_id = ?", libraryID).
+		Order("sf.rank").
 		Limit(limit).
 		Offset(offset).
 		Scan(ctx, &results)
@@ -304,11 +305,12 @@ func (svc *Service) searchPeopleInternal(ctx context.Context, ftsQuery string, l
 	results := []PersonSearchResult{}
 
 	err := svc.db.NewSelect().
-		TableExpr("persons_fts").
-		ColumnExpr("person_id AS id, library_id, name, sort_name").
+		TableExpr("persons_fts pf").
+		Join("JOIN persons p ON p.id = pf.person_id").
+		ColumnExpr("pf.person_id AS id, pf.library_id, p.name, p.sort_name").
 		Where("persons_fts MATCH ?", ftsQuery).
-		Where("library_id = ?", libraryID).
-		Order("rank").
+		Where("pf.library_id = ?", libraryID).
+		Order("pf.rank").
 		Limit(limit).
 		Offset(offset).
 		Scan(ctx, &results)
@@ -338,19 +340,31 @@ func (svc *Service) IndexBook(ctx context.Context, book *models.Book) error {
 		return errors.WithStack(err)
 	}
 
-	// Collect author names (deduplicated - same person can have multiple roles)
+	// Collect author names and their aliases (deduplicated)
 	seenAuthors := make(map[string]bool)
+	seenAuthorIDs := make(map[int]bool)
 	var authorNames []string
 	for _, author := range book.Authors {
 		if author.Person != nil && !seenAuthors[author.Person.Name] {
 			authorNames = append(authorNames, author.Person.Name)
 			seenAuthors[author.Person.Name] = true
 		}
+		if author.Person != nil && !seenAuthorIDs[author.PersonID] {
+			seenAuthorIDs[author.PersonID] = true
+			aliasNames, _ := svc.queryAliasNames(ctx, "person_aliases", "person_id", author.PersonID)
+			for _, a := range aliasNames {
+				if !seenAuthors[a] {
+					authorNames = append(authorNames, a)
+					seenAuthors[a] = true
+				}
+			}
+		}
 	}
 
-	// Collect file names and narrators (deduplicated)
+	// Collect file names and narrators with aliases (deduplicated)
 	var filenames []string
 	seenNarrators := make(map[string]bool)
+	seenNarratorIDs := make(map[int]bool)
 	var narratorNames []string
 	for _, file := range book.Files {
 		filenames = append(filenames, file.Filepath)
@@ -359,14 +373,26 @@ func (svc *Service) IndexBook(ctx context.Context, book *models.Book) error {
 				narratorNames = append(narratorNames, narrator.Person.Name)
 				seenNarrators[narrator.Person.Name] = true
 			}
+			if narrator.Person != nil && !seenNarratorIDs[narrator.PersonID] {
+				seenNarratorIDs[narrator.PersonID] = true
+				aliasNames, _ := svc.queryAliasNames(ctx, "person_aliases", "person_id", narrator.PersonID)
+				for _, a := range aliasNames {
+					if !seenNarrators[a] {
+						narratorNames = append(narratorNames, a)
+						seenNarrators[a] = true
+					}
+				}
+			}
 		}
 	}
 
-	// Collect series names
+	// Collect series names with aliases
 	var seriesNames []string
 	for _, bs := range book.BookSeries {
 		if bs.Series != nil {
 			seriesNames = append(seriesNames, bs.Series.Name)
+			aliasNames, _ := svc.queryAliasNames(ctx, "series_aliases", "series_id", bs.SeriesID)
+			seriesNames = append(seriesNames, aliasNames...)
 		}
 	}
 
@@ -441,12 +467,17 @@ func (svc *Service) IndexSeries(ctx context.Context, series *models.Series) erro
 		description = *series.Description
 	}
 
+	nameWithAliases, err := svc.nameWithAliases(ctx, "series_aliases", "series_id", series.ID, series.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
 	_, err = svc.db.ExecContext(ctx,
 		`INSERT INTO series_fts (series_id, library_id, name, description, book_titles, book_authors)
 		 VALUES (?, ?, ?, ?, ?, ?)`,
 		series.ID,
 		series.LibraryID,
-		series.Name,
+		nameWithAliases,
 		description,
 		strings.Join(bookTitles, " "),
 		strings.Join(bookAuthors, " "),
@@ -471,10 +502,15 @@ func (svc *Service) IndexPerson(ctx context.Context, person *models.Person) erro
 		return errors.WithStack(err)
 	}
 
+	nameWithAliases, err := svc.nameWithAliases(ctx, "person_aliases", "person_id", person.ID, person.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
 	_, err = svc.db.ExecContext(ctx,
 		`INSERT INTO persons_fts (person_id, library_id, name, sort_name)
 		 VALUES (?, ?, ?, ?)`,
-		person.ID, person.LibraryID, person.Name, person.SortName,
+		person.ID, person.LibraryID, nameWithAliases, person.SortName,
 	)
 	return errors.WithStack(err)
 }
@@ -496,10 +532,15 @@ func (svc *Service) IndexGenre(ctx context.Context, genre *models.Genre) error {
 		return errors.WithStack(err)
 	}
 
+	nameWithAliases, err := svc.nameWithAliases(ctx, "genre_aliases", "genre_id", genre.ID, genre.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
 	_, err = svc.db.ExecContext(ctx,
 		`INSERT INTO genres_fts (genre_id, library_id, name)
 		 VALUES (?, ?, ?)`,
-		genre.ID, genre.LibraryID, genre.Name,
+		genre.ID, genre.LibraryID, nameWithAliases,
 	)
 	return errors.WithStack(err)
 }
@@ -521,10 +562,15 @@ func (svc *Service) IndexTag(ctx context.Context, tag *models.Tag) error {
 		return errors.WithStack(err)
 	}
 
+	nameWithAliases, err := svc.nameWithAliases(ctx, "tag_aliases", "tag_id", tag.ID, tag.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
 	_, err = svc.db.ExecContext(ctx,
 		`INSERT INTO tags_fts (tag_id, library_id, name)
 		 VALUES (?, ?, ?)`,
-		tag.ID, tag.LibraryID, tag.Name,
+		tag.ID, tag.LibraryID, nameWithAliases,
 	)
 	return errors.WithStack(err)
 }
@@ -536,6 +582,69 @@ func (svc *Service) DeleteFromTagIndex(ctx context.Context, tagID int) error {
 		Where("tag_id = ?", tagID).
 		Exec(ctx)
 	return errors.WithStack(err)
+}
+
+// ReindexBookByID re-indexes a single book in books_fts using the same SQL
+// pattern as RebuildAllIndexes. Useful when related data changes (e.g., an
+// author's or series' aliases are modified) without a full book model in hand.
+func (svc *Service) ReindexBookByID(ctx context.Context, bookID int) error {
+	_, err := svc.db.NewDelete().
+		TableExpr("books_fts").
+		Where("book_id = ?", bookID).
+		Exec(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	_, err = svc.db.ExecContext(ctx, `
+		INSERT INTO books_fts (book_id, library_id, title, filepath, subtitle, authors, filenames, narrators, series_names)
+		SELECT
+			b.id,
+			b.library_id,
+			b.title,
+			b.filepath,
+			COALESCE(b.subtitle, ''),
+			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (
+				SELECT DISTINCT p.name FROM authors a JOIN persons p ON a.person_id = p.id WHERE a.book_id = b.id
+				UNION
+				SELECT DISTINCT pa.name FROM authors a JOIN person_aliases pa ON pa.person_id = a.person_id WHERE a.book_id = b.id
+			)), ''),
+			COALESCE((SELECT GROUP_CONCAT(f.filepath, ' ') FROM files f WHERE f.book_id = b.id), ''),
+			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (
+				SELECT DISTINCT p.name FROM files f JOIN narrators n ON n.file_id = f.id JOIN persons p ON n.person_id = p.id WHERE f.book_id = b.id
+				UNION
+				SELECT DISTINCT pa.name FROM files f JOIN narrators n ON n.file_id = f.id JOIN person_aliases pa ON pa.person_id = n.person_id WHERE f.book_id = b.id
+			)), ''),
+			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (
+				SELECT s.name FROM book_series bs JOIN series s ON bs.series_id = s.id WHERE bs.book_id = b.id
+				UNION
+				SELECT sa.name FROM book_series bs JOIN series_aliases sa ON sa.series_id = bs.series_id WHERE bs.book_id = b.id
+			)), '')
+		FROM books b
+		WHERE b.id = ?
+	`, bookID)
+	return errors.WithStack(err)
+}
+
+func (svc *Service) queryAliasNames(ctx context.Context, table, fkColumn string, resourceID int) ([]string, error) {
+	var names []string
+	err := svc.db.NewSelect().
+		TableExpr(table).
+		Column("name").
+		Where(fkColumn+" = ?", resourceID).
+		Scan(ctx, &names)
+	return names, errors.WithStack(err)
+}
+
+func (svc *Service) nameWithAliases(ctx context.Context, table, fkColumn string, resourceID int, primaryName string) (string, error) {
+	aliasNames, err := svc.queryAliasNames(ctx, table, fkColumn, resourceID)
+	if err != nil {
+		return primaryName, err
+	}
+	if len(aliasNames) == 0 {
+		return primaryName, nil
+	}
+	return primaryName + " " + strings.Join(aliasNames, " "), nil
 }
 
 // RebuildAllIndexes rebuilds all FTS indexes from scratch.
@@ -563,7 +672,7 @@ func (svc *Service) RebuildAllIndexes(ctx context.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Rebuild books index
+	// Rebuild books index (includes person and series aliases in authors/narrators/series_names)
 	_, err = svc.db.ExecContext(ctx, `
 		INSERT INTO books_fts (book_id, library_id, title, filepath, subtitle, authors, filenames, narrators, series_names)
 		SELECT
@@ -572,23 +681,35 @@ func (svc *Service) RebuildAllIndexes(ctx context.Context) error {
 			b.title,
 			b.filepath,
 			COALESCE(b.subtitle, ''),
-			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (SELECT DISTINCT p.name FROM authors a JOIN persons p ON a.person_id = p.id WHERE a.book_id = b.id)), ''),
+			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (
+				SELECT DISTINCT p.name FROM authors a JOIN persons p ON a.person_id = p.id WHERE a.book_id = b.id
+				UNION
+				SELECT DISTINCT pa.name FROM authors a JOIN person_aliases pa ON pa.person_id = a.person_id WHERE a.book_id = b.id
+			)), ''),
 			COALESCE((SELECT GROUP_CONCAT(f.filepath, ' ') FROM files f WHERE f.book_id = b.id), ''),
-			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (SELECT DISTINCT p.name FROM files f JOIN narrators n ON n.file_id = f.id JOIN persons p ON n.person_id = p.id WHERE f.book_id = b.id)), ''),
-			COALESCE((SELECT GROUP_CONCAT(s.name, ' ') FROM book_series bs JOIN series s ON bs.series_id = s.id WHERE bs.book_id = b.id), '')
+			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (
+				SELECT DISTINCT p.name FROM files f JOIN narrators n ON n.file_id = f.id JOIN persons p ON n.person_id = p.id WHERE f.book_id = b.id
+				UNION
+				SELECT DISTINCT pa.name FROM files f JOIN narrators n ON n.file_id = f.id JOIN person_aliases pa ON pa.person_id = n.person_id WHERE f.book_id = b.id
+			)), ''),
+			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (
+				SELECT s.name FROM book_series bs JOIN series s ON bs.series_id = s.id WHERE bs.book_id = b.id
+				UNION
+				SELECT sa.name FROM book_series bs JOIN series_aliases sa ON sa.series_id = bs.series_id WHERE bs.book_id = b.id
+			)), '')
 		FROM books b
 	`)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	// Rebuild series index
+	// Rebuild series index (includes series aliases in name column)
 	_, err = svc.db.ExecContext(ctx, `
 		INSERT INTO series_fts (series_id, library_id, name, description, book_titles, book_authors)
 		SELECT
 			s.id,
 			s.library_id,
-			s.name,
+			s.name || COALESCE(' ' || (SELECT GROUP_CONCAT(sa.name, ' ') FROM series_aliases sa WHERE sa.series_id = s.id), ''),
 			COALESCE(s.description, ''),
 			COALESCE((SELECT GROUP_CONCAT(b.title, ' ') FROM book_series bs JOIN books b ON bs.book_id = b.id WHERE bs.series_id = s.id), ''),
 			COALESCE((SELECT GROUP_CONCAT(name, ' ') FROM (SELECT DISTINCT p.name FROM book_series bs JOIN books b ON bs.book_id = b.id JOIN authors a ON a.book_id = b.id JOIN persons p ON a.person_id = p.id WHERE bs.series_id = s.id)), '')
@@ -598,30 +719,34 @@ func (svc *Service) RebuildAllIndexes(ctx context.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Rebuild persons index
+	// Rebuild persons index (includes person aliases in name column)
 	_, err = svc.db.ExecContext(ctx, `
 		INSERT INTO persons_fts (person_id, library_id, name, sort_name)
-		SELECT id, library_id, name, sort_name
+		SELECT id, library_id,
+			name || COALESCE(' ' || (SELECT GROUP_CONCAT(pa.name, ' ') FROM person_aliases pa WHERE pa.person_id = persons.id), ''),
+			sort_name
 		FROM persons
 	`)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	// Rebuild genres index
+	// Rebuild genres index (includes genre aliases in name column)
 	_, err = svc.db.ExecContext(ctx, `
 		INSERT INTO genres_fts (genre_id, library_id, name)
-		SELECT id, library_id, name
+		SELECT id, library_id,
+			name || COALESCE(' ' || (SELECT GROUP_CONCAT(ga.name, ' ') FROM genre_aliases ga WHERE ga.genre_id = genres.id), '')
 		FROM genres
 	`)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	// Rebuild tags index
+	// Rebuild tags index (includes tag aliases in name column)
 	_, err = svc.db.ExecContext(ctx, `
 		INSERT INTO tags_fts (tag_id, library_id, name)
-		SELECT id, library_id, name
+		SELECT id, library_id,
+			name || COALESCE(' ' || (SELECT GROUP_CONCAT(ta.name, ' ') FROM tag_aliases ta WHERE ta.tag_id = tags.id), '')
 		FROM tags
 	`)
 	if err != nil {

--- a/pkg/search/service.go
+++ b/pkg/search/service.go
@@ -142,16 +142,17 @@ func (svc *Service) searchBooksInternal(ctx context.Context, ftsQuery string, li
 	remaining := limit - len(results)
 	if remaining > 0 {
 		q := svc.db.NewSelect().
-			TableExpr("books_fts").
-			ColumnExpr("book_id AS id, library_id, title, subtitle, authors").
+			TableExpr("books_fts bf").
+			ColumnExpr("bf.book_id AS id, bf.library_id, bf.title, bf.subtitle").
+			ColumnExpr("(SELECT GROUP_CONCAT(DISTINCT p.name) FROM authors a JOIN persons p ON p.id = a.person_id WHERE a.book_id = bf.book_id) AS authors").
 			Where("books_fts MATCH ?", ftsQuery).
-			Where("library_id = ?", libraryID).
-			Order("rank").
+			Where("bf.library_id = ?", libraryID).
+			Order("bf.rank").
 			Limit(remaining + len(seenIDs)). // Fetch extra to account for potential duplicates
 			Offset(offset)
 
 		if len(fileTypes) > 0 {
-			q = q.Where("book_id IN (SELECT DISTINCT book_id FROM files WHERE file_type IN (?))", bun.List(fileTypes))
+			q = q.Where("bf.book_id IN (SELECT DISTINCT book_id FROM files WHERE file_type IN (?))", bun.List(fileTypes))
 		}
 
 		ftsResults := []BookSearchResult{}

--- a/pkg/search/service_test.go
+++ b/pkg/search/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -479,4 +480,379 @@ func TestRebuildAllIndexes_DeduplicatesAuthorNames(t *testing.T) {
 
 	// The author name should appear only once, not duplicated
 	require.Equal(t, "Stan Lee", results.Books[0].Authors, "Author name should not be duplicated")
+}
+
+// --- Helper to insert an alias row directly ---
+
+func insertAlias(t *testing.T, db *bun.DB, table, fkColumn string, resourceID, libraryID int, name string) {
+	t.Helper()
+	_, err := db.NewRaw(
+		"INSERT INTO "+table+" (created_at, "+fkColumn+", name, library_id) VALUES (?, ?, ?, ?)",
+		time.Now(), resourceID, name, libraryID,
+	).Exec(context.Background())
+	require.NoError(t, err)
+}
+
+// --- Alias FTS tests ---
+
+func TestIndexGenre_IncludesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	genre := &models.Genre{LibraryID: library.ID, Name: "Science Fiction"}
+	_, err = db.NewInsert().Model(genre).Exec(ctx)
+	require.NoError(t, err)
+
+	insertAlias(t, db, "genre_aliases", "genre_id", genre.ID, library.ID, "SciFi")
+	insertAlias(t, db, "genre_aliases", "genre_id", genre.ID, library.ID, "SF")
+
+	svc := NewService(db)
+	err = svc.IndexGenre(ctx, genre)
+	require.NoError(t, err)
+
+	var count int
+	err = db.NewSelect().TableExpr("genres_fts").
+		ColumnExpr("COUNT(*)").
+		Where("genres_fts MATCH ?", `"SciFi"`).
+		Where("library_id = ?", library.ID).
+		Scan(ctx, &count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "Should find genre by alias 'SciFi'")
+}
+
+func TestIndexTag_IncludesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	tag := &models.Tag{LibraryID: library.ID, Name: "Artificial Intelligence"}
+	_, err = db.NewInsert().Model(tag).Exec(ctx)
+	require.NoError(t, err)
+
+	insertAlias(t, db, "tag_aliases", "tag_id", tag.ID, library.ID, "AI")
+
+	svc := NewService(db)
+	err = svc.IndexTag(ctx, tag)
+	require.NoError(t, err)
+
+	var count int
+	err = db.NewSelect().TableExpr("tags_fts").
+		ColumnExpr("COUNT(*)").
+		Where("tags_fts MATCH ?", `"AI"`).
+		Where("library_id = ?", library.ID).
+		Scan(ctx, &count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "Should find tag by alias 'AI'")
+}
+
+func TestIndexPerson_IncludesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	person := &models.Person{LibraryID: library.ID, Name: "Stephen King", SortName: "King, Stephen", SortNameSource: "file"}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	insertAlias(t, db, "person_aliases", "person_id", person.ID, library.ID, "Richard Bachman")
+
+	svc := NewService(db)
+	err = svc.IndexPerson(ctx, person)
+	require.NoError(t, err)
+
+	results, _, err := svc.SearchPeople(ctx, library.ID, "Bachman", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "Should find person by alias 'Bachman'")
+	require.Equal(t, "Stephen King", results[0].Name)
+}
+
+func TestIndexSeries_IncludesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	series := &models.Series{LibraryID: library.ID, Name: "A Song of Ice and Fire", NameSource: "file", SortName: "Song of Ice and Fire, A", SortNameSource: "file"}
+	_, err = db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+
+	insertAlias(t, db, "series_aliases", "series_id", series.ID, library.ID, "Game of Thrones")
+
+	svc := NewService(db)
+	err = svc.IndexSeries(ctx, series)
+	require.NoError(t, err)
+
+	results, _, err := svc.SearchSeries(ctx, library.ID, "Thrones", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "Should find series by alias 'Thrones'")
+	require.Equal(t, "A Song of Ice and Fire", results[0].Name)
+}
+
+func TestIndexBook_IncludesAuthorAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	person := &models.Person{LibraryID: library.ID, Name: "Stephen King", SortName: "King, Stephen", SortNameSource: "file"}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	insertAlias(t, db, "person_aliases", "person_id", person.ID, library.ID, "Richard Bachman")
+
+	book := &models.Book{
+		LibraryID: library.ID, Filepath: "/test/book", Title: "Thinner",
+		TitleSource: "file", SortTitle: "Thinner", SortTitleSource: "file", AuthorSource: "file",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewInsert().Model(&models.Author{}).
+		Value("book_id", "?", book.ID).
+		Value("person_id", "?", person.ID).
+		Value("sort_order", "?", 0).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{LibraryID: library.ID, BookID: book.ID, Filepath: "/test/book/thinner.epub", FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain, FilesizeBytes: 1000}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	book.Authors = []*models.Author{{PersonID: person.ID, Person: person, SortOrder: 0}}
+	book.Files = []*models.File{file}
+
+	svc := NewService(db)
+	err = svc.IndexBook(ctx, book)
+	require.NoError(t, err)
+
+	results, err := svc.GlobalSearch(ctx, library.ID, "Bachman")
+	require.NoError(t, err)
+	require.Len(t, results.Books, 1, "Should find book by author alias 'Bachman'")
+	require.Equal(t, "Thinner", results.Books[0].Title)
+}
+
+func TestIndexBook_IncludesNarratorAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	narrator := &models.Person{LibraryID: library.ID, Name: "Jim Dale", SortName: "Dale, Jim", SortNameSource: "file"}
+	_, err = db.NewInsert().Model(narrator).Exec(ctx)
+	require.NoError(t, err)
+
+	insertAlias(t, db, "person_aliases", "person_id", narrator.ID, library.ID, "James Dale")
+
+	book := &models.Book{
+		LibraryID: library.ID, Filepath: "/test/audiobook", Title: "Harry Potter",
+		TitleSource: "file", SortTitle: "Harry Potter", SortTitleSource: "file", AuthorSource: "file",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	m4bFile := &models.File{LibraryID: library.ID, BookID: book.ID, Filepath: "/test/audiobook/hp.m4b", FileType: models.FileTypeM4B, FileRole: models.FileRoleMain, FilesizeBytes: 1000}
+	_, err = db.NewInsert().Model(m4bFile).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewInsert().Model(&models.Narrator{}).
+		Value("file_id", "?", m4bFile.ID).
+		Value("person_id", "?", narrator.ID).
+		Value("sort_order", "?", 0).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	m4bFile.Narrators = []*models.Narrator{{PersonID: narrator.ID, Person: narrator, SortOrder: 0}}
+	book.Files = []*models.File{m4bFile}
+
+	svc := NewService(db)
+	err = svc.IndexBook(ctx, book)
+	require.NoError(t, err)
+
+	results, err := svc.GlobalSearch(ctx, library.ID, "James Dale")
+	require.NoError(t, err)
+	require.Len(t, results.Books, 1, "Should find book by narrator alias 'James Dale'")
+}
+
+func TestIndexBook_IncludesSeriesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	series := &models.Series{LibraryID: library.ID, Name: "The Dark Tower", NameSource: "file", SortName: "Dark Tower, The", SortNameSource: "file"}
+	_, err = db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+
+	insertAlias(t, db, "series_aliases", "series_id", series.ID, library.ID, "DT Series")
+
+	book := &models.Book{
+		LibraryID: library.ID, Filepath: "/test/dt", Title: "The Gunslinger",
+		TitleSource: "file", SortTitle: "Gunslinger, The", SortTitleSource: "file", AuthorSource: "file",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewInsert().Model(&models.BookSeries{}).
+		Value("book_id", "?", book.ID).
+		Value("series_id", "?", series.ID).
+		Value("sort_order", "?", 0).
+		Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{LibraryID: library.ID, BookID: book.ID, Filepath: "/test/dt/gunslinger.epub", FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain, FilesizeBytes: 1000}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	book.BookSeries = []*models.BookSeries{{SeriesID: series.ID, Series: series, SortOrder: 0}}
+	book.Files = []*models.File{file}
+
+	svc := NewService(db)
+	err = svc.IndexBook(ctx, book)
+	require.NoError(t, err)
+
+	results, err := svc.GlobalSearch(ctx, library.ID, "DT Series")
+	require.NoError(t, err)
+	require.Len(t, results.Books, 1, "Should find book by series alias 'DT Series'")
+}
+
+func TestIndexBook_ExcludesGenreAndTagAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	genre := &models.Genre{LibraryID: library.ID, Name: "Horror"}
+	_, err = db.NewInsert().Model(genre).Exec(ctx)
+	require.NoError(t, err)
+	insertAlias(t, db, "genre_aliases", "genre_id", genre.ID, library.ID, "Spooky")
+
+	book := &models.Book{
+		LibraryID: library.ID, Filepath: "/test/horror", Title: "It",
+		TitleSource: "file", SortTitle: "It", SortTitleSource: "file", AuthorSource: "file",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{LibraryID: library.ID, BookID: book.ID, Filepath: "/test/horror/it.epub", FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain, FilesizeBytes: 1000}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	book.Files = []*models.File{file}
+
+	svc := NewService(db)
+	err = svc.IndexBook(ctx, book)
+	require.NoError(t, err)
+
+	results, err := svc.GlobalSearch(ctx, library.ID, "Spooky")
+	require.NoError(t, err)
+	require.Empty(t, results.Books, "Genre aliases should not be in books_fts")
+}
+
+func TestRebuildAllIndexes_IncludesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	person := &models.Person{LibraryID: library.ID, Name: "Stephen King", SortName: "King, Stephen", SortNameSource: "file"}
+	_, err = db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+	insertAlias(t, db, "person_aliases", "person_id", person.ID, library.ID, "Richard Bachman")
+
+	series := &models.Series{LibraryID: library.ID, Name: "The Dark Tower", NameSource: "file", SortName: "Dark Tower, The", SortNameSource: "file"}
+	_, err = db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+	insertAlias(t, db, "series_aliases", "series_id", series.ID, library.ID, "DT Series")
+
+	genre := &models.Genre{LibraryID: library.ID, Name: "Horror"}
+	_, err = db.NewInsert().Model(genre).Exec(ctx)
+	require.NoError(t, err)
+	insertAlias(t, db, "genre_aliases", "genre_id", genre.ID, library.ID, "Spooky")
+
+	tag := &models.Tag{LibraryID: library.ID, Name: "Bestseller"}
+	_, err = db.NewInsert().Model(tag).Exec(ctx)
+	require.NoError(t, err)
+	insertAlias(t, db, "tag_aliases", "tag_id", tag.ID, library.ID, "Popular")
+
+	book := &models.Book{
+		LibraryID: library.ID, Filepath: "/test/dt", Title: "The Gunslinger",
+		TitleSource: "file", SortTitle: "Gunslinger, The", SortTitleSource: "file", AuthorSource: "file",
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewInsert().Model(&models.Author{}).
+		Value("book_id", "?", book.ID).Value("person_id", "?", person.ID).Value("sort_order", "?", 0).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewInsert().Model(&models.BookSeries{}).
+		Value("book_id", "?", book.ID).Value("series_id", "?", series.ID).Value("sort_order", "?", 0).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{LibraryID: library.ID, BookID: book.ID, Filepath: "/test/dt/gunslinger.epub", FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain, FilesizeBytes: 1000}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	svc := NewService(db)
+	err = svc.RebuildAllIndexes(ctx)
+	require.NoError(t, err)
+
+	people, _, err := svc.SearchPeople(ctx, library.ID, "Bachman", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, people, 1, "RebuildAllIndexes should include person aliases")
+
+	seriesResults, _, err := svc.SearchSeries(ctx, library.ID, "DT Series", 10, 0)
+	require.NoError(t, err)
+	require.Len(t, seriesResults, 1, "RebuildAllIndexes should include series aliases")
+
+	var genreCount int
+	err = db.NewSelect().TableExpr("genres_fts").ColumnExpr("COUNT(*)").
+		Where("genres_fts MATCH ?", `"Spooky"`).Where("library_id = ?", library.ID).Scan(ctx, &genreCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, genreCount, "RebuildAllIndexes should include genre aliases")
+
+	var tagCount int
+	err = db.NewSelect().TableExpr("tags_fts").ColumnExpr("COUNT(*)").
+		Where("tags_fts MATCH ?", `"Popular"`).Where("library_id = ?", library.ID).Scan(ctx, &tagCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, tagCount, "RebuildAllIndexes should include tag aliases")
+
+	bookResults, err := svc.GlobalSearch(ctx, library.ID, "Bachman")
+	require.NoError(t, err)
+	require.Len(t, bookResults.Books, 1, "RebuildAllIndexes should include author aliases in books_fts")
+
+	bookResults, err = svc.GlobalSearch(ctx, library.ID, "DT Series")
+	require.NoError(t, err)
+	require.Len(t, bookResults.Books, 1, "RebuildAllIndexes should include series aliases in books_fts")
 }

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -183,10 +183,12 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	// Sync aliases if provided
+	aliasesChanged := false
 	if params.Aliases != nil {
 		if err := h.aliasService.SyncAliases(ctx, aliases.SeriesConfig, id, series.LibraryID, params.Aliases); err != nil {
 			return errors.WithStack(err)
 		}
+		aliasesChanged = true
 	}
 
 	// Reload the model
@@ -201,6 +203,20 @@ func (h *handler) update(c echo.Context) error {
 	log := logger.FromContext(ctx)
 	if err := h.searchService.IndexSeries(ctx, series); err != nil {
 		log.Warn("failed to update search index for series", logger.Data{"series_id": series.ID, "error": err.Error()})
+	}
+
+	// Re-index associated books when aliases change (books_fts includes series aliases)
+	if aliasesChanged {
+		bookIDs, err := h.seriesService.GetSeriesBookIDs(ctx, id)
+		if err != nil {
+			log.Warn("failed to get series book IDs for FTS reindex after alias change", logger.Data{"series_id": id, "error": err.Error()})
+		} else {
+			for _, bookID := range bookIDs {
+				if err := h.searchService.ReindexBookByID(ctx, bookID); err != nil {
+					log.Warn("failed to reindex book after series alias change", logger.Data{"series_id": id, "book_id": bookID, "error": err.Error()})
+				}
+			}
+		}
 	}
 
 	// Get book count

--- a/pkg/series/service.go
+++ b/pkg/series/service.go
@@ -340,6 +340,16 @@ func (svc *Service) GetSeriesBookCount(ctx context.Context, seriesID int) (int, 
 	return count, errors.WithStack(err)
 }
 
+func (svc *Service) GetSeriesBookIDs(ctx context.Context, seriesID int) ([]int, error) {
+	var ids []int
+	err := svc.db.NewSelect().
+		Model((*models.BookSeries)(nil)).
+		Column("book_id").
+		Where("series_id = ?", seriesID).
+		Scan(ctx, &ids)
+	return ids, errors.WithStack(err)
+}
+
 // buildFTSPrefixQuery builds an FTS5 query for prefix/typeahead search.
 // It sanitizes the input to prevent FTS5 injection and appends a wildcard.
 func buildFTSPrefixQuery(input string) string {

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -181,7 +181,7 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	if nameChanged {
+	if nameChanged || params.Aliases != nil {
 		log := logger.FromContext(ctx)
 		if err := h.searchService.IndexTag(ctx, tag); err != nil {
 			log.Warn("failed to update search index for tag", logger.Data{"tag_id": tag.ID, "error": err.Error()})


### PR DESCRIPTION
Closes #205

## Summary
- Resource FTS indexes (genres, tags, series, persons) now include alias names alongside primary names, so searching by alias surfaces the correct resource
- `books_fts` includes author/narrator aliases in the `authors`/`narrators` columns and series aliases in `series_names` — genre/tag aliases are intentionally excluded per spec
- Publisher and imprint LIKE-based search extended to match alias names via subquery
- When person or series aliases are added/removed, all associated books are re-indexed in `books_fts`
- `RebuildAllIndexes` updated with UNION-based SQL to include aliases during bulk rebuild
- Search result display JOINs back to the main table so displayed names are always the canonical primary name (not the FTS text with aliases concatenated)

## Test plan
- Search tests for each resource type by alias name (genre, tag, series, person)
- Book search tests by author alias, narrator alias, and series alias
- Negative test: genre/tag aliases do NOT appear in books_fts
- RebuildAllIndexes test verifies aliases are included in all FTS indexes
- Publisher and imprint LIKE search tests match alias names
- All existing search tests still pass (no regressions)