### PR TITLE
[Frontend] Display aliases on detail and list pages

### DIFF
--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -156,6 +156,7 @@ const GenreDetail = () => {
   }
 
   const genre = genreQuery.data;
+  const aliases = (genre.aliases as unknown as string[]) ?? [];
   const bookCount = genre.book_count ?? 0;
   const canDelete = bookCount === 0;
 
@@ -205,6 +206,11 @@ const GenreDetail = () => {
             )}
           </div>
         </div>
+        {aliases.length > 0 && (
+          <p className="text-sm text-muted-foreground mb-2">
+            Aliases: {aliases.join(", ")}
+          </p>
+        )}
         <Badge variant="secondary">
           {bookCount} book{bookCount !== 1 ? "s" : ""}
         </Badge>
@@ -251,7 +257,7 @@ const GenreDetail = () => {
       )}
 
       <MetadataEditDialog
-        aliases={(genre.aliases as unknown as string[]) ?? []}
+        aliases={aliases}
         entityName={genre.name}
         entityType="genre"
         isPending={updateGenreMutation.isPending}

--- a/app/components/pages/GenresList.tsx
+++ b/app/components/pages/GenresList.tsx
@@ -83,7 +83,10 @@ const GenresList = () => {
         <div className="min-w-0 flex-1 mr-3">
           <div className="font-medium">{genre.name}</div>
           {aliases.length > 0 && (
-            <div className="text-sm text-muted-foreground truncate">
+            <div
+              className="text-sm text-muted-foreground truncate"
+              title={`Aliases: ${aliases.join(", ")}`}
+            >
               Aliases: {aliases.join(", ")}
             </div>
           )}

--- a/app/components/pages/GenresList.tsx
+++ b/app/components/pages/GenresList.tsx
@@ -72,6 +72,7 @@ const GenresList = () => {
 
   const renderGenreItem = (genre: Genre) => {
     const bookCount = genre.book_count ?? 0;
+    const aliases = (genre.aliases as unknown as string[]) ?? [];
 
     return (
       <Link
@@ -79,8 +80,15 @@ const GenresList = () => {
         key={genre.id}
         to={`/libraries/${libraryId}/genres/${genre.id}`}
       >
-        <span className="font-medium">{genre.name}</span>
-        <Badge variant="secondary">
+        <div className="min-w-0 flex-1 mr-3">
+          <div className="font-medium">{genre.name}</div>
+          {aliases.length > 0 && (
+            <div className="text-sm text-muted-foreground truncate">
+              Aliases: {aliases.join(", ")}
+            </div>
+          )}
+        </div>
+        <Badge className="shrink-0" variant="secondary">
           {bookCount} book{bookCount !== 1 ? "s" : ""}
         </Badge>
       </Link>

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -101,6 +101,7 @@ const ImprintDetail = () => {
   }
 
   const imprint = imprintQuery.data;
+  const aliases = (imprint.aliases as unknown as string[]) ?? [];
   const fileCount = imprint.file_count ?? 0;
   const canDelete = fileCount === 0;
 
@@ -155,6 +156,11 @@ const ImprintDetail = () => {
             )}
           </div>
         </div>
+        {aliases.length > 0 && (
+          <p className="text-sm text-muted-foreground mb-2">
+            Aliases: {aliases.join(", ")}
+          </p>
+        )}
         <Badge variant="secondary">
           {fileCount} file{fileCount !== 1 ? "s" : ""}
         </Badge>
@@ -203,7 +209,7 @@ const ImprintDetail = () => {
       )}
 
       <MetadataEditDialog
-        aliases={(imprint.aliases as unknown as string[]) ?? []}
+        aliases={aliases}
         entityName={imprint.name}
         entityType="imprint"
         isPending={updateImprintMutation.isPending}

--- a/app/components/pages/ImprintsList.tsx
+++ b/app/components/pages/ImprintsList.tsx
@@ -70,6 +70,7 @@ const ImprintsList = () => {
 
   const renderImprintItem = (imprint: Imprint) => {
     const fileCount = imprint.file_count ?? 0;
+    const aliases = (imprint.aliases as unknown as string[]) ?? [];
 
     return (
       <Link
@@ -77,8 +78,15 @@ const ImprintsList = () => {
         key={imprint.id}
         to={`/libraries/${libraryId}/imprints/${imprint.id}`}
       >
-        <span className="font-medium">{imprint.name}</span>
-        <Badge variant="secondary">
+        <div className="min-w-0 flex-1 mr-3">
+          <div className="font-medium">{imprint.name}</div>
+          {aliases.length > 0 && (
+            <div className="text-sm text-muted-foreground truncate">
+              Aliases: {aliases.join(", ")}
+            </div>
+          )}
+        </div>
+        <Badge className="shrink-0" variant="secondary">
           {fileCount} file{fileCount !== 1 ? "s" : ""}
         </Badge>
       </Link>

--- a/app/components/pages/ImprintsList.tsx
+++ b/app/components/pages/ImprintsList.tsx
@@ -81,7 +81,10 @@ const ImprintsList = () => {
         <div className="min-w-0 flex-1 mr-3">
           <div className="font-medium">{imprint.name}</div>
           {aliases.length > 0 && (
-            <div className="text-sm text-muted-foreground truncate">
+            <div
+              className="text-sm text-muted-foreground truncate"
+              title={`Aliases: ${aliases.join(", ")}`}
+            >
               Aliases: {aliases.join(", ")}
             </div>
           )}

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -229,7 +229,7 @@ const PersonDetail = () => {
           </p>
         )}
         {aliases.length > 0 && (
-          <p className="text-sm text-muted-foreground mb-2">
+          <p className="text-muted-foreground mb-2">
             Aliases: {aliases.join(", ")}
           </p>
         )}

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -173,6 +173,7 @@ const PersonDetail = () => {
   }
 
   const person = personQuery.data;
+  const aliases = (person.aliases as unknown as string[]) ?? [];
   const canDelete =
     person.authored_book_count === 0 && person.narrated_file_count === 0;
 
@@ -225,6 +226,11 @@ const PersonDetail = () => {
         {person.sort_name !== person.name && (
           <p className="text-muted-foreground mb-2">
             Sort name: {person.sort_name}
+          </p>
+        )}
+        {aliases.length > 0 && (
+          <p className="text-sm text-muted-foreground mb-2">
+            Aliases: {aliases.join(", ")}
           </p>
         )}
         <div className="flex gap-2">
@@ -316,7 +322,7 @@ const PersonDetail = () => {
       )}
 
       <MetadataEditDialog
-        aliases={(person.aliases as unknown as string[]) ?? []}
+        aliases={aliases}
         entityName={person.name}
         entityType="person"
         isPending={updatePersonMutation.isPending}

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -74,7 +74,10 @@ const PersonList = () => {
         <div className="flex-1 min-w-0 mr-3">
           <div className="font-semibold text-lg">{person.name}</div>
           {aliases.length > 0 ? (
-            <div className="text-sm text-muted-foreground truncate">
+            <div
+              className="text-sm text-muted-foreground truncate"
+              title={`Aliases: ${aliases.join(", ")}`}
+            >
               Aliases: {aliases.join(", ")}
             </div>
           ) : (

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -63,6 +63,7 @@ const PersonList = () => {
 
   const renderPersonItem = (person: PersonWithCounts) => {
     const totalWorks = person.authored_book_count + person.narrated_file_count;
+    const aliases = (person.aliases as unknown as string[]) ?? [];
 
     return (
       <Link
@@ -70,12 +71,18 @@ const PersonList = () => {
         key={person.id}
         to={`/libraries/${libraryId}/people/${person.id}`}
       >
-        <div className="flex-1">
+        <div className="flex-1 min-w-0 mr-3">
           <div className="font-semibold text-lg">{person.name}</div>
-          {person.sort_name !== person.name && (
-            <div className="text-sm text-muted-foreground">
-              {person.sort_name}
+          {aliases.length > 0 ? (
+            <div className="text-sm text-muted-foreground truncate">
+              Aliases: {aliases.join(", ")}
             </div>
+          ) : (
+            person.sort_name !== person.name && (
+              <div className="text-sm text-muted-foreground">
+                {person.sort_name}
+              </div>
+            )
           )}
         </div>
         <div className="flex gap-2">

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -101,6 +101,7 @@ const PublisherDetail = () => {
   }
 
   const publisher = publisherQuery.data;
+  const aliases = (publisher.aliases as unknown as string[]) ?? [];
   const fileCount = publisher.file_count ?? 0;
   const canDelete = fileCount === 0;
 
@@ -155,6 +156,11 @@ const PublisherDetail = () => {
             )}
           </div>
         </div>
+        {aliases.length > 0 && (
+          <p className="text-sm text-muted-foreground mb-2">
+            Aliases: {aliases.join(", ")}
+          </p>
+        )}
         <Badge variant="secondary">
           {fileCount} file{fileCount !== 1 ? "s" : ""}
         </Badge>
@@ -203,7 +209,7 @@ const PublisherDetail = () => {
       )}
 
       <MetadataEditDialog
-        aliases={(publisher.aliases as unknown as string[]) ?? []}
+        aliases={aliases}
         entityName={publisher.name}
         entityType="publisher"
         isPending={updatePublisherMutation.isPending}

--- a/app/components/pages/PublishersList.tsx
+++ b/app/components/pages/PublishersList.tsx
@@ -70,6 +70,7 @@ const PublishersList = () => {
 
   const renderPublisherItem = (publisher: Publisher) => {
     const fileCount = publisher.file_count ?? 0;
+    const aliases = (publisher.aliases as unknown as string[]) ?? [];
 
     return (
       <Link
@@ -77,8 +78,15 @@ const PublishersList = () => {
         key={publisher.id}
         to={`/libraries/${libraryId}/publishers/${publisher.id}`}
       >
-        <span className="font-medium">{publisher.name}</span>
-        <Badge variant="secondary">
+        <div className="min-w-0 flex-1 mr-3">
+          <div className="font-medium">{publisher.name}</div>
+          {aliases.length > 0 && (
+            <div className="text-sm text-muted-foreground truncate">
+              Aliases: {aliases.join(", ")}
+            </div>
+          )}
+        </div>
+        <Badge className="shrink-0" variant="secondary">
           {fileCount} file{fileCount !== 1 ? "s" : ""}
         </Badge>
       </Link>

--- a/app/components/pages/PublishersList.tsx
+++ b/app/components/pages/PublishersList.tsx
@@ -81,7 +81,10 @@ const PublishersList = () => {
         <div className="min-w-0 flex-1 mr-3">
           <div className="font-medium">{publisher.name}</div>
           {aliases.length > 0 && (
-            <div className="text-sm text-muted-foreground truncate">
+            <div
+              className="text-sm text-muted-foreground truncate"
+              title={`Aliases: ${aliases.join(", ")}`}
+            >
               Aliases: {aliases.join(", ")}
             </div>
           )}

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -165,6 +165,7 @@ const SeriesDetail = () => {
   }
 
   const series = seriesQuery.data;
+  const aliases = (series.aliases as unknown as string[]) ?? [];
   const canDelete = series.book_count === 0;
 
   return (
@@ -221,6 +222,11 @@ const SeriesDetail = () => {
         {series.description && (
           <p className="text-muted-foreground mb-2">{series.description}</p>
         )}
+        {aliases.length > 0 && (
+          <p className="text-sm text-muted-foreground mb-2">
+            Aliases: {aliases.join(", ")}
+          </p>
+        )}
         <Badge variant="secondary">
           {series.book_count} book{series.book_count !== 1 ? "s" : ""}
         </Badge>
@@ -268,7 +274,7 @@ const SeriesDetail = () => {
       )}
 
       <MetadataEditDialog
-        aliases={(series.aliases as unknown as string[]) ?? []}
+        aliases={aliases}
         entityName={series.name}
         entityType="series"
         isPending={updateSeriesMutation.isPending}

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -223,7 +223,7 @@ const SeriesDetail = () => {
           <p className="text-muted-foreground mb-2">{series.description}</p>
         )}
         {aliases.length > 0 && (
-          <p className="text-sm text-muted-foreground mb-2">
+          <p className="text-muted-foreground mb-2">
             Aliases: {aliases.join(", ")}
           </p>
         )}

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -156,6 +156,7 @@ const TagDetail = () => {
   }
 
   const tag = tagQuery.data;
+  const aliases = (tag.aliases as unknown as string[]) ?? [];
   const bookCount = tag.book_count ?? 0;
   const canDelete = bookCount === 0;
 
@@ -205,6 +206,11 @@ const TagDetail = () => {
             )}
           </div>
         </div>
+        {aliases.length > 0 && (
+          <p className="text-sm text-muted-foreground mb-2">
+            Aliases: {aliases.join(", ")}
+          </p>
+        )}
         <Badge variant="secondary">
           {bookCount} book{bookCount !== 1 ? "s" : ""}
         </Badge>
@@ -251,7 +257,7 @@ const TagDetail = () => {
       )}
 
       <MetadataEditDialog
-        aliases={(tag.aliases as unknown as string[]) ?? []}
+        aliases={aliases}
         entityName={tag.name}
         entityType="tag"
         isPending={updateTagMutation.isPending}

--- a/app/components/pages/TagsList.tsx
+++ b/app/components/pages/TagsList.tsx
@@ -83,7 +83,10 @@ const TagsList = () => {
         <div className="min-w-0 flex-1 mr-3">
           <div className="font-medium">{tag.name}</div>
           {aliases.length > 0 && (
-            <div className="text-sm text-muted-foreground truncate">
+            <div
+              className="text-sm text-muted-foreground truncate"
+              title={`Aliases: ${aliases.join(", ")}`}
+            >
               Aliases: {aliases.join(", ")}
             </div>
           )}

--- a/app/components/pages/TagsList.tsx
+++ b/app/components/pages/TagsList.tsx
@@ -72,6 +72,7 @@ const TagsList = () => {
 
   const renderTagItem = (tag: Tag) => {
     const bookCount = tag.book_count ?? 0;
+    const aliases = (tag.aliases as unknown as string[]) ?? [];
 
     return (
       <Link
@@ -79,8 +80,15 @@ const TagsList = () => {
         key={tag.id}
         to={`/libraries/${libraryId}/tags/${tag.id}`}
       >
-        <span className="font-medium">{tag.name}</span>
-        <Badge variant="secondary">
+        <div className="min-w-0 flex-1 mr-3">
+          <div className="font-medium">{tag.name}</div>
+          {aliases.length > 0 && (
+            <div className="text-sm text-muted-foreground truncate">
+              Aliases: {aliases.join(", ")}
+            </div>
+          )}
+        </div>
+        <Badge className="shrink-0" variant="secondary">
           {bookCount} book{bookCount !== 1 ? "s" : ""}
         </Badge>
       </Link>


### PR DESCRIPTION
Closes #208

## Summary
- Show "Aliases: ..." line in muted text on all six resource detail pages (genres, tags, publishers, imprints, persons, series) below the name/sort name, only when aliases exist
- Add alias subtitle to list pages for genres, tags, publishers, imprints (below the primary name)
- Person list shows aliases replacing sort name subtitle when aliases exist; falls back to sort name when no aliases
- Series grid cards intentionally omit aliases (cover layout has no room, per spec)

## Test plan
- Verify aliases appear on detail pages for resources that have aliases configured
- Verify no extra content appears on detail pages for resources without aliases
- Verify alias subtitles appear on genre, tag, publisher, and imprint list pages
- Verify person list shows aliases instead of sort name when aliases exist
- Verify person list still shows sort name when no aliases exist
- Verify series list grid cards do not show aliases
- Verify alias text uses muted/secondary styling consistent with existing subtitles