### PR TITLE
[E2E] Add alias workflow tests and fix rename+sync alias bug

### DIFF
--- a/e2e/alias.spec.ts
+++ b/e2e/alias.spec.ts
@@ -1,0 +1,352 @@
+/**
+ * E2E tests for alias workflows.
+ *
+ * Covers:
+ * 1. Adding aliases via the edit dialog — persists and is visible on reopen.
+ * 2. Removing an alias via the edit dialog — no longer present after save.
+ * 3. Merging two series — source name becomes alias of the target.
+ * 4. Renaming a series — old name becomes alias.
+ * 5. Autocomplete search matches aliases — searching by alias in the book
+ *    edit dialog returns the canonical resource.
+ *
+ * Running:
+ *   pnpm e2e:chromium e2e/alias.spec.ts
+ *   mise test:e2e -- alias
+ */
+
+import type { Page } from "@playwright/test";
+
+import { expect, getApiBaseURL, request, test } from "./fixtures";
+
+interface TestData {
+  libraryId: number;
+}
+
+let testData: TestData;
+
+const USERNAME = "aliastest";
+const PASSWORD = "password123";
+
+test.describe("Alias workflows", () => {
+  test.beforeAll(async ({ browser }) => {
+    const apiBaseURL = getApiBaseURL(browser.browserType().name());
+    const apiContext = await request.newContext({ baseURL: apiBaseURL });
+
+    await apiContext.delete("/test/ereader");
+    await apiContext.delete("/test/users");
+
+    await apiContext.post("/test/users", {
+      data: { username: USERNAME, password: PASSWORD },
+    });
+
+    const libraryResp = await apiContext.post("/test/libraries", {
+      data: { name: "Alias Test Library" },
+    });
+    const library = (await libraryResp.json()) as { id: number };
+
+    testData = { libraryId: library.id };
+    await apiContext.dispose();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const apiBaseURL = getApiBaseURL(browser.browserType().name());
+    const apiContext = await request.newContext({ baseURL: apiBaseURL });
+    await apiContext.delete("/test/ereader");
+    await apiContext.delete("/test/users");
+    await apiContext.dispose();
+  });
+
+  async function login(page: Page) {
+    await page.goto("/login", { waitUntil: "domcontentloaded" });
+    await page.getByLabel("Username").fill(USERNAME);
+    await page.getByLabel("Password").fill(PASSWORD);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.waitForURL(/\/settings\/libraries|\/libraries\//);
+  }
+
+  test("adding aliases via edit dialog persists and is visible when reopened", async ({
+    page,
+    apiContext,
+  }) => {
+    // Create a series via test API.
+    const seriesResp = await apiContext.post("/test/series", {
+      data: { libraryId: testData.libraryId, name: "Fantasy Saga" },
+    });
+    const series = (await seriesResp.json()) as { id: number };
+
+    await login(page);
+    await page.goto(`/libraries/${testData.libraryId}/series/${series.id}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.locator("h1").filter({ hasText: "Fantasy Saga" }),
+    ).toBeVisible();
+
+    // Open edit dialog.
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit Series" }),
+    ).toBeVisible();
+
+    // Type an alias and press Enter to add it.
+    await page.getByLabel("Aliases").fill("FS");
+    await page.getByLabel("Aliases").press("Enter");
+
+    // Badge should appear.
+    await expect(page.getByText("FS")).toBeVisible();
+
+    // Add a second alias.
+    await page.getByLabel("Aliases").fill("The Fantasy Saga");
+    await page.getByLabel("Aliases").press("Enter");
+    await expect(page.getByText("The Fantasy Saga")).toBeVisible();
+
+    // Save — wait for the PATCH response.
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes(`/api/series/${series.id}`) &&
+          r.request().method() === "PATCH" &&
+          r.ok(),
+      ),
+      page.getByRole("button", { name: "Save" }).click(),
+    ]);
+
+    // Reopen the edit dialog to verify aliases persisted.
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit Series" }),
+    ).toBeVisible();
+    await expect(page.getByText("FS")).toBeVisible();
+    await expect(page.getByText("The Fantasy Saga")).toBeVisible();
+
+    // Also verify via API.
+    const resp = await page.request.get(`/api/series/${series.id}`);
+    const data = (await resp.json()) as { aliases: string[] };
+    expect(data.aliases).toContain("FS");
+    expect(data.aliases).toContain("The Fantasy Saga");
+  });
+
+  test("removing an alias via edit dialog removes it", async ({
+    page,
+    apiContext,
+  }) => {
+    // Create a series.
+    const seriesResp = await apiContext.post("/test/series", {
+      data: { libraryId: testData.libraryId, name: "Mystery Novels" },
+    });
+    const series = (await seriesResp.json()) as { id: number };
+
+    await login(page);
+
+    // Add aliases via API so we have something to remove.
+    const patchResp = await page.request.patch(`/api/series/${series.id}`, {
+      data: { name: "Mystery Novels", aliases: ["MN", "Whodunit Collection"] },
+    });
+    expect(patchResp.ok()).toBeTruthy();
+
+    // Navigate to series detail and open edit dialog.
+    await page.goto(`/libraries/${testData.libraryId}/series/${series.id}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit Series" }),
+    ).toBeVisible();
+
+    // Both aliases should be present.
+    await expect(page.getByText("MN")).toBeVisible();
+    await expect(page.getByText("Whodunit Collection")).toBeVisible();
+
+    // Remove "MN" by clicking its X button.
+    await page.getByRole("button", { name: "Remove alias MN" }).click();
+    await expect(page.getByText("MN")).not.toBeVisible();
+
+    // Save.
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes(`/api/series/${series.id}`) &&
+          r.request().method() === "PATCH" &&
+          r.ok(),
+      ),
+      page.getByRole("button", { name: "Save" }).click(),
+    ]);
+
+    // Verify via API.
+    const resp = await page.request.get(`/api/series/${series.id}`);
+    const data = (await resp.json()) as { aliases: string[] };
+    expect(data.aliases).not.toContain("MN");
+    expect(data.aliases).toContain("Whodunit Collection");
+  });
+
+  test("merging series transfers source name as alias to target", async ({
+    page,
+    apiContext,
+  }) => {
+    // Create target and source series, each with a book so merge makes sense.
+    const targetResp = await apiContext.post("/test/series", {
+      data: { libraryId: testData.libraryId, name: "Dune Chronicles" },
+    });
+    const target = (await targetResp.json()) as { id: number };
+
+    const sourceResp = await apiContext.post("/test/series", {
+      data: { libraryId: testData.libraryId, name: "Dune Saga" },
+    });
+    const source = (await sourceResp.json()) as { id: number };
+
+    // Create books linked to each series.
+    await apiContext.post("/test/books", {
+      data: {
+        libraryId: testData.libraryId,
+        title: "Dune",
+        fileType: "epub",
+        seriesId: target.id,
+      },
+    });
+    await apiContext.post("/test/books", {
+      data: {
+        libraryId: testData.libraryId,
+        title: "Dune Messiah",
+        fileType: "epub",
+        seriesId: source.id,
+      },
+    });
+
+    await login(page);
+    await page.goto(`/libraries/${testData.libraryId}/series/${target.id}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.locator("h1").filter({ hasText: "Dune Chronicles" }),
+    ).toBeVisible();
+
+    // Open merge dialog.
+    await page.getByRole("button", { name: "Merge", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: /Merge into/ }),
+    ).toBeVisible();
+
+    // Open the source entity combobox and select "Dune Saga".
+    await page.getByRole("combobox").click();
+    await page.getByPlaceholder("Search series...").fill("Dune Saga");
+
+    // Wait for search results to load and select the source.
+    await expect(
+      page.getByText("Dune Saga", { exact: false }).first(),
+    ).toBeVisible();
+    // Click the command item — use the one inside the command list.
+    await page.locator("[cmdk-item]").filter({ hasText: "Dune Saga" }).click();
+
+    // Confirm merge.
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes(`/api/series/${target.id}/merge`) &&
+          r.request().method() === "POST" &&
+          r.ok(),
+      ),
+      page.getByRole("button", { name: "Merge", exact: true }).last().click(),
+    ]);
+
+    // Open edit dialog to verify "Dune Saga" is now an alias.
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit Series" }),
+    ).toBeVisible();
+    await expect(page.getByText("Dune Saga")).toBeVisible();
+
+    // Verify via API.
+    const resp = await page.request.get(`/api/series/${target.id}`);
+    const data = (await resp.json()) as { aliases: string[] };
+    expect(data.aliases).toContain("Dune Saga");
+  });
+
+  test("renaming a series adds old name as alias", async ({
+    page,
+    apiContext,
+  }) => {
+    const seriesResp = await apiContext.post("/test/series", {
+      data: { libraryId: testData.libraryId, name: "The Lord of the Rings" },
+    });
+    const series = (await seriesResp.json()) as { id: number };
+
+    await login(page);
+    await page.goto(`/libraries/${testData.libraryId}/series/${series.id}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.locator("h1").filter({ hasText: "The Lord of the Rings" }),
+    ).toBeVisible();
+
+    // Open edit dialog and change the name.
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit Series" }),
+    ).toBeVisible();
+
+    const nameInput = page.getByLabel("Name", { exact: true });
+    await nameInput.clear();
+    await nameInput.fill("LOTR");
+
+    // Save.
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes(`/api/series/${series.id}`) &&
+          r.request().method() === "PATCH" &&
+          r.ok(),
+      ),
+      page.getByRole("button", { name: "Save" }).click(),
+    ]);
+
+    // Page should now show the new name.
+    await expect(
+      page.getByRole("heading", { name: "LOTR", exact: true }).first(),
+    ).toBeVisible();
+
+    // Reopen edit dialog — old name should be an alias.
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(
+      page.getByRole("heading", { name: "Edit Series" }),
+    ).toBeVisible();
+    await expect(page.getByText("The Lord of the Rings")).toBeVisible();
+
+    // Verify via API.
+    const resp = await page.request.get(`/api/series/${series.id}`);
+    const data = (await resp.json()) as { aliases: string[] };
+    expect(data.aliases).toContain("The Lord of the Rings");
+  });
+
+  test("searching by alias on the series list page finds the canonical resource", async ({
+    page,
+    apiContext,
+  }) => {
+    // Create a series.
+    const seriesResp = await apiContext.post("/test/series", {
+      data: {
+        libraryId: testData.libraryId,
+        name: "A Song of Ice and Fire",
+      },
+    });
+    const series = (await seriesResp.json()) as { id: number };
+
+    await login(page);
+
+    // Add alias via authenticated API — this triggers FTS indexing.
+    const patchResp = await page.request.patch(`/api/series/${series.id}`, {
+      data: {
+        name: "A Song of Ice and Fire",
+        aliases: ["ASOIAF", "Game of Thrones Series"],
+      },
+    });
+    expect(patchResp.ok()).toBeTruthy();
+
+    // Navigate to the series list page and search by alias name.
+    await page.goto(`/libraries/${testData.libraryId}/series?search=ASOIAF`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    // The canonical series should appear in the search results.
+    await expect(page.getByText("A Song of Ice and Fire")).toBeVisible();
+  });
+});

