### PR TITLE
[Fix] Add Cache-Control headers to download/stream endpoints

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -117,6 +117,23 @@ file.CoverImageFilename = &newCoverPath
 
 **Conditional-GET for cover endpoints:** `/files/:id/cover` serves via `c.File()` — `http.ServeContent` handles `Last-Modified`/`If-Modified-Since` from the cover file's on-disk mtime, which is sufficient because the served file's identity is pinned by the URL. `/books/:id/cover` (and its OPDS / eReader mirrors) and `/series/:id/cover` are different: the served file is *selected*, and that selection can change without any change to the newly-selected cover file's mtime — flipping the library's `CoverAspectRatio` setting on a hybrid book (EPUB + M4B) swaps which file's cover is served, removing a file from a hybrid book falls back to the remaining file's cover, and a series' first book can change because of book deletion / re-sorting / series-number changes. Mtime-only revalidation returns stale 304s in those cases. Both `pkg/covers.ServeBookCover` and `pkg/series/handlers.go::seriesCover` therefore issue an `ETag: "<file_id>-<mtime_unix>"` that bakes the selected file's identity into the validator, check `If-None-Match` manually, and pass `time.Time{}` to `http.ServeContent` so it omits `Last-Modified` and skips IMS handling (which would otherwise shortcut to 304 using just the new file's mtime).
 
+### Cache-Control Headers for File-Serving Endpoints
+
+All file-serving endpoints must include a `Cache-Control` header to prevent reverse proxies (OpenResty, Nginx, Cloudflare) from heuristically caching responses that include `Last-Modified` but no `Cache-Control`, which can serve stale content even after Shisho's internal caches are cleared.
+
+| Endpoint Category | Header | Reason |
+|---|---|---|
+| **Cover endpoints** (`/cover`) | `Cache-Control: private, no-cache` | Allows conditional revalidation via `Last-Modified`/`ETag` |
+| **Download/stream endpoints** (`/download`, `/stream`) | `Cache-Control: private, no-store` | No proxy caching at all — generated files can change without the URL changing |
+| **Page endpoint** (`getPage`) | `Cache-Control: public, max-age=31536000, immutable` | Rendered pages are immutable per fileID+pageNum |
+
+When adding a new endpoint that serves files via `c.File()` or `c.Stream()`, set the appropriate `Cache-Control` header before the call:
+
+```go
+c.Response().Header().Set("Cache-Control", "private, no-store")
+return c.File(path)
+```
+
 ### Data Source Priority System
 
 Metadata sources ranked (lower number = higher precedence):

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -1770,6 +1770,7 @@ func (h *handler) downloadFile(c echo.Context) error {
 	}
 
 	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 
 	return c.File(cachedPath)
 }
@@ -1805,6 +1806,7 @@ func (h *handler) downloadOriginalFile(c echo.Context) error {
 
 	filename := filepath.Base(file.Filepath)
 	httputil.SetAttachmentFilename(c.Response(), filename)
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 
 	return c.File(file.Filepath)
 }
@@ -1875,6 +1877,7 @@ func (h *handler) downloadKepubFile(c echo.Context) error {
 	}
 
 	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 
 	return c.File(cachedPath)
 }
