### PR TITLE
[Frontend] Build ResourceList component and migrate all list pages

### DIFF
--- a/app/components/library/ResourceList.tsx
+++ b/app/components/library/ResourceList.tsx
@@ -11,8 +11,6 @@ import { usePageTitle } from "@/hooks/usePageTitle";
 import type { useResourceListState } from "@/hooks/useResourceListState";
 import type { ResourceListResponse } from "@/types";
 
-const ITEMS_PER_PAGE = 50;
-
 interface BadgeConfig {
   label: string;
   count: number;
@@ -26,7 +24,7 @@ interface ItemConfig {
   badges: BadgeConfig[];
 }
 
-interface ResourceListProps<T> {
+interface ResourceListProps<T extends { id: number }> {
   title: string;
   subtitle: string;
   searchPlaceholder: string;
@@ -38,7 +36,7 @@ interface ResourceListProps<T> {
   maxWidth?: string;
 }
 
-const ResourceList = <T,>({
+const ResourceList = <T extends { id: number }>({
   title,
   subtitle,
   searchPlaceholder,
@@ -76,22 +74,22 @@ const ResourceList = <T,>({
     confirmedSearch !== null && debouncedSearch !== confirmedSearch;
 
   const total = query.data?.total ?? 0;
-  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
+  const totalPages = Math.ceil(total / limit);
 
-  const renderItem = (item: T, index: number) => {
+  const renderItem = (item: T) => {
     const config = itemConfig(item);
 
     return (
       <Link
         className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
-        key={index}
+        key={item.id}
         to={linkTo(item, libraryId)}
       >
         <div className="min-w-0 flex-1 mr-3">
-          <div className="flex items-baseline gap-0">
+          <div className="flex items-baseline">
             <span className="font-semibold text-lg">{config.name}</span>
             {config.secondaryText && (
-              <span className="text-sm text-muted-foreground ml-0">
+              <span className="text-sm text-muted-foreground">
                 <span className="mx-1.5 text-muted-foreground/50">·</span>
                 {config.secondaryText}
               </span>

--- a/app/components/library/ResourceList.tsx
+++ b/app/components/library/ResourceList.tsx
@@ -1,0 +1,171 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import LibraryLayout from "@/components/library/LibraryLayout";
+import LoadingSpinner from "@/components/library/LoadingSpinner";
+import PaginationFooter from "@/components/library/PaginationFooter";
+import { SearchInput } from "@/components/library/SearchInput";
+import { Badge } from "@/components/ui/badge";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import type { useResourceListState } from "@/hooks/useResourceListState";
+import type { ResourceListResponse } from "@/types";
+
+const ITEMS_PER_PAGE = 50;
+
+interface BadgeConfig {
+  label: string;
+  count: number;
+  variant?: "default" | "secondary" | "outline" | "destructive";
+}
+
+interface ItemConfig {
+  name: string;
+  secondaryText?: string;
+  aliases: string[];
+  badges: BadgeConfig[];
+}
+
+interface ResourceListProps<T> {
+  title: string;
+  subtitle: string;
+  searchPlaceholder: string;
+  query: UseQueryResult<ResourceListResponse<T>>;
+  state: ReturnType<typeof useResourceListState>;
+  itemConfig: (item: T) => ItemConfig;
+  linkTo: (item: T, libraryId: string) => string;
+  itemLabel: string;
+  maxWidth?: string;
+}
+
+const ResourceList = <T,>({
+  title,
+  subtitle,
+  searchPlaceholder,
+  query,
+  state,
+  itemConfig,
+  linkTo,
+  itemLabel,
+  maxWidth = "max-w-3xl",
+}: ResourceListProps<T>) => {
+  usePageTitle(title);
+
+  const {
+    libraryId,
+    currentPage,
+    searchQuery,
+    debouncedSearch,
+    handleDebouncedSearchChange,
+    limit,
+    offset,
+    handlePageChange,
+  } = state;
+
+  // Track the search value that produced the currently displayed data
+  const [confirmedSearch, setConfirmedSearch] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (query.isSuccess && !query.isFetching) {
+      setConfirmedSearch(debouncedSearch);
+    }
+  }, [query.isSuccess, query.isFetching, debouncedSearch]);
+
+  // Data is stale if search changed but query hasn't completed yet
+  const isStaleData =
+    confirmedSearch !== null && debouncedSearch !== confirmedSearch;
+
+  const total = query.data?.total ?? 0;
+  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
+
+  const renderItem = (item: T, index: number) => {
+    const config = itemConfig(item);
+
+    return (
+      <Link
+        className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
+        key={index}
+        to={linkTo(item, libraryId)}
+      >
+        <div className="min-w-0 flex-1 mr-3">
+          <div className="flex items-baseline gap-0">
+            <span className="font-semibold text-lg">{config.name}</span>
+            {config.secondaryText && (
+              <span className="text-sm text-muted-foreground ml-0">
+                <span className="mx-1.5 text-muted-foreground/50">·</span>
+                {config.secondaryText}
+              </span>
+            )}
+          </div>
+          {config.aliases.length > 0 && (
+            <div
+              className="text-sm text-muted-foreground truncate"
+              title={config.aliases.join(", ")}
+            >
+              {config.aliases.join(", ")}
+            </div>
+          )}
+        </div>
+        <div className="flex gap-2 shrink-0">
+          {config.badges.map((badge) => (
+            <Badge key={badge.label} variant={badge.variant ?? "secondary"}>
+              {badge.count} {badge.label}
+            </Badge>
+          ))}
+        </div>
+      </Link>
+    );
+  };
+
+  return (
+    <LibraryLayout maxWidth={maxWidth}>
+      <div className="mb-6">
+        <h1 className="text-2xl font-semibold mb-2">{title}</h1>
+        <p className="text-muted-foreground">{subtitle}</p>
+      </div>
+
+      <div className="mb-6">
+        <SearchInput
+          initialValue={searchQuery}
+          onDebouncedChange={handleDebouncedSearchChange}
+          placeholder={searchPlaceholder}
+        />
+      </div>
+
+      {(query.isLoading || query.isFetching || isStaleData) && (
+        <LoadingSpinner />
+      )}
+
+      {query.isSuccess && !query.isFetching && !isStaleData && (
+        <>
+          {total > 0 && (
+            <div className="mb-4 text-sm text-muted-foreground">
+              Showing {offset + 1}-{Math.min(offset + limit, total)} of {total}{" "}
+              {itemLabel}
+            </div>
+          )}
+
+          {query.data.items.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              {confirmedSearch
+                ? `No ${itemLabel} found matching your search.`
+                : `No ${itemLabel} in this library yet.`}
+            </div>
+          ) : (
+            <div className="space-y-1 mb-6">
+              {query.data.items.map(renderItem)}
+            </div>
+          )}
+
+          <PaginationFooter
+            currentPage={currentPage}
+            onPageChange={handlePageChange}
+            totalPages={totalPages}
+          />
+        </>
+      )}
+    </LibraryLayout>
+  );
+};
+
+export default ResourceList;

--- a/app/components/pages/GenresList.tsx
+++ b/app/components/pages/GenresList.tsx
@@ -1,151 +1,37 @@
-import { useEffect, useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
-
-import LibraryLayout from "@/components/library/LibraryLayout";
-import LoadingSpinner from "@/components/library/LoadingSpinner";
-import PaginationFooter from "@/components/library/PaginationFooter";
-import { SearchInput } from "@/components/library/SearchInput";
-import { Badge } from "@/components/ui/badge";
+import ResourceList from "@/components/library/ResourceList";
 import { useGenresList } from "@/hooks/queries/genres";
-import { usePageTitle } from "@/hooks/usePageTitle";
+import { useResourceListState } from "@/hooks/useResourceListState";
 import type { Genre } from "@/types";
 
-const ITEMS_PER_PAGE = 50;
-
 const GenresList = () => {
-  usePageTitle("Genres");
-
-  const { libraryId } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const searchQuery = searchParams.get("search") ?? "";
-
-  const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
-
-  const handleDebouncedSearchChange = (value: string) => {
-    setDebouncedSearch(value);
-    if (value !== searchQuery) {
-      setSearchParams((prev) => {
-        const newParams = new URLSearchParams(prev);
-        if (value) {
-          newParams.set("search", value);
-        } else {
-          newParams.delete("search");
-        }
-        newParams.set("page", "1");
-        return newParams;
-      });
-    }
-  };
-
-  const limit = ITEMS_PER_PAGE;
-  const offset = (currentPage - 1) * limit;
-
-  const genresQuery = useGenresList({
-    limit,
-    offset,
-    library_id: libraryId ? parseInt(libraryId, 10) : undefined,
-    search: debouncedSearch || undefined,
-  });
-
-  // Track the search value that produced the currently displayed data
-  const [confirmedSearch, setConfirmedSearch] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (genresQuery.isSuccess && !genresQuery.isFetching) {
-      setConfirmedSearch(debouncedSearch);
-    }
-  }, [genresQuery.isSuccess, genresQuery.isFetching, debouncedSearch]);
-
-  // Data is stale if search changed but query hasn't completed yet
-  const isStaleData =
-    confirmedSearch !== null && debouncedSearch !== confirmedSearch;
-
-  const total = genresQuery.data?.total ?? 0;
-  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
-
-  const handlePageChange = (page: number) => {
-    const newParams = new URLSearchParams(searchParams);
-    newParams.set("page", page.toString());
-    setSearchParams(newParams);
-  };
-
-  const renderGenreItem = (genre: Genre) => {
-    const bookCount = genre.book_count ?? 0;
-    const aliases = (genre.aliases as unknown as string[]) ?? [];
-
-    return (
-      <Link
-        className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
-        key={genre.id}
-        to={`/libraries/${libraryId}/genres/${genre.id}`}
-      >
-        <div className="min-w-0 flex-1 mr-3">
-          <div className="font-medium">{genre.name}</div>
-          {aliases.length > 0 && (
-            <div
-              className="text-sm text-muted-foreground truncate"
-              title={`Aliases: ${aliases.join(", ")}`}
-            >
-              Aliases: {aliases.join(", ")}
-            </div>
-          )}
-        </div>
-        <Badge className="shrink-0" variant="secondary">
-          {bookCount} book{bookCount !== 1 ? "s" : ""}
-        </Badge>
-      </Link>
-    );
-  };
+  const state = useResourceListState();
+  const query = useGenresList(state.queryParams);
 
   return (
-    <LibraryLayout maxWidth="max-w-3xl">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold mb-2">Genres</h1>
-        <p className="text-muted-foreground">Browse genres in your library</p>
-      </div>
-
-      <div className="mb-6">
-        <SearchInput
-          initialValue={searchQuery}
-          onDebouncedChange={handleDebouncedSearchChange}
-          placeholder="Search genres..."
-        />
-      </div>
-
-      {(genresQuery.isLoading || genresQuery.isFetching || isStaleData) && (
-        <LoadingSpinner />
-      )}
-
-      {genresQuery.isSuccess && !genresQuery.isFetching && !isStaleData && (
-        <>
-          {total > 0 && (
-            <div className="mb-4 text-sm text-muted-foreground">
-              Showing {offset + 1}-{Math.min(offset + limit, total)} of {total}{" "}
-              genres
-            </div>
-          )}
-
-          {genresQuery.data.items.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">
-              {confirmedSearch
-                ? "No genres found matching your search."
-                : "No genres in this library yet."}
-            </div>
-          ) : (
-            <div className="space-y-1 mb-6">
-              {genresQuery.data.items.map(renderGenreItem)}
-            </div>
-          )}
-
-          <PaginationFooter
-            currentPage={currentPage}
-            onPageChange={handlePageChange}
-            totalPages={totalPages}
-          />
-        </>
-      )}
-    </LibraryLayout>
+    <ResourceList<Genre>
+      itemConfig={(genre) => {
+        const bookCount = genre.book_count ?? 0;
+        return {
+          name: genre.name,
+          aliases: genre.aliases.map((a) => a.name),
+          badges: [
+            {
+              label: bookCount === 1 ? "book" : "books",
+              count: bookCount,
+            },
+          ],
+        };
+      }}
+      itemLabel="genres"
+      linkTo={(genre, libraryId) =>
+        `/libraries/${libraryId}/genres/${genre.id}`
+      }
+      query={query}
+      searchPlaceholder="Search genres..."
+      state={state}
+      subtitle="Browse genres in your library"
+      title="Genres"
+    />
   );
 };
 

--- a/app/components/pages/ImprintsList.tsx
+++ b/app/components/pages/ImprintsList.tsx
@@ -1,162 +1,37 @@
-import { useEffect, useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
-
-import LibraryLayout from "@/components/library/LibraryLayout";
-import { SearchInput } from "@/components/library/SearchInput";
-import { Badge } from "@/components/ui/badge";
+import ResourceList from "@/components/library/ResourceList";
 import { useImprintsList } from "@/hooks/queries/imprints";
-import { usePageTitle } from "@/hooks/usePageTitle";
+import { useResourceListState } from "@/hooks/useResourceListState";
 import type { Imprint } from "@/types";
 
-const ITEMS_PER_PAGE = 50;
-
 const ImprintsList = () => {
-  usePageTitle("Imprints");
-
-  const { libraryId } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const searchQuery = searchParams.get("search") ?? "";
-
-  const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
-
-  const handleDebouncedSearchChange = (value: string) => {
-    setDebouncedSearch(value);
-    if (value !== searchQuery) {
-      setSearchParams((prev) => {
-        const newParams = new URLSearchParams(prev);
-        if (value) {
-          newParams.set("search", value);
-        } else {
-          newParams.delete("search");
-        }
-        newParams.set("page", "1");
-        return newParams;
-      });
-    }
-  };
-
-  const limit = ITEMS_PER_PAGE;
-  const offset = (currentPage - 1) * limit;
-
-  const imprintsQuery = useImprintsList({
-    limit,
-    offset,
-    library_id: libraryId ? parseInt(libraryId, 10) : undefined,
-    search: debouncedSearch || undefined,
-  });
-
-  // Track the search value that produced the currently displayed data
-  const [confirmedSearch, setConfirmedSearch] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (imprintsQuery.isSuccess && !imprintsQuery.isFetching) {
-      setConfirmedSearch(debouncedSearch);
-    }
-  }, [imprintsQuery.isSuccess, imprintsQuery.isFetching, debouncedSearch]);
-
-  // Data is stale if search changed but query hasn't completed yet
-  const isStaleData =
-    confirmedSearch !== null && debouncedSearch !== confirmedSearch;
-
-  const total = imprintsQuery.data?.total ?? 0;
-  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
-
-  const handlePageChange = (page: number) => {
-    const newParams = new URLSearchParams(searchParams);
-    newParams.set("page", page.toString());
-    setSearchParams(newParams);
-  };
-
-  const renderImprintItem = (imprint: Imprint) => {
-    const fileCount = imprint.file_count ?? 0;
-    const aliases = (imprint.aliases as unknown as string[]) ?? [];
-
-    return (
-      <Link
-        className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
-        key={imprint.id}
-        to={`/libraries/${libraryId}/imprints/${imprint.id}`}
-      >
-        <div className="min-w-0 flex-1 mr-3">
-          <div className="font-medium">{imprint.name}</div>
-          {aliases.length > 0 && (
-            <div
-              className="text-sm text-muted-foreground truncate"
-              title={`Aliases: ${aliases.join(", ")}`}
-            >
-              Aliases: {aliases.join(", ")}
-            </div>
-          )}
-        </div>
-        <Badge className="shrink-0" variant="secondary">
-          {fileCount} file{fileCount !== 1 ? "s" : ""}
-        </Badge>
-      </Link>
-    );
-  };
+  const state = useResourceListState();
+  const query = useImprintsList(state.queryParams);
 
   return (
-    <LibraryLayout maxWidth="max-w-3xl">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold mb-2">Imprints</h1>
-        <p className="text-muted-foreground">Browse imprints in your library</p>
-      </div>
-
-      <div className="mb-6">
-        <SearchInput
-          initialValue={searchQuery}
-          onDebouncedChange={handleDebouncedSearchChange}
-          placeholder="Search imprints..."
-        />
-      </div>
-
-      {(imprintsQuery.isLoading || imprintsQuery.isFetching || isStaleData) && (
-        <div className="text-muted-foreground">Loading...</div>
-      )}
-
-      {imprintsQuery.isSuccess &&
-        !imprintsQuery.isFetching &&
-        !isStaleData &&
-        imprintsQuery.data.items.length === 0 && (
-          <div className="text-center py-8 text-muted-foreground">
-            {confirmedSearch
-              ? "No imprints found matching your search."
-              : "No imprints in this library yet."}
-          </div>
-        )}
-
-      {imprintsQuery.isSuccess &&
-        !imprintsQuery.isFetching &&
-        !isStaleData &&
-        imprintsQuery.data.items.length > 0 && (
-          <div className="space-y-1">
-            {imprintsQuery.data.items.map(renderImprintItem)}
-          </div>
-        )}
-
-      {totalPages > 1 && (
-        <div className="mt-6 flex justify-center gap-2">
-          <button
-            className="px-3 py-1 rounded-md border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            disabled={currentPage <= 1}
-            onClick={() => handlePageChange(currentPage - 1)}
-          >
-            Previous
-          </button>
-          <span className="px-3 py-1">
-            Page {currentPage} of {totalPages}
-          </span>
-          <button
-            className="px-3 py-1 rounded-md border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            disabled={currentPage >= totalPages}
-            onClick={() => handlePageChange(currentPage + 1)}
-          >
-            Next
-          </button>
-        </div>
-      )}
-    </LibraryLayout>
+    <ResourceList<Imprint>
+      itemConfig={(imprint) => {
+        const fileCount = imprint.file_count ?? 0;
+        return {
+          name: imprint.name,
+          aliases: imprint.aliases.map((a) => a.name),
+          badges: [
+            {
+              label: fileCount === 1 ? "file" : "files",
+              count: fileCount,
+            },
+          ],
+        };
+      }}
+      itemLabel="imprints"
+      linkTo={(imprint, libraryId) =>
+        `/libraries/${libraryId}/imprints/${imprint.id}`
+      }
+      query={query}
+      searchPlaceholder="Search imprints..."
+      state={state}
+      subtitle="Browse imprints in your library"
+      title="Imprints"
+    />
   );
 };
 

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -1,166 +1,61 @@
-import { useEffect, useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
-
-import LibraryLayout from "@/components/library/LibraryLayout";
-import LoadingSpinner from "@/components/library/LoadingSpinner";
-import PaginationFooter from "@/components/library/PaginationFooter";
-import { SearchInput } from "@/components/library/SearchInput";
-import { Badge } from "@/components/ui/badge";
+import ResourceList from "@/components/library/ResourceList";
 import { usePeopleList, type PersonWithCounts } from "@/hooks/queries/people";
-import { usePageTitle } from "@/hooks/usePageTitle";
-
-const ITEMS_PER_PAGE = 24;
+import { useResourceListState } from "@/hooks/useResourceListState";
 
 const PersonList = () => {
-  usePageTitle("People");
-
-  const { libraryId } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const searchQuery = searchParams.get("search") ?? "";
-  const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
-
-  const handleDebouncedSearchChange = (value: string) => {
-    setDebouncedSearch(value);
-    if (value !== searchQuery) {
-      setSearchParams((prev) => {
-        const newParams = new URLSearchParams(prev);
-        if (value) {
-          newParams.set("search", value);
-        } else {
-          newParams.delete("search");
-        }
-        newParams.set("page", "1");
-        return newParams;
-      });
-    }
-  };
-
-  const limit = ITEMS_PER_PAGE;
-  const offset = (currentPage - 1) * limit;
-
-  const peopleQuery = usePeopleList({
-    limit,
-    offset,
-    library_id: libraryId ? parseInt(libraryId, 10) : undefined,
-    search: debouncedSearch || undefined,
-  });
-
-  // Track the search value that produced the currently displayed data
-  const [confirmedSearch, setConfirmedSearch] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (peopleQuery.isSuccess && !peopleQuery.isFetching) {
-      setConfirmedSearch(debouncedSearch);
-    }
-  }, [peopleQuery.isSuccess, peopleQuery.isFetching, debouncedSearch]);
-
-  // Data is stale if search changed but query hasn't completed yet
-  const isStaleData =
-    confirmedSearch !== null && debouncedSearch !== confirmedSearch;
-
-  const totalPages = Math.ceil((peopleQuery.data?.total ?? 0) / ITEMS_PER_PAGE);
-
-  const renderPersonItem = (person: PersonWithCounts) => {
-    const totalWorks = person.authored_book_count + person.narrated_file_count;
-    const aliases = (person.aliases as unknown as string[]) ?? [];
-
-    return (
-      <Link
-        className="flex items-center justify-between p-4 rounded-md border border-border hover:bg-muted/50 transition-colors"
-        key={person.id}
-        to={`/libraries/${libraryId}/people/${person.id}`}
-      >
-        <div className="flex-1 min-w-0 mr-3">
-          <div className="font-semibold text-lg">{person.name}</div>
-          {aliases.length > 0 ? (
-            <div
-              className="text-sm text-muted-foreground truncate"
-              title={`Aliases: ${aliases.join(", ")}`}
-            >
-              Aliases: {aliases.join(", ")}
-            </div>
-          ) : (
-            person.sort_name !== person.name && (
-              <div className="text-sm text-muted-foreground">
-                {person.sort_name}
-              </div>
-            )
-          )}
-        </div>
-        <div className="flex gap-2">
-          {person.authored_book_count > 0 && (
-            <Badge variant="secondary">
-              {person.authored_book_count} book
-              {person.authored_book_count !== 1 ? "s" : ""} authored
-            </Badge>
-          )}
-          {person.narrated_file_count > 0 && (
-            <Badge variant="outline">
-              {person.narrated_file_count} file
-              {person.narrated_file_count !== 1 ? "s" : ""} narrated
-            </Badge>
-          )}
-          {totalWorks === 0 && <Badge variant="outline">No works</Badge>}
-        </div>
-      </Link>
-    );
-  };
+  const state = useResourceListState();
+  const query = usePeopleList(state.queryParams);
 
   return (
-    <LibraryLayout maxWidth="max-w-4xl">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold mb-2">People</h1>
-        <p className="text-muted-foreground">
-          Authors, narrators, and other contributors
-        </p>
-      </div>
+    <ResourceList<PersonWithCounts>
+      itemConfig={(person) => {
+        const badges = [];
+        if (person.authored_book_count > 0) {
+          badges.push({
+            label:
+              person.authored_book_count === 1
+                ? "book authored"
+                : "books authored",
+            count: person.authored_book_count,
+          });
+        }
+        if (person.narrated_file_count > 0) {
+          badges.push({
+            label:
+              person.narrated_file_count === 1
+                ? "file narrated"
+                : "files narrated",
+            count: person.narrated_file_count,
+            variant: "outline" as const,
+          });
+        }
+        if (badges.length === 0) {
+          badges.push({
+            label: "works",
+            count: 0,
+            variant: "outline" as const,
+          });
+        }
 
-      <div className="mb-6">
-        <SearchInput
-          className="max-w-md"
-          initialValue={searchQuery}
-          onDebouncedChange={handleDebouncedSearchChange}
-          placeholder="Search by name..."
-        />
-      </div>
-
-      {(peopleQuery.isLoading || peopleQuery.isFetching || isStaleData) && (
-        <LoadingSpinner />
-      )}
-
-      {peopleQuery.isSuccess && !peopleQuery.isFetching && !isStaleData && (
-        <>
-          {peopleQuery.data.total > 0 && (
-            <div className="mb-4 text-sm text-muted-foreground">
-              Showing {offset + 1}-
-              {Math.min(offset + limit, peopleQuery.data.total)} of{" "}
-              {peopleQuery.data.total} people
-            </div>
-          )}
-
-          <div className="space-y-2 mb-6">
-            {peopleQuery.data.items.length === 0 ? (
-              <div className="text-center py-8 text-muted-foreground">
-                {confirmedSearch
-                  ? "No people found matching your search."
-                  : "No people in this library yet."}
-              </div>
-            ) : (
-              peopleQuery.data.items.map(renderPersonItem)
-            )}
-          </div>
-
-          <PaginationFooter
-            buildHref={(page) =>
-              `?page=${page}${searchQuery ? `&search=${searchQuery}` : ""}`
-            }
-            currentPage={currentPage}
-            totalPages={totalPages}
-          />
-        </>
-      )}
-    </LibraryLayout>
+        return {
+          name: person.name,
+          secondaryText:
+            person.sort_name !== person.name ? person.sort_name : undefined,
+          aliases: person.aliases.map((a) => a.name),
+          badges,
+        };
+      }}
+      itemLabel="people"
+      linkTo={(person, libraryId) =>
+        `/libraries/${libraryId}/people/${person.id}`
+      }
+      maxWidth="max-w-4xl"
+      query={query}
+      searchPlaceholder="Search by name..."
+      state={state}
+      subtitle="Authors, narrators, and other contributors"
+      title="People"
+    />
   );
 };
 

--- a/app/components/pages/PublishersList.tsx
+++ b/app/components/pages/PublishersList.tsx
@@ -1,164 +1,37 @@
-import { useEffect, useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
-
-import LibraryLayout from "@/components/library/LibraryLayout";
-import { SearchInput } from "@/components/library/SearchInput";
-import { Badge } from "@/components/ui/badge";
+import ResourceList from "@/components/library/ResourceList";
 import { usePublishersList } from "@/hooks/queries/publishers";
-import { usePageTitle } from "@/hooks/usePageTitle";
+import { useResourceListState } from "@/hooks/useResourceListState";
 import type { Publisher } from "@/types";
 
-const ITEMS_PER_PAGE = 50;
-
 const PublishersList = () => {
-  usePageTitle("Publishers");
-
-  const { libraryId } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const searchQuery = searchParams.get("search") ?? "";
-
-  const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
-
-  const handleDebouncedSearchChange = (value: string) => {
-    setDebouncedSearch(value);
-    if (value !== searchQuery) {
-      setSearchParams((prev) => {
-        const newParams = new URLSearchParams(prev);
-        if (value) {
-          newParams.set("search", value);
-        } else {
-          newParams.delete("search");
-        }
-        newParams.set("page", "1");
-        return newParams;
-      });
-    }
-  };
-
-  const limit = ITEMS_PER_PAGE;
-  const offset = (currentPage - 1) * limit;
-
-  const publishersQuery = usePublishersList({
-    limit,
-    offset,
-    library_id: libraryId ? parseInt(libraryId, 10) : undefined,
-    search: debouncedSearch || undefined,
-  });
-
-  // Track the search value that produced the currently displayed data
-  const [confirmedSearch, setConfirmedSearch] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (publishersQuery.isSuccess && !publishersQuery.isFetching) {
-      setConfirmedSearch(debouncedSearch);
-    }
-  }, [publishersQuery.isSuccess, publishersQuery.isFetching, debouncedSearch]);
-
-  // Data is stale if search changed but query hasn't completed yet
-  const isStaleData =
-    confirmedSearch !== null && debouncedSearch !== confirmedSearch;
-
-  const total = publishersQuery.data?.total ?? 0;
-  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
-
-  const handlePageChange = (page: number) => {
-    const newParams = new URLSearchParams(searchParams);
-    newParams.set("page", page.toString());
-    setSearchParams(newParams);
-  };
-
-  const renderPublisherItem = (publisher: Publisher) => {
-    const fileCount = publisher.file_count ?? 0;
-    const aliases = (publisher.aliases as unknown as string[]) ?? [];
-
-    return (
-      <Link
-        className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
-        key={publisher.id}
-        to={`/libraries/${libraryId}/publishers/${publisher.id}`}
-      >
-        <div className="min-w-0 flex-1 mr-3">
-          <div className="font-medium">{publisher.name}</div>
-          {aliases.length > 0 && (
-            <div
-              className="text-sm text-muted-foreground truncate"
-              title={`Aliases: ${aliases.join(", ")}`}
-            >
-              Aliases: {aliases.join(", ")}
-            </div>
-          )}
-        </div>
-        <Badge className="shrink-0" variant="secondary">
-          {fileCount} file{fileCount !== 1 ? "s" : ""}
-        </Badge>
-      </Link>
-    );
-  };
+  const state = useResourceListState();
+  const query = usePublishersList(state.queryParams);
 
   return (
-    <LibraryLayout maxWidth="max-w-3xl">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold mb-2">Publishers</h1>
-        <p className="text-muted-foreground">
-          Browse publishers in your library
-        </p>
-      </div>
-
-      <div className="mb-6">
-        <SearchInput
-          initialValue={searchQuery}
-          onDebouncedChange={handleDebouncedSearchChange}
-          placeholder="Search publishers..."
-        />
-      </div>
-
-      {(publishersQuery.isLoading ||
-        publishersQuery.isFetching ||
-        isStaleData) && <div className="text-muted-foreground">Loading...</div>}
-
-      {publishersQuery.isSuccess &&
-        !publishersQuery.isFetching &&
-        !isStaleData &&
-        publishersQuery.data.items.length === 0 && (
-          <div className="text-center py-8 text-muted-foreground">
-            {confirmedSearch
-              ? "No publishers found matching your search."
-              : "No publishers in this library yet."}
-          </div>
-        )}
-
-      {publishersQuery.isSuccess &&
-        !publishersQuery.isFetching &&
-        !isStaleData &&
-        publishersQuery.data.items.length > 0 && (
-          <div className="space-y-1">
-            {publishersQuery.data.items.map(renderPublisherItem)}
-          </div>
-        )}
-
-      {totalPages > 1 && (
-        <div className="mt-6 flex justify-center gap-2">
-          <button
-            className="px-3 py-1 rounded-md border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            disabled={currentPage <= 1}
-            onClick={() => handlePageChange(currentPage - 1)}
-          >
-            Previous
-          </button>
-          <span className="px-3 py-1">
-            Page {currentPage} of {totalPages}
-          </span>
-          <button
-            className="px-3 py-1 rounded-md border cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            disabled={currentPage >= totalPages}
-            onClick={() => handlePageChange(currentPage + 1)}
-          >
-            Next
-          </button>
-        </div>
-      )}
-    </LibraryLayout>
+    <ResourceList<Publisher>
+      itemConfig={(publisher) => {
+        const fileCount = publisher.file_count ?? 0;
+        return {
+          name: publisher.name,
+          aliases: publisher.aliases.map((a) => a.name),
+          badges: [
+            {
+              label: fileCount === 1 ? "file" : "files",
+              count: fileCount,
+            },
+          ],
+        };
+      }}
+      itemLabel="publishers"
+      linkTo={(publisher, libraryId) =>
+        `/libraries/${libraryId}/publishers/${publisher.id}`
+      }
+      query={query}
+      searchPlaceholder="Search publishers..."
+      state={state}
+      subtitle="Browse publishers in your library"
+      title="Publishers"
+    />
   );
 };
 

--- a/app/components/pages/TagsList.tsx
+++ b/app/components/pages/TagsList.tsx
@@ -1,151 +1,35 @@
-import { useEffect, useState } from "react";
-import { Link, useParams, useSearchParams } from "react-router-dom";
-
-import LibraryLayout from "@/components/library/LibraryLayout";
-import LoadingSpinner from "@/components/library/LoadingSpinner";
-import PaginationFooter from "@/components/library/PaginationFooter";
-import { SearchInput } from "@/components/library/SearchInput";
-import { Badge } from "@/components/ui/badge";
+import ResourceList from "@/components/library/ResourceList";
 import { useTagsList } from "@/hooks/queries/tags";
-import { usePageTitle } from "@/hooks/usePageTitle";
+import { useResourceListState } from "@/hooks/useResourceListState";
 import type { Tag } from "@/types";
 
-const ITEMS_PER_PAGE = 50;
-
 const TagsList = () => {
-  usePageTitle("Tags");
-
-  const { libraryId } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const searchQuery = searchParams.get("search") ?? "";
-
-  const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
-
-  const handleDebouncedSearchChange = (value: string) => {
-    setDebouncedSearch(value);
-    if (value !== searchQuery) {
-      setSearchParams((prev) => {
-        const newParams = new URLSearchParams(prev);
-        if (value) {
-          newParams.set("search", value);
-        } else {
-          newParams.delete("search");
-        }
-        newParams.set("page", "1");
-        return newParams;
-      });
-    }
-  };
-
-  const limit = ITEMS_PER_PAGE;
-  const offset = (currentPage - 1) * limit;
-
-  const tagsQuery = useTagsList({
-    limit,
-    offset,
-    library_id: libraryId ? parseInt(libraryId, 10) : undefined,
-    search: debouncedSearch || undefined,
-  });
-
-  // Track the search value that produced the currently displayed data
-  const [confirmedSearch, setConfirmedSearch] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (tagsQuery.isSuccess && !tagsQuery.isFetching) {
-      setConfirmedSearch(debouncedSearch);
-    }
-  }, [tagsQuery.isSuccess, tagsQuery.isFetching, debouncedSearch]);
-
-  // Data is stale if search changed but query hasn't completed yet
-  const isStaleData =
-    confirmedSearch !== null && debouncedSearch !== confirmedSearch;
-
-  const total = tagsQuery.data?.total ?? 0;
-  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
-
-  const handlePageChange = (page: number) => {
-    const newParams = new URLSearchParams(searchParams);
-    newParams.set("page", page.toString());
-    setSearchParams(newParams);
-  };
-
-  const renderTagItem = (tag: Tag) => {
-    const bookCount = tag.book_count ?? 0;
-    const aliases = (tag.aliases as unknown as string[]) ?? [];
-
-    return (
-      <Link
-        className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
-        key={tag.id}
-        to={`/libraries/${libraryId}/tags/${tag.id}`}
-      >
-        <div className="min-w-0 flex-1 mr-3">
-          <div className="font-medium">{tag.name}</div>
-          {aliases.length > 0 && (
-            <div
-              className="text-sm text-muted-foreground truncate"
-              title={`Aliases: ${aliases.join(", ")}`}
-            >
-              Aliases: {aliases.join(", ")}
-            </div>
-          )}
-        </div>
-        <Badge className="shrink-0" variant="secondary">
-          {bookCount} book{bookCount !== 1 ? "s" : ""}
-        </Badge>
-      </Link>
-    );
-  };
+  const state = useResourceListState();
+  const query = useTagsList(state.queryParams);
 
   return (
-    <LibraryLayout maxWidth="max-w-3xl">
-      <div className="mb-6">
-        <h1 className="text-2xl font-semibold mb-2">Tags</h1>
-        <p className="text-muted-foreground">Browse tags in your library</p>
-      </div>
-
-      <div className="mb-6">
-        <SearchInput
-          initialValue={searchQuery}
-          onDebouncedChange={handleDebouncedSearchChange}
-          placeholder="Search tags..."
-        />
-      </div>
-
-      {(tagsQuery.isLoading || tagsQuery.isFetching || isStaleData) && (
-        <LoadingSpinner />
-      )}
-
-      {tagsQuery.isSuccess && !tagsQuery.isFetching && !isStaleData && (
-        <>
-          {total > 0 && (
-            <div className="mb-4 text-sm text-muted-foreground">
-              Showing {offset + 1}-{Math.min(offset + limit, total)} of {total}{" "}
-              tags
-            </div>
-          )}
-
-          {tagsQuery.data.items.length === 0 ? (
-            <div className="text-center py-8 text-muted-foreground">
-              {confirmedSearch
-                ? "No tags found matching your search."
-                : "No tags in this library yet."}
-            </div>
-          ) : (
-            <div className="space-y-1 mb-6">
-              {tagsQuery.data.items.map(renderTagItem)}
-            </div>
-          )}
-
-          <PaginationFooter
-            currentPage={currentPage}
-            onPageChange={handlePageChange}
-            totalPages={totalPages}
-          />
-        </>
-      )}
-    </LibraryLayout>
+    <ResourceList<Tag>
+      itemConfig={(tag) => {
+        const bookCount = tag.book_count ?? 0;
+        return {
+          name: tag.name,
+          aliases: tag.aliases.map((a) => a.name),
+          badges: [
+            {
+              label: bookCount === 1 ? "book" : "books",
+              count: bookCount,
+            },
+          ],
+        };
+      }}
+      itemLabel="tags"
+      linkTo={(tag, libraryId) => `/libraries/${libraryId}/tags/${tag.id}`}
+      query={query}
+      searchPlaceholder="Search tags..."
+      state={state}
+      subtitle="Browse tags in your library"
+      title="Tags"
+    />
   );
 };
 

--- a/app/hooks/useResourceListState.ts
+++ b/app/hooks/useResourceListState.ts
@@ -1,0 +1,71 @@
+import { useCallback, useState } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+
+const ITEMS_PER_PAGE = 50;
+
+export interface ResourceListQuery {
+  limit: number;
+  offset: number;
+  search?: string;
+  library_id?: number;
+}
+
+/** Hook that manages URL-driven search and pagination state for resource lists. */
+export function useResourceListState() {
+  const { libraryId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const searchQuery = searchParams.get("search") ?? "";
+
+  const [debouncedSearch, setDebouncedSearch] = useState(searchQuery);
+
+  const handleDebouncedSearchChange = useCallback(
+    (value: string) => {
+      setDebouncedSearch(value);
+      if (value !== searchQuery) {
+        setSearchParams((prev) => {
+          const newParams = new URLSearchParams(prev);
+          if (value) {
+            newParams.set("search", value);
+          } else {
+            newParams.delete("search");
+          }
+          newParams.set("page", "1");
+          return newParams;
+        });
+      }
+    },
+    [searchQuery, setSearchParams],
+  );
+
+  const limit = ITEMS_PER_PAGE;
+  const offset = (currentPage - 1) * limit;
+
+  const queryParams: ResourceListQuery = {
+    limit,
+    offset,
+    library_id: libraryId ? parseInt(libraryId, 10) : undefined,
+    search: debouncedSearch || undefined,
+  };
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set("page", page.toString());
+      setSearchParams(newParams);
+    },
+    [searchParams, setSearchParams],
+  );
+
+  return {
+    libraryId: libraryId ?? "",
+    currentPage,
+    searchQuery,
+    debouncedSearch,
+    handleDebouncedSearchChange,
+    queryParams,
+    limit,
+    offset,
+    handlePageChange,
+  };
+}


### PR DESCRIPTION
Closes #238

## Summary

- Built a shared `ResourceList<T>` component and `useResourceListState` hook that encapsulate all list page boilerplate: URL-driven debounced search, pagination, loading/stale/empty states, item count display ("Showing X-Y of Z"), and `PaginationFooter`
- Rewrote all five resource list pages (People, Genres, Tags, Publishers, Imprints) as thin wrappers that configure the data hook, item rendering, and routing — eliminating ~587 net lines of duplicated code
- Fixed several inconsistencies: Publishers/Imprints now use `PaginationFooter` (were raw `<button>` elements), show `LoadingSpinner` (were "Loading..." text), and display item counts
- People list now uses 50 items per page (was 24) to match all other lists
- Aliases no longer show the "Aliases:" prefix on any list page — displayed as comma-separated text with tooltip
- People list shows sort name inline (baseline-aligned, smaller/muted, dot separator) when it differs from name

## Test plan

- All 708 existing unit/component tests pass with no regressions
- 61 Chromium E2E tests pass (includes sidebar navigation to list pages)
- TypeScript, ESLint, and Prettier checks all pass
- Full `mise check:quiet` passes (all 4 pipelines)