### PR TITLE
[Fix] Use SQL-based FTS reindex in series merge/delete handlers

### DIFF
--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -396,9 +396,8 @@ func (h *handler) merge(c echo.Context) error {
 		log.Warn("failed to remove merged series from search index", logger.Data{"series_id": params.SourceID, "error": err.Error()})
 	}
 
-	// Books that moved from source to target carry the source series name in
-	// their books_fts row; re-index them so the target series name is what
-	// shows up in search.
+	// Books that moved need their books_fts row refreshed to reflect the
+	// target series name and the source name (now an alias of the target).
 	for _, bookID := range movedBookIDs {
 		if err := h.searchService.ReindexBookByID(ctx, bookID); err != nil {
 			log.Warn("failed to update book search index after series merge", logger.Data{"book_id": bookID, "error": err.Error()})

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -400,12 +400,7 @@ func (h *handler) merge(c echo.Context) error {
 	// their books_fts row; re-index them so the target series name is what
 	// shows up in search.
 	for _, bookID := range movedBookIDs {
-		book, err := h.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
-		if err != nil {
-			log.Warn("failed to retrieve book for FTS reindex after series merge", logger.Data{"book_id": bookID, "error": err.Error()})
-			continue
-		}
-		if err := h.searchService.IndexBook(ctx, book); err != nil {
+		if err := h.searchService.ReindexBookByID(ctx, bookID); err != nil {
 			log.Warn("failed to update book search index after series merge", logger.Data{"book_id": bookID, "error": err.Error()})
 		}
 	}
@@ -459,12 +454,7 @@ func (h *handler) deleteSeries(c echo.Context) error {
 	for _, bookID := range affectedBookIDs {
 		h.bookService.RecomputeReviewedForBook(ctx, bookID)
 
-		book, err := h.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
-		if err != nil {
-			log.Warn("failed to retrieve book for FTS reindex after series delete", logger.Data{"book_id": bookID, "error": err.Error()})
-			continue
-		}
-		if err := h.searchService.IndexBook(ctx, book); err != nil {
+		if err := h.searchService.ReindexBookByID(ctx, bookID); err != nil {
 			log.Warn("failed to update book search index after series delete", logger.Data{"book_id": bookID, "error": err.Error()})
 		}
 	}

--- a/pkg/series/service_test.go
+++ b/pkg/series/service_test.go
@@ -311,8 +311,8 @@ func TestMergeSeriesHandler_ReindexesAffectedBooks(t *testing.T) {
 	require.NoError(t, h.merge(c))
 	require.Equal(t, http.StatusNoContent, rec.Code)
 
-	assert.Equal(t, "New Target Name", readBooksFTSSeriesNames(ctx, t, db, book.ID),
-		"books_fts.series_names must reflect the target series name after a merge")
+	assert.Equal(t, "New Target Name Old Source Name", readBooksFTSSeriesNames(ctx, t, db, book.ID),
+		"books_fts.series_names must include the target name and the source name (now an alias)")
 }
 
 // TestDeleteSeries_HardDeletesRowAndFTS pins the post-soft-delete behavior:


### PR DESCRIPTION
## Summary
- Series merge and delete handlers were using `RetrieveBook` + `IndexBook` (multi-step ORM approach) to re-index affected books' FTS rows, which produced stale series names intermittently in CI
- Switched to `ReindexBookByID` which builds series_names via a single SQL query joining book_series and series directly, matching the pattern already used by `RebuildAllIndexes` and the series update handler's alias-change path
- Fixed the merge reindex test expectation: after PR #222 added `TransferAliasesOnMerge`, the source series name becomes an alias of the target, so `books_fts.series_names` correctly includes both names

## Test plan
- `TestMergeSeriesHandler_ReindexesAffectedBooks` passes consistently (was flaking in CI)
- `TestDeleteSeriesHandler_ReindexesAffectedBooks` continues to pass
- Full `pkg/series/` test suite passes with `-race`