@@ -2080,6 +2083,7 @@ func (h *handler) streamFile(c echo.Context) error {
 	// Set Accept-Ranges header to indicate we support range requests
 	c.Response().Header().Set("Accept-Ranges", "bytes")
 	c.Response().Header().Set("Content-Type", "audio/mp4")
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 
 	// Check for Range header
 	rangeHeader := c.Request().Header.Get("Range")

--- a/pkg/books/handlers_download_cache_control_test.go
+++ b/pkg/books/handlers_download_cache_control_test.go
@@ -1,0 +1,60 @@
+package books
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadOriginalFile_SetsCacheControlNoStore(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	library, book := setupTestLibraryAndBook(t, db)
+	epubPath := createTestEPUBFile(t)
+	file := setupTestFile(t, db, book, "epub", epubPath)
+	user := setupTestUser(t, db, library.ID, true)
+
+	e := setupTestServer(t, db)
+	req := httptest.NewRequest(http.MethodGet, "/books/files/"+strconv.Itoa(file.ID)+"/download/original", nil)
+	rr := executeRequestWithUser(t, e, req, user)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
+}
+
+func TestStreamFile_SetsCacheControlNoStore(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	library, book := setupTestLibraryAndBook(t, db)
+	m4bPath := createTestM4BFile(t, 1000)
+	file := setupTestFile(t, db, book, "m4b", m4bPath)
+	user := setupTestUser(t, db, library.ID, true)
+
+	e := setupTestServer(t, db)
+	req := httptest.NewRequest(http.MethodGet, "/books/files/"+strconv.Itoa(file.ID)+"/stream", nil)
+	rr := executeRequestWithUser(t, e, req, user)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
+}
+
+func TestStreamFile_RangeRequest_SetsCacheControlNoStore(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	library, book := setupTestLibraryAndBook(t, db)
+	m4bPath := createTestM4BFile(t, 1000)
+	file := setupTestFile(t, db, book, "m4b", m4bPath)
+	user := setupTestUser(t, db, library.ID, true)
+
+	e := setupTestServer(t, db)
+	req := httptest.NewRequest(http.MethodGet, "/books/files/"+strconv.Itoa(file.ID)+"/stream", nil)
+	req.Header.Set("Range", "bytes=0-99")
+	rr := executeRequestWithUser(t, e, req, user)
+
+	require.Equal(t, http.StatusPartialContent, rr.Code)
+	assert.Equal(t, "private, no-store", rr.Header().Get("Cache-Control"))
+}

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -801,12 +801,14 @@ func (h *handler) DownloadFile(c echo.Context) error {
 			})
 			filename := filepath.Base(file.Filepath)
 			httputil.SetAttachmentFilename(c.Response(), filename)
+			c.Response().Header().Set("Cache-Control", "private, no-store")
 			return c.File(file.Filepath)
 		}
 		return errors.WithStack(err)
 	}
 
 	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 	return c.File(cachedPath)
 }
 
@@ -875,6 +877,7 @@ func (h *handler) DownloadFileKepub(c echo.Context) error {
 			})
 			filename := filepath.Base(file.Filepath)
 			httputil.SetAttachmentFilename(c.Response(), filename)
+			c.Response().Header().Set("Cache-Control", "private, no-store")
 			return c.File(file.Filepath)
 		}
 		var genErr *filegen.GenerationError
@@ -886,12 +889,14 @@ func (h *handler) DownloadFileKepub(c echo.Context) error {
 			})
 			filename := filepath.Base(file.Filepath)
 			httputil.SetAttachmentFilename(c.Response(), filename)
+			c.Response().Header().Set("Cache-Control", "private, no-store")
 			return c.File(file.Filepath)
 		}
 		return errors.WithStack(err)
 	}
 
 	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 	return c.File(cachedPath)
 }
 

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -200,6 +200,7 @@ func (h *handler) download(c echo.Context) error {
 
 	filename := fmt.Sprintf("shisho-download-%d-books.zip", data.FileCount)
 	httputil.SetAttachmentFilename(c.Response(), filename)
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 
 	return c.File(zipPath)
 }