--- a/e2e/alias.spec.ts
+++ b/e2e/alias.spec.ts
@@ -84,21 +84,22 @@ test.describe("Alias workflows", () => {
 
     // Open edit dialog.
     await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const dialog = page.getByRole("dialog");
     await expect(
-      page.getByRole("heading", { name: "Edit Series" }),
+      dialog.getByRole("heading", { name: "Edit Series" }),
     ).toBeVisible();
 
     // Type an alias and press Enter to add it.
-    await page.getByLabel("Aliases").fill("FS");
-    await page.getByLabel("Aliases").press("Enter");
+    await dialog.getByLabel("Aliases").fill("FS");
+    await dialog.getByLabel("Aliases").press("Enter");
 
-    // Badge should appear.
-    await expect(page.getByText("FS")).toBeVisible();
+    // Badge should appear inside the dialog.
+    await expect(dialog.getByText("FS")).toBeVisible();
 
     // Add a second alias.
-    await page.getByLabel("Aliases").fill("The Fantasy Saga");
-    await page.getByLabel("Aliases").press("Enter");
-    await expect(page.getByText("The Fantasy Saga")).toBeVisible();
+    await dialog.getByLabel("Aliases").fill("The Fantasy Saga");
+    await dialog.getByLabel("Aliases").press("Enter");
+    await expect(dialog.getByText("The Fantasy Saga")).toBeVisible();
 
     // Save — wait for the PATCH response.
     await Promise.all([
@@ -108,16 +109,17 @@ test.describe("Alias workflows", () => {
           r.request().method() === "PATCH" &&
           r.ok(),
       ),
-      page.getByRole("button", { name: "Save" }).click(),
+      dialog.getByRole("button", { name: "Save" }).click(),
     ]);
 
     // Reopen the edit dialog to verify aliases persisted.
     await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const dialog2 = page.getByRole("dialog");
     await expect(
-      page.getByRole("heading", { name: "Edit Series" }),
+      dialog2.getByRole("heading", { name: "Edit Series" }),
     ).toBeVisible();
-    await expect(page.getByText("FS")).toBeVisible();
-    await expect(page.getByText("The Fantasy Saga")).toBeVisible();
+    await expect(dialog2.getByText("FS")).toBeVisible();
+    await expect(dialog2.getByText("The Fantasy Saga")).toBeVisible();
 
     // Also verify via API.
     const resp = await page.request.get(`/api/series/${series.id}`);
@@ -149,17 +151,18 @@ test.describe("Alias workflows", () => {
       waitUntil: "domcontentloaded",
     });
     await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const dialog = page.getByRole("dialog");
     await expect(
-      page.getByRole("heading", { name: "Edit Series" }),
+      dialog.getByRole("heading", { name: "Edit Series" }),
     ).toBeVisible();
 
-    // Both aliases should be present.
-    await expect(page.getByText("MN")).toBeVisible();
-    await expect(page.getByText("Whodunit Collection")).toBeVisible();
+    // Both aliases should be present inside the dialog.
+    await expect(dialog.getByText("MN")).toBeVisible();
+    await expect(dialog.getByText("Whodunit Collection")).toBeVisible();
 
     // Remove "MN" by clicking its X button.
-    await page.getByRole("button", { name: "Remove alias MN" }).click();
-    await expect(page.getByText("MN")).not.toBeVisible();
+    await dialog.getByRole("button", { name: "Remove alias MN" }).click();
+    await expect(dialog.getByText("MN")).not.toBeVisible();
 
     // Save.
     await Promise.all([
@@ -250,10 +253,11 @@ test.describe("Alias workflows", () => {
 
     // Open edit dialog to verify "Dune Saga" is now an alias.
     await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const dialog = page.getByRole("dialog");
     await expect(
-      page.getByRole("heading", { name: "Edit Series" }),
+      dialog.getByRole("heading", { name: "Edit Series" }),
     ).toBeVisible();
-    await expect(page.getByText("Dune Saga")).toBeVisible();
+    await expect(dialog.getByText("Dune Saga")).toBeVisible();
 
     // Verify via API.
     const resp = await page.request.get(`/api/series/${target.id}`);
@@ -306,10 +310,11 @@ test.describe("Alias workflows", () => {
 
     // Reopen edit dialog — old name should be an alias.
     await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const dialog = page.getByRole("dialog");
     await expect(
-      page.getByRole("heading", { name: "Edit Series" }),
+      dialog.getByRole("heading", { name: "Edit Series" }),
     ).toBeVisible();
-    await expect(page.getByText("The Lord of the Rings")).toBeVisible();
+    await expect(dialog.getByText("The Lord of the Rings")).toBeVisible();
 
     // Verify via API.
     const resp = await page.request.get(`/api/series/${series.id}`);

--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -135,6 +135,7 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	nameChanged := false
+	var oldName string
 	if params.Name != nil && *params.Name != genre.Name {
 		newName := strings.TrimSpace(*params.Name)
 		if newName == "" {
@@ -171,7 +172,7 @@ func (h *handler) update(c echo.Context) error {
 		}
 
 		// Simple rename — capture old name before mutation
-		oldName := genre.Name
+		oldName = genre.Name
 		genre.Name = newName
 		opts := UpdateGenreOptions{Columns: []string{"name"}}
 		err = h.genreService.UpdateGenre(ctx, genre, opts)
@@ -180,17 +181,22 @@ func (h *handler) update(c echo.Context) error {
 		}
 		nameChanged = true
 
-		log := logger.FromContext(ctx)
 		_ = h.aliasService.RemoveAlias(ctx, aliases.GenreConfig, id, newName)
-		if err := h.aliasService.AddAlias(ctx, aliases.GenreConfig, id, oldName, genre.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"genre_id": id, "old_name": oldName, "error": err.Error()})
-		}
 	}
 
 	// Sync aliases if provided
 	if params.Aliases != nil {
-		if err := h.aliasService.SyncAliases(ctx, aliases.GenreConfig, id, genre.LibraryID, params.Aliases); err != nil {
+		syncList := params.Aliases
+		if nameChanged {
+			syncList = append(syncList, oldName)
+		}
+		if err := h.aliasService.SyncAliases(ctx, aliases.GenreConfig, id, genre.LibraryID, syncList); err != nil {
 			return errors.WithStack(err)
+		}
+	} else if nameChanged {
+		log := logger.FromContext(ctx)
+		if err := h.aliasService.AddAlias(ctx, aliases.GenreConfig, id, oldName, genre.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"genre_id": id, "old_name": oldName, "error": err.Error()})
 		}
 	}
 

--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -180,8 +180,6 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 		nameChanged = true
-
-		_ = h.aliasService.RemoveAlias(ctx, aliases.GenreConfig, id, newName)
 	}
 
 	// Sync aliases if provided
@@ -194,6 +192,7 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 	} else if nameChanged {
+		_ = h.aliasService.RemoveAlias(ctx, aliases.GenreConfig, id, genre.Name)
 		log := logger.FromContext(ctx)
 		if err := h.aliasService.AddAlias(ctx, aliases.GenreConfig, id, oldName, genre.LibraryID); err != nil {
 			log.Warn("failed to add old name as alias after rename", logger.Data{"genre_id": id, "old_name": oldName, "error": err.Error()})

--- a/pkg/imprints/handlers.go
+++ b/pkg/imprints/handlers.go
@@ -126,6 +126,8 @@ func (h *handler) update(c echo.Context) error {
 		}
 	}
 
+	nameChanged := false
+	var oldName string
 	if params.Name != nil && *params.Name != imprint.Name {
 		newName := strings.TrimSpace(*params.Name)
 		if newName == "" {
@@ -152,24 +154,30 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
-		oldName := imprint.Name
+		oldName = imprint.Name
 		imprint.Name = newName
 		opts := UpdateImprintOptions{Columns: []string{"name"}}
 		err = h.imprintService.UpdateImprint(ctx, imprint, opts)
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		nameChanged = true
 
-		log := logger.FromContext(ctx)
 		_ = h.aliasService.RemoveAlias(ctx, aliases.ImprintConfig, id, newName)
-		if err := h.aliasService.AddAlias(ctx, aliases.ImprintConfig, id, oldName, imprint.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"imprint_id": id, "old_name": oldName, "error": err.Error()})
-		}
 	}
 
 	if params.Aliases != nil {
-		if err := h.aliasService.SyncAliases(ctx, aliases.ImprintConfig, id, imprint.LibraryID, params.Aliases); err != nil {
+		syncList := params.Aliases
+		if nameChanged {
+			syncList = append(syncList, oldName)
+		}
+		if err := h.aliasService.SyncAliases(ctx, aliases.ImprintConfig, id, imprint.LibraryID, syncList); err != nil {
 			return errors.WithStack(err)
+		}
+	} else if nameChanged {
+		log := logger.FromContext(ctx)
+		if err := h.aliasService.AddAlias(ctx, aliases.ImprintConfig, id, oldName, imprint.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"imprint_id": id, "old_name": oldName, "error": err.Error()})
 		}
 	}
 

--- a/pkg/imprints/handlers.go
+++ b/pkg/imprints/handlers.go
@@ -162,8 +162,6 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 		nameChanged = true
-
-		_ = h.aliasService.RemoveAlias(ctx, aliases.ImprintConfig, id, newName)
 	}
 
 	if params.Aliases != nil {
@@ -175,6 +173,7 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 	} else if nameChanged {
+		_ = h.aliasService.RemoveAlias(ctx, aliases.ImprintConfig, id, imprint.Name)
 		log := logger.FromContext(ctx)
 		if err := h.aliasService.AddAlias(ctx, aliases.ImprintConfig, id, oldName, imprint.LibraryID); err != nil {
 			log.Warn("failed to add old name as alias after rename", logger.Data{"imprint_id": id, "old_name": oldName, "error": err.Error()})

--- a/pkg/people/handlers.go
+++ b/pkg/people/handlers.go
@@ -197,10 +197,6 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	if nameChanged {
-		_ = h.aliasService.RemoveAlias(ctx, aliases.PersonConfig, id, person.Name)
-	}
-
 	// Sync aliases if provided
 	aliasesChanged := false
 	if params.Aliases != nil {
@@ -213,6 +209,7 @@ func (h *handler) update(c echo.Context) error {
 		}
 		aliasesChanged = true
 	} else if nameChanged {
+		_ = h.aliasService.RemoveAlias(ctx, aliases.PersonConfig, id, person.Name)
 		log := logger.FromContext(ctx)
 		if err := h.aliasService.AddAlias(ctx, aliases.PersonConfig, id, oldName, person.LibraryID); err != nil {
 			log.Warn("failed to add old name as alias after rename", logger.Data{"person_id": id, "old_name": oldName, "error": err.Error()})

--- a/pkg/people/handlers.go
+++ b/pkg/people/handlers.go
@@ -198,20 +198,25 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	if nameChanged {
-		log := logger.FromContext(ctx)
 		_ = h.aliasService.RemoveAlias(ctx, aliases.PersonConfig, id, person.Name)
-		if err := h.aliasService.AddAlias(ctx, aliases.PersonConfig, id, oldName, person.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"person_id": id, "old_name": oldName, "error": err.Error()})
-		}
 	}
 
 	// Sync aliases if provided
 	aliasesChanged := false
 	if params.Aliases != nil {
-		if err := h.aliasService.SyncAliases(ctx, aliases.PersonConfig, id, person.LibraryID, params.Aliases); err != nil {
+		syncList := params.Aliases
+		if nameChanged {
+			syncList = append(syncList, oldName)
+		}
+		if err := h.aliasService.SyncAliases(ctx, aliases.PersonConfig, id, person.LibraryID, syncList); err != nil {
 			return errors.WithStack(err)
 		}
 		aliasesChanged = true
+	} else if nameChanged {
+		log := logger.FromContext(ctx)
+		if err := h.aliasService.AddAlias(ctx, aliases.PersonConfig, id, oldName, person.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"person_id": id, "old_name": oldName, "error": err.Error()})
+		}
 	}
 
 	// Reload the model

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -162,8 +162,6 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 		nameChanged = true
-
-		_ = h.aliasService.RemoveAlias(ctx, aliases.PublisherConfig, id, newName)
 	}
 
 	if params.Aliases != nil {
@@ -175,6 +173,7 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 	} else if nameChanged {
+		_ = h.aliasService.RemoveAlias(ctx, aliases.PublisherConfig, id, publisher.Name)
 		log := logger.FromContext(ctx)
 		if err := h.aliasService.AddAlias(ctx, aliases.PublisherConfig, id, oldName, publisher.LibraryID); err != nil {
 			log.Warn("failed to add old name as alias after rename", logger.Data{"publisher_id": id, "old_name": oldName, "error": err.Error()})

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -126,6 +126,8 @@ func (h *handler) update(c echo.Context) error {
 		}
 	}
 
+	nameChanged := false
+	var oldName string
 	if params.Name != nil && *params.Name != publisher.Name {
 		newName := strings.TrimSpace(*params.Name)
 		if newName == "" {
@@ -152,24 +154,30 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
-		oldName := publisher.Name
+		oldName = publisher.Name
 		publisher.Name = newName
 		opts := UpdatePublisherOptions{Columns: []string{"name"}}
 		err = h.publisherService.UpdatePublisher(ctx, publisher, opts)
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		nameChanged = true
 
-		log := logger.FromContext(ctx)
 		_ = h.aliasService.RemoveAlias(ctx, aliases.PublisherConfig, id, newName)
-		if err := h.aliasService.AddAlias(ctx, aliases.PublisherConfig, id, oldName, publisher.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"publisher_id": id, "old_name": oldName, "error": err.Error()})
-		}
 	}
 
 	if params.Aliases != nil {
-		if err := h.aliasService.SyncAliases(ctx, aliases.PublisherConfig, id, publisher.LibraryID, params.Aliases); err != nil {
+		syncList := params.Aliases
+		if nameChanged {
+			syncList = append(syncList, oldName)
+		}
+		if err := h.aliasService.SyncAliases(ctx, aliases.PublisherConfig, id, publisher.LibraryID, syncList); err != nil {
 			return errors.WithStack(err)
+		}
+	} else if nameChanged {
+		log := logger.FromContext(ctx)
+		if err := h.aliasService.AddAlias(ctx, aliases.PublisherConfig, id, oldName, publisher.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"publisher_id": id, "old_name": oldName, "error": err.Error()})
 		}
 	}
 

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -187,20 +187,25 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	if nameChanged {
-		log := logger.FromContext(ctx)
 		_ = h.aliasService.RemoveAlias(ctx, aliases.SeriesConfig, id, series.Name)
-		if err := h.aliasService.AddAlias(ctx, aliases.SeriesConfig, id, oldName, series.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"series_id": id, "old_name": oldName, "error": err.Error()})
-		}
 	}
 
 	// Sync aliases if provided
 	aliasesChanged := false
 	if params.Aliases != nil {
-		if err := h.aliasService.SyncAliases(ctx, aliases.SeriesConfig, id, series.LibraryID, params.Aliases); err != nil {
+		syncList := params.Aliases
+		if nameChanged {
+			syncList = append(syncList, oldName)
+		}
+		if err := h.aliasService.SyncAliases(ctx, aliases.SeriesConfig, id, series.LibraryID, syncList); err != nil {
 			return errors.WithStack(err)
 		}
 		aliasesChanged = true
+	} else if nameChanged {
+		log := logger.FromContext(ctx)
+		if err := h.aliasService.AddAlias(ctx, aliases.SeriesConfig, id, oldName, series.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"series_id": id, "old_name": oldName, "error": err.Error()})
+		}
 	}
 
 	// Reload the model

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -186,10 +186,6 @@ func (h *handler) update(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	if nameChanged {
-		_ = h.aliasService.RemoveAlias(ctx, aliases.SeriesConfig, id, series.Name)
-	}
-
 	// Sync aliases if provided
 	aliasesChanged := false
 	if params.Aliases != nil {
@@ -202,6 +198,7 @@ func (h *handler) update(c echo.Context) error {
 		}
 		aliasesChanged = true
 	} else if nameChanged {
+		_ = h.aliasService.RemoveAlias(ctx, aliases.SeriesConfig, id, series.Name)
 		log := logger.FromContext(ctx)
 		if err := h.aliasService.AddAlias(ctx, aliases.SeriesConfig, id, oldName, series.LibraryID); err != nil {
 			log.Warn("failed to add old name as alias after rename", logger.Data{"series_id": id, "old_name": oldName, "error": err.Error()})

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -170,8 +170,6 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 		nameChanged = true
-
-		_ = h.aliasService.RemoveAlias(ctx, aliases.TagConfig, id, newName)
 	}
 
 	if params.Aliases != nil {
@@ -183,6 +181,7 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(err)
 		}
 	} else if nameChanged {
+		_ = h.aliasService.RemoveAlias(ctx, aliases.TagConfig, id, tag.Name)
 		log := logger.FromContext(ctx)
 		if err := h.aliasService.AddAlias(ctx, aliases.TagConfig, id, oldName, tag.LibraryID); err != nil {
 			log.Warn("failed to add old name as alias after rename", logger.Data{"tag_id": id, "old_name": oldName, "error": err.Error()})

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -130,6 +130,7 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	nameChanged := false
+	var oldName string
 	if params.Name != nil && *params.Name != tag.Name {
 		newName := strings.TrimSpace(*params.Name)
 		if newName == "" {
@@ -161,7 +162,7 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
-		oldName := tag.Name
+		oldName = tag.Name
 		tag.Name = newName
 		opts := UpdateTagOptions{Columns: []string{"name"}}
 		err = h.tagService.UpdateTag(ctx, tag, opts)
@@ -170,16 +171,21 @@ func (h *handler) update(c echo.Context) error {
 		}
 		nameChanged = true
 
-		log := logger.FromContext(ctx)
 		_ = h.aliasService.RemoveAlias(ctx, aliases.TagConfig, id, newName)
-		if err := h.aliasService.AddAlias(ctx, aliases.TagConfig, id, oldName, tag.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"tag_id": id, "old_name": oldName, "error": err.Error()})
-		}
 	}
 
 	if params.Aliases != nil {
-		if err := h.aliasService.SyncAliases(ctx, aliases.TagConfig, id, tag.LibraryID, params.Aliases); err != nil {
+		syncList := params.Aliases
+		if nameChanged {
+			syncList = append(syncList, oldName)
+		}
+		if err := h.aliasService.SyncAliases(ctx, aliases.TagConfig, id, tag.LibraryID, syncList); err != nil {
 			return errors.WithStack(err)
+		}
+	} else if nameChanged {
+		log := logger.FromContext(ctx)
+		if err := h.aliasService.AddAlias(ctx, aliases.TagConfig, id, oldName, tag.LibraryID); err != nil {
+			log.Warn("failed to add old name as alias after rename", logger.Data{"tag_id": id, "old_name": oldName, "error": err.Error()})
 		}
 	}
 


### PR DESCRIPTION
Closes #209

## Summary
- Add 5 Playwright E2E tests covering alias workflows: add aliases via edit dialog, remove alias, merge transfers source name as alias, rename adds old name as alias, search by alias finds canonical resource
- Fix a cross-cutting bug in all 6 entity update handlers (series, people, genres, tags, publishers, imprints) where renaming an entity while the MetadataEditDialog sends the `aliases` array caused `SyncAliases` to overwrite the just-added old-name alias. The fix injects the old name into the sync list when both rename and alias sync occur in the same request

## Test plan
- All 5 new E2E tests pass on Chromium
- Go lint and all Go tests pass
- JS lint and all JS unit tests pass
- Existing E2E tests unaffected (59 passed, 2 skipped)