### PR TITLE
[Backend] Add FTS indexes for publishers/imprints and sidebar navigation

### DIFF
--- a/app/components/library/useLibraryNavItems.ts
+++ b/app/components/library/useLibraryNavItems.ts
@@ -1,8 +1,10 @@
 import {
   Book,
   Bookmark,
+  Building2,
   Layers,
   Settings,
+  Stamp,
   Tags,
   Users,
   type LucideIcon,
@@ -36,6 +38,8 @@ export const useLibraryNavItems = (): LibraryNavItem[] | null => {
       !location.pathname.startsWith(`${basePath}/people`) &&
       !location.pathname.startsWith(`${basePath}/genres`) &&
       !location.pathname.startsWith(`${basePath}/tags`) &&
+      !location.pathname.startsWith(`${basePath}/publishers`) &&
+      !location.pathname.startsWith(`${basePath}/imprints`) &&
       !location.pathname.startsWith(`${basePath}/settings`));
 
   return [
@@ -72,6 +76,20 @@ export const useLibraryNavItems = (): LibraryNavItem[] | null => {
       Icon: Tags,
       label: "Tags",
       isActive: location.pathname.startsWith(`${basePath}/tags`),
+      show: true,
+    },
+    {
+      to: `${basePath}/publishers`,
+      Icon: Building2,
+      label: "Publishers",
+      isActive: location.pathname.startsWith(`${basePath}/publishers`),
+      show: true,
+    },
+    {
+      to: `${basePath}/imprints`,
+      Icon: Stamp,
+      label: "Imprints",
+      isActive: location.pathname.startsWith(`${basePath}/imprints`),
       show: true,
     },
     {

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -447,7 +447,7 @@ The app uses SQLite Full-Text Search (FTS5) for fast searching.
 
 **Key files:**
 - `pkg/search/service.go` - Search service with index methods
-- FTS tables: `books_fts`, `series_fts`, `persons_fts`, `genres_fts`, `tags_fts`
+- FTS tables: `books_fts`, `series_fts`, `persons_fts`, `genres_fts`, `tags_fts`, `publishers_fts`, `imprints_fts`
 
 **IMPORTANT - Search Index Updates:**
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1023,6 +1023,9 @@ func (h *handler) updateFile(c echo.Context) error {
 				} else {
 					file.PublisherID = &publisher.ID
 					file.Publisher = publisher
+					if err := h.searchService.IndexPublisher(ctx, publisher); err != nil {
+						log.Warn("failed to update search index for publisher", logger.Data{"publisher_id": publisher.ID, "error": err.Error()})
+					}
 				}
 			}
 			file.PublisherSource = strPtr(models.DataSourceManual)
@@ -1047,6 +1050,9 @@ func (h *handler) updateFile(c echo.Context) error {
 				} else {
 					file.ImprintID = &imprint.ID
 					file.Imprint = imprint
+					if err := h.searchService.IndexImprint(ctx, imprint); err != nil {
+						log.Warn("failed to update search index for imprint", logger.Data{"imprint_id": imprint.ID, "error": err.Error()})
+					}
 				}
 			}
 			file.ImprintSource = strPtr(models.DataSourceManual)
@@ -2507,6 +2513,24 @@ func (h *handler) deleteBook(c echo.Context) error {
 			log.Warn("failed to remove orphaned tag from search index", logger.Data{"tag_id": tagID, "error": err.Error()})
 		}
 	}
