### PR TITLE
[Frontend] Add alias management to MetadataEditDialog

### DIFF
--- a/app/components/library/MetadataEditDialog.test.tsx
+++ b/app/components/library/MetadataEditDialog.test.tsx
@@ -193,6 +193,332 @@ describe("MetadataEditDialog", () => {
     });
   });
 
+  describe("alias management", () => {
+    it("should show existing aliases as chips when dialog opens", async () => {
+      const onSave = vi.fn();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Sci-Fi", "SF"]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+        expect(screen.getByText("SF")).toBeInTheDocument();
+      });
+    });
+
+    it("should add alias when typing and pressing Enter", async () => {
+      const user = createUser();
+      const onSave = vi.fn();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={[]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Name")).toBeInTheDocument();
+      });
+
+      const aliasInput = screen.getByPlaceholderText(
+        "Type alias and press Enter",
+      );
+      await user.type(aliasInput, "Sci-Fi{enter}");
+
+      expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+      expect(aliasInput).toHaveValue("");
+    });
+
+    it("should remove alias when clicking X button", async () => {
+      const user = createUser();
+      const onSave = vi.fn();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Sci-Fi", "SF"]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+      });
+
+      const removeButtons = screen.getAllByRole("button", {
+        name: /remove alias/i,
+      });
+      await user.click(removeButtons[0]);
+
+      expect(screen.queryByText("Sci-Fi")).not.toBeInTheDocument();
+      expect(screen.getByText("SF")).toBeInTheDocument();
+    });
+
+    it("should prevent adding empty alias", async () => {
+      const user = createUser();
+      const onSave = vi.fn();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={[]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Name")).toBeInTheDocument();
+      });
+
+      const aliasInput = screen.getByPlaceholderText(
+        "Type alias and press Enter",
+      );
+      await user.type(aliasInput, "   {enter}");
+
+      // No chip should be added
+      const chips = screen.queryAllByRole("button", {
+        name: /remove alias/i,
+      });
+      expect(chips).toHaveLength(0);
+    });
+
+    it("should prevent adding duplicate alias (case-insensitive)", async () => {
+      const user = createUser();
+      const onSave = vi.fn();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Sci-Fi"]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+      });
+
+      const aliasInput = screen.getByPlaceholderText("Add another...");
+      await user.type(aliasInput, "sci-fi{enter}");
+
+      // Should still have only one chip
+      const chips = screen.getAllByRole("button", { name: /remove alias/i });
+      expect(chips).toHaveLength(1);
+    });
+
+    it("should include aliases in onSave payload", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Sci-Fi"]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+      });
+
+      // Add another alias
+      const aliasInput = screen.getByPlaceholderText("Add another...");
+      await user.type(aliasInput, "SF{enter}");
+
+      // Save button should be enabled (alias change = hasChanges)
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith({
+          name: "Science Fiction",
+          aliases: ["Sci-Fi", "SF"],
+        });
+      });
+    });
+
+    it("should detect alias changes for hasChanges/save button", async () => {
+      const user = createUser();
+      const onSave = vi.fn();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Sci-Fi"]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+      });
+
+      // Save button should be disabled - no changes yet
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      expect(saveButton).toBeDisabled();
+
+      // Remove an alias
+      const removeButton = screen.getByRole("button", {
+        name: /remove alias/i,
+      });
+      await user.click(removeButton);
+
+      // Save button should now be enabled
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+    });
+
+    it("should display server-side error when onSave throws", async () => {
+      const user = createUser();
+      const onSave = vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            'alias "Sci-Fi" conflicts with existing genre "Science Fiction"',
+          ),
+        );
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={[]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Name")).toBeInTheDocument();
+      });
+
+      // Add an alias and save
+      const aliasInput = screen.getByPlaceholderText(
+        "Type alias and press Enter",
+      );
+      await user.type(aliasInput, "Sci-Fi{enter}");
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /alias "Sci-Fi" conflicts with existing genre "Science Fiction"/,
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("should work for person entity type with sort name and aliases", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Bob"]}
+            entityName="Robert Jordan"
+            entityType="person"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+            sortName="Jordan, Robert"
+            sortNameSource="manual"
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Bob")).toBeInTheDocument();
+      });
+
+      // Add alias
+      const aliasInput = screen.getByPlaceholderText("Add another...");
+      await user.type(aliasInput, "RJ{enter}");
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith({
+          name: "Robert Jordan",
+          sort_name: "Jordan, Robert",
+          aliases: ["Bob", "RJ"],
+        });
+      });
+    });
+  });
+
   describe("hasChanges comparison against initial state", () => {
     it("should compute hasChanges against initial values, not live props", async () => {
       // This test exposes the bug: hasChanges compares form values against

--- a/app/components/library/MetadataEditDialog.tsx
+++ b/app/components/library/MetadataEditDialog.tsx
@@ -1,7 +1,8 @@
-import { Loader2 } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { SortNameInput } from "@/components/common/SortNameInput";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DialogBody,
@@ -31,9 +32,14 @@ interface MetadataEditDialogProps {
   onOpenChange: (open: boolean) => void;
   entityType: EntityType;
   entityName: string;
+  aliases?: string[];
   sortName?: string;
   sortNameSource?: DataSource;
-  onSave: (data: { name: string; sort_name?: string }) => Promise<void>;
+  onSave: (data: {
+    name: string;
+    sort_name?: string;
+    aliases?: string[];
+  }) => Promise<void>;
   isPending: boolean;
 }
 
@@ -51,6 +57,7 @@ export function MetadataEditDialog({
   onOpenChange,
   entityType,
   entityName,
+  aliases,
   sortName,
   sortNameSource,
   onSave,
@@ -58,11 +65,15 @@ export function MetadataEditDialog({
 }: MetadataEditDialogProps) {
   const [name, setName] = useState(entityName);
   const [editSortName, setEditSortName] = useState(sortName || "");
+  const [editAliases, setEditAliases] = useState<string[]>([]);
+  const [aliasInput, setAliasInput] = useState("");
+  const [serverError, setServerError] = useState<string | null>(null);
   const [changesSaved, setChangesSaved] = useState(false);
   // Store initial values when dialog opens - used for hasChanges comparison
   const [initialValues, setInitialValues] = useState<{
     name: string;
     sortName: string;
+    aliases: string[];
   } | null>(null);
 
   const hasSortName = entityType === "person" || entityType === "series";
@@ -93,27 +104,57 @@ export function MetadataEditDialog({
           : null;
     const effectiveSortName =
       sortName || (generateSort ? generateSort(initialName) : "");
+    const initialAliases = aliases ?? [];
     setName(initialName);
     setEditSortName(semanticSortName);
+    setEditAliases([...initialAliases]);
+    setAliasInput("");
+    setServerError(null);
     setInitialValues({
       name: initialName,
       sortName: effectiveSortName,
+      aliases: [...initialAliases],
     });
     setChangesSaved(false);
-  }, [open, entityName, sortName, sortNameSource, entityType]);
+  }, [open, entityName, sortName, sortNameSource, entityType, aliases]);
+
+  const handleAddAlias = () => {
+    const trimmed = aliasInput.trim();
+    if (!trimmed) return;
+    if (editAliases.some((a) => a.toLowerCase() === trimmed.toLowerCase()))
+      return;
+    setEditAliases([...editAliases, trimmed]);
+    setAliasInput("");
+  };
+
+  const handleRemoveAlias = (index: number) => {
+    setEditAliases(editAliases.filter((_, i) => i !== index));
+  };
+
+  const handleAliasKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAddAlias();
+    }
+  };
 
   const handleSubmit = async () => {
+    setServerError(null);
     try {
-      const data: { name: string; sort_name?: string } = { name };
+      const data: { name: string; sort_name?: string; aliases?: string[] } = {
+        name,
+      };
       if (hasSortName) {
-        // Pass empty string through - backend interprets it as "regenerate sort name"
         data.sort_name = editSortName;
       }
+      data.aliases = editAliases;
       await onSave(data);
       setChangesSaved(true);
       requestClose();
-    } catch {
-      // Error handling (e.g., toast) is done by the parent callback
+    } catch (err) {
+      if (err instanceof Error) {
+        setServerError(err.message);
+      }
     }
   };
 
@@ -130,10 +171,14 @@ export function MetadataEditDialog({
           : null;
     const effectiveSortName =
       editSortName || (generateSort ? generateSort(name) : "");
+    const aliasesChanged =
+      editAliases.length !== initialValues.aliases.length ||
+      editAliases.some((a, i) => a !== initialValues.aliases[i]);
     // Compare against stored initial values, not live props
     return (
       name !== initialValues.name ||
-      (hasSortName && effectiveSortName !== initialValues.sortName)
+      (hasSortName && effectiveSortName !== initialValues.sortName) ||
+      aliasesChanged
     );
   }, [
     name,
@@ -142,6 +187,7 @@ export function MetadataEditDialog({
     changesSaved,
     initialValues,
     entityType,
+    editAliases,
   ]);
 
   const { requestClose } = useFormDialogClose(open, onOpenChange, hasChanges);
@@ -179,6 +225,46 @@ export function MetadataEditDialog({
               />
             </div>
           )}
+
+          <div className="space-y-2">
+            <Label htmlFor="aliases">Aliases</Label>
+            <div className="flex flex-wrap gap-1.5 rounded-md border border-input bg-transparent px-3 py-1.5">
+              {editAliases.map((alias, index) => (
+                <Badge
+                  className="max-w-full gap-1 pr-1"
+                  key={alias}
+                  variant="secondary"
+                >
+                  <span className="truncate" title={alias}>
+                    {alias}
+                  </span>
+                  <button
+                    aria-label={`Remove alias ${alias}`}
+                    className="shrink-0 ml-0.5 rounded-sm hover:bg-muted cursor-pointer"
+                    onClick={() => handleRemoveAlias(index)}
+                    type="button"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </Badge>
+              ))}
+              <input
+                className="flex-1 min-w-[120px] bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+                id="aliases"
+                onChange={(e) => setAliasInput(e.target.value)}
+                onKeyDown={handleAliasKeyDown}
+                placeholder={
+                  editAliases.length === 0
+                    ? "Type alias and press Enter"
+                    : "Add another..."
+                }
+                value={aliasInput}
+              />
+            </div>
+            {serverError && (
+              <p className="text-sm text-destructive">{serverError}</p>
+            )}
+          </div>
         </DialogBody>
 
         <DialogFooter>

--- a/app/components/library/MetadataEditDialog.tsx
+++ b/app/components/library/MetadataEditDialog.tsx
@@ -199,7 +199,7 @@ export function MetadataEditDialog({
           <DialogTitle>Edit {ENTITY_LABELS[entityType]}</DialogTitle>
           <DialogDescription>
             Update the {ENTITY_LABELS[entityType].toLowerCase()} name
-            {hasSortName ? " and sort order" : ""}.
+            {hasSortName ? ", sort order," : ""} and aliases.
           </DialogDescription>
         </DialogHeader>
 
@@ -228,11 +228,11 @@ export function MetadataEditDialog({
 
           <div className="space-y-2">
             <Label htmlFor="aliases">Aliases</Label>
-            <div className="flex flex-wrap gap-1.5 rounded-md border border-input bg-transparent px-3 py-1.5">
+            <div className="flex flex-wrap gap-1.5 rounded-md border border-input bg-transparent px-3 py-1.5 focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]">
               {editAliases.map((alias, index) => (
                 <Badge
                   className="max-w-full gap-1 pr-1"
-                  key={alias}
+                  key={index}
                   variant="secondary"
                 >
                   <span className="truncate" title={alias}>

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -109,11 +109,11 @@ const GenreDetail = () => {
     { enabled: mergeOpen && !!genreQuery.data?.library_id },
   );
 
-  const handleEdit = async (data: { name: string }) => {
+  const handleEdit = async (data: { name: string; aliases?: string[] }) => {
     if (!genreId) return;
     await updateGenreMutation.mutateAsync({
       genreId,
-      payload: { name: data.name },
+      payload: { name: data.name, aliases: data.aliases },
     });
     setEditOpen(false);
   };
@@ -251,6 +251,7 @@ const GenreDetail = () => {
       )}
 
       <MetadataEditDialog
+        aliases={(genre.aliases as unknown as string[]) ?? []}
         entityName={genre.name}
         entityType="genre"
         isPending={updateGenreMutation.isPending}

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -53,11 +53,11 @@ const ImprintDetail = () => {
     { enabled: mergeOpen && !!imprintQuery.data?.library_id },
   );
 
-  const handleEdit = async (data: { name: string }) => {
+  const handleEdit = async (data: { name: string; aliases?: string[] }) => {
     if (!imprintId) return;
     await updateImprintMutation.mutateAsync({
       imprintId,
-      payload: { name: data.name },
+      payload: { name: data.name, aliases: data.aliases },
     });
     setEditOpen(false);
   };
@@ -203,6 +203,7 @@ const ImprintDetail = () => {
       )}
 
       <MetadataEditDialog
+        aliases={(imprint.aliases as unknown as string[]) ?? []}
         entityName={imprint.name}
         entityType="imprint"
         isPending={updateImprintMutation.isPending}

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -117,13 +117,18 @@ const PersonDetail = () => {
     { enabled: mergeOpen && !!personQuery.data?.library_id },
   );
 
-  const handleEdit = async (data: { name: string; sort_name?: string }) => {
+  const handleEdit = async (data: {
+    name: string;
+    sort_name?: string;
+    aliases?: string[];
+  }) => {
     if (!personId) return;
     await updatePersonMutation.mutateAsync({
       personId,
       payload: {
         name: data.name,
         sort_name: data.sort_name,
+        aliases: data.aliases,
       },
     });
     setEditOpen(false);
@@ -311,6 +316,7 @@ const PersonDetail = () => {
       )}
 
       <MetadataEditDialog
+        aliases={(person.aliases as unknown as string[]) ?? []}
         entityName={person.name}
         entityType="person"
         isPending={updatePersonMutation.isPending}

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -53,11 +53,11 @@ const PublisherDetail = () => {
     { enabled: mergeOpen && !!publisherQuery.data?.library_id },
   );
 
-  const handleEdit = async (data: { name: string }) => {
+  const handleEdit = async (data: { name: string; aliases?: string[] }) => {
     if (!publisherId) return;
     await updatePublisherMutation.mutateAsync({
       publisherId,
-      payload: { name: data.name },
+      payload: { name: data.name, aliases: data.aliases },
     });
     setEditOpen(false);
   };
@@ -203,6 +203,7 @@ const PublisherDetail = () => {
       )}
 
       <MetadataEditDialog
+        aliases={(publisher.aliases as unknown as string[]) ?? []}
         entityName={publisher.name}
         entityType="publisher"
         isPending={updatePublisherMutation.isPending}

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -109,13 +109,18 @@ const SeriesDetail = () => {
     { enabled: mergeOpen && !!seriesQuery.data?.library_id },
   );
 
-  const handleEdit = async (data: { name: string; sort_name?: string }) => {
+  const handleEdit = async (data: {
+    name: string;
+    sort_name?: string;
+    aliases?: string[];
+  }) => {
     if (!seriesId) return;
     await updateSeriesMutation.mutateAsync({
       seriesId,
       payload: {
         name: data.name,
         sort_name: data.sort_name,
+        aliases: data.aliases,
       },
     });
     setEditOpen(false);
@@ -263,6 +268,7 @@ const SeriesDetail = () => {
       )}
 
       <MetadataEditDialog
+        aliases={(series.aliases as unknown as string[]) ?? []}
         entityName={series.name}
         entityType="series"
         isPending={updateSeriesMutation.isPending}

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -109,11 +109,11 @@ const TagDetail = () => {
     { enabled: mergeOpen && !!tagQuery.data?.library_id },
   );
 
-  const handleEdit = async (data: { name: string }) => {
+  const handleEdit = async (data: { name: string; aliases?: string[] }) => {
     if (!tagId) return;
     await updateTagMutation.mutateAsync({
       tagId,
-      payload: { name: data.name },
+      payload: { name: data.name, aliases: data.aliases },
     });
     setEditOpen(false);
   };
@@ -251,6 +251,7 @@ const TagDetail = () => {
       )}
 
       <MetadataEditDialog
+        aliases={(tag.aliases as unknown as string[]) ?? []}
         entityName={tag.name}
         entityType="tag"
         isPending={updateTagMutation.isPending}


### PR DESCRIPTION
Closes #207

## Summary
- Add tag-style chip input for aliases to the MetadataEditDialog, positioned below the name field (and sort name where applicable)
- Existing aliases load as removable chips when the dialog opens; users type + Enter to add new aliases
- Client-side validation prevents empty and duplicate (case-insensitive) aliases
- Server-side uniqueness errors from the PATCH endpoint are displayed inline in the dialog
- Unsaved changes detection includes alias modifications
- All six resource types (genre, tag, series, person, publisher, imprint) pass aliases through to the dialog and include them in the save payload

## Test plan
- Unit tests added for: chip rendering, add via Enter, remove via X, empty prevention, duplicate prevention (case-insensitive), onSave payload inclusion, hasChanges detection, server error display, person entity with sort name + aliases
- Verified in browser: added aliases to Science Fiction genre, confirmed persistence on reopen, confirmed remove works, confirmed person edit dialog renders all three sections (name, sort name, aliases)
- Full `mise check:quiet` passes (lint, test, test:js:fast, lint:js)