### PR TITLE
[Fix] Reset to file metadata drops author from directory name

### DIFF
--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -1378,36 +1378,6 @@ func (w *Worker) scanFileCore(
 				}
 			}
 		}
-
-		// Reorganize book directory on disk if title or authors changed and library has OrganizeFileStructure enabled
-		// Only do this during resyncs - during full scans, organization would rename directories while
-		// other files are still being discovered/processed, breaking the scan
-		if (bookTitleChanged || authorsChanged) && isResync {
-			// Reload book to get fresh author data for organization
-			book, err = w.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &book.ID})
-			if err != nil {
-				logWarn("failed to reload book for organization", logger.Data{"error": err.Error()})
-			} else {
-				// Call UpdateBook with OrganizeFiles flag to trigger file/folder organization
-				if err := w.bookService.UpdateBook(ctx, book, books.UpdateBookOptions{OrganizeFiles: true}); err != nil {
-					logWarn("failed to organize book files after title/author change", logger.Data{
-						"book_id": book.ID,
-						"error":   err.Error(),
-					})
-				} else {
-					// Reload book again to get updated file paths
-					book, err = w.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &book.ID})
-					if err != nil {
-						logWarn("failed to reload book after organization", logger.Data{"error": err.Error()})
-					}
-					// Also reload file to get updated filepath
-					file, err = w.bookService.RetrieveFileWithRelations(ctx, file.ID)
-					if err != nil {
-						logWarn("failed to reload file after organization", logger.Data{"error": err.Error()})
-					}
-				}
-			}
-		}
 	} // end if isMainFile
 
 	// ==========================================================================
@@ -1967,6 +1937,33 @@ func (w *Worker) scanFileCore(
 	if relUpdates.DeleteAuthors || relUpdates.DeleteSeries || relUpdates.DeleteGenres || relUpdates.DeleteTags || relUpdates.DeleteNarrators {
 		if err := w.UpdateBookRelationships(ctx, book.ID, relUpdates); err != nil {
 			logWarn("failed to update book relationships", logger.Data{"error": err.Error()})
+		}
+	}
+
+	// Reorganize book directory on disk if title or authors changed and library has OrganizeFileStructure enabled.
+	// Only do this during resyncs - during full scans, organization would rename directories while
+	// other files are still being discovered/processed, breaking the scan.
+	// This must run AFTER UpdateBookRelationships so the fresh DB read includes the new authors.
+	if isMainFile && (bookTitleChanged || authorsChanged) && isResync {
+		book, err = w.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &book.ID})
+		if err != nil {
+			logWarn("failed to reload book for organization", logger.Data{"error": err.Error()})
+		} else {
+			if err := w.bookService.UpdateBook(ctx, book, books.UpdateBookOptions{OrganizeFiles: true}); err != nil {
+				logWarn("failed to organize book files after title/author change", logger.Data{
+					"book_id": book.ID,
+					"error":   err.Error(),
+				})
+			} else {
+				book, err = w.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &book.ID})
+				if err != nil {
+					logWarn("failed to reload book after organization", logger.Data{"error": err.Error()})
+				}
+				file, err = w.bookService.RetrieveFileWithRelations(ctx, file.ID)
+				if err != nil {
+					logWarn("failed to reload file after organization", logger.Data{"error": err.Error()})
+				}
+			}
 		}
 	}
 

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -5352,6 +5352,61 @@ func TestScanFileByID_ResetMode_ReplacedFile_UsesNewChapters(t *testing.T) {
 	assert.Equal(t, "Good 3", chaptersAfterReset[2].Title)
 }
 
+func TestScanFileByID_ResetMode_OrganizesWithAuthors(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	// Setup: Library with OrganizeFileStructure enabled
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibraryWithOptions([]string{libraryPath}, true)
+
+	// Create a book directory with author prefix
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Test Author] Reset Organize Book")
+	testgen.GenerateEPUB(t, bookDir, "Reset Organize Book.epub", testgen.EPUBOptions{
+		Title:   "Reset Organize Book",
+		Authors: []string{"Test Author"},
+	})
+
+	// Run initial scan
+	err := tc.runScan()
+	require.NoError(t, err)
+
+	allBooks := tc.listBooks()
+	require.Len(t, allBooks, 1)
+	book, err := tc.bookService.RetrieveBook(tc.ctx, books.RetrieveBookOptions{ID: &allBooks[0].ID})
+	require.NoError(t, err)
+	require.NotEmpty(t, book.Authors)
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	fileID := files[0].ID
+
+	// Verify directory has author prefix before reset
+	assert.Contains(t, book.Filepath, "[Test Author]")
+
+	// Run reset scan
+	result, err := tc.worker.scanInternal(tc.ctx, ScanOptions{
+		FileID:       fileID,
+		ForceRefresh: true,
+		SkipPlugins:  true,
+		Reset:        true,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Reload book after reset
+	book, err = tc.bookService.RetrieveBook(tc.ctx, books.RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+
+	// Authors should be repopulated from EPUB metadata
+	require.NotEmpty(t, book.Authors, "authors should be repopulated after reset")
+	assert.Equal(t, "Test Author", book.Authors[0].Person.Name)
+
+	// Directory should still have the author prefix (organization should use the new authors)
+	assert.Contains(t, book.Filepath, "[Test Author]",
+		"directory should retain author prefix after reset — organization must use freshly-written authors")
+}
+
 func TestScanFileByID_ResetMode_FilepathFallbackTitle(t *testing.T) {
 	t.Parallel()
 	tc := newTestContext(t)


### PR DESCRIPTION
## Summary
- "Reset to file metadata" on a book in an organized library was dropping the `[Author]` prefix from the directory name, even though the author was correctly repopulated from the file's embedded metadata
- Root cause: the file organization block in `scanFileCore` ran **before** `UpdateBookRelationships` committed the new authors to the DB, so the fresh book reload saw an empty author list
- Moved the organization block to run after relationship writes so the DB read picks up the newly-written authors

## Test plan
- New regression test `TestScanFileByID_ResetMode_OrganizesWithAuthors` verifies the directory retains its `[Author]` prefix after reset
- All existing file organization and reset mode tests continue to pass
- Manually test: create a book in an organized library, reset to file metadata, verify the directory still has the author bracket prefix