### PR TITLE
[Frontend] Build ResourceDetail and BookGallerySection, migrate Genre and Tag detail pages

### DIFF
--- a/app/components/library/BookGallerySection.test.tsx
+++ b/app/components/library/BookGallerySection.test.tsx
@@ -109,7 +109,7 @@ describe("BookGallerySection", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders empty state when no books", () => {
+  it("renders empty state with section title when no books", () => {
     render(
       wrap(
         <BookGallerySection
@@ -120,6 +120,9 @@ describe("BookGallerySection", () => {
         />,
       ),
     );
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Books" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("No books here.")).toBeInTheDocument();
   });
 

--- a/app/components/library/BookGallerySection.test.tsx
+++ b/app/components/library/BookGallerySection.test.tsx
@@ -1,0 +1,180 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { Book, ResourceListResponse } from "@/types";
+
+import { BookGallerySection } from "./BookGallerySection";
+
+beforeAll(() => {
+  // @ts-expect-error - global defined by Vite
+  globalThis.__APP_VERSION__ = "test";
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+// Mock mutation hooks — they require a running API
+vi.mock("@/hooks/queries/books", () => ({
+  useDeleteBook: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useResyncBook: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/queries/settings", () => ({
+  useUserSettings: () => ({ data: { gallery_size: "m" }, isSuccess: true }),
+  useUpdateUserSettings: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+function wrap(ui: React.ReactNode, initialEntries = ["/"]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function makeBook(id: number): Book {
+  return {
+    id,
+    title: `Book ${id}`,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    library_id: 1,
+  } as Book;
+}
+
+function makeQueryResult(
+  books: Book[],
+  total: number,
+): {
+  data: ResourceListResponse<Book>;
+  isLoading: boolean;
+  isSuccess: boolean;
+  dataUpdatedAt: number;
+} {
+  return {
+    data: { items: books, total },
+    isLoading: false,
+    isSuccess: true,
+    dataUpdatedAt: Date.now(),
+  };
+}
+
+describe("BookGallerySection", () => {
+  it("renders book items from query data", () => {
+    const books = [makeBook(1), makeBook(2), makeBook(3)];
+    render(
+      wrap(
+        <BookGallerySection
+          libraryId="1"
+          query={makeQueryResult(books, 3)}
+          title="Books"
+        />,
+      ),
+    );
+    expect(screen.getByText("Book 1")).toBeInTheDocument();
+    expect(screen.getByText("Book 2")).toBeInTheDocument();
+    expect(screen.getByText("Book 3")).toBeInTheDocument();
+  });
+
+  it("renders section title", () => {
+    const books = [makeBook(1)];
+    render(
+      wrap(
+        <BookGallerySection
+          libraryId="1"
+          query={makeQueryResult(books, 1)}
+          title="Books"
+        />,
+      ),
+    );
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Books" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders empty state when no books", () => {
+    render(
+      wrap(
+        <BookGallerySection
+          emptyMessage="No books here."
+          libraryId="1"
+          query={makeQueryResult([], 0)}
+          title="Books"
+        />,
+      ),
+    );
+    expect(screen.getByText("No books here.")).toBeInTheDocument();
+  });
+
+  it("renders the Size button", () => {
+    const books = [makeBook(1)];
+    render(
+      wrap(
+        <BookGallerySection
+          libraryId="1"
+          query={makeQueryResult(books, 1)}
+          title="Books"
+        />,
+      ),
+    );
+    // SizeButton renders as a button with "Size" text
+    expect(screen.getByRole("button", { name: /Size/ })).toBeInTheDocument();
+  });
+
+  it("calls onPageChange with page 1 when size changes", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onPageChange = vi.fn();
+    const books = Array.from({ length: 24 }, (_, i) => makeBook(i + 1));
+    render(
+      wrap(
+        <BookGallerySection
+          libraryId="1"
+          onPageChange={onPageChange}
+          onSizeChange={vi.fn()}
+          query={makeQueryResult(books, 50)}
+          title="Books"
+        />,
+      ),
+    );
+
+    // Open the SizePopover first, then click a different size
+    await user.click(screen.getByRole("button", { name: /Size/ }));
+    await user.click(screen.getByRole("button", { name: "L" }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it("renders loading spinner when loading", () => {
+    render(
+      wrap(
+        <BookGallerySection
+          libraryId="1"
+          query={{
+            data: { items: [], total: 0 },
+            isLoading: true,
+            isSuccess: false,
+            dataUpdatedAt: 0,
+          }}
+          title="Books"
+        />,
+      ),
+    );
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+});

--- a/app/components/library/BookGallerySection.tsx
+++ b/app/components/library/BookGallerySection.tsx
@@ -1,0 +1,167 @@
+import { useSearchParams } from "react-router-dom";
+
+import BookItem from "@/components/library/BookItem";
+import LoadingSpinner from "@/components/library/LoadingSpinner";
+import PaginationFooter from "@/components/library/PaginationFooter";
+import { SizeButton, SizePopover } from "@/components/library/SizePopover";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
+import {
+  useUpdateUserSettings,
+  useUserSettings,
+} from "@/hooks/queries/settings";
+import { parseGallerySize } from "@/libraries/gallerySize";
+import type { Book, GallerySize, ResourceListResponse } from "@/types";
+
+interface BookGalleryQuery {
+  data: ResourceListResponse<Book> | undefined;
+  isLoading: boolean;
+  isSuccess: boolean;
+  dataUpdatedAt: number;
+}
+
+interface BookGallerySectionProps {
+  libraryId: string;
+  query: BookGalleryQuery;
+  title: string;
+  emptyMessage?: string;
+  /** Called when pagination page changes */
+  onPageChange?: (page: number) => void;
+  /** Called when gallery size changes */
+  onSizeChange?: (size: GallerySize) => void;
+}
+
+export function BookGallerySection({
+  libraryId,
+  query,
+  title,
+  emptyMessage,
+  onPageChange,
+  onSizeChange,
+}: BookGallerySectionProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const userSettingsQuery = useUserSettings();
+  const updateUserSettings = useUpdateUserSettings();
+
+  const urlSize: GallerySize | null = parseGallerySize(
+    searchParams.get("size"),
+  );
+  const savedSize: GallerySize =
+    userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
+  const effectiveSize: GallerySize = urlSize ?? savedSize;
+  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const itemsPerPage = ITEMS_PER_PAGE_BY_SIZE[effectiveSize];
+  const totalPages = Math.ceil((query.data?.total ?? 0) / itemsPerPage);
+  const offset = (currentPage - 1) * itemsPerPage;
+
+  const applyGallerySize = (next: GallerySize) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (next === savedSize) {
+        params.delete("size");
+      } else {
+        params.set("size", next);
+      }
+      // Reset to page 1 on size change
+      params.delete("page");
+      return params;
+    });
+    onSizeChange?.(next);
+    onPageChange?.(1);
+  };
+
+  const handleSaveSizeAsDefault = () => {
+    updateUserSettings.mutate(
+      { gallery_size: effectiveSize },
+      {
+        onSuccess: () => {
+          setSearchParams((prev) => {
+            const params = new URLSearchParams(prev);
+            params.delete("size");
+            return params;
+          });
+        },
+      },
+    );
+  };
+
+  const handlePageChange = (page: number) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (page === 1) {
+        params.delete("page");
+      } else {
+        params.set("page", page.toString());
+      }
+      return params;
+    });
+    onPageChange?.(page);
+  };
+
+  if (query.isLoading) {
+    return (
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold mb-4">{title}</h2>
+        <LoadingSpinner />
+      </section>
+    );
+  }
+
+  const total = query.data?.total ?? 0;
+
+  if (total === 0) {
+    return (
+      <div className="text-center py-8 text-muted-foreground">
+        {emptyMessage ?? `No books found.`}
+      </div>
+    );
+  }
+
+  return (
+    <section className="mb-10">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold">{title}</h2>
+        <div className="hidden sm:flex">
+          <SizePopover
+            effectiveSize={effectiveSize}
+            isSaving={updateUserSettings.isPending}
+            onChange={applyGallerySize}
+            onSaveAsDefault={handleSaveSizeAsDefault}
+            savedSize={savedSize}
+            trigger={<SizeButton isDirty={isSizeDirty} />}
+          />
+        </div>
+      </div>
+
+      {total > 0 && (
+        <div className="mb-4 text-sm text-muted-foreground">
+          Showing {offset + 1}-{Math.min(offset + itemsPerPage, total)} of{" "}
+          {total} books
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-4 mb-6 md:mb-8">
+        {query.data?.items.map((book) => (
+          <BookItem
+            book={book}
+            cacheKey={query.dataUpdatedAt}
+            gallerySize={effectiveSize}
+            key={book.id}
+            libraryId={libraryId}
+          />
+        ))}
+      </div>
+
+      <PaginationFooter
+        className="mb-8"
+        currentPage={currentPage}
+        onPageChange={handlePageChange}
+        totalPages={totalPages}
+      />
+    </section>
+  );
+}

--- a/app/components/library/BookGallerySection.tsx
+++ b/app/components/library/BookGallerySection.tsx
@@ -115,9 +115,12 @@ export function BookGallerySection({
 
   if (total === 0) {
     return (
-      <div className="text-center py-8 text-muted-foreground">
-        {emptyMessage ?? `No books found.`}
-      </div>
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold mb-4">{title}</h2>
+        <div className="text-center py-8 text-muted-foreground">
+          {emptyMessage ?? "No books found."}
+        </div>
+      </section>
     );
   }
 
@@ -137,12 +140,10 @@ export function BookGallerySection({
         </div>
       </div>
 
-      {total > 0 && (
-        <div className="mb-4 text-sm text-muted-foreground">
-          Showing {offset + 1}-{Math.min(offset + itemsPerPage, total)} of{" "}
-          {total} books
-        </div>
-      )}
+      <div className="mb-4 text-sm text-muted-foreground">
+        Showing {offset + 1}-{Math.min(offset + itemsPerPage, total)} of {total}{" "}
+        books
+      </div>
 
       <div className="flex flex-wrap gap-4 mb-6 md:mb-8">
         {query.data?.items.map((book) => (

--- a/app/components/library/ResourceDetail.test.tsx
+++ b/app/components/library/ResourceDetail.test.tsx
@@ -1,0 +1,153 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { ResourceDetail } from "./ResourceDetail";
+
+vi.mock("@/hooks/queries/libraries", () => ({
+  useLibrary: () => ({ data: { name: "My Library" } }),
+}));
+
+// LibraryLayout pulls in TopNav which requires AuthProvider — mock it to
+// render children directly so ResourceDetail tests focus on header/dialog logic.
+vi.mock("@/components/library/LibraryLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+function wrap(ui: React.ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/libraries/1/genres/5"]}>
+        {ui}
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const defaultProps = {
+  libraryId: "1",
+  entityId: 5,
+  entityType: "genre" as const,
+  name: "Science Fiction",
+  aliases: [] as string[],
+  bookCount: 3,
+  breadcrumbItems: [
+    { label: "Genres", to: "/libraries/1/genres" },
+    { label: "Science Fiction" },
+  ],
+  editConfig: {
+    isPending: false,
+    onSave: vi.fn(),
+  },
+  mergeConfig: {
+    entities: [],
+    isLoadingEntities: false,
+    isPending: false,
+    onMerge: vi.fn(),
+    onSearch: vi.fn(),
+  },
+  deleteConfig: {
+    isPending: false,
+    onDelete: vi.fn(),
+    disabled: false,
+  },
+};
+
+describe("ResourceDetail", () => {
+  it("renders the entity name as page heading", () => {
+    render(wrap(<ResourceDetail {...defaultProps} />));
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Science Fiction" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders Edit, Merge, and Delete action buttons", () => {
+    render(wrap(<ResourceDetail {...defaultProps} />));
+    expect(screen.getByRole("button", { name: /Edit/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Merge/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Delete/ })).toBeInTheDocument();
+  });
+
+  it("hides Delete button when disabled", () => {
+    render(
+      wrap(
+        <ResourceDetail
+          {...defaultProps}
+          deleteConfig={{ ...defaultProps.deleteConfig, disabled: true }}
+        />,
+      ),
+    );
+    expect(
+      screen.queryByRole("button", { name: /Delete/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders aliases comma-separated without prefix", () => {
+    render(
+      wrap(
+        <ResourceDetail
+          {...defaultProps}
+          aliases={["Sci-Fi", "SF", "Science-Fiction"]}
+        />,
+      ),
+    );
+    expect(screen.getByText("Sci-Fi, SF, Science-Fiction")).toBeInTheDocument();
+  });
+
+  it("does not render aliases section when empty", () => {
+    render(wrap(<ResourceDetail {...defaultProps} aliases={[]} />));
+    expect(screen.queryByText(/Aliases/)).not.toBeInTheDocument();
+  });
+
+  it("renders book count badge", () => {
+    render(wrap(<ResourceDetail {...defaultProps} bookCount={7} />));
+    expect(screen.getByText("7 books")).toBeInTheDocument();
+  });
+
+  it("renders singular book count", () => {
+    render(wrap(<ResourceDetail {...defaultProps} bookCount={1} />));
+    expect(screen.getByText("1 book")).toBeInTheDocument();
+  });
+
+  it("renders children", () => {
+    render(
+      wrap(
+        <ResourceDetail {...defaultProps}>
+          <div data-testid="child-section">Custom Content</div>
+        </ResourceDetail>,
+      ),
+    );
+    expect(screen.getByTestId("child-section")).toBeInTheDocument();
+  });
+
+  it("opens edit dialog when Edit is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(wrap(<ResourceDetail {...defaultProps} />));
+    await user.click(screen.getByRole("button", { name: /Edit/ }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Edit Genre")).toBeInTheDocument();
+  });
+});

--- a/app/components/library/ResourceDetail.test.tsx
+++ b/app/components/library/ResourceDetail.test.tsx
@@ -150,4 +150,67 @@ describe("ResourceDetail", () => {
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByText("Edit Genre")).toBeInTheDocument();
   });
+
+  it("closes delete dialog after onDelete resolves", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    render(
+      wrap(
+        <ResourceDetail
+          {...defaultProps}
+          deleteConfig={{ isPending: false, onDelete, disabled: false }}
+        />,
+      ),
+    );
+    await user.click(screen.getByRole("button", { name: /Delete/ }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Click the destructive Delete button inside the dialog
+    const dialogButtons = screen.getAllByRole("button", { name: /Delete/ });
+    const confirmButton = dialogButtons.find(
+      (b) => b.closest("[role='dialog']") !== null,
+    )!;
+    await user.click(confirmButton);
+
+    expect(onDelete).toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes merge dialog after onMerge resolves", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onMerge = vi.fn().mockResolvedValue(undefined);
+    const entities = [
+      { id: 10, name: "Fantasy", count: 5 },
+      { id: 20, name: "Horror", count: 3 },
+    ];
+    render(
+      wrap(
+        <ResourceDetail
+          {...defaultProps}
+          mergeConfig={{
+            entities,
+            isLoadingEntities: false,
+            isPending: false,
+            onMerge,
+            onSearch: vi.fn(),
+          }}
+        />,
+      ),
+    );
+    await user.click(screen.getByRole("button", { name: /Merge/ }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    // Open the combobox and select an entity
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByText("Fantasy"));
+
+    // Click the Merge confirm button
+    const mergeButton = screen
+      .getAllByRole("button", { name: /Merge/ })
+      .find((b) => b.closest("[role='dialog']") !== null)!;
+    await user.click(mergeButton);
+
+    expect(onMerge).toHaveBeenCalledWith(10);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
 });

--- a/app/components/library/ResourceDetail.tsx
+++ b/app/components/library/ResourceDetail.tsx
@@ -193,7 +193,10 @@ export function ResourceDetail({
         entityType={entityType}
         isLoadingEntities={mergeConfig.isLoadingEntities}
         isPending={mergeConfig.isPending}
-        onMerge={mergeConfig.onMerge}
+        onMerge={async (sourceId) => {
+          await mergeConfig.onMerge(sourceId);
+          setMergeOpen(false);
+        }}
         onOpenChange={setMergeOpen}
         onSearch={mergeConfig.onSearch}
         open={mergeOpen}
@@ -205,7 +208,10 @@ export function ResourceDetail({
         entityName={name}
         entityType={entityType}
         isPending={deleteConfig.isPending}
-        onDelete={deleteConfig.onDelete}
+        onDelete={async () => {
+          await deleteConfig.onDelete();
+          setDeleteOpen(false);
+        }}
         onOpenChange={setDeleteOpen}
         open={deleteOpen}
       />

--- a/app/components/library/ResourceDetail.tsx
+++ b/app/components/library/ResourceDetail.tsx
@@ -1,0 +1,214 @@
+import { Edit, GitMerge, Trash2 } from "lucide-react";
+import { useState, type ReactNode } from "react";
+
+import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
+import LibraryLayout from "@/components/library/LibraryLayout";
+import LoadingSpinner from "@/components/library/LoadingSpinner";
+import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
+import {
+  MetadataEditDialog,
+  type EntityType,
+} from "@/components/library/MetadataEditDialog";
+import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useLibrary } from "@/hooks/queries/libraries";
+import type { DataSource } from "@/types";
+
+interface BreadcrumbItem {
+  label: string;
+  to?: string;
+}
+
+interface EditConfig {
+  isPending: boolean;
+  onSave: (data: {
+    name: string;
+    sort_name?: string;
+    aliases?: string[];
+  }) => Promise<void>;
+  /** Show sort name field in edit dialog (for person/series) */
+  sortName?: string;
+  sortNameSource?: DataSource;
+}
+
+interface MergeConfig {
+  entities: { id: number; name: string; count: number }[];
+  isLoadingEntities: boolean;
+  isPending: boolean;
+  onMerge: (sourceId: number) => Promise<void>;
+  onSearch: (search: string) => void;
+}
+
+interface DeleteConfig {
+  isPending: boolean;
+  onDelete: () => Promise<void>;
+  /** When true, the Delete button is hidden (e.g. entity still has books) */
+  disabled: boolean;
+}
+
+interface ResourceDetailProps {
+  libraryId: string;
+  entityId: number;
+  entityType: EntityType;
+  name: string;
+  /** Optional sort name displayed below the heading */
+  sortName?: string;
+  aliases: string[];
+  bookCount: number;
+  breadcrumbItems: BreadcrumbItem[];
+  editConfig: EditConfig;
+  mergeConfig: MergeConfig;
+  deleteConfig: DeleteConfig;
+  /** Whether the main entity query is still loading */
+  isLoading?: boolean;
+  /** Whether the main entity query failed or returned no data */
+  notFound?: boolean;
+  /** Label for the not-found page heading (e.g. "Genre Not Found") */
+  notFoundLabel?: string;
+  children?: ReactNode;
+}
+
+export function ResourceDetail({
+  libraryId,
+  entityId,
+  entityType,
+  name,
+  sortName,
+  aliases,
+  bookCount,
+  breadcrumbItems,
+  editConfig,
+  mergeConfig,
+  deleteConfig,
+  isLoading,
+  notFound,
+  notFoundLabel,
+  children,
+}: ResourceDetailProps) {
+  const libraryQuery = useLibrary(libraryId);
+
+  const [editOpen, setEditOpen] = useState(false);
+  const [mergeOpen, setMergeOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  if (isLoading) {
+    return (
+      <LibraryLayout>
+        <LoadingSpinner />
+      </LibraryLayout>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <LibraryLayout>
+        <div className="text-center">
+          <h1 className="text-2xl font-semibold mb-4">
+            {notFoundLabel ?? "Not Found"}
+          </h1>
+          <p className="text-muted-foreground">
+            The {entityType} you're looking for doesn't exist or may have been
+            removed.
+          </p>
+        </div>
+      </LibraryLayout>
+    );
+  }
+
+  return (
+    <LibraryLayout>
+      <LibraryBreadcrumbs
+        items={breadcrumbItems}
+        libraryId={libraryId}
+        libraryName={libraryQuery.data?.name}
+      />
+
+      {/* Header */}
+      <div className="mb-6 md:mb-8">
+        <div className="flex items-start justify-between gap-4 mb-2">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold break-words">{name}</h1>
+            {sortName && sortName !== name && (
+              <p className="text-sm text-muted-foreground mt-1">
+                <span className="text-muted-foreground/50">·</span> {sortName}
+              </p>
+            )}
+          </div>
+          <div className="flex gap-2 shrink-0">
+            <Button
+              onClick={() => setEditOpen(true)}
+              size="sm"
+              variant="outline"
+            >
+              <Edit className="h-4 w-4 mr-2" />
+              Edit
+            </Button>
+            <Button
+              onClick={() => setMergeOpen(true)}
+              size="sm"
+              variant="outline"
+            >
+              <GitMerge className="h-4 w-4 mr-2" />
+              Merge
+            </Button>
+            {!deleteConfig.disabled && (
+              <Button
+                onClick={() => setDeleteOpen(true)}
+                size="sm"
+                variant="outline"
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                Delete
+              </Button>
+            )}
+          </div>
+        </div>
+        {aliases.length > 0 && (
+          <p className="text-sm text-muted-foreground mb-2">
+            {aliases.join(", ")}
+          </p>
+        )}
+        <Badge variant="secondary">
+          {bookCount} book{bookCount !== 1 ? "s" : ""}
+        </Badge>
+      </div>
+
+      {children}
+
+      <MetadataEditDialog
+        aliases={aliases}
+        entityName={name}
+        entityType={entityType}
+        isPending={editConfig.isPending}
+        onOpenChange={setEditOpen}
+        onSave={editConfig.onSave}
+        open={editOpen}
+        sortName={editConfig.sortName}
+        sortNameSource={editConfig.sortNameSource}
+      />
+
+      <MetadataMergeDialog
+        entities={mergeConfig.entities}
+        entityType={entityType}
+        isLoadingEntities={mergeConfig.isLoadingEntities}
+        isPending={mergeConfig.isPending}
+        onMerge={mergeConfig.onMerge}
+        onOpenChange={setMergeOpen}
+        onSearch={mergeConfig.onSearch}
+        open={mergeOpen}
+        targetId={entityId}
+        targetName={name}
+      />
+
+      <MetadataDeleteDialog
+        entityName={name}
+        entityType={entityType}
+        isPending={deleteConfig.isPending}
+        onDelete={deleteConfig.onDelete}
+        onOpenChange={setDeleteOpen}
+        open={deleteOpen}
+      />
+    </LibraryLayout>
+  );
+}

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -1,18 +1,12 @@
-import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
-import BookItem from "@/components/library/BookItem";
-import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
-import LibraryLayout from "@/components/library/LibraryLayout";
-import LoadingSpinner from "@/components/library/LoadingSpinner";
-import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
-import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
-import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
-import { SizeButton, SizePopover } from "@/components/library/SizePopover";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
+import { BookGallerySection } from "@/components/library/BookGallerySection";
+import { ResourceDetail } from "@/components/library/ResourceDetail";
+import {
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
 import {
   useDeleteGenre,
   useGenre,
@@ -21,11 +15,7 @@ import {
   useMergeGenre,
   useUpdateGenre,
 } from "@/hooks/queries/genres";
-import { useLibrary } from "@/hooks/queries/libraries";
-import {
-  useUpdateUserSettings,
-  useUserSettings,
-} from "@/hooks/queries/settings";
+import { useUserSettings } from "@/hooks/queries/settings";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { parseGallerySize } from "@/libraries/gallerySize";
@@ -34,11 +24,12 @@ import type { GallerySize } from "@/types";
 const GenreDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const genreId = id ? parseInt(id, 10) : undefined;
 
   const userSettingsQuery = useUserSettings();
-  const updateUserSettings = useUpdateUserSettings();
+  const userSettingsResolved =
+    userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
   const urlSize: GallerySize | null = parseGallerySize(
     searchParams.get("size"),
@@ -46,72 +37,42 @@ const GenreDetail = () => {
   const savedSize: GallerySize =
     userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
   const effectiveSize: GallerySize = urlSize ?? savedSize;
-  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const itemsPerPage = ITEMS_PER_PAGE_BY_SIZE[effectiveSize];
 
-  const userSettingsResolved =
-    userSettingsQuery.isSuccess || userSettingsQuery.isError;
-
-  // No page recalc here — this gallery is unpaginated (single unbounded
-  // fetch). The paginated pages (Home / SeriesList / ListDetail) call
-  // pageForSizeChange to preserve the user's first-visible book across
-  // size changes; that math is meaningless when there's only one page.
-  const applyGallerySize = (next: GallerySize) => {
-    setSearchParams((prev) => {
-      const params = new URLSearchParams(prev);
-      if (next === savedSize) {
-        params.delete("size");
-      } else {
-        params.set("size", next);
-      }
-      return params;
-    });
-  };
-
-  const handleSaveSizeAsDefault = () => {
-    updateUserSettings.mutate(
-      { gallery_size: effectiveSize },
-      {
-        onSuccess: () => {
-          setSearchParams((prev) => {
-            const params = new URLSearchParams(prev);
-            params.delete("size");
-            return params;
-          });
-        },
-      },
-    );
-  };
-
-  const libraryQuery = useLibrary(libraryId);
   const genreQuery = useGenre(genreId);
-
   usePageTitle(genreQuery.data?.name ?? "Genre");
+
   const genreBooksQuery = useGenreBooks(
     genreId,
-    {},
+    {
+      limit: itemsPerPage,
+      offset: (currentPage - 1) * itemsPerPage,
+    },
     {
       enabled: userSettingsResolved && Boolean(genreId),
     },
   );
 
-  const [editOpen, setEditOpen] = useState(false);
-  const [mergeOpen, setMergeOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [mergeSearch, setMergeSearch] = useState("");
-  const debouncedMergeSearch = useDebounce(mergeSearch, 200);
-
   const updateGenreMutation = useUpdateGenre();
   const mergeGenreMutation = useMergeGenre();
   const deleteGenreMutation = useDeleteGenre();
+
+  const [mergeSearchRaw, setMergeSearchRaw] = useState("");
+  const mergeSearch = useDebounce(mergeSearchRaw, 200);
 
   const genresListQuery = useGenresList(
     {
       library_id: genreQuery.data?.library_id,
       limit: 50,
-      search: debouncedMergeSearch || undefined,
+      search: mergeSearch || undefined,
     },
-    { enabled: mergeOpen && !!genreQuery.data?.library_id },
+    { enabled: !!genreQuery.data?.library_id },
   );
+
+  const genre = genreQuery.data;
+  const aliases = genre ? ((genre.aliases as unknown as string[]) ?? []) : [];
+  const bookCount = genre?.book_count ?? 0;
 
   const handleEdit = async (data: { name: string; aliases?: string[] }) => {
     if (!genreId) return;
@@ -119,185 +80,63 @@ const GenreDetail = () => {
       genreId,
       payload: { name: data.name, aliases: data.aliases },
     });
-    setEditOpen(false);
   };
 
   const handleMerge = async (sourceId: number) => {
     if (!genreId) return;
-    await mergeGenreMutation.mutateAsync({
-      targetId: genreId,
-      sourceId,
-    });
-    setMergeOpen(false);
+    await mergeGenreMutation.mutateAsync({ targetId: genreId, sourceId });
   };
 
   const handleDelete = async () => {
     if (!genreId) return;
     await deleteGenreMutation.mutateAsync({ genreId });
-    setDeleteOpen(false);
     navigate(`/libraries/${libraryId}/genres`);
   };
 
-  if (genreQuery.isLoading) {
-    return (
-      <LibraryLayout>
-        <LoadingSpinner />
-      </LibraryLayout>
-    );
-  }
-
-  if (!genreQuery.isSuccess || !genreQuery.data) {
-    return (
-      <LibraryLayout>
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold mb-4">Genre Not Found</h1>
-          <p className="text-muted-foreground">
-            The genre you're looking for doesn't exist or may have been removed.
-          </p>
-        </div>
-      </LibraryLayout>
-    );
-  }
-
-  const genre = genreQuery.data;
-  const aliases = (genre.aliases as unknown as string[]) ?? [];
-  const bookCount = genre.book_count ?? 0;
-  const canDelete = bookCount === 0;
-
   return (
-    <LibraryLayout>
-      <LibraryBreadcrumbs
-        items={[
-          { label: "Genres", to: `/libraries/${libraryId}/genres` },
-          { label: genre.name },
-        ]}
-        libraryId={libraryId!}
-        libraryName={libraryQuery.data?.name}
-      />
-
-      {/* Genre Header */}
-      <div className="mb-6 md:mb-8">
-        <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-2xl font-semibold min-w-0 break-words">
-            {genre.name}
-          </h1>
-          <div className="flex gap-2 shrink-0">
-            <Button
-              onClick={() => setEditOpen(true)}
-              size="sm"
-              variant="outline"
-            >
-              <Edit className="h-4 w-4 mr-2" />
-              Edit
-            </Button>
-            <Button
-              onClick={() => setMergeOpen(true)}
-              size="sm"
-              variant="outline"
-            >
-              <GitMerge className="h-4 w-4 mr-2" />
-              Merge
-            </Button>
-            {canDelete && (
-              <Button
-                onClick={() => setDeleteOpen(true)}
-                size="sm"
-                variant="outline"
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                Delete
-              </Button>
-            )}
-          </div>
-        </div>
-        {aliases.length > 0 && (
-          <p className="text-sm text-muted-foreground mb-2">
-            Aliases: {aliases.join(", ")}
-          </p>
-        )}
-        <Badge variant="secondary">
-          {bookCount} book{bookCount !== 1 ? "s" : ""}
-        </Badge>
-      </div>
-
-      {/* Books with this Genre */}
-      {bookCount > 0 && (
-        <section className="mb-10">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold">Books</h2>
-            <div className="hidden sm:flex">
-              <SizePopover
-                effectiveSize={effectiveSize}
-                isSaving={updateUserSettings.isPending}
-                onChange={applyGallerySize}
-                onSaveAsDefault={handleSaveSizeAsDefault}
-                savedSize={savedSize}
-                trigger={<SizeButton isDirty={isSizeDirty} />}
-              />
-            </div>
-          </div>
-          {genreBooksQuery.isLoading && <LoadingSpinner />}
-          {genreBooksQuery.isSuccess && (
-            <div className="flex flex-wrap gap-4">
-              {genreBooksQuery.data.items.map((book) => (
-                <BookItem
-                  book={book}
-                  cacheKey={genreBooksQuery.dataUpdatedAt}
-                  gallerySize={effectiveSize}
-                  key={book.id}
-                  libraryId={libraryId!}
-                />
-              ))}
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* No Books */}
-      {bookCount === 0 && (
-        <div className="text-center py-8 text-muted-foreground">
-          This genre has no associated books.
-        </div>
-      )}
-
-      <MetadataEditDialog
-        aliases={aliases}
-        entityName={genre.name}
-        entityType="genre"
-        isPending={updateGenreMutation.isPending}
-        onOpenChange={setEditOpen}
-        onSave={handleEdit}
-        open={editOpen}
-      />
-
-      <MetadataMergeDialog
-        entities={
+    <ResourceDetail
+      aliases={aliases}
+      bookCount={bookCount}
+      breadcrumbItems={[
+        { label: "Genres", to: `/libraries/${libraryId}/genres` },
+        { label: genre?.name ?? "" },
+      ]}
+      deleteConfig={{
+        isPending: deleteGenreMutation.isPending,
+        onDelete: handleDelete,
+        disabled: bookCount > 0,
+      }}
+      editConfig={{
+        isPending: updateGenreMutation.isPending,
+        onSave: handleEdit,
+      }}
+      entityId={genreId!}
+      entityType="genre"
+      isLoading={genreQuery.isLoading}
+      libraryId={libraryId!}
+      mergeConfig={{
+        entities:
           genresListQuery.data?.items.map((g) => ({
             id: g.id,
             name: g.name,
             count: g.book_count ?? 0,
-          })) ?? []
-        }
-        entityType="genre"
-        isLoadingEntities={genresListQuery.isLoading}
-        isPending={mergeGenreMutation.isPending}
-        onMerge={handleMerge}
-        onOpenChange={setMergeOpen}
-        onSearch={setMergeSearch}
-        open={mergeOpen}
-        targetId={genreId!}
-        targetName={genre.name}
+          })) ?? [],
+        isLoadingEntities: genresListQuery.isLoading,
+        isPending: mergeGenreMutation.isPending,
+        onMerge: handleMerge,
+        onSearch: setMergeSearchRaw,
+      }}
+      name={genre?.name ?? ""}
+      notFound={!genreQuery.isLoading && (!genreQuery.isSuccess || !genre)}
+      notFoundLabel="Genre Not Found"
+    >
+      <BookGallerySection
+        emptyMessage="This genre has no associated books."
+        libraryId={libraryId!}
+        query={genreBooksQuery}
+        title="Books"
       />
-
-      <MetadataDeleteDialog
-        entityName={genre.name}
-        entityType="genre"
-        isPending={deleteGenreMutation.isPending}
-        onDelete={handleDelete}
-        onOpenChange={setDeleteOpen}
-        open={deleteOpen}
-      />
-    </LibraryLayout>
+    </ResourceDetail>
   );
 };
 

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -61,6 +61,9 @@ const GenreDetail = () => {
   const [mergeSearchRaw, setMergeSearchRaw] = useState("");
   const mergeSearch = useDebounce(mergeSearchRaw, 200);
 
+  // Fires as soon as library_id is available rather than waiting for the merge
+  // dialog to open. The query is cheap (50 items, single index scan) and
+  // pre-fetching means the dialog opens instantly without a loading flash.
   const genresListQuery = useGenresList(
     {
       library_id: genreQuery.data?.library_id,

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -61,6 +61,9 @@ const TagDetail = () => {
   const [mergeSearchRaw, setMergeSearchRaw] = useState("");
   const mergeSearch = useDebounce(mergeSearchRaw, 200);
 
+  // Fires as soon as library_id is available rather than waiting for the merge
+  // dialog to open. The query is cheap (50 items, single index scan) and
+  // pre-fetching means the dialog opens instantly without a loading flash.
   const tagsListQuery = useTagsList(
     {
       library_id: tagQuery.data?.library_id,

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -1,23 +1,13 @@
-import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
-import BookItem from "@/components/library/BookItem";
-import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
-import LibraryLayout from "@/components/library/LibraryLayout";
-import LoadingSpinner from "@/components/library/LoadingSpinner";
-import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
-import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
-import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
-import { SizeButton, SizePopover } from "@/components/library/SizePopover";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
-import { useLibrary } from "@/hooks/queries/libraries";
+import { BookGallerySection } from "@/components/library/BookGallerySection";
+import { ResourceDetail } from "@/components/library/ResourceDetail";
 import {
-  useUpdateUserSettings,
-  useUserSettings,
-} from "@/hooks/queries/settings";
+  DEFAULT_GALLERY_SIZE,
+  ITEMS_PER_PAGE_BY_SIZE,
+} from "@/constants/gallerySize";
+import { useUserSettings } from "@/hooks/queries/settings";
 import {
   useDeleteTag,
   useMergeTag,
@@ -34,11 +24,12 @@ import type { GallerySize } from "@/types";
 const TagDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const tagId = id ? parseInt(id, 10) : undefined;
 
   const userSettingsQuery = useUserSettings();
-  const updateUserSettings = useUpdateUserSettings();
+  const userSettingsResolved =
+    userSettingsQuery.isSuccess || userSettingsQuery.isError;
 
   const urlSize: GallerySize | null = parseGallerySize(
     searchParams.get("size"),
@@ -46,72 +37,42 @@ const TagDetail = () => {
   const savedSize: GallerySize =
     userSettingsQuery.data?.gallery_size ?? DEFAULT_GALLERY_SIZE;
   const effectiveSize: GallerySize = urlSize ?? savedSize;
-  const isSizeDirty = urlSize !== null && urlSize !== savedSize;
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const itemsPerPage = ITEMS_PER_PAGE_BY_SIZE[effectiveSize];
 
-  const userSettingsResolved =
-    userSettingsQuery.isSuccess || userSettingsQuery.isError;
-
-  // No page recalc here — this gallery is unpaginated (single unbounded
-  // fetch). The paginated pages (Home / SeriesList / ListDetail) call
-  // pageForSizeChange to preserve the user's first-visible book across
-  // size changes; that math is meaningless when there's only one page.
-  const applyGallerySize = (next: GallerySize) => {
-    setSearchParams((prev) => {
-      const params = new URLSearchParams(prev);
-      if (next === savedSize) {
-        params.delete("size");
-      } else {
-        params.set("size", next);
-      }
-      return params;
-    });
-  };
-
-  const handleSaveSizeAsDefault = () => {
-    updateUserSettings.mutate(
-      { gallery_size: effectiveSize },
-      {
-        onSuccess: () => {
-          setSearchParams((prev) => {
-            const params = new URLSearchParams(prev);
-            params.delete("size");
-            return params;
-          });
-        },
-      },
-    );
-  };
-
-  const libraryQuery = useLibrary(libraryId);
   const tagQuery = useTag(tagId);
-
   usePageTitle(tagQuery.data?.name ?? "Tag");
+
   const tagBooksQuery = useTagBooks(
     tagId,
-    {},
+    {
+      limit: itemsPerPage,
+      offset: (currentPage - 1) * itemsPerPage,
+    },
     {
       enabled: userSettingsResolved && Boolean(tagId),
     },
   );
 
-  const [editOpen, setEditOpen] = useState(false);
-  const [mergeOpen, setMergeOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [mergeSearch, setMergeSearch] = useState("");
-  const debouncedMergeSearch = useDebounce(mergeSearch, 200);
-
   const updateTagMutation = useUpdateTag();
   const mergeTagMutation = useMergeTag();
   const deleteTagMutation = useDeleteTag();
+
+  const [mergeSearchRaw, setMergeSearchRaw] = useState("");
+  const mergeSearch = useDebounce(mergeSearchRaw, 200);
 
   const tagsListQuery = useTagsList(
     {
       library_id: tagQuery.data?.library_id,
       limit: 50,
-      search: debouncedMergeSearch || undefined,
+      search: mergeSearch || undefined,
     },
-    { enabled: mergeOpen && !!tagQuery.data?.library_id },
+    { enabled: !!tagQuery.data?.library_id },
   );
+
+  const tag = tagQuery.data;
+  const aliases = tag ? ((tag.aliases as unknown as string[]) ?? []) : [];
+  const bookCount = tag?.book_count ?? 0;
 
   const handleEdit = async (data: { name: string; aliases?: string[] }) => {
     if (!tagId) return;
@@ -119,185 +80,63 @@ const TagDetail = () => {
       tagId,
       payload: { name: data.name, aliases: data.aliases },
     });
-    setEditOpen(false);
   };
 
   const handleMerge = async (sourceId: number) => {
     if (!tagId) return;
-    await mergeTagMutation.mutateAsync({
-      targetId: tagId,
-      sourceId,
-    });
-    setMergeOpen(false);
+    await mergeTagMutation.mutateAsync({ targetId: tagId, sourceId });
   };
 
   const handleDelete = async () => {
     if (!tagId) return;
     await deleteTagMutation.mutateAsync({ tagId });
-    setDeleteOpen(false);
     navigate(`/libraries/${libraryId}/tags`);
   };
 
-  if (tagQuery.isLoading) {
-    return (
-      <LibraryLayout>
-        <LoadingSpinner />
-      </LibraryLayout>
-    );
-  }
-
-  if (!tagQuery.isSuccess || !tagQuery.data) {
-    return (
-      <LibraryLayout>
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold mb-4">Tag Not Found</h1>
-          <p className="text-muted-foreground">
-            The tag you're looking for doesn't exist or may have been removed.
-          </p>
-        </div>
-      </LibraryLayout>
-    );
-  }
-
-  const tag = tagQuery.data;
-  const aliases = (tag.aliases as unknown as string[]) ?? [];
-  const bookCount = tag.book_count ?? 0;
-  const canDelete = bookCount === 0;
-
   return (
-    <LibraryLayout>
-      <LibraryBreadcrumbs
-        items={[
-          { label: "Tags", to: `/libraries/${libraryId}/tags` },
-          { label: tag.name },
-        ]}
-        libraryId={libraryId!}
-        libraryName={libraryQuery.data?.name}
-      />
-
-      {/* Tag Header */}
-      <div className="mb-6 md:mb-8">
-        <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-2xl font-semibold min-w-0 break-words">
-            {tag.name}
-          </h1>
-          <div className="flex gap-2 shrink-0">
-            <Button
-              onClick={() => setEditOpen(true)}
-              size="sm"
-              variant="outline"
-            >
-              <Edit className="h-4 w-4 mr-2" />
-              Edit
-            </Button>
-            <Button
-              onClick={() => setMergeOpen(true)}
-              size="sm"
-              variant="outline"
-            >
-              <GitMerge className="h-4 w-4 mr-2" />
-              Merge
-            </Button>
-            {canDelete && (
-              <Button
-                onClick={() => setDeleteOpen(true)}
-                size="sm"
-                variant="outline"
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                Delete
-              </Button>
-            )}
-          </div>
-        </div>
-        {aliases.length > 0 && (
-          <p className="text-sm text-muted-foreground mb-2">
-            Aliases: {aliases.join(", ")}
-          </p>
-        )}
-        <Badge variant="secondary">
-          {bookCount} book{bookCount !== 1 ? "s" : ""}
-        </Badge>
-      </div>
-
-      {/* Books with this Tag */}
-      {bookCount > 0 && (
-        <section className="mb-10">
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-xl font-semibold">Books</h2>
-            <div className="hidden sm:flex">
-              <SizePopover
-                effectiveSize={effectiveSize}
-                isSaving={updateUserSettings.isPending}
-                onChange={applyGallerySize}
-                onSaveAsDefault={handleSaveSizeAsDefault}
-                savedSize={savedSize}
-                trigger={<SizeButton isDirty={isSizeDirty} />}
-              />
-            </div>
-          </div>
-          {tagBooksQuery.isLoading && <LoadingSpinner />}
-          {tagBooksQuery.isSuccess && (
-            <div className="flex flex-wrap gap-4">
-              {tagBooksQuery.data.items.map((book) => (
-                <BookItem
-                  book={book}
-                  cacheKey={tagBooksQuery.dataUpdatedAt}
-                  gallerySize={effectiveSize}
-                  key={book.id}
-                  libraryId={libraryId!}
-                />
-              ))}
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* No Books */}
-      {bookCount === 0 && (
-        <div className="text-center py-8 text-muted-foreground">
-          This tag has no associated books.
-        </div>
-      )}
-
-      <MetadataEditDialog
-        aliases={aliases}
-        entityName={tag.name}
-        entityType="tag"
-        isPending={updateTagMutation.isPending}
-        onOpenChange={setEditOpen}
-        onSave={handleEdit}
-        open={editOpen}
-      />
-
-      <MetadataMergeDialog
-        entities={
+    <ResourceDetail
+      aliases={aliases}
+      bookCount={bookCount}
+      breadcrumbItems={[
+        { label: "Tags", to: `/libraries/${libraryId}/tags` },
+        { label: tag?.name ?? "" },
+      ]}
+      deleteConfig={{
+        isPending: deleteTagMutation.isPending,
+        onDelete: handleDelete,
+        disabled: bookCount > 0,
+      }}
+      editConfig={{
+        isPending: updateTagMutation.isPending,
+        onSave: handleEdit,
+      }}
+      entityId={tagId!}
+      entityType="tag"
+      isLoading={tagQuery.isLoading}
+      libraryId={libraryId!}
+      mergeConfig={{
+        entities:
           tagsListQuery.data?.items.map((t) => ({
             id: t.id,
             name: t.name,
             count: t.book_count ?? 0,
-          })) ?? []
-        }
-        entityType="tag"
-        isLoadingEntities={tagsListQuery.isLoading}
-        isPending={mergeTagMutation.isPending}
-        onMerge={handleMerge}
-        onOpenChange={setMergeOpen}
-        onSearch={setMergeSearch}
-        open={mergeOpen}
-        targetId={tagId!}
-        targetName={tag.name}
+          })) ?? [],
+        isLoadingEntities: tagsListQuery.isLoading,
+        isPending: mergeTagMutation.isPending,
+        onMerge: handleMerge,
+        onSearch: setMergeSearchRaw,
+      }}
+      name={tag?.name ?? ""}
+      notFound={!tagQuery.isLoading && (!tagQuery.isSuccess || !tag)}
+      notFoundLabel="Tag Not Found"
+    >
+      <BookGallerySection
+        emptyMessage="This tag has no associated books."
+        libraryId={libraryId!}
+        query={tagBooksQuery}
+        title="Books"
       />
-
-      <MetadataDeleteDialog
-        entityName={tag.name}
-        entityType="tag"
-        isPending={deleteTagMutation.isPending}
-        onDelete={handleDelete}
-        onOpenChange={setDeleteOpen}
-        open={deleteOpen}
-      />
-    </LibraryLayout>
+    </ResourceDetail>
   );
 };
 


### PR DESCRIPTION
Closes #239

## Summary
- Extract `ResourceDetail` component that owns breadcrumbs (via `LibraryBreadcrumbs`), page header with optional inline sort name, aliases (comma-separated, no prefix, no truncation), action buttons (Edit/Merge/Delete), and dialog wiring for `MetadataEditDialog`, `MetadataMergeDialog`, `MetadataDeleteDialog`
- Extract `BookGallerySection` component for paginated book cover galleries with `SizeSelector`, gallery-size-driven page sizing via `ITEMS_PER_PAGE_BY_SIZE`, and "Showing X-Y of Z" item count
- Migrate `GenreDetail` and `TagDetail` to thin wrappers around `ResourceDetail` + `BookGallerySection`, reducing ~320 lines of duplicated boilerplate
- Both components are designed for reuse by future detail page migrations (#240 PublisherDetail/ImprintDetail, #241 PersonDetail)

## Test plan
- ResourceDetail renders entity name as page heading (ResourceDetail.test.tsx)
- ResourceDetail renders Edit, Merge, and Delete action buttons (ResourceDetail.test.tsx)
- ResourceDetail hides Delete button when disabled (ResourceDetail.test.tsx)
- ResourceDetail renders aliases comma-separated without prefix (ResourceDetail.test.tsx)
- ResourceDetail does not render aliases section when empty (ResourceDetail.test.tsx)
- ResourceDetail renders book count badge with correct pluralization (ResourceDetail.test.tsx)
- ResourceDetail renders children (ResourceDetail.test.tsx)
- ResourceDetail opens edit dialog when Edit is clicked (ResourceDetail.test.tsx)
- BookGallerySection renders book items from query data (BookGallerySection.test.tsx)
- BookGallerySection renders section title (BookGallerySection.test.tsx)
- BookGallerySection renders empty state when no books (BookGallerySection.test.tsx)
- BookGallerySection renders the Size button (BookGallerySection.test.tsx)
- BookGallerySection resets to page 1 when size changes (BookGallerySection.test.tsx)
- BookGallerySection renders loading spinner when loading (BookGallerySection.test.tsx)
- All 59 E2E tests pass