--- a/pkg/jobs/handlers_download_cache_control_test.go
+++ b/pkg/jobs/handlers_download_cache_control_test.go
@@ -1,0 +1,116 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/downloadcache"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownload_SetsCacheControlNoStore(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Create a library and a file for the library-access check.
+	lib := insertTestLibrary(t, db, "Test Lib")
+
+	file := &models.File{
+		LibraryID:     lib.ID,
+		BookID:        0,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/fake.epub",
+		FilesizeBytes: 100,
+	}
+	// Need a book for the FK. Seed one.
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Test",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        "/tmp",
+	}
+	_, err := db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file.BookID = book.ID
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	// Set up the download cache dir and create the expected zip file.
+	cacheDir := t.TempDir()
+	dlCache := downloadcache.NewCache(cacheDir, 1<<30)
+
+	fpHash := "testfingerprint123"
+	bulkDir := filepath.Join(cacheDir, "bulk")
+	require.NoError(t, os.MkdirAll(bulkDir, 0o755))
+	zipPath := filepath.Join(bulkDir, fpHash+".zip")
+	require.NoError(t, os.WriteFile(zipPath, []byte("PK\x03\x04fake zip"), 0o644))
+
+	// Create a completed bulk-download job.
+	jobData := fmt.Sprintf(`{"fingerprint_hash":"%s","file_ids":[%d],"file_count":1}`, fpHash, file.ID)
+	job := &models.Job{
+		Type:   models.JobTypeBulkDownload,
+		Status: models.JobStatusCompleted,
+		Data:   jobData,
+	}
+	_, err = db.NewInsert().Model(job).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create an admin user with library access.
+	user := &models.User{
+		Username:     "dluser",
+		PasswordHash: "hash",
+		RoleID:       1, // admin
+		IsActive:     true,
+	}
+	_, err = db.NewInsert().Model(user).Exec(ctx)
+	require.NoError(t, err)
+
+	access := &models.UserLibraryAccess{UserID: user.ID, LibraryID: &lib.ID}
+	_, err = db.NewInsert().Model(access).Exec(ctx)
+	require.NoError(t, err)
+	user.LibraryAccess = []*models.UserLibraryAccess{access}
+
+	// Load role with permissions so the handler's permission check passes.
+	err = db.NewSelect().
+		Model(user).
+		Relation("Role").
+		Relation("Role.Permissions").
+		Where("u.id = ?", user.ID).
+		Scan(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		jobService:    NewService(db),
+		db:            db,
+		downloadCache: dlCache,
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/jobs/"+strconv.Itoa(job.ID)+"/download", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(job.ID))
+	c.Set("user", user)
+
+	require.NoError(t, h.download(c))
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "private, no-store", rec.Header().Get("Cache-Control"))
+}

--- a/pkg/kobo/handlers.go
+++ b/pkg/kobo/handlers.go
@@ -679,6 +679,7 @@ func getBaseURL(c echo.Context) string {
 // serveFileWithHeaders serves a file with proper Content-Type and Content-Disposition headers.
 func serveFileWithHeaders(c echo.Context, filepath, filename string) error {
 	c.Response().Header().Set("Content-Type", "application/octet-stream")
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 	httputil.SetAttachmentFilename(c.Response(), filename)
 	return c.File(filepath)
 }

--- a/pkg/opds/handlers.go
+++ b/pkg/opds/handlers.go
@@ -735,12 +735,14 @@ func (h *handler) download(c echo.Context) error {
 			// Fall back to original file
 			filename := filepath.Base(file.Filepath)
 			httputil.SetAttachmentFilename(c.Response(), filename)
+			c.Response().Header().Set("Cache-Control", "private, no-store")
 			return c.File(file.Filepath)
 		}
 		return errors.WithStack(err)
 	}
 
 	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 
 	return c.File(cachedPath)
 }
@@ -805,6 +807,7 @@ func (h *handler) downloadKepub(c echo.Context) error {
 			// Fall back to original file for unsupported types (M4B)
 			filename := filepath.Base(file.Filepath)
 			httputil.SetAttachmentFilename(c.Response(), filename)
+			c.Response().Header().Set("Cache-Control", "private, no-store")
 			return c.File(file.Filepath)
 		}
 		// For other errors, also fall back to original
@@ -817,12 +820,14 @@ func (h *handler) downloadKepub(c echo.Context) error {
 			})
 			filename := filepath.Base(file.Filepath)
 			httputil.SetAttachmentFilename(c.Response(), filename)
+			c.Response().Header().Set("Cache-Control", "private, no-store")
 			return c.File(file.Filepath)
 		}
 		return errors.WithStack(err)
 	}
 
 	httputil.SetAttachmentFilename(c.Response(), downloadFilename)
+	c.Response().Header().Set("Cache-Control", "private, no-store")
 
 	return c.File(cachedPath)
 }


### PR DESCRIPTION
Closes #233

## Summary
- Add `Cache-Control: private, no-store` to all 10 download/stream endpoints across books, ereader, OPDS, Kobo, and jobs handlers
- Prevents reverse proxies (OpenResty, Nginx, Cloudflare) from heuristically caching generated files, which caused stale content to be served even after clearing Shisho's download cache
- Add Cache-Control documentation section to `pkg/CLAUDE.md` covering the header requirements for cover, download/stream, and page endpoints

## Test plan
- Added tests verifying `Cache-Control: private, no-store` header on `downloadOriginalFile`, `streamFile` (full and range requests), and jobs `download` endpoints
- All existing stream and cover cache tests continue to pass
- Full `mise check:quiet` passes