### PR TITLE
[Backend] Normalize list responses and add pagination to detail sub-endpoints

### DIFF
--- a/app/components/library/BookSelectionList.tsx
+++ b/app/components/library/BookSelectionList.tsx
@@ -45,7 +45,7 @@ export function BookSelectionList({
   );
 
   const availableBooks =
-    booksQuery.data?.books?.filter((book) => book.id !== excludeBookId) ?? [];
+    booksQuery.data?.items?.filter((book) => book.id !== excludeBookId) ?? [];
 
   return (
     <RadioGroup onValueChange={onSelectBook} value={selectedBookId}>

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -67,7 +67,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
   );
 
   const downloadInfo = useMemo(() => {
-    const allBooks = allSelectedBooksQuery.data?.books;
+    const allBooks = allSelectedBooksQuery.data?.items;
     if (!allBooks || selectedBookIds.length === 0) return null;
 
     const fileIds: number[] = [];
@@ -86,7 +86,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
     }
 
     return { fileIds, totalSize };
-  }, [allSelectedBooksQuery.data?.books, selectedBookIds]);
+  }, [allSelectedBooksQuery.data?.items, selectedBookIds]);
 
   const handleDownload = async () => {
     if (!downloadInfo || downloadInfo.fileIds.length === 0) return;
@@ -503,7 +503,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
       />
 
       <DeleteConfirmationDialog
-        books={allSelectedBooksQuery.data?.books?.map((b) => ({
+        books={allSelectedBooksQuery.data?.items?.map((b) => ({
           id: b.id,
           title: b.title,
           files: b.files,

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -86,9 +86,13 @@ const GenreDetail = () => {
   const genreQuery = useGenre(genreId);
 
   usePageTitle(genreQuery.data?.name ?? "Genre");
-  const genreBooksQuery = useGenreBooks(genreId, {
-    enabled: userSettingsResolved && Boolean(genreId),
-  });
+  const genreBooksQuery = useGenreBooks(
+    genreId,
+    {},
+    {
+      enabled: userSettingsResolved && Boolean(genreId),
+    },
+  );
 
   const [editOpen, setEditOpen] = useState(false);
   const [mergeOpen, setMergeOpen] = useState(false);
@@ -235,7 +239,7 @@ const GenreDetail = () => {
           {genreBooksQuery.isLoading && <LoadingSpinner />}
           {genreBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
-              {genreBooksQuery.data.map((book) => (
+              {genreBooksQuery.data.items.map((book) => (
                 <BookItem
                   book={book}
                   cacheKey={genreBooksQuery.dataUpdatedAt}
@@ -268,7 +272,7 @@ const GenreDetail = () => {
 
       <MetadataMergeDialog
         entities={
-          genresListQuery.data?.genres.map((g) => ({
+          genresListQuery.data?.items.map((g) => ({
             id: g.id,
             name: g.name,
             count: g.book_count ?? 0,

--- a/app/components/pages/GenresList.tsx
+++ b/app/components/pages/GenresList.tsx
@@ -126,7 +126,7 @@ const GenresList = () => {
             </div>
           )}
 
-          {genresQuery.data.genres.length === 0 ? (
+          {genresQuery.data.items.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               {confirmedSearch
                 ? "No genres found matching your search."
@@ -134,7 +134,7 @@ const GenresList = () => {
             </div>
           ) : (
             <div className="space-y-1 mb-6">
-              {genresQuery.data.genres.map(renderGenreItem)}
+              {genresQuery.data.items.map(renderGenreItem)}
             </div>
           )}
 

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -210,12 +210,12 @@ const HomeContent = () => {
   });
 
   const genres = useMemo(
-    () => genresQuery.data?.genres ?? [],
-    [genresQuery.data?.genres],
+    () => genresQuery.data?.items ?? [],
+    [genresQuery.data?.items],
   );
   const tags = useMemo(
-    () => tagsQuery.data?.tags ?? [],
-    [tagsQuery.data?.tags],
+    () => tagsQuery.data?.items ?? [],
+    [tagsQuery.data?.items],
   );
 
   // Cache genre/tag objects so selected items persist across searches
@@ -518,8 +518,8 @@ const HomeContent = () => {
   });
 
   const pageBookIds = useMemo(
-    () => booksQuery.data?.books?.map((b) => b.id) ?? [],
-    [booksQuery.data?.books],
+    () => booksQuery.data?.items?.map((b) => b.id) ?? [],
+    [booksQuery.data?.items],
   );
 
   const renderBookItem = (book: Book) => (
@@ -664,7 +664,7 @@ const HomeContent = () => {
             booksQuery.isSuccess && !booksQuery.isFetching && !isStaleData
           }
           itemLabel="books"
-          items={booksQuery.data?.books ?? []}
+          items={booksQuery.data?.items ?? []}
           itemsPerPage={itemsPerPage}
           renderItem={renderBookItem}
           total={booksQuery.data?.total ?? 0}

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -173,7 +173,7 @@ const ImprintDetail = () => {
           {imprintFilesQuery.isLoading && <LoadingSpinner />}
           {imprintFilesQuery.isSuccess && (
             <div className="space-y-3">
-              {imprintFilesQuery.data.map((file) => (
+              {imprintFilesQuery.data.items.map((file) => (
                 <div
                   className="border-l-4 border-l-primary pl-4 py-2"
                   key={file.id}
@@ -220,7 +220,7 @@ const ImprintDetail = () => {
 
       <MetadataMergeDialog
         entities={
-          imprintsListQuery.data?.imprints.map((imp) => ({
+          imprintsListQuery.data?.items.map((imp) => ({
             id: imp.id,
             name: imp.name,
             count: imp.file_count ?? 0,

--- a/app/components/pages/ImprintsList.tsx
+++ b/app/components/pages/ImprintsList.tsx
@@ -118,7 +118,7 @@ const ImprintsList = () => {
       {imprintsQuery.isSuccess &&
         !imprintsQuery.isFetching &&
         !isStaleData &&
-        imprintsQuery.data.imprints.length === 0 && (
+        imprintsQuery.data.items.length === 0 && (
           <div className="text-center py-8 text-muted-foreground">
             {confirmedSearch
               ? "No imprints found matching your search."
@@ -129,9 +129,9 @@ const ImprintsList = () => {
       {imprintsQuery.isSuccess &&
         !imprintsQuery.isFetching &&
         !isStaleData &&
-        imprintsQuery.data.imprints.length > 0 && (
+        imprintsQuery.data.items.length > 0 && (
           <div className="space-y-1">
-            {imprintsQuery.data.imprints.map(renderImprintItem)}
+            {imprintsQuery.data.items.map(renderImprintItem)}
           </div>
         )}
 

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -93,9 +93,13 @@ const PersonDetail = () => {
   const personQuery = usePerson(personId);
 
   usePageTitle(personQuery.data?.name ?? "Person");
-  const authoredBooksQuery = usePersonAuthoredBooks(personId, {
-    enabled: userSettingsResolved && Boolean(personId),
-  });
+  const authoredBooksQuery = usePersonAuthoredBooks(
+    personId,
+    {},
+    {
+      enabled: userSettingsResolved && Boolean(personId),
+    },
+  );
   const narratedFilesQuery = usePersonNarratedFiles(personId);
 
   const [editOpen, setEditOpen] = useState(false);
@@ -268,7 +272,7 @@ const PersonDetail = () => {
           {authoredBooksQuery.isLoading && <LoadingSpinner />}
           {authoredBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
-              {authoredBooksQuery.data.map((book) => (
+              {authoredBooksQuery.data.items.map((book) => (
                 <BookItem
                   book={book}
                   cacheKey={authoredBooksQuery.dataUpdatedAt}
@@ -289,7 +293,7 @@ const PersonDetail = () => {
           {narratedFilesQuery.isLoading && <LoadingSpinner />}
           {narratedFilesQuery.isSuccess && (
             <div className="space-y-2">
-              {narratedFilesQuery.data.map((file) => (
+              {narratedFilesQuery.data.items.map((file) => (
                 <Link
                   className="flex items-center justify-between p-4 rounded-md border border-border hover:bg-muted/50 transition-colors"
                   key={file.id}
@@ -335,7 +339,7 @@ const PersonDetail = () => {
 
       <MetadataMergeDialog
         entities={
-          peopleListQuery.data?.people.map((p) => ({
+          peopleListQuery.data?.items.map((p) => ({
             id: p.id,
             name: p.name,
             count: p.authored_book_count + p.narrated_file_count,

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -140,14 +140,14 @@ const PersonList = () => {
           )}
 
           <div className="space-y-2 mb-6">
-            {peopleQuery.data.people.length === 0 ? (
+            {peopleQuery.data.items.length === 0 ? (
               <div className="text-center py-8 text-muted-foreground">
                 {confirmedSearch
                   ? "No people found matching your search."
                   : "No people in this library yet."}
               </div>
             ) : (
-              peopleQuery.data.people.map(renderPersonItem)
+              peopleQuery.data.items.map(renderPersonItem)
             )}
           </div>
 

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -173,7 +173,7 @@ const PublisherDetail = () => {
           {publisherFilesQuery.isLoading && <LoadingSpinner />}
           {publisherFilesQuery.isSuccess && (
             <div className="space-y-3">
-              {publisherFilesQuery.data.map((file) => (
+              {publisherFilesQuery.data.items.map((file) => (
                 <div
                   className="border-l-4 border-l-primary pl-4 py-2"
                   key={file.id}
@@ -220,7 +220,7 @@ const PublisherDetail = () => {
 
       <MetadataMergeDialog
         entities={
-          publishersListQuery.data?.publishers.map((p) => ({
+          publishersListQuery.data?.items.map((p) => ({
             id: p.id,
             name: p.name,
             count: p.file_count ?? 0,

--- a/app/components/pages/PublishersList.tsx
+++ b/app/components/pages/PublishersList.tsx
@@ -120,7 +120,7 @@ const PublishersList = () => {
       {publishersQuery.isSuccess &&
         !publishersQuery.isFetching &&
         !isStaleData &&
-        publishersQuery.data.publishers.length === 0 && (
+        publishersQuery.data.items.length === 0 && (
           <div className="text-center py-8 text-muted-foreground">
             {confirmedSearch
               ? "No publishers found matching your search."
@@ -131,9 +131,9 @@ const PublishersList = () => {
       {publishersQuery.isSuccess &&
         !publishersQuery.isFetching &&
         !isStaleData &&
-        publishersQuery.data.publishers.length > 0 && (
+        publishersQuery.data.items.length > 0 && (
           <div className="space-y-1">
-            {publishersQuery.data.publishers.map(renderPublisherItem)}
+            {publishersQuery.data.items.map(renderPublisherItem)}
           </div>
         )}
 

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -287,7 +287,7 @@ const SeriesDetail = () => {
 
       <MetadataMergeDialog
         entities={
-          seriesListQuery.data?.series.map((s) => ({
+          seriesListQuery.data?.items.map((s) => ({
             id: s.id,
             name: s.name,
             count: s.book_count ?? 0,

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -288,7 +288,7 @@ const SeriesList = () => {
           seriesQuery.isSuccess && !seriesQuery.isFetching && !isStaleData
         }
         itemLabel="series"
-        items={seriesQuery.data?.series ?? []}
+        items={seriesQuery.data?.items ?? []}
         itemsPerPage={itemsPerPage}
         renderItem={renderSeriesItem}
         total={seriesQuery.data?.total ?? 0}

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -86,9 +86,13 @@ const TagDetail = () => {
   const tagQuery = useTag(tagId);
 
   usePageTitle(tagQuery.data?.name ?? "Tag");
-  const tagBooksQuery = useTagBooks(tagId, {
-    enabled: userSettingsResolved && Boolean(tagId),
-  });
+  const tagBooksQuery = useTagBooks(
+    tagId,
+    {},
+    {
+      enabled: userSettingsResolved && Boolean(tagId),
+    },
+  );
 
   const [editOpen, setEditOpen] = useState(false);
   const [mergeOpen, setMergeOpen] = useState(false);
@@ -235,7 +239,7 @@ const TagDetail = () => {
           {tagBooksQuery.isLoading && <LoadingSpinner />}
           {tagBooksQuery.isSuccess && (
             <div className="flex flex-wrap gap-4">
-              {tagBooksQuery.data.map((book) => (
+              {tagBooksQuery.data.items.map((book) => (
                 <BookItem
                   book={book}
                   cacheKey={tagBooksQuery.dataUpdatedAt}
@@ -268,7 +272,7 @@ const TagDetail = () => {
 
       <MetadataMergeDialog
         entities={
-          tagsListQuery.data?.tags.map((t) => ({
+          tagsListQuery.data?.items.map((t) => ({
             id: t.id,
             name: t.name,
             count: t.book_count ?? 0,

--- a/app/components/pages/TagsList.tsx
+++ b/app/components/pages/TagsList.tsx
@@ -126,7 +126,7 @@ const TagsList = () => {
             </div>
           )}
 
-          {tagsQuery.data.tags.length === 0 ? (
+          {tagsQuery.data.items.length === 0 ? (
             <div className="text-center py-8 text-muted-foreground">
               {confirmedSearch
                 ? "No tags found matching your search."
@@ -134,7 +134,7 @@ const TagsList = () => {
             </div>
           ) : (
             <div className="space-y-1 mb-6">
-              {tagsQuery.data.tags.map(renderTagItem)}
+              {tagsQuery.data.items.map(renderTagItem)}
             </div>
           )}
 

--- a/app/hooks/queries/books.ts
+++ b/app/hooks/queries/books.ts
@@ -18,6 +18,7 @@ import type {
   MergeBooksResponse,
   MoveFilesPayload,
   MoveFilesResponse,
+  ResourceListResponse,
   UpdateBookPayload,
   UpdateFilePayload,
 } from "@/types";
@@ -53,10 +54,7 @@ export const useBook = (
   });
 };
 
-export interface ListBooksData {
-  books: Book[];
-  total: number;
-}
+export type ListBooksData = ResourceListResponse<Book>;
 
 export const useBooks = (
   query: ListBooksQuery = {},

--- a/app/hooks/queries/entity-search.test.ts
+++ b/app/hooks/queries/entity-search.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./entity-search";
 
 const mockPeopleData = {
-  people: [
+  items: [
     { id: 1, name: "Alice", authored_book_count: 3, narrated_file_count: 0 },
     { id: 2, name: "Bob", authored_book_count: 1, narrated_file_count: 5 },
   ],
@@ -23,7 +23,7 @@ vi.mock("./people", () => ({
 vi.mock("./genres", () => ({
   useGenresList: () => ({
     data: {
-      genres: [
+      items: [
         { name: "Fantasy", book_count: 5 },
         { name: "Sci-Fi", book_count: 12 },
       ],
@@ -34,25 +34,25 @@ vi.mock("./genres", () => ({
 }));
 vi.mock("./tags", () => ({
   useTagsList: () => ({
-    data: { tags: [{ name: "favorite", book_count: 2 }], total: 1 },
+    data: { items: [{ name: "favorite", book_count: 2 }], total: 1 },
     isLoading: false,
   }),
 }));
 vi.mock("./series", () => ({
   useSeriesList: () => ({
-    data: { series: [{ name: "Dune", book_count: 6 }], total: 1 },
+    data: { items: [{ name: "Dune", book_count: 6 }], total: 1 },
     isLoading: false,
   }),
 }));
 vi.mock("./publishers", () => ({
   usePublishersList: () => ({
-    data: { publishers: [{ name: "Tor", file_count: 8 }], total: 1 },
+    data: { items: [{ name: "Tor", file_count: 8 }], total: 1 },
     isLoading: false,
   }),
 }));
 vi.mock("./imprints", () => ({
   useImprintsList: () => ({
-    data: { imprints: [{ name: "Orbit", file_count: 3 }], total: 1 },
+    data: { items: [{ name: "Orbit", file_count: 3 }], total: 1 },
     isLoading: false,
   }),
 }));

--- a/app/hooks/queries/entity-search.ts
+++ b/app/hooks/queries/entity-search.ts
@@ -52,7 +52,7 @@ export function usePeopleSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.people.map((p: PersonWithCounts) => ({
+  const adapted = data?.items.map((p: PersonWithCounts) => ({
     name: p.name,
     id: p.id,
     authored_book_count: p.authored_book_count,
@@ -82,7 +82,7 @@ export function useSeriesSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.series.map((s) => ({
+  const adapted = data?.items.map((s) => ({
     name: s.name,
     book_count: s.book_count,
   }));
@@ -102,7 +102,7 @@ export function usePublisherSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.publishers.map((p) => ({
+  const adapted = data?.items.map((p) => ({
     name: p.name,
     file_count: p.file_count,
   }));
@@ -122,7 +122,7 @@ export function useImprintSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.imprints.map((i) => ({
+  const adapted = data?.items.map((i) => ({
     name: i.name,
     file_count: i.file_count,
   }));
@@ -142,7 +142,7 @@ export function useGenreSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.genres.map((g) => ({
+  const adapted = data?.items.map((g) => ({
     name: g.name,
     book_count: g.book_count,
   }));
@@ -162,7 +162,7 @@ export function useTagSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.tags.map((t) => ({
+  const adapted = data?.items.map((t) => ({
     name: t.name,
     book_count: t.book_count,
   }));
@@ -196,7 +196,7 @@ export function useGenreItemCounts(
   return useMemo(() => {
     const map = new Map<string, number>();
     for (let i = 0; i < results.length; i++) {
-      const genre = results[i].data?.genres.find(
+      const genre = results[i].data?.items.find(
         (g) => g.name.toLowerCase() === values[i].toLowerCase(),
       );
       if (genre) map.set(values[i], genre.book_count);
@@ -233,7 +233,7 @@ export function useTagItemCounts(
   return useMemo(() => {
     const map = new Map<string, number>();
     for (let i = 0; i < results.length; i++) {
-      const tag = results[i].data?.tags.find(
+      const tag = results[i].data?.items.find(
         (t) => t.name.toLowerCase() === values[i].toLowerCase(),
       );
       if (tag) map.set(values[i], tag.book_count);

--- a/app/hooks/queries/genres.ts
+++ b/app/hooks/queries/genres.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Book, Genre } from "@/types";
+import type { Book, Genre, ResourceListResponse } from "@/types";
 import type {
   ListGenresQuery,
   UpdateGenrePayload,
@@ -20,10 +20,7 @@ export enum QueryKey {
   GenreBooks = "GenreBooks",
 }
 
-export interface ListGenresData {
-  genres: Genre[];
-  total: number;
-}
+export type ListGenresData = ResourceListResponse<Genre>;
 
 export const useGenresList = (
   query: ListGenresQuery = {},
@@ -58,19 +55,31 @@ export const useGenre = (
   });
 };
 
+export interface GenreBooksQuery {
+  limit?: number;
+  offset?: number;
+}
+
 export const useGenreBooks = (
   genreId?: number,
+  query: GenreBooksQuery = {},
   options: Omit<
-    UseQueryOptions<Book[], ShishoAPIError>,
+    UseQueryOptions<ResourceListResponse<Book>, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<Book[], ShishoAPIError>({
+  return useQuery<ResourceListResponse<Book>, ShishoAPIError>({
     enabled: options.enabled !== undefined ? options.enabled : Boolean(genreId),
     ...options,
-    queryKey: [QueryKey.GenreBooks, genreId],
+    queryKey: [QueryKey.GenreBooks, genreId, query],
     queryFn: ({ signal }) => {
-      return API.request("GET", `/genres/${genreId}/books`, null, null, signal);
+      return API.request(
+        "GET",
+        `/genres/${genreId}/books`,
+        null,
+        query,
+        signal,
+      );
     },
   });
 };

--- a/app/hooks/queries/imprints.ts
+++ b/app/hooks/queries/imprints.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { File, Imprint } from "@/types";
+import type { File, Imprint, ResourceListResponse } from "@/types";
 import type {
   ListImprintsQuery,
   UpdateImprintPayload,
@@ -20,10 +20,7 @@ export enum QueryKey {
   ImprintFiles = "ImprintFiles",
 }
 
-export interface ListImprintsData {
-  imprints: Imprint[];
-  total: number;
-}
+export type ListImprintsData = ResourceListResponse<Imprint>;
 
 export const useImprintsList = (
   query: ListImprintsQuery = {},
@@ -59,24 +56,30 @@ export const useImprint = (
   });
 };
 
+export interface ImprintFilesQuery {
+  limit?: number;
+  offset?: number;
+}
+
 export const useImprintFiles = (
   imprintId?: number,
+  query: ImprintFilesQuery = {},
   options: Omit<
-    UseQueryOptions<File[], ShishoAPIError>,
+    UseQueryOptions<ResourceListResponse<File>, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<File[], ShishoAPIError>({
+  return useQuery<ResourceListResponse<File>, ShishoAPIError>({
     enabled:
       options.enabled !== undefined ? options.enabled : Boolean(imprintId),
     ...options,
-    queryKey: [QueryKey.ImprintFiles, imprintId],
+    queryKey: [QueryKey.ImprintFiles, imprintId, query],
     queryFn: ({ signal }) => {
       return API.request(
         "GET",
         `/imprints/${imprintId}/files`,
         null,
-        null,
+        query,
         signal,
       );
     },

--- a/app/hooks/queries/people.ts
+++ b/app/hooks/queries/people.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Book, File, Person } from "@/types";
+import type { Book, File, Person, ResourceListResponse } from "@/types";
 import type { UpdatePersonPayload } from "@/types/generated/people";
 
 import { QueryKey as BooksQueryKey } from "./books";
@@ -31,10 +31,7 @@ export interface PersonWithCounts extends Person {
   narrated_file_count: number;
 }
 
-export interface ListPeopleData {
-  people: PersonWithCounts[];
-  total: number;
-}
+export type ListPeopleData = ResourceListResponse<PersonWithCounts>;
 
 export const usePeopleList = (
   query: ListPeopleQuery = {},
@@ -70,24 +67,30 @@ export const usePerson = (
   });
 };
 
+export interface PersonSubResourceQuery {
+  limit?: number;
+  offset?: number;
+}
+
 export const usePersonAuthoredBooks = (
   personId?: number,
+  query: PersonSubResourceQuery = {},
   options: Omit<
-    UseQueryOptions<Book[], ShishoAPIError>,
+    UseQueryOptions<ResourceListResponse<Book>, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<Book[], ShishoAPIError>({
+  return useQuery<ResourceListResponse<Book>, ShishoAPIError>({
     enabled:
       options.enabled !== undefined ? options.enabled : Boolean(personId),
     ...options,
-    queryKey: [QueryKey.PersonAuthoredBooks, personId],
+    queryKey: [QueryKey.PersonAuthoredBooks, personId, query],
     queryFn: ({ signal }) => {
       return API.request(
         "GET",
         `/people/${personId}/authored-books`,
         null,
-        null,
+        query,
         signal,
       );
     },
@@ -96,22 +99,23 @@ export const usePersonAuthoredBooks = (
 
 export const usePersonNarratedFiles = (
   personId?: number,
+  query: PersonSubResourceQuery = {},
   options: Omit<
-    UseQueryOptions<File[], ShishoAPIError>,
+    UseQueryOptions<ResourceListResponse<File>, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<File[], ShishoAPIError>({
+  return useQuery<ResourceListResponse<File>, ShishoAPIError>({
     enabled:
       options.enabled !== undefined ? options.enabled : Boolean(personId),
     ...options,
-    queryKey: [QueryKey.PersonNarratedFiles, personId],
+    queryKey: [QueryKey.PersonNarratedFiles, personId, query],
     queryFn: ({ signal }) => {
       return API.request(
         "GET",
         `/people/${personId}/narrated-files`,
         null,
-        null,
+        query,
         signal,
       );
     },

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { File, Publisher } from "@/types";
+import type { File, Publisher, ResourceListResponse } from "@/types";
 import type {
   ListPublishersQuery,
   UpdatePublisherPayload,
@@ -20,10 +20,7 @@ export enum QueryKey {
   PublisherFiles = "PublisherFiles",
 }
 
-export interface ListPublishersData {
-  publishers: Publisher[];
-  total: number;
-}
+export type ListPublishersData = ResourceListResponse<Publisher>;
 
 export const usePublishersList = (
   query: ListPublishersQuery = {},
@@ -65,24 +62,30 @@ export const usePublisher = (
   });
 };
 
+export interface PublisherFilesQuery {
+  limit?: number;
+  offset?: number;
+}
+
 export const usePublisherFiles = (
   publisherId?: number,
+  query: PublisherFilesQuery = {},
   options: Omit<
-    UseQueryOptions<File[], ShishoAPIError>,
+    UseQueryOptions<ResourceListResponse<File>, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<File[], ShishoAPIError>({
+  return useQuery<ResourceListResponse<File>, ShishoAPIError>({
     enabled:
       options.enabled !== undefined ? options.enabled : Boolean(publisherId),
     ...options,
-    queryKey: [QueryKey.PublisherFiles, publisherId],
+    queryKey: [QueryKey.PublisherFiles, publisherId, query],
     queryFn: ({ signal }) => {
       return API.request(
         "GET",
         `/publishers/${publisherId}/files`,
         null,
-        null,
+        query,
         signal,
       );
     },

--- a/app/hooks/queries/series.ts
+++ b/app/hooks/queries/series.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Book, Series } from "@/types";
+import type { Book, ResourceListResponse, Series } from "@/types";
 import type {
   ListSeriesQuery,
   UpdateSeriesPayload,
@@ -27,10 +27,7 @@ export interface SeriesWithCount extends Series {
 
 export type { ListSeriesQuery };
 
-export interface ListSeriesData {
-  series: Series[];
-  total: number;
-}
+export type ListSeriesData = ResourceListResponse<Series>;
 
 export const useSeriesList = (
   query: ListSeriesQuery = {},

--- a/app/hooks/queries/tags.ts
+++ b/app/hooks/queries/tags.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Book, Tag } from "@/types";
+import type { Book, ResourceListResponse, Tag } from "@/types";
 import type { ListTagsQuery, UpdateTagPayload } from "@/types/generated/tags";
 
 import { QueryKey as BooksQueryKey } from "./books";
@@ -17,10 +17,7 @@ export enum QueryKey {
   TagBooks = "TagBooks",
 }
 
-export interface ListTagsData {
-  tags: Tag[];
-  total: number;
-}
+export type ListTagsData = ResourceListResponse<Tag>;
 
 export const useTagsList = (
   query: ListTagsQuery = {},
@@ -55,19 +52,25 @@ export const useTag = (
   });
 };
 
+export interface TagBooksQuery {
+  limit?: number;
+  offset?: number;
+}
+
 export const useTagBooks = (
   tagId?: number,
+  query: TagBooksQuery = {},
   options: Omit<
-    UseQueryOptions<Book[], ShishoAPIError>,
+    UseQueryOptions<ResourceListResponse<Book>, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<Book[], ShishoAPIError>({
+  return useQuery<ResourceListResponse<Book>, ShishoAPIError>({
     enabled: options.enabled !== undefined ? options.enabled : Boolean(tagId),
     ...options,
-    queryKey: [QueryKey.TagBooks, tagId],
+    queryKey: [QueryKey.TagBooks, tagId, query],
     queryFn: ({ signal }) => {
-      return API.request("GET", `/tags/${tagId}/books`, null, null, signal);
+      return API.request("GET", `/tags/${tagId}/books`, null, query, signal);
     },
   });
 };

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -38,10 +38,26 @@ export * from "./generated/roles";
 export * from "./generated/search";
 export * from "./generated/series";
 export * from "./generated/people";
-export * from "./generated/genres";
-export * from "./generated/tags";
-export * from "./generated/publishers";
-export * from "./generated/imprints";
+export {
+  type ListGenresQuery,
+  type UpdateGenrePayload,
+  type MergeGenresPayload,
+} from "./generated/genres";
+export {
+  type ListTagsQuery,
+  type UpdateTagPayload,
+  type MergeTagsPayload,
+} from "./generated/tags";
+export {
+  type ListPublishersQuery,
+  type UpdatePublisherPayload,
+  type MergePublishersPayload,
+} from "./generated/publishers";
+export {
+  type ListImprintsQuery,
+  type UpdateImprintPayload,
+  type MergeImprintsPayload,
+} from "./generated/imprints";
 export * from "./generated/chapters";
 export {
   type CreateListPayload,
@@ -57,6 +73,11 @@ export {
 } from "./generated/lists";
 
 export type { UserSettings } from "@/hooks/queries/settings";
+
+export interface ResourceListResponse<T> {
+  items: T[];
+  total: number;
+}
 
 // Delete operation types
 // TODO: Move these to validators.go and regenerate via tygo

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -192,7 +192,7 @@ func (h *handler) list(c echo.Context) error {
 	}
 
 	resp := struct {
-		Books []*models.Book `json:"books"`
+		Items []*models.Book `json:"items"`
 		Total int            `json:"total"`
 	}{books, total}
 

--- a/pkg/books/handlers_list_test.go
+++ b/pkg/books/handlers_list_test.go
@@ -87,13 +87,13 @@ func TestListHandler_ExplicitSortWins(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 
 	var resp struct {
-		Books []*models.Book `json:"books"`
+		Items []*models.Book `json:"items"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Len(t, resp.Books, 2)
+	require.Len(t, resp.Items, 2)
 	// title:asc → Apple before Cheese.
-	assert.Equal(t, apple.ID, resp.Books[0].ID)
-	assert.Equal(t, cheese.ID, resp.Books[1].ID)
+	assert.Equal(t, apple.ID, resp.Items[0].ID)
+	assert.Equal(t, cheese.ID, resp.Items[1].ID)
 }
 
 // TestListHandler_StoredPreferenceUsed verifies that when no URL sort is
@@ -129,15 +129,15 @@ func TestListHandler_StoredPreferenceUsed(t *testing.T) {
 	require.NoError(t, h.list(c))
 
 	var resp struct {
-		Books []*models.Book `json:"books"`
+		Items []*models.Book `json:"items"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Len(t, resp.Books, 2)
+	require.Len(t, resp.Items, 2)
 	// title:asc → apple (alphabetical) before banana. If the resolver
 	// hadn't fired, the builtin default (date_added:desc) would return
 	// banana (newer) first and the assertion would fail.
-	assert.Equal(t, apple.ID, resp.Books[0].ID)
-	assert.Equal(t, banana.ID, resp.Books[1].ID)
+	assert.Equal(t, apple.ID, resp.Items[0].ID)
+	assert.Equal(t, banana.ID, resp.Items[1].ID)
 }
 
 // TestListHandler_InvalidSortReturns400 verifies sort validation.
@@ -200,13 +200,13 @@ func TestListHandler_NoLibraryIDSkipsStoredLookup(t *testing.T) {
 	require.NoError(t, h.list(c))
 
 	var resp struct {
-		Books []*models.Book `json:"books"`
+		Items []*models.Book `json:"items"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Len(t, resp.Books, 2)
+	require.Len(t, resp.Items, 2)
 	// Without library_id the resolver is skipped, so the stored title:asc
 	// preference is ignored and the builtin default (date_added:desc) wins
 	// → Cheese (newer) before Apple (older).
-	assert.Equal(t, cheese.ID, resp.Books[0].ID)
-	assert.Equal(t, apple.ID, resp.Books[1].ID)
+	assert.Equal(t, cheese.ID, resp.Items[0].ID)
+	assert.Equal(t, apple.ID, resp.Items[1].ID)
 }

--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -100,8 +100,8 @@ func (h *handler) list(c echo.Context) error {
 	}
 
 	response := map[string]any{
-		"genres": result,
-		"total":  total,
+		"items": result,
+		"total": total,
 	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
@@ -233,6 +233,11 @@ func (h *handler) books(c echo.Context) error {
 		return errcodes.NotFound("Genre")
 	}
 
+	params := SubResourceQuery{}
+	if err := c.Bind(&params); err != nil {
+		return errors.WithStack(err)
+	}
+
 	// Fetch the genre to check library access
 	genre, err := h.genreService.RetrieveGenre(ctx, RetrieveGenreOptions{
 		ID: &id,
@@ -248,12 +253,17 @@ func (h *handler) books(c echo.Context) error {
 		}
 	}
 
-	books, err := h.genreService.GetBooks(ctx, id)
+	books, total, err := h.genreService.GetBooksPaginated(ctx, id, params.Limit, params.Offset)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, books))
+	response := map[string]any{
+		"items": books,
+		"total": total,
+	}
+
+	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
 
 func (h *handler) merge(c echo.Context) error {

--- a/pkg/genres/handlers_test.go
+++ b/pkg/genres/handlers_test.go
@@ -3,7 +3,9 @@ package genres
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -13,12 +15,37 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/aliases"
 	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/migrations"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/search"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
 )
+
+func setupHandlerTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
 
 func newTestEcho(t *testing.T) *echo.Echo {
 	t.Helper()
@@ -125,6 +152,151 @@ func TestUpdateGenre_SequentialRenames_NoDuplicateAliases(t *testing.T) {
 	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"Science Fiction", "Sci-Fi"}, aliasList)
+}
+
+func seedGenreWithBooks(t *testing.T, db *bun.DB, lib *models.Library, genreName string, bookTitles []string) *models.Genre {
+	t.Helper()
+	ctx := context.Background()
+
+	genre := &models.Genre{LibraryID: lib.ID, Name: genreName}
+	_, err := db.NewInsert().Model(genre).Exec(ctx)
+	require.NoError(t, err)
+
+	for _, title := range bookTitles {
+		book := &models.Book{
+			LibraryID:       lib.ID,
+			Title:           title,
+			Filepath:        t.TempDir(),
+			TitleSource:     models.DataSourceFilepath,
+			SortTitle:       title,
+			SortTitleSource: models.DataSourceFilepath,
+			AuthorSource:    models.DataSourceFilepath,
+		}
+		_, err = db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+
+		bg := &models.BookGenre{BookID: book.ID, GenreID: genre.ID}
+		_, err = db.NewInsert().Model(bg).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	return genre
+}
+
+func TestBooks_DefaultPagination(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	e := newTestEcho(t)
+	lib := createTestLibrary(t, db)
+	genre := seedGenreWithBooks(t, db, lib, "Fiction", []string{"Alpha", "Beta", "Charlie"})
+	h := newTestHandler(t, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(genre.ID))
+
+	err := h.books(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Items []models.Book `json:"items"`
+		Total int           `json:"total"`
+	}
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, resp.Total)
+	assert.Len(t, resp.Items, 3)
+	assert.Equal(t, "Alpha", resp.Items[0].Title)
+}
+
+func TestBooks_ExplicitLimitOffset(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	e := newTestEcho(t)
+	lib := createTestLibrary(t, db)
+	genre := seedGenreWithBooks(t, db, lib, "Fiction", []string{"Alpha", "Beta", "Charlie", "Delta", "Echo"})
+	h := newTestHandler(t, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/?limit=2&offset=1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(genre.ID))
+
+	err := h.books(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Items []models.Book `json:"items"`
+		Total int           `json:"total"`
+	}
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Equal(t, 5, resp.Total)
+	assert.Len(t, resp.Items, 2)
+	assert.Equal(t, "Beta", resp.Items[0].Title)
+	assert.Equal(t, "Charlie", resp.Items[1].Title)
+}
+
+func TestBooks_ResponseShape(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	e := newTestEcho(t)
+	lib := createTestLibrary(t, db)
+	_ = seedGenreWithBooks(t, db, lib, "Empty Genre", nil)
+	h := newTestHandler(t, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+
+	err := h.books(c)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &raw)
+	require.NoError(t, err)
+
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	assert.True(t, hasItems, "response must have 'items' key")
+	assert.True(t, hasTotal, "response must have 'total' key")
+	assert.Len(t, raw, 2, "response must have exactly 2 keys")
+}
+
+func TestList_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	e := newTestEcho(t)
+	lib := createTestLibrary(t, db)
+	_ = seedGenreWithBooks(t, db, lib, "Fiction", []string{"Book1"})
+	h := newTestHandler(t, db)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.list(c)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &raw)
+	require.NoError(t, err)
+
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasGenres := raw["genres"]
+	assert.True(t, hasItems, "list response must use 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.False(t, hasGenres, "list response must NOT use 'genres' key")
 }
 
 func TestUpdateGenre_RenameBackToOriginalName(t *testing.T) {

--- a/pkg/genres/service.go
+++ b/pkg/genres/service.go
@@ -249,6 +249,25 @@ func (svc *Service) GetBooks(ctx context.Context, genreID int) ([]*models.Book, 
 	return books, nil
 }
 
+// GetBooksPaginated returns a paginated list of books with this genre.
+func (svc *Service) GetBooksPaginated(ctx context.Context, genreID, limit, offset int) ([]*models.Book, int, error) {
+	var books []*models.Book
+
+	total, err := svc.db.NewSelect().
+		Model(&books).
+		Join("INNER JOIN book_genres bg ON bg.book_id = b.id").
+		Where("bg.genre_id = ?", genreID).
+		Order("b.title ASC").
+		Limit(limit).
+		Offset(offset).
+		ScanAndCount(ctx)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+
+	return books, total, nil
+}
+
 // MergeGenres merges sourceGenre into targetGenre (moves all associations, deletes source).
 func (svc *Service) MergeGenres(ctx context.Context, targetID, sourceID int) error {
 	return svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {

--- a/pkg/genres/validators.go
+++ b/pkg/genres/validators.go
@@ -7,6 +7,11 @@ type ListGenresQuery struct {
 	Search    *string `query:"search" json:"search,omitempty" validate:"omitempty,max=100" tstype:"string"`
 }
 
+type SubResourceQuery struct {
+	Limit  int `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
+	Offset int `query:"offset" json:"offset,omitempty" validate:"min=0"`
+}
+
 type UpdateGenrePayload struct {
 	Name    *string  `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
 	Aliases []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`

--- a/pkg/imprints/handlers.go
+++ b/pkg/imprints/handlers.go
@@ -96,8 +96,8 @@ func (h *handler) list(c echo.Context) error {
 	}
 
 	response := map[string]any{
-		"imprints": result,
-		"total":    total,
+		"items": result,
+		"total": total,
 	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
@@ -220,6 +220,11 @@ func (h *handler) files(c echo.Context) error {
 		return errcodes.NotFound("Imprint")
 	}
 
+	params := SubResourceQuery{}
+	if err := c.Bind(&params); err != nil {
+		return errors.WithStack(err)
+	}
+
 	imprint, err := h.imprintService.RetrieveImprint(ctx, RetrieveImprintOptions{
 		ID: &id,
 	})
@@ -233,12 +238,17 @@ func (h *handler) files(c echo.Context) error {
 		}
 	}
 
-	files, err := h.imprintService.GetFiles(ctx, id)
+	files, total, err := h.imprintService.GetFilesPaginated(ctx, id, params.Limit, params.Offset)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, files))
+	response := map[string]any{
+		"items": files,
+		"total": total,
+	}
+
+	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
 
 func (h *handler) merge(c echo.Context) error {

--- a/pkg/imprints/handlers_test.go
+++ b/pkg/imprints/handlers_test.go
@@ -1,0 +1,235 @@
+package imprints
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+// setupHandlerTestDB creates an in-memory SQLite database using a named memory
+// URI so that Bun's ScanAndCount (which opens a second connection for the COUNT
+// query) sees the same database. Plain ":memory:" gives each connection its own
+// private database, which causes "no such table" errors from ScanAndCount.
+func setupHandlerTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func newTestEcho(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	return e
+}
+
+func newTestHandler(db *bun.DB) *handler {
+	return &handler{
+		imprintService: NewService(db),
+		aliasService:   aliases.NewService(db),
+		searchService:  search.NewService(db),
+	}
+}
+
+func seedImprintWithFiles(t *testing.T, db *bun.DB, lib *models.Library, impName string, fileNames []string) *models.Imprint {
+	t.Helper()
+	ctx := context.Background()
+
+	imprint := &models.Imprint{LibraryID: lib.ID, Name: impName}
+	_, err := db.NewInsert().Model(imprint).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Book for " + impName,
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book for " + impName,
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	for _, name := range fileNames {
+		file := &models.File{
+			LibraryID:     lib.ID,
+			BookID:        book.ID,
+			FileType:      models.FileTypeEPUB,
+			FileRole:      models.FileRoleMain,
+			Filepath:      "/tmp/" + name + ".epub",
+			FilesizeBytes: 1,
+			ImprintID:     &imprint.ID,
+		}
+		_, err = db.NewInsert().Model(file).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	return imprint
+}
+
+func TestFiles_DefaultPagination(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	imp := seedImprintWithFiles(t, db, lib, "Vintage", []string{"f1", "f2", "f3"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(imp.ID))
+
+	err := h.files(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 3)
+}
+
+func TestFiles_ExplicitLimitOffset(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	imp := seedImprintWithFiles(t, db, lib, "Anchor", []string{"f1", "f2", "f3", "f4", "f5"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/?limit=2&offset=1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(imp.ID))
+
+	err := h.files(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}
+
+func TestFiles_ResponseShape(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	imp := seedImprintWithFiles(t, db, lib, "Tor", []string{"f1"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(imp.ID))
+
+	err := h.files(c)
+	require.NoError(t, err)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Len(t, resp, 2, "response should have exactly 2 keys")
+	assert.Contains(t, resp, "items")
+	assert.Contains(t, resp, "total")
+}
+
+func TestList_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		imp := &models.Imprint{LibraryID: lib.ID, Name: fmt.Sprintf("Imprint %d", i)}
+		_, err := db.NewInsert().Model(imp).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.list(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Contains(t, resp, "items", "response should use 'items' key")
+	assert.NotContains(t, resp, "imprints", "response should not use 'imprints' key")
+	assert.Contains(t, resp, "total")
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}

--- a/pkg/imprints/service.go
+++ b/pkg/imprints/service.go
@@ -250,6 +250,25 @@ func (svc *Service) GetFiles(ctx context.Context, imprintID int) ([]*models.File
 	return files, nil
 }
 
+// GetFilesPaginated returns a paginated list of files with this imprint.
+func (svc *Service) GetFilesPaginated(ctx context.Context, imprintID, limit, offset int) ([]*models.File, int, error) {
+	var files []*models.File
+
+	total, err := svc.db.NewSelect().
+		Model(&files).
+		Where("f.imprint_id = ?", imprintID).
+		Relation("Book").
+		Order("f.filepath ASC").
+		Limit(limit).
+		Offset(offset).
+		ScanAndCount(ctx)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+
+	return files, total, nil
+}
+
 // MergeImprints merges sourceImprint into targetImprint (moves all file associations, deletes source).
 func (svc *Service) MergeImprints(ctx context.Context, targetID, sourceID int) error {
 	return svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {

--- a/pkg/imprints/validators.go
+++ b/pkg/imprints/validators.go
@@ -7,6 +7,11 @@ type ListImprintsQuery struct {
 	Search    *string `query:"search" json:"search,omitempty" validate:"omitempty,max=100" tstype:"string"`
 }
 
+type SubResourceQuery struct {
+	Limit  int `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
+	Offset int `query:"offset" json:"offset,omitempty" validate:"min=0"`
+}
+
 type UpdateImprintPayload struct {
 	Name    *string  `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
 	Aliases []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`

--- a/pkg/people/handlers.go
+++ b/pkg/people/handlers.go
@@ -125,9 +125,9 @@ func (h *handler) list(c echo.Context) error {
 		result[i] = PersonWithCounts{p, authoredCount, narratedCount, aliasList}
 	}
 
-	response := map[string]interface{}{
-		"people": result,
-		"total":  total,
+	response := map[string]any{
+		"items": result,
+		"total": total,
 	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
@@ -331,6 +331,11 @@ func (h *handler) authoredBooks(c echo.Context) error {
 		return errcodes.NotFound("Person")
 	}
 
+	params := SubResourceQuery{}
+	if err := c.Bind(&params); err != nil {
+		return errors.WithStack(err)
+	}
+
 	// Fetch the person to check library access
 	person, err := h.personService.RetrievePerson(ctx, RetrievePersonOptions{
 		ID: &id,
@@ -346,12 +351,17 @@ func (h *handler) authoredBooks(c echo.Context) error {
 		}
 	}
 
-	books, err := h.personService.GetAuthoredBooks(ctx, id)
+	books, total, err := h.personService.GetAuthoredBooksPaginated(ctx, id, params.Limit, params.Offset)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, books))
+	response := map[string]any{
+		"items": books,
+		"total": total,
+	}
+
+	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
 
 func (h *handler) narratedFiles(c echo.Context) error {
@@ -361,6 +371,11 @@ func (h *handler) narratedFiles(c echo.Context) error {
 		return errcodes.NotFound("Person")
 	}
 
+	params := SubResourceQuery{}
+	if err := c.Bind(&params); err != nil {
+		return errors.WithStack(err)
+	}
+
 	// Fetch the person to check library access
 	person, err := h.personService.RetrievePerson(ctx, RetrievePersonOptions{
 		ID: &id,
@@ -376,12 +391,17 @@ func (h *handler) narratedFiles(c echo.Context) error {
 		}
 	}
 
-	files, err := h.personService.GetNarratedFiles(ctx, id)
+	files, total, err := h.personService.GetNarratedFilesPaginated(ctx, id, params.Limit, params.Offset)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, files))
+	response := map[string]any{
+		"items": files,
+		"total": total,
+	}
+
+	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
 
 func (h *handler) merge(c echo.Context) error {

--- a/pkg/people/handlers_test.go
+++ b/pkg/people/handlers_test.go
@@ -1,0 +1,397 @@
+package people
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+// setupHandlerTestDB creates an in-memory SQLite database using a named memory
+// URI so that Bun's ScanAndCount (which opens a second connection for the COUNT
+// query) sees the same database. Plain ":memory:" gives each connection its own
+// private database, which causes "no such table" errors from ScanAndCount.
+func setupHandlerTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func newTestEcho(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	return e
+}
+
+func createTestLibrary(t *testing.T, db *bun.DB) *models.Library {
+	t.Helper()
+	lib := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(lib).Exec(context.Background())
+	require.NoError(t, err)
+	return lib
+}
+
+func newTestHandler(db *bun.DB) *handler {
+	return &handler{
+		personService: NewService(db),
+		aliasService:  aliases.NewService(db),
+		searchService: search.NewService(db),
+	}
+}
+
+func seedPersonWithAuthoredBooks(t *testing.T, db *bun.DB, lib *models.Library, personName string, bookTitles []string) *models.Person {
+	t.Helper()
+	ctx := context.Background()
+
+	person := &models.Person{
+		LibraryID:      lib.ID,
+		Name:           personName,
+		SortName:       personName,
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err := db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	for _, title := range bookTitles {
+		book := &models.Book{
+			LibraryID:       lib.ID,
+			Title:           title,
+			TitleSource:     models.DataSourceFilepath,
+			SortTitle:       title,
+			SortTitleSource: models.DataSourceFilepath,
+			AuthorSource:    models.DataSourceFilepath,
+			Filepath:        t.TempDir(),
+		}
+		_, err := db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+
+		author := &models.Author{
+			BookID:    book.ID,
+			PersonID:  person.ID,
+			SortOrder: 1,
+		}
+		_, err = db.NewInsert().Model(author).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	return person
+}
+
+func seedPersonWithNarratedFiles(t *testing.T, db *bun.DB, lib *models.Library, personName string, fileNames []string) *models.Person {
+	t.Helper()
+	ctx := context.Background()
+
+	person := &models.Person{
+		LibraryID:      lib.ID,
+		Name:           personName,
+		SortName:       personName,
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err := db.NewInsert().Model(person).Exec(ctx)
+	require.NoError(t, err)
+
+	for _, name := range fileNames {
+		book := &models.Book{
+			LibraryID:       lib.ID,
+			Title:           "Book for " + name,
+			TitleSource:     models.DataSourceFilepath,
+			SortTitle:       "Book for " + name,
+			SortTitleSource: models.DataSourceFilepath,
+			AuthorSource:    models.DataSourceFilepath,
+			Filepath:        t.TempDir(),
+		}
+		_, err := db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+
+		file := &models.File{
+			LibraryID:     lib.ID,
+			BookID:        book.ID,
+			FileType:      models.FileTypeM4B,
+			FileRole:      models.FileRoleMain,
+			Filepath:      "/tmp/" + name + ".m4b",
+			FilesizeBytes: 1,
+		}
+		_, err = db.NewInsert().Model(file).Exec(ctx)
+		require.NoError(t, err)
+
+		narrator := &models.Narrator{
+			FileID:    file.ID,
+			PersonID:  person.ID,
+			SortOrder: 1,
+		}
+		_, err = db.NewInsert().Model(narrator).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	return person
+}
+
+func TestAuthoredBooks_DefaultPagination(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	person := seedPersonWithAuthoredBooks(t, db, lib, "Author A", []string{"B1", "B2", "B3"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(person.ID))
+
+	err := h.authoredBooks(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 3)
+}
+
+func TestAuthoredBooks_ExplicitLimitOffset(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	person := seedPersonWithAuthoredBooks(t, db, lib, "Author B", []string{"B1", "B2", "B3", "B4", "B5"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/?limit=2&offset=1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(person.ID))
+
+	err := h.authoredBooks(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}
+
+func TestAuthoredBooks_ResponseShape(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	person := seedPersonWithAuthoredBooks(t, db, lib, "Author C", []string{"B1"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(person.ID))
+
+	err := h.authoredBooks(c)
+	require.NoError(t, err)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Len(t, resp, 2, "response should have exactly 2 keys")
+	assert.Contains(t, resp, "items")
+	assert.Contains(t, resp, "total")
+}
+
+func TestNarratedFiles_DefaultPagination(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	person := seedPersonWithNarratedFiles(t, db, lib, "Narrator A", []string{"n1", "n2", "n3"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(person.ID))
+
+	err := h.narratedFiles(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 3)
+}
+
+func TestNarratedFiles_ExplicitLimitOffset(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	person := seedPersonWithNarratedFiles(t, db, lib, "Narrator B", []string{"n1", "n2", "n3", "n4", "n5"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/?limit=2&offset=1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(person.ID))
+
+	err := h.narratedFiles(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}
+
+func TestNarratedFiles_ResponseShape(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	person := seedPersonWithNarratedFiles(t, db, lib, "Narrator C", []string{"n1"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(person.ID))
+
+	err := h.narratedFiles(c)
+	require.NoError(t, err)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Len(t, resp, 2, "response should have exactly 2 keys")
+	assert.Contains(t, resp, "items")
+	assert.Contains(t, resp, "total")
+}
+
+func TestList_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		person := &models.Person{
+			LibraryID:      lib.ID,
+			Name:           fmt.Sprintf("Person %d", i),
+			SortName:       fmt.Sprintf("Person %d", i),
+			SortNameSource: models.DataSourceFilepath,
+		}
+		_, err := db.NewInsert().Model(person).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.list(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Contains(t, resp, "items", "response should use 'items' key")
+	assert.NotContains(t, resp, "people", "response should not use 'people' key")
+	assert.Contains(t, resp, "total")
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}

--- a/pkg/people/service.go
+++ b/pkg/people/service.go
@@ -284,6 +284,46 @@ func (svc *Service) GetNarratedFiles(ctx context.Context, personID int) ([]*mode
 	return files, nil
 }
 
+// GetAuthoredBooksPaginated returns a paginated list of books authored by this person.
+func (svc *Service) GetAuthoredBooksPaginated(ctx context.Context, personID, limit, offset int) ([]*models.Book, int, error) {
+	var books []*models.Book
+
+	total, err := svc.db.NewSelect().
+		Model(&books).
+		Distinct().
+		Join("INNER JOIN authors a ON a.book_id = b.id").
+		Where("a.person_id = ?", personID).
+		Order("b.title ASC").
+		Limit(limit).
+		Offset(offset).
+		ScanAndCount(ctx)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+
+	return books, total, nil
+}
+
+// GetNarratedFilesPaginated returns a paginated list of files narrated by this person.
+func (svc *Service) GetNarratedFilesPaginated(ctx context.Context, personID, limit, offset int) ([]*models.File, int, error) {
+	var files []*models.File
+
+	total, err := svc.db.NewSelect().
+		Model(&files).
+		Relation("Book").
+		Join("INNER JOIN narrators n ON n.file_id = f.id").
+		Where("n.person_id = ?", personID).
+		Order("f.filepath ASC").
+		Limit(limit).
+		Offset(offset).
+		ScanAndCount(ctx)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+
+	return files, total, nil
+}
+
 // GetAuthoredBookCount returns the count of books authored by this person.
 func (svc *Service) GetAuthoredBookCount(ctx context.Context, personID int) (int, error) {
 	count, err := svc.db.NewSelect().

--- a/pkg/people/validators.go
+++ b/pkg/people/validators.go
@@ -7,6 +7,11 @@ type ListPeopleQuery struct {
 	Search    *string `query:"search" json:"search,omitempty" validate:"omitempty,max=100" tstype:"string"`
 }
 
+type SubResourceQuery struct {
+	Limit  int `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
+	Offset int `query:"offset" json:"offset,omitempty" validate:"min=0"`
+}
+
 type UpdatePersonPayload struct {
 	Name     *string  `json:"name,omitempty" validate:"omitempty,max=300"`
 	SortName *string  `json:"sort_name,omitempty" validate:"omitempty,max=300"`

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -96,8 +96,8 @@ func (h *handler) list(c echo.Context) error {
 	}
 
 	response := map[string]any{
-		"publishers": result,
-		"total":      total,
+		"items": result,
+		"total": total,
 	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
@@ -220,6 +220,11 @@ func (h *handler) files(c echo.Context) error {
 		return errcodes.NotFound("Publisher")
 	}
 
+	params := SubResourceQuery{}
+	if err := c.Bind(&params); err != nil {
+		return errors.WithStack(err)
+	}
+
 	publisher, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{
 		ID: &id,
 	})
@@ -233,12 +238,17 @@ func (h *handler) files(c echo.Context) error {
 		}
 	}
 
-	files, err := h.publisherService.GetFiles(ctx, id)
+	files, total, err := h.publisherService.GetFilesPaginated(ctx, id, params.Limit, params.Offset)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, files))
+	response := map[string]any{
+		"items": files,
+		"total": total,
+	}
+
+	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
 
 func (h *handler) merge(c echo.Context) error {

--- a/pkg/publishers/handlers_test.go
+++ b/pkg/publishers/handlers_test.go
@@ -1,0 +1,235 @@
+package publishers
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+// setupHandlerTestDB creates an in-memory SQLite database using a named memory
+// URI so that Bun's ScanAndCount (which opens a second connection for the COUNT
+// query) sees the same database. Plain ":memory:" gives each connection its own
+// private database, which causes "no such table" errors from ScanAndCount.
+func setupHandlerTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func newTestEcho(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	return e
+}
+
+func newTestHandler(db *bun.DB) *handler {
+	return &handler{
+		publisherService: NewService(db),
+		aliasService:     aliases.NewService(db),
+		searchService:    search.NewService(db),
+	}
+}
+
+func seedPublisherWithFiles(t *testing.T, db *bun.DB, lib *models.Library, pubName string, fileNames []string) *models.Publisher {
+	t.Helper()
+	ctx := context.Background()
+
+	publisher := &models.Publisher{LibraryID: lib.ID, Name: pubName}
+	_, err := db.NewInsert().Model(publisher).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Book for " + pubName,
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book for " + pubName,
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	for _, name := range fileNames {
+		file := &models.File{
+			LibraryID:     lib.ID,
+			BookID:        book.ID,
+			FileType:      models.FileTypeEPUB,
+			FileRole:      models.FileRoleMain,
+			Filepath:      "/tmp/" + name + ".epub",
+			FilesizeBytes: 1,
+			PublisherID:   &publisher.ID,
+		}
+		_, err = db.NewInsert().Model(file).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	return publisher
+}
+
+func TestFiles_DefaultPagination(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	pub := seedPublisherWithFiles(t, db, lib, "Penguin", []string{"f1", "f2", "f3"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(pub.ID))
+
+	err := h.files(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 3)
+}
+
+func TestFiles_ExplicitLimitOffset(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	pub := seedPublisherWithFiles(t, db, lib, "HarperCollins", []string{"f1", "f2", "f3", "f4", "f5"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/?limit=2&offset=1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(pub.ID))
+
+	err := h.files(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}
+
+func TestFiles_ResponseShape(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	pub := seedPublisherWithFiles(t, db, lib, "Tor", []string{"f1"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(pub.ID))
+
+	err := h.files(c)
+	require.NoError(t, err)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Len(t, resp, 2, "response should have exactly 2 keys")
+	assert.Contains(t, resp, "items")
+	assert.Contains(t, resp, "total")
+}
+
+func TestList_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		pub := &models.Publisher{LibraryID: lib.ID, Name: fmt.Sprintf("Publisher %d", i)}
+		_, err := db.NewInsert().Model(pub).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.list(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Contains(t, resp, "items", "response should use 'items' key")
+	assert.NotContains(t, resp, "publishers", "response should not use 'publishers' key")
+	assert.Contains(t, resp, "total")
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -250,6 +250,25 @@ func (svc *Service) GetFiles(ctx context.Context, publisherID int) ([]*models.Fi
 	return files, nil
 }
 
+// GetFilesPaginated returns a paginated list of files with this publisher.
+func (svc *Service) GetFilesPaginated(ctx context.Context, publisherID, limit, offset int) ([]*models.File, int, error) {
+	var files []*models.File
+
+	total, err := svc.db.NewSelect().
+		Model(&files).
+		Where("f.publisher_id = ?", publisherID).
+		Relation("Book").
+		Order("f.filepath ASC").
+		Limit(limit).
+		Offset(offset).
+		ScanAndCount(ctx)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+
+	return files, total, nil
+}
+
 // MergePublishers merges sourcePublisher into targetPublisher (moves all file associations, deletes source).
 func (svc *Service) MergePublishers(ctx context.Context, targetID, sourceID int) error {
 	return svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {

--- a/pkg/publishers/validators.go
+++ b/pkg/publishers/validators.go
@@ -7,6 +7,11 @@ type ListPublishersQuery struct {
 	Search    *string `query:"search" json:"search,omitempty" validate:"omitempty,max=100" tstype:"string"`
 }
 
+type SubResourceQuery struct {
+	Limit  int `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
+	Offset int `query:"offset" json:"offset,omitempty" validate:"min=0"`
+}
+
 type UpdatePublisherPayload struct {
 	Name    *string  `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
 	Aliases []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -108,9 +108,9 @@ func (h *handler) list(c echo.Context) error {
 		result[i] = SeriesWithCount{s, count, aliasList}
 	}
 
-	response := map[string]interface{}{
-		"series": result,
-		"total":  total,
+	response := map[string]any{
+		"items": result,
+		"total": total,
 	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -97,7 +97,7 @@ func (h *handler) list(c echo.Context) error {
 	}
 
 	response := map[string]any{
-		"tags":  result,
+		"items": result,
 		"total": total,
 	}
 
@@ -221,6 +221,11 @@ func (h *handler) books(c echo.Context) error {
 		return errcodes.NotFound("Tag")
 	}
 
+	params := SubResourceQuery{}
+	if err := c.Bind(&params); err != nil {
+		return errors.WithStack(err)
+	}
+
 	tag, err := h.tagService.RetrieveTag(ctx, RetrieveTagOptions{
 		ID: &id,
 	})
@@ -234,12 +239,17 @@ func (h *handler) books(c echo.Context) error {
 		}
 	}
 
-	books, err := h.tagService.GetBooks(ctx, id)
+	books, total, err := h.tagService.GetBooksPaginated(ctx, id, params.Limit, params.Offset)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, books))
+	response := map[string]any{
+		"items": books,
+		"total": total,
+	}
+
+	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
 
 func (h *handler) merge(c echo.Context) error {

--- a/pkg/tags/handlers_test.go
+++ b/pkg/tags/handlers_test.go
@@ -1,0 +1,227 @@
+package tags
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/search"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+// setupHandlerTestDB creates an in-memory SQLite database using a named memory
+// URI so that Bun's ScanAndCount (which opens a second connection for the COUNT
+// query) sees the same database. Plain ":memory:" gives each connection its own
+// private database, which causes "no such table" errors from ScanAndCount.
+func setupHandlerTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+func newTestEcho(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	return e
+}
+
+func newTestHandler(db *bun.DB) *handler {
+	return &handler{
+		tagService:    NewService(db),
+		aliasService:  aliases.NewService(db),
+		searchService: search.NewService(db),
+	}
+}
+
+func seedTagWithBooks(t *testing.T, db *bun.DB, lib *models.Library, tagName string, bookTitles []string) *models.Tag {
+	t.Helper()
+	ctx := context.Background()
+
+	tag := &models.Tag{LibraryID: lib.ID, Name: tagName}
+	_, err := db.NewInsert().Model(tag).Exec(ctx)
+	require.NoError(t, err)
+
+	for _, title := range bookTitles {
+		book := &models.Book{
+			LibraryID:       lib.ID,
+			Title:           title,
+			TitleSource:     models.DataSourceFilepath,
+			SortTitle:       title,
+			SortTitleSource: models.DataSourceFilepath,
+			AuthorSource:    models.DataSourceFilepath,
+			Filepath:        t.TempDir(),
+		}
+		_, err := db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+
+		bt := &models.BookTag{BookID: book.ID, TagID: tag.ID}
+		_, err = db.NewInsert().Model(bt).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	return tag
+}
+
+func TestBooks_DefaultPagination(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	tag := seedTagWithBooks(t, db, lib, "Fantasy", []string{"Book A", "Book B", "Book C"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(tag.ID))
+
+	err := h.books(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 3)
+}
+
+func TestBooks_ExplicitLimitOffset(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	tag := seedTagWithBooks(t, db, lib, "Sci-Fi", []string{"B1", "B2", "B3", "B4", "B5"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/?limit=2&offset=1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(tag.ID))
+
+	err := h.books(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 5, total)
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}
+
+func TestBooks_ResponseShape(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	tag := seedTagWithBooks(t, db, lib, "Horror", []string{"H1"})
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(tag.ID))
+
+	err := h.books(c)
+	require.NoError(t, err)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Len(t, resp, 2, "response should have exactly 2 keys")
+	assert.Contains(t, resp, "items")
+	assert.Contains(t, resp, "total")
+}
+
+func TestList_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		tag := &models.Tag{LibraryID: lib.ID, Name: fmt.Sprintf("Tag %d", i)}
+		_, err := db.NewInsert().Model(tag).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := h.list(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	assert.Contains(t, resp, "items", "response should use 'items' key")
+	assert.NotContains(t, resp, "tags", "response should not use 'tags' key")
+	assert.Contains(t, resp, "total")
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}

--- a/pkg/tags/service.go
+++ b/pkg/tags/service.go
@@ -249,6 +249,25 @@ func (svc *Service) GetBooks(ctx context.Context, tagID int) ([]*models.Book, er
 	return books, nil
 }
 
+// GetBooksPaginated returns a paginated list of books with this tag.
+func (svc *Service) GetBooksPaginated(ctx context.Context, tagID, limit, offset int) ([]*models.Book, int, error) {
+	var books []*models.Book
+
+	total, err := svc.db.NewSelect().
+		Model(&books).
+		Join("INNER JOIN book_tags bt ON bt.book_id = b.id").
+		Where("bt.tag_id = ?", tagID).
+		Order("b.title ASC").
+		Limit(limit).
+		Offset(offset).
+		ScanAndCount(ctx)
+	if err != nil {
+		return nil, 0, errors.WithStack(err)
+	}
+
+	return books, total, nil
+}
+
 // MergeTags merges sourceTag into targetTag (moves all associations, deletes source).
 func (svc *Service) MergeTags(ctx context.Context, targetID, sourceID int) error {
 	return svc.db.RunInTx(ctx, &sql.TxOptions{}, func(ctx context.Context, tx bun.Tx) error {

--- a/pkg/tags/validators.go
+++ b/pkg/tags/validators.go
@@ -7,6 +7,11 @@ type ListTagsQuery struct {
 	Search    *string `query:"search" json:"search,omitempty" validate:"omitempty,max=100" tstype:"string"`
 }
 
+type SubResourceQuery struct {
+	Limit  int `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
+	Offset int `query:"offset" json:"offset,omitempty" validate:"min=0"`
+}
+
 type UpdateTagPayload struct {
 	Name    *string  `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
 	Aliases []string `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`


### PR DESCRIPTION
Closes #237

## Summary
- Normalize all list endpoint responses to use `{"items": [...], "total": N}` instead of resource-specific keys (`books`, `series`, `genres`, `tags`, `publishers`, `imprints`, `people`)
- Add `limit`/`offset` pagination support to 6 detail sub-endpoints: genres/books, tags/books, publishers/files, imprints/files, people/authored-books, people/narrated-files
- Update all frontend query hooks, consumers, and tests to use the new `items` key and paginated sub-endpoint signatures
- Add handler tests for each paginated sub-endpoint (default pagination, explicit limit/offset, response shape, list response key)

## Test plan
- All Go handler tests pass for the 6 new paginated sub-endpoints (genres, tags, publishers, imprints, people)
- Books list handler tests updated and passing with new `items` key
- Entity-search adapter tests updated and passing with new response shape
- `mise check:quiet` passes (Go lint, Go tests, JS lint, JS unit tests, E2E chromium)