+	orphanedPublisherIDs, err := h.publisherService.CleanupOrphanedPublishers(ctx)
+	if err != nil {
+		log.Warn("failed to cleanup orphaned publishers", logger.Data{"error": err.Error()})
+	}
+	for _, pubID := range orphanedPublisherIDs {
+		if err := h.searchService.DeleteFromPublisherIndex(ctx, pubID); err != nil {
+			log.Warn("failed to remove orphaned publisher from search index", logger.Data{"publisher_id": pubID, "error": err.Error()})
+		}
+	}
+	orphanedImprintIDs, err := h.imprintService.CleanupOrphanedImprints(ctx)
+	if err != nil {
+		log.Warn("failed to cleanup orphaned imprints", logger.Data{"error": err.Error()})
+	}
+	for _, impID := range orphanedImprintIDs {
+		if err := h.searchService.DeleteFromImprintIndex(ctx, impID); err != nil {
+			log.Warn("failed to remove orphaned imprint from search index", logger.Data{"imprint_id": impID, "error": err.Error()})
+		}
+	}
 
 	return c.JSON(http.StatusOK, DeleteBookResponse{
 		FilesDeleted: result.FilesDeleted,
@@ -2600,6 +2624,24 @@ func (h *handler) deleteFile(c echo.Context) error {
 		for _, tagID := range orphanedTagIDs {
 			if err := h.searchService.DeleteFromTagIndex(ctx, tagID); err != nil {
 				log.Warn("failed to remove orphaned tag from search index", logger.Data{"tag_id": tagID, "error": err})
+			}
+		}
+		orphanedPublisherIDs, err := h.publisherService.CleanupOrphanedPublishers(ctx)
+		if err != nil {
+			log.Warn("failed to cleanup orphaned publishers", logger.Data{"error": err})
+		}
+		for _, pubID := range orphanedPublisherIDs {
+			if err := h.searchService.DeleteFromPublisherIndex(ctx, pubID); err != nil {
+				log.Warn("failed to remove orphaned publisher from search index", logger.Data{"publisher_id": pubID, "error": err})
+			}
+		}
+		orphanedImprintIDs, err := h.imprintService.CleanupOrphanedImprints(ctx)
+		if err != nil {
+			log.Warn("failed to cleanup orphaned imprints", logger.Data{"error": err})
+		}
+		for _, impID := range orphanedImprintIDs {
+			if err := h.searchService.DeleteFromImprintIndex(ctx, impID); err != nil {
+				log.Warn("failed to remove orphaned imprint from search index", logger.Data{"imprint_id": impID, "error": err})
 			}
 		}
 	}
@@ -2711,6 +2753,24 @@ func (h *handler) deleteBooks(c echo.Context) error {
 	for _, tagID := range orphanedTagIDs {
 		if err := h.searchService.DeleteFromTagIndex(ctx, tagID); err != nil {
 			log.Warn("failed to remove orphaned tag from search index", logger.Data{"tag_id": tagID, "error": err.Error()})
+		}
+	}
+	orphanedPublisherIDs, err := h.publisherService.CleanupOrphanedPublishers(ctx)
+	if err != nil {
+		log.Warn("failed to cleanup orphaned publishers", logger.Data{"error": err.Error()})
+	}
+	for _, pubID := range orphanedPublisherIDs {
+		if err := h.searchService.DeleteFromPublisherIndex(ctx, pubID); err != nil {
+			log.Warn("failed to remove orphaned publisher from search index", logger.Data{"publisher_id": pubID, "error": err.Error()})
+		}
+	}
+	orphanedImprintIDs, err := h.imprintService.CleanupOrphanedImprints(ctx)
+	if err != nil {
+		log.Warn("failed to cleanup orphaned imprints", logger.Data{"error": err.Error()})
+	}
+	for _, impID := range orphanedImprintIDs {
+		if err := h.searchService.DeleteFromImprintIndex(ctx, impID); err != nil {
+			log.Warn("failed to remove orphaned imprint from search index", logger.Data{"imprint_id": impID, "error": err.Error()})
 		}
 	}
 

--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -154,10 +154,13 @@ func (h *handler) update(c echo.Context) error {
 				return errors.WithStack(err)
 			}
 
-			// Remove merged genre from FTS index
+			// Remove merged genre from FTS index and re-index the target
 			log := logger.FromContext(ctx)
 			if err := h.searchService.DeleteFromGenreIndex(ctx, id); err != nil {
 				log.Warn("failed to remove merged genre from search index", logger.Data{"genre_id": id, "error": err.Error()})
+			}
+			if err := h.searchService.IndexGenre(ctx, existing); err != nil {
+				log.Warn("failed to re-index target genre after merge", logger.Data{"genre_id": existing.ID, "error": err.Error()})
 			}
 
 			// Return the target genre
@@ -286,10 +289,13 @@ func (h *handler) merge(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Remove the merged (source) genre from FTS index
+	// Remove the merged (source) genre from FTS index and re-index the target
 	log := logger.FromContext(ctx)
 	if err := h.searchService.DeleteFromGenreIndex(ctx, params.SourceID); err != nil {
 		log.Warn("failed to remove merged genre from search index", logger.Data{"genre_id": params.SourceID, "error": err.Error()})
+	}
+	if err := h.searchService.IndexGenre(ctx, genre); err != nil {
+		log.Warn("failed to re-index target genre after merge", logger.Data{"genre_id": genre.ID, "error": err.Error()})
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/pkg/imprints/handlers.go
+++ b/pkg/imprints/handlers.go
@@ -150,6 +150,9 @@ func (h *handler) update(c echo.Context) error {
 			if err := h.searchService.DeleteFromImprintIndex(ctx, id); err != nil {
 				log.Warn("failed to remove merged imprint from search index", logger.Data{"imprint_id": id, "error": err.Error()})
 			}
+			if err := h.searchService.IndexImprint(ctx, existing); err != nil {
+				log.Warn("failed to re-index target imprint after merge", logger.Data{"imprint_id": existing.ID, "error": err.Error()})
+			}
 
 			fileCount, _ := h.imprintService.GetFileCount(ctx, existing.ID)
 			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.ImprintConfig, existing.ID)
@@ -271,6 +274,9 @@ func (h *handler) merge(c echo.Context) error {
 	log := logger.FromContext(ctx)
 	if err := h.searchService.DeleteFromImprintIndex(ctx, params.SourceID); err != nil {
 		log.Warn("failed to remove merged imprint from search index", logger.Data{"imprint_id": params.SourceID, "error": err.Error()})
+	}
+	if err := h.searchService.IndexImprint(ctx, imprint); err != nil {
+		log.Warn("failed to re-index target imprint after merge", logger.Data{"imprint_id": imprint.ID, "error": err.Error()})
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/pkg/imprints/handlers.go
+++ b/pkg/imprints/handlers.go
@@ -11,11 +11,13 @@ import (
 	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
 )
 
 type handler struct {
 	imprintService *Service
 	aliasService   *aliases.Service
+	searchService  *search.Service
 }
 
 func (h *handler) retrieve(c echo.Context) error {
@@ -144,6 +146,11 @@ func (h *handler) update(c echo.Context) error {
 				return errors.WithStack(err)
 			}
 
+			log := logger.FromContext(ctx)
+			if err := h.searchService.DeleteFromImprintIndex(ctx, id); err != nil {
+				log.Warn("failed to remove merged imprint from search index", logger.Data{"imprint_id": id, "error": err.Error()})
+			}
+
 			fileCount, _ := h.imprintService.GetFileCount(ctx, existing.ID)
 			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.ImprintConfig, existing.ID)
 			response := struct {
@@ -183,6 +190,13 @@ func (h *handler) update(c echo.Context) error {
 	imprint, err = h.imprintService.RetrieveImprint(ctx, RetrieveImprintOptions{ID: &id})
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	if nameChanged || params.Aliases != nil {
+		log := logger.FromContext(ctx)
+		if err := h.searchService.IndexImprint(ctx, imprint); err != nil {
+			log.Warn("failed to update search index for imprint", logger.Data{"imprint_id": imprint.ID, "error": err.Error()})
+		}
 	}
 
 	fileCount, _ := h.imprintService.GetFileCount(ctx, id)
@@ -254,6 +268,11 @@ func (h *handler) merge(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	log := logger.FromContext(ctx)
+	if err := h.searchService.DeleteFromImprintIndex(ctx, params.SourceID); err != nil {
+		log.Warn("failed to remove merged imprint from search index", logger.Data{"imprint_id": params.SourceID, "error": err.Error()})
+	}
+
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -280,6 +299,11 @@ func (h *handler) deleteImprint(c echo.Context) error {
 	err = h.imprintService.DeleteImprint(ctx, id)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	log := logger.FromContext(ctx)
+	if err := h.searchService.DeleteFromImprintIndex(ctx, id); err != nil {
+		log.Warn("failed to remove imprint from search index", logger.Data{"imprint_id": id, "error": err.Error()})
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/pkg/imprints/routes.go
+++ b/pkg/imprints/routes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
 	"github.com/uptrace/bun"
 )
 
@@ -12,10 +13,12 @@ import (
 func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware) {
 	imprintService := NewService(db)
 	aliasService := aliases.NewService(db)
+	searchService := search.NewService(db)
 
 	h := &handler{
 		imprintService: imprintService,
 		aliasService:   aliasService,
+		searchService:  searchService,
 	}
 
 	g.GET("", h.list)

--- a/pkg/imprints/service.go
+++ b/pkg/imprints/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
 	"github.com/uptrace/bun"
 )
 
@@ -152,10 +153,11 @@ func (svc *Service) listImprintsWithTotal(ctx context.Context, opts ListImprints
 	if len(opts.LibraryIDs) > 0 {
 		q = q.Where("imp.library_id IN (?)", bun.List(opts.LibraryIDs))
 	}
-	// Search using LIKE (no FTS for imprints) — also matches alias names
 	if opts.Search != nil && *opts.Search != "" {
-		search := "%" + strings.ToLower(*opts.Search) + "%"
-		q = q.Where("(LOWER(imp.name) LIKE ? OR imp.id IN (SELECT imprint_id FROM imprint_aliases WHERE LOWER(name) LIKE ? AND library_id = imp.library_id))", search, search)
+		ftsQuery := search.BuildPrefixQuery(*opts.Search)
+		if ftsQuery != "" {
+			q = q.Where("imp.id IN (SELECT imprint_id FROM imprints_fts WHERE imprints_fts MATCH ?)", ftsQuery)
+		}
 	}
 	if opts.Limit != nil {
 		q = q.Limit(*opts.Limit)
@@ -274,15 +276,18 @@ func (svc *Service) MergeImprints(ctx context.Context, targetID, sourceID int) e
 	})
 }
 
-// CleanupOrphanedImprints deletes imprints with no file associations.
-func (svc *Service) CleanupOrphanedImprints(ctx context.Context) (int, error) {
-	result, err := svc.db.NewDelete().
+// CleanupOrphanedImprints deletes imprints with no file associations and
+// returns the IDs of deleted imprints. Callers must pass the returned IDs to
+// searchService.DeleteFromImprintIndex to keep imprints_fts in sync.
+func (svc *Service) CleanupOrphanedImprints(ctx context.Context) ([]int, error) {
+	deletedIDs := []int{}
+	err := svc.db.NewDelete().
 		Model((*models.Imprint)(nil)).
 		Where("id NOT IN (SELECT DISTINCT imprint_id FROM files WHERE imprint_id IS NOT NULL)").
-		Exec(ctx)
+		Returning("id").
+		Scan(ctx, &deletedIDs)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	n, _ := result.RowsAffected()
-	return int(n), nil
+	return deletedIDs, nil
 }

--- a/pkg/imprints/service_test.go
+++ b/pkg/imprints/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
@@ -108,6 +109,7 @@ func TestListImprints_SearchMatchesAliases(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()
 	svc := NewService(db)
+	searchSvc := search.NewService(db)
 
 	lib := createTestLibrary(t, db)
 
@@ -121,10 +123,13 @@ func TestListImprints_SearchMatchesAliases(t *testing.T) {
 	).Exec(ctx)
 	require.NoError(t, err)
 
-	search := "Vintage Classics"
+	err = searchSvc.IndexImprint(ctx, imp)
+	require.NoError(t, err)
+
+	searchStr := "Vintage Classics"
 	results, err := svc.ListImprints(ctx, ListImprintsOptions{
 		LibraryID: &lib.ID,
-		Search:    &search,
+		Search:    &searchStr,
 	})
 	require.NoError(t, err)
 	require.Len(t, results, 1, "Should find imprint by alias 'Vintage Classics'")

--- a/pkg/migrations/20260504000000_create_publisher_imprint_fts.go
+++ b/pkg/migrations/20260504000000_create_publisher_imprint_fts.go
@@ -1,0 +1,68 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`
+			CREATE VIRTUAL TABLE publishers_fts USING fts5(
+				publisher_id UNINDEXED,
+				library_id UNINDEXED,
+				name,
+				tokenize='unicode61',
+				prefix='2,3'
+			)
+		`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = db.Exec(`
+			CREATE VIRTUAL TABLE imprints_fts USING fts5(
+				imprint_id UNINDEXED,
+				library_id UNINDEXED,
+				name,
+				tokenize='unicode61',
+				prefix='2,3'
+			)
+		`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		// Populate from existing data (including aliases)
+		_, err = db.Exec(`
+			INSERT INTO publishers_fts (publisher_id, library_id, name)
+			SELECT id, library_id,
+				name || COALESCE(' ' || (SELECT GROUP_CONCAT(pa.name, ' ') FROM publisher_aliases pa WHERE pa.publisher_id = publishers.id), '')
+			FROM publishers
+		`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		_, err = db.Exec(`
+			INSERT INTO imprints_fts (imprint_id, library_id, name)
+			SELECT id, library_id,
+				name || COALESCE(' ' || (SELECT GROUP_CONCAT(ia.name, ' ') FROM imprint_aliases ia WHERE ia.imprint_id = imprints.id), '')
+			FROM imprints
+		`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec("DROP TABLE IF EXISTS imprints_fts")
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec("DROP TABLE IF EXISTS publishers_fts")
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/plugins/handler.go
+++ b/pkg/plugins/handler.go
@@ -90,6 +90,8 @@ type searchIndexer interface {
 	IndexPerson(ctx context.Context, person *models.Person) error
 	IndexGenre(ctx context.Context, genre *models.Genre) error
 	IndexTag(ctx context.Context, tag *models.Tag) error
+	IndexPublisher(ctx context.Context, publisher *models.Publisher) error
+	IndexImprint(ctx context.Context, imprint *models.Imprint) error
 }
 
 // pageExtractor renders a page from a page-based file (CBZ/PDF) and writes

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -351,6 +351,11 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 			targetFile.PublisherID = &publisher.ID
 			targetFile.PublisherSource = &pluginSource
 			fileColumns = append(fileColumns, "publisher_id", "publisher_source")
+			if h.enrich.searchIndexer != nil {
+				if err := h.enrich.searchIndexer.IndexPublisher(ctx, publisher); err != nil {
+					log.Warn("failed to index publisher", logger.Data{"publisher_id": publisher.ID, "error": err.Error()})
+				}
+			}
 		}
 	}
 
@@ -364,6 +369,11 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 			targetFile.ImprintID = &imprint.ID
 			targetFile.ImprintSource = &pluginSource
 			fileColumns = append(fileColumns, "imprint_id", "imprint_source")
+			if h.enrich.searchIndexer != nil {
+				if err := h.enrich.searchIndexer.IndexImprint(ctx, imprint); err != nil {
+					log.Warn("failed to index imprint", logger.Data{"imprint_id": imprint.ID, "error": err.Error()})
+				}
+			}
 		}
 	}
 

--- a/pkg/plugins/handler_persist_metadata_test.go
+++ b/pkg/plugins/handler_persist_metadata_test.go
@@ -509,11 +509,13 @@ func TestPersistMetadata_CoverPage_EPUB_Ignored(t *testing.T) {
 // invisible to search-driven dropdowns (e.g. the series combobox in the
 // IdentifyReviewForm).
 type stubSearchIndexer struct {
-	indexedBookIDs   []int
-	indexedSeriesIDs []int
-	indexedPersonIDs []int
-	indexedGenreIDs  []int
-	indexedTagIDs    []int
+	indexedBookIDs      []int
+	indexedSeriesIDs    []int
+	indexedPersonIDs    []int
+	indexedGenreIDs     []int
+	indexedTagIDs       []int
+	indexedPublisherIDs []int
+	indexedImprintIDs   []int
 }
 
 func (s *stubSearchIndexer) IndexBook(_ context.Context, b *models.Book) error {
@@ -538,6 +540,16 @@ func (s *stubSearchIndexer) IndexGenre(_ context.Context, g *models.Genre) error
 
 func (s *stubSearchIndexer) IndexTag(_ context.Context, tag *models.Tag) error {
 	s.indexedTagIDs = append(s.indexedTagIDs, tag.ID)
+	return nil
+}
+
+func (s *stubSearchIndexer) IndexPublisher(_ context.Context, pub *models.Publisher) error {
+	s.indexedPublisherIDs = append(s.indexedPublisherIDs, pub.ID)
+	return nil
+}
+
+func (s *stubSearchIndexer) IndexImprint(_ context.Context, imp *models.Imprint) error {
+	s.indexedImprintIDs = append(s.indexedImprintIDs, imp.ID)
 	return nil
 }
 

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -150,6 +150,9 @@ func (h *handler) update(c echo.Context) error {
 			if err := h.searchService.DeleteFromPublisherIndex(ctx, id); err != nil {
 				log.Warn("failed to remove merged publisher from search index", logger.Data{"publisher_id": id, "error": err.Error()})
 			}
+			if err := h.searchService.IndexPublisher(ctx, existing); err != nil {
+				log.Warn("failed to re-index target publisher after merge", logger.Data{"publisher_id": existing.ID, "error": err.Error()})
+			}
 
 			fileCount, _ := h.publisherService.GetFileCount(ctx, existing.ID)
 			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PublisherConfig, existing.ID)
@@ -271,6 +274,9 @@ func (h *handler) merge(c echo.Context) error {
 	log := logger.FromContext(ctx)
 	if err := h.searchService.DeleteFromPublisherIndex(ctx, params.SourceID); err != nil {
 		log.Warn("failed to remove merged publisher from search index", logger.Data{"publisher_id": params.SourceID, "error": err.Error()})
+	}
+	if err := h.searchService.IndexPublisher(ctx, publisher); err != nil {
+		log.Warn("failed to re-index target publisher after merge", logger.Data{"publisher_id": publisher.ID, "error": err.Error()})
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -11,11 +11,13 @@ import (
 	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
 )
 
 type handler struct {
 	publisherService *Service
 	aliasService     *aliases.Service
+	searchService    *search.Service
 }
 
 func (h *handler) retrieve(c echo.Context) error {
@@ -144,6 +146,11 @@ func (h *handler) update(c echo.Context) error {
 				return errors.WithStack(err)
 			}
 
+			log := logger.FromContext(ctx)
+			if err := h.searchService.DeleteFromPublisherIndex(ctx, id); err != nil {
+				log.Warn("failed to remove merged publisher from search index", logger.Data{"publisher_id": id, "error": err.Error()})
+			}
+
 			fileCount, _ := h.publisherService.GetFileCount(ctx, existing.ID)
 			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PublisherConfig, existing.ID)
 			response := struct {
@@ -183,6 +190,13 @@ func (h *handler) update(c echo.Context) error {
 	publisher, err = h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{ID: &id})
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	if nameChanged || params.Aliases != nil {
+		log := logger.FromContext(ctx)
+		if err := h.searchService.IndexPublisher(ctx, publisher); err != nil {
+			log.Warn("failed to update search index for publisher", logger.Data{"publisher_id": publisher.ID, "error": err.Error()})
+		}
 	}
 
 	fileCount, _ := h.publisherService.GetFileCount(ctx, id)
@@ -254,6 +268,11 @@ func (h *handler) merge(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	log := logger.FromContext(ctx)
+	if err := h.searchService.DeleteFromPublisherIndex(ctx, params.SourceID); err != nil {
+		log.Warn("failed to remove merged publisher from search index", logger.Data{"publisher_id": params.SourceID, "error": err.Error()})
+	}
+
 	return c.NoContent(http.StatusNoContent)
 }
 
@@ -280,6 +299,11 @@ func (h *handler) deletePublisher(c echo.Context) error {
 	err = h.publisherService.DeletePublisher(ctx, id)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	log := logger.FromContext(ctx)
+	if err := h.searchService.DeleteFromPublisherIndex(ctx, id); err != nil {
+		log.Warn("failed to remove publisher from search index", logger.Data{"publisher_id": id, "error": err.Error()})
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/pkg/publishers/routes.go
+++ b/pkg/publishers/routes.go
@@ -5,6 +5,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
 	"github.com/uptrace/bun"
 )
 
@@ -12,10 +13,12 @@ import (
 func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Middleware) {
 	publisherService := NewService(db)
 	aliasService := aliases.NewService(db)
+	searchService := search.NewService(db)
 
 	h := &handler{
 		publisherService: publisherService,
 		aliasService:     aliasService,
+		searchService:    searchService,
 	}
 
 	g.GET("", h.list)

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
 	"github.com/uptrace/bun"
 )
 
@@ -152,10 +153,11 @@ func (svc *Service) listPublishersWithTotal(ctx context.Context, opts ListPublis
 	if len(opts.LibraryIDs) > 0 {
 		q = q.Where("pub.library_id IN (?)", bun.List(opts.LibraryIDs))
 	}
-	// Search using LIKE (no FTS for publishers) — also matches alias names
 	if opts.Search != nil && *opts.Search != "" {
-		search := "%" + strings.ToLower(*opts.Search) + "%"
-		q = q.Where("(LOWER(pub.name) LIKE ? OR pub.id IN (SELECT publisher_id FROM publisher_aliases WHERE LOWER(name) LIKE ? AND library_id = pub.library_id))", search, search)
+		ftsQuery := search.BuildPrefixQuery(*opts.Search)
+		if ftsQuery != "" {
+			q = q.Where("pub.id IN (SELECT publisher_id FROM publishers_fts WHERE publishers_fts MATCH ?)", ftsQuery)
+		}
 	}
 	if opts.Limit != nil {
 		q = q.Limit(*opts.Limit)
@@ -274,15 +276,18 @@ func (svc *Service) MergePublishers(ctx context.Context, targetID, sourceID int)
 	})
 }
 
-// CleanupOrphanedPublishers deletes publishers with no file associations.
-func (svc *Service) CleanupOrphanedPublishers(ctx context.Context) (int, error) {
-	result, err := svc.db.NewDelete().
+// CleanupOrphanedPublishers deletes publishers with no file associations and
+// returns the IDs of deleted publishers. Callers must pass the returned IDs to
+// searchService.DeleteFromPublisherIndex to keep publishers_fts in sync.
+func (svc *Service) CleanupOrphanedPublishers(ctx context.Context) ([]int, error) {
+	deletedIDs := []int{}
+	err := svc.db.NewDelete().
 		Model((*models.Publisher)(nil)).
 		Where("id NOT IN (SELECT DISTINCT publisher_id FROM files WHERE publisher_id IS NOT NULL)").
-		Exec(ctx)
+		Returning("id").
+		Scan(ctx, &deletedIDs)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return nil, errors.WithStack(err)
 	}
-	n, _ := result.RowsAffected()
-	return int(n), nil
+	return deletedIDs, nil
 }

--- a/pkg/publishers/service_test.go
+++ b/pkg/publishers/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
@@ -108,6 +109,7 @@ func TestListPublishers_SearchMatchesAliases(t *testing.T) {
 	db := setupTestDB(t)
 	ctx := context.Background()
 	svc := NewService(db)
+	searchSvc := search.NewService(db)
 
 	lib := createTestLibrary(t, db)
 
@@ -121,10 +123,13 @@ func TestListPublishers_SearchMatchesAliases(t *testing.T) {
 	).Exec(ctx)
 	require.NoError(t, err)
 
-	search := "PRH"
+	err = searchSvc.IndexPublisher(ctx, pub)
+	require.NoError(t, err)
+
+	searchStr := "PRH"
 	results, err := svc.ListPublishers(ctx, ListPublishersOptions{
 		LibraryID: &lib.ID,
-		Search:    &search,
+		Search:    &searchStr,
 	})
 	require.NoError(t, err)
 	require.Len(t, results, 1, "Should find publisher by alias 'PRH'")

--- a/pkg/search/service.go
+++ b/pkg/search/service.go
@@ -587,6 +587,7 @@ func (svc *Service) DeleteFromTagIndex(ctx context.Context, tagID int) error {
 
 // IndexPublisher adds or updates a publisher in the FTS index.
 func (svc *Service) IndexPublisher(ctx context.Context, publisher *models.Publisher) error {
+	// First, delete any existing entry
 	err := svc.DeleteFromPublisherIndex(ctx, publisher.ID)
 	if err != nil {
 		return errors.WithStack(err)
@@ -616,6 +617,7 @@ func (svc *Service) DeleteFromPublisherIndex(ctx context.Context, publisherID in
 
 // IndexImprint adds or updates an imprint in the FTS index.
 func (svc *Service) IndexImprint(ctx context.Context, imprint *models.Imprint) error {
+	// First, delete any existing entry
 	err := svc.DeleteFromImprintIndex(ctx, imprint.ID)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/search/service.go
+++ b/pkg/search/service.go
@@ -585,6 +585,64 @@ func (svc *Service) DeleteFromTagIndex(ctx context.Context, tagID int) error {
 	return errors.WithStack(err)
 }
 
+// IndexPublisher adds or updates a publisher in the FTS index.
+func (svc *Service) IndexPublisher(ctx context.Context, publisher *models.Publisher) error {
+	err := svc.DeleteFromPublisherIndex(ctx, publisher.ID)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	nameWithAliases, err := svc.nameWithAliases(ctx, "publisher_aliases", "publisher_id", publisher.ID, publisher.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	_, err = svc.db.ExecContext(ctx,
+		`INSERT INTO publishers_fts (publisher_id, library_id, name)
+		 VALUES (?, ?, ?)`,
+		publisher.ID, publisher.LibraryID, nameWithAliases,
+	)
+	return errors.WithStack(err)
+}
+
+// DeleteFromPublisherIndex removes a publisher from the FTS index.
+func (svc *Service) DeleteFromPublisherIndex(ctx context.Context, publisherID int) error {
+	_, err := svc.db.NewDelete().
+		TableExpr("publishers_fts").
+		Where("publisher_id = ?", publisherID).
+		Exec(ctx)
+	return errors.WithStack(err)
+}
+
+// IndexImprint adds or updates an imprint in the FTS index.
+func (svc *Service) IndexImprint(ctx context.Context, imprint *models.Imprint) error {
+	err := svc.DeleteFromImprintIndex(ctx, imprint.ID)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	nameWithAliases, err := svc.nameWithAliases(ctx, "imprint_aliases", "imprint_id", imprint.ID, imprint.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	_, err = svc.db.ExecContext(ctx,
+		`INSERT INTO imprints_fts (imprint_id, library_id, name)
+		 VALUES (?, ?, ?)`,
+		imprint.ID, imprint.LibraryID, nameWithAliases,
+	)
+	return errors.WithStack(err)
+}
+
+// DeleteFromImprintIndex removes an imprint from the FTS index.
+func (svc *Service) DeleteFromImprintIndex(ctx context.Context, imprintID int) error {
+	_, err := svc.db.NewDelete().
+		TableExpr("imprints_fts").
+		Where("imprint_id = ?", imprintID).
+		Exec(ctx)
+	return errors.WithStack(err)
+}
+
 // ReindexBookByID re-indexes a single book in books_fts using the same SQL
 // pattern as RebuildAllIndexes. Useful when related data changes (e.g., an
 // author's or series' aliases are modified) without a full book model in hand.
@@ -672,6 +730,14 @@ func (svc *Service) RebuildAllIndexes(ctx context.Context) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	_, err = svc.db.ExecContext(ctx, "DELETE FROM publishers_fts")
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	_, err = svc.db.ExecContext(ctx, "DELETE FROM imprints_fts")
+	if err != nil {
+		return errors.WithStack(err)
+	}
 
 	// Rebuild books index (includes person and series aliases in authors/narrators/series_names)
 	_, err = svc.db.ExecContext(ctx, `
@@ -749,6 +815,28 @@ func (svc *Service) RebuildAllIndexes(ctx context.Context) error {
 		SELECT id, library_id,
 			name || COALESCE(' ' || (SELECT GROUP_CONCAT(ta.name, ' ') FROM tag_aliases ta WHERE ta.tag_id = tags.id), '')
 		FROM tags
+	`)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Rebuild publishers index (includes publisher aliases in name column)
+	_, err = svc.db.ExecContext(ctx, `
+		INSERT INTO publishers_fts (publisher_id, library_id, name)
+		SELECT id, library_id,
+			name || COALESCE(' ' || (SELECT GROUP_CONCAT(pa.name, ' ') FROM publisher_aliases pa WHERE pa.publisher_id = publishers.id), '')
+		FROM publishers
+	`)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Rebuild imprints index (includes imprint aliases in name column)
+	_, err = svc.db.ExecContext(ctx, `
+		INSERT INTO imprints_fts (imprint_id, library_id, name)
+		SELECT id, library_id,
+			name || COALESCE(' ' || (SELECT GROUP_CONCAT(ia.name, ' ') FROM imprint_aliases ia WHERE ia.imprint_id = imprints.id), '')
+		FROM imprints
 	`)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/search/service_test.go
+++ b/pkg/search/service_test.go
@@ -776,6 +776,64 @@ func TestIndexBook_ExcludesGenreAndTagAliases(t *testing.T) {
 	require.Empty(t, results.Books, "Genre aliases should not be in books_fts")
 }
 
+func TestIndexPublisher_IncludesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	publisher := &models.Publisher{LibraryID: library.ID, Name: "Penguin Random House"}
+	_, err = db.NewInsert().Model(publisher).Exec(ctx)
+	require.NoError(t, err)
+
+	insertAlias(t, db, "publisher_aliases", "publisher_id", publisher.ID, library.ID, "PRH")
+
+	svc := NewService(db)
+	err = svc.IndexPublisher(ctx, publisher)
+	require.NoError(t, err)
+
+	var count int
+	err = db.NewSelect().TableExpr("publishers_fts").
+		ColumnExpr("COUNT(*)").
+		Where("publishers_fts MATCH ?", `"PRH"`).
+		Where("library_id = ?", library.ID).
+		Scan(ctx, &count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "Should find publisher by alias 'PRH'")
+}
+
+func TestIndexImprint_IncludesAliases(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{Name: "Lib", CoverAspectRatio: "book"}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	imprint := &models.Imprint{LibraryID: library.ID, Name: "Del Rey"}
+	_, err = db.NewInsert().Model(imprint).Exec(ctx)
+	require.NoError(t, err)
+
+	insertAlias(t, db, "imprint_aliases", "imprint_id", imprint.ID, library.ID, "DelRey Books")
+
+	svc := NewService(db)
+	err = svc.IndexImprint(ctx, imprint)
+	require.NoError(t, err)
+
+	var count int
+	err = db.NewSelect().TableExpr("imprints_fts").
+		ColumnExpr("COUNT(*)").
+		Where("imprints_fts MATCH ?", `"DelRey"`).
+		Where("library_id = ?", library.ID).
+		Scan(ctx, &count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count, "Should find imprint by alias 'DelRey Books'")
+}
+
 func TestRebuildAllIndexes_IncludesAliases(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
@@ -804,6 +862,16 @@ func TestRebuildAllIndexes_IncludesAliases(t *testing.T) {
 	_, err = db.NewInsert().Model(tag).Exec(ctx)
 	require.NoError(t, err)
 	insertAlias(t, db, "tag_aliases", "tag_id", tag.ID, library.ID, "Popular")
+
+	publisher := &models.Publisher{LibraryID: library.ID, Name: "Simon & Schuster"}
+	_, err = db.NewInsert().Model(publisher).Exec(ctx)
+	require.NoError(t, err)
+	insertAlias(t, db, "publisher_aliases", "publisher_id", publisher.ID, library.ID, "S&S")
+
+	imprint := &models.Imprint{LibraryID: library.ID, Name: "Scribner"}
+	_, err = db.NewInsert().Model(imprint).Exec(ctx)
+	require.NoError(t, err)
+	insertAlias(t, db, "imprint_aliases", "imprint_id", imprint.ID, library.ID, "Scribner Books")
 
 	book := &models.Book{
 		LibraryID: library.ID, Filepath: "/test/dt", Title: "The Gunslinger",
@@ -855,4 +923,16 @@ func TestRebuildAllIndexes_IncludesAliases(t *testing.T) {
 	bookResults, err = svc.GlobalSearch(ctx, library.ID, "DT Series")
 	require.NoError(t, err)
 	require.Len(t, bookResults.Books, 1, "RebuildAllIndexes should include series aliases in books_fts")
+
+	var pubCount int
+	err = db.NewSelect().TableExpr("publishers_fts").ColumnExpr("COUNT(*)").
+		Where("publishers_fts MATCH ?", `"S&S"`).Where("library_id = ?", library.ID).Scan(ctx, &pubCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, pubCount, "RebuildAllIndexes should include publisher aliases")
+
+	var impCount int
+	err = db.NewSelect().TableExpr("imprints_fts").ColumnExpr("COUNT(*)").
+		Where("imprints_fts MATCH ?", `"Scribner Books"`).Where("library_id = ?", library.ID).Scan(ctx, &impCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, impCount, "RebuildAllIndexes should include imprint aliases")
 }

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -151,6 +151,9 @@ func (h *handler) update(c echo.Context) error {
 			if err := h.searchService.DeleteFromTagIndex(ctx, id); err != nil {
 				log.Warn("failed to remove merged tag from search index", logger.Data{"tag_id": id, "error": err.Error()})
 			}
+			if err := h.searchService.IndexTag(ctx, existing); err != nil {
+				log.Warn("failed to re-index target tag after merge", logger.Data{"tag_id": existing.ID, "error": err.Error()})
+			}
 
 			bookCount, _ := h.tagService.GetBookCount(ctx, existing.ID)
 			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, existing.ID)
@@ -272,6 +275,9 @@ func (h *handler) merge(c echo.Context) error {
 	log := logger.FromContext(ctx)
 	if err := h.searchService.DeleteFromTagIndex(ctx, params.SourceID); err != nil {
 		log.Warn("failed to remove merged tag from search index", logger.Data{"tag_id": params.SourceID, "error": err.Error()})
+	}
+	if err := h.searchService.IndexTag(ctx, tag); err != nil {
+		log.Warn("failed to re-index target tag after merge", logger.Data{"tag_id": tag.ID, "error": err.Error()})
 	}
 
 	return c.NoContent(http.StatusNoContent)

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -4383,4 +4383,22 @@ func (w *Worker) indexBookRelations(ctx context.Context, book *models.Book, oldR
 			logWarn("failed to update search index for tag", logger.Data{"tag_id": bt.Tag.ID, "error": err.Error()})
 		}
 	}
+
+	// Publishers / imprints: file-level, re-index each file's publisher/imprint.
+	seenPublishers := map[int]bool{}
+	seenImprints := map[int]bool{}
+	for _, f := range book.Files {
+		if f.Publisher != nil && !seenPublishers[f.Publisher.ID] {
+			seenPublishers[f.Publisher.ID] = true
+			if err := w.searchService.IndexPublisher(ctx, f.Publisher); err != nil {
+				logWarn("failed to update search index for publisher", logger.Data{"publisher_id": f.Publisher.ID, "error": err.Error()})
+			}
+		}
+		if f.Imprint != nil && !seenImprints[f.Imprint.ID] {
+			seenImprints[f.Imprint.ID] = true
+			if err := w.searchService.IndexImprint(ctx, f.Imprint); err != nil {
+				logWarn("failed to update search index for imprint", logger.Data{"imprint_id": f.Imprint.ID, "error": err.Error()})
+			}
+		}
+	}
 }

--- a/pkg/worker/worker.go
+++ b/pkg/worker/worker.go
@@ -447,8 +447,8 @@ func (w *Worker) checkPluginUpdates() {
 	}
 }
 
-// cleanupOrphanedEntities removes series, people, genres, and tags
-// that are no longer referenced by any books.
+// cleanupOrphanedEntities removes series, people, genres, tags, publishers,
+// and imprints that are no longer referenced by any books or files.
 func (w *Worker) cleanupOrphanedEntities(ctx context.Context, log logger.Logger) {
 	if deletedIDs, err := w.seriesService.CleanupOrphanedSeries(ctx); err != nil {
 		log.Err(err).Warn("failed to cleanup orphaned series")
@@ -492,6 +492,28 @@ func (w *Worker) cleanupOrphanedEntities(ctx context.Context, log logger.Logger)
 			}
 		}
 		log.Info("cleaned up orphaned tags", logger.Data{"count": len(deletedIDs)})
+	}
+
+	if deletedIDs, err := w.publisherService.CleanupOrphanedPublishers(ctx); err != nil {
+		log.Err(err).Warn("failed to cleanup orphaned publishers")
+	} else if len(deletedIDs) > 0 {
+		for _, id := range deletedIDs {
+			if err := w.searchService.DeleteFromPublisherIndex(ctx, id); err != nil {
+				log.Err(err).Warn("failed to remove orphaned publisher from search index", logger.Data{"publisher_id": id})
+			}
+		}
+		log.Info("cleaned up orphaned publishers", logger.Data{"count": len(deletedIDs)})
+	}
+
+	if deletedIDs, err := w.imprintService.CleanupOrphanedImprints(ctx); err != nil {
+		log.Err(err).Warn("failed to cleanup orphaned imprints")
+	} else if len(deletedIDs) > 0 {
+		for _, id := range deletedIDs {
+			if err := w.searchService.DeleteFromImprintIndex(ctx, id); err != nil {
+				log.Err(err).Warn("failed to remove orphaned imprint from search index", logger.Data{"imprint_id": id})
+			}
+		}
+		log.Info("cleaned up orphaned imprints", logger.Data{"count": len(deletedIDs)})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `publishers_fts` and `imprints_fts` FTS5 virtual tables with a migration that populates them from existing data (including aliases)
- Integrate search service into publisher/imprint handlers (index on update/alias change, delete from index on delete/merge) and switch list queries from LIKE to FTS5 MATCH
- Add Publishers (Building2 icon) and Imprints (Stamp icon) to the library sidebar navigation
- Add publisher/imprint orphan cleanup with FTS index purge to the worker's `cleanupOrphanedEntities`, and update `CleanupOrphaned*` methods to return deleted IDs for FTS sync

## Test plan
- Verify publishers and imprints appear in the sidebar between Tags and Settings
- Search for a publisher/imprint by name on the list page — should use FTS
- Search for a publisher/imprint by alias name — should match via the FTS index
- Rename a publisher/imprint and verify searching by the new name works
- Merge two publishers/imprints and verify the source is removed from search
- Delete a publisher/imprint and verify it no longer appears in search results
- Run a library scan and confirm `RebuildAllIndexes` populates the new FTS tables