### PR TITLE
[Frontend] Build FileListSection, migrate Publisher and Imprint detail pages

### DIFF
--- a/app/components/library/FileCoverThumbnail.test.tsx
+++ b/app/components/library/FileCoverThumbnail.test.tsx
@@ -79,4 +79,32 @@ describe("FileCoverThumbnail", () => {
     );
     expect(container.querySelector("img")).not.toBeNull();
   });
+
+  it("applies interactive styles by default", () => {
+    const { container } = render(<FileCoverThumbnail file={makeFile()} />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("cursor-pointer");
+    expect(wrapper.className).toContain("hover:scale-105");
+    expect(wrapper.className).toContain("hover:shadow-md");
+  });
+
+  it("applies interactive styles when interactive is explicitly true", () => {
+    const { container } = render(
+      <FileCoverThumbnail file={makeFile()} interactive={true} />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain("cursor-pointer");
+    expect(wrapper.className).toContain("hover:scale-105");
+    expect(wrapper.className).toContain("hover:shadow-md");
+  });
+
+  it("removes interactive styles when interactive is false", () => {
+    const { container } = render(
+      <FileCoverThumbnail file={makeFile()} interactive={false} />,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).not.toContain("cursor-pointer");
+    expect(wrapper.className).not.toContain("hover:scale-105");
+    expect(wrapper.className).not.toContain("hover:shadow-md");
+  });
 });

--- a/app/components/library/FileCoverThumbnail.tsx
+++ b/app/components/library/FileCoverThumbnail.tsx
@@ -13,6 +13,11 @@ interface FileCoverThumbnailProps {
    * Typically a React Query `dataUpdatedAt` from a mutation-aware query.
    */
   cacheKey?: number;
+  /**
+   * Whether to apply interactive styles (cursor-pointer, hover:scale, hover:shadow).
+   * Defaults to true. Pass false for non-interactive contexts like file list rows.
+   */
+  interactive?: boolean;
 }
 
 /**
@@ -25,6 +30,7 @@ function FileCoverThumbnail({
   className,
   onClick,
   cacheKey,
+  interactive = true,
 }: FileCoverThumbnailProps) {
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
@@ -52,8 +58,10 @@ function FileCoverThumbnail({
   return (
     <div
       className={cn(
-        "relative overflow-hidden rounded border border-border shrink-0 cursor-pointer",
-        "transition-all duration-200 hover:scale-105 hover:shadow-md",
+        "relative overflow-hidden rounded border border-border shrink-0",
+        interactive && "cursor-pointer",
+        interactive &&
+          "transition-all duration-200 hover:scale-105 hover:shadow-md",
         aspectClass,
         className,
       )}

--- a/app/components/library/FileListSection.test.tsx
+++ b/app/components/library/FileListSection.test.tsx
@@ -1,0 +1,255 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { File, ResourceListResponse } from "@/types";
+
+import { FileListSection } from "./FileListSection";
+
+beforeAll(() => {
+  // @ts-expect-error - global defined by Vite
+  globalThis.__APP_VERSION__ = "test";
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+function wrap(ui: React.ReactNode, initialEntries = ["/"]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function makeFile(id: number, overrides: Partial<File> = {}): File {
+  return {
+    id,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    library_id: 1,
+    book_id: id * 10,
+    filepath: `/library/book-${id}.epub`,
+    file_type: "epub",
+    file_role: "main",
+    filesize_bytes: 1000,
+    cover_image_filename: "cover.jpg",
+    name: `Edition ${id}`,
+    book: {
+      id: id * 10,
+      title: `Book Title ${id}`,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+      library_id: 1,
+    },
+    ...overrides,
+  } as File;
+}
+
+function makeQueryResult(
+  files: File[],
+  total: number,
+): {
+  data: ResourceListResponse<File>;
+  isLoading: boolean;
+  isSuccess: boolean;
+  dataUpdatedAt: number;
+} {
+  return {
+    data: { items: files, total },
+    isLoading: false,
+    isSuccess: true,
+    dataUpdatedAt: Date.now(),
+  };
+}
+
+describe("FileListSection", () => {
+  it("renders section title", () => {
+    const files = [makeFile(1)];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 1)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Files" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders file name and book title for each row", () => {
+    const files = [makeFile(1), makeFile(2)];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 2)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByText("Edition 1")).toBeInTheDocument();
+    expect(screen.getByText("Edition 2")).toBeInTheDocument();
+    expect(screen.getByText("Book Title 1")).toBeInTheDocument();
+    expect(screen.getByText("Book Title 2")).toBeInTheDocument();
+  });
+
+  it("renders file type badge", () => {
+    const files = [makeFile(1, { file_type: "epub" })];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 1)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByText("EPUB")).toBeInTheDocument();
+  });
+
+  it("renders duration for audio files", () => {
+    const files = [
+      makeFile(1, {
+        file_type: "m4b",
+        audiobook_duration_seconds: 3661,
+      }),
+    ];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 1)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByText("1h 1m")).toBeInTheDocument();
+  });
+
+  it("renders page count for CBZ files", () => {
+    const files = [makeFile(1, { file_type: "cbz", page_count: 42 })];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 1)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByText("42 pages")).toBeInTheDocument();
+  });
+
+  it("renders page count for PDF files", () => {
+    const files = [makeFile(1, { file_type: "pdf", page_count: 100 })];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 1)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByText("100 pages")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no files", () => {
+    render(
+      wrap(
+        <FileListSection
+          emptyMessage="No files here."
+          libraryId="1"
+          query={makeQueryResult([], 0)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByText("No files here.")).toBeInTheDocument();
+  });
+
+  it("renders loading spinner when loading", () => {
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={{
+            data: { items: [], total: 0 },
+            isLoading: true,
+            isSuccess: false,
+            dataUpdatedAt: 0,
+          }}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("renders showing count text", () => {
+    const files = [makeFile(1), makeFile(2)];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 2)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByText(/Showing 1-2 of 2 files/)).toBeInTheDocument();
+  });
+
+  it("renders each row as a link to the parent book", () => {
+    const files = [makeFile(1)];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 1)}
+          title="Files"
+        />,
+      ),
+    );
+    const links = screen.getAllByRole("link");
+    const rowLink = links.find((link) =>
+      link.getAttribute("href")?.includes("/books/10"),
+    );
+    expect(rowLink).toBeDefined();
+  });
+
+  it("shows filename when file has no name", () => {
+    const files = [
+      makeFile(1, { name: undefined, filepath: "/library/mybook.epub" }),
+    ];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 1)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByText("mybook.epub")).toBeInTheDocument();
+  });
+});

--- a/app/components/library/FileListSection.tsx
+++ b/app/components/library/FileListSection.tsx
@@ -1,0 +1,147 @@
+import { Link, useSearchParams } from "react-router-dom";
+
+import FileCoverThumbnail from "@/components/library/FileCoverThumbnail";
+import LoadingSpinner from "@/components/library/LoadingSpinner";
+import PaginationFooter from "@/components/library/PaginationFooter";
+import { Badge } from "@/components/ui/badge";
+import type { File, ResourceListResponse } from "@/types";
+import { formatDuration, getFilename } from "@/utils/format";
+
+const ITEMS_PER_PAGE = 50;
+
+interface FileListQuery {
+  data: ResourceListResponse<File> | undefined;
+  isLoading: boolean;
+  isSuccess: boolean;
+  dataUpdatedAt: number;
+}
+
+interface FileListSectionProps {
+  libraryId: string;
+  query: FileListQuery;
+  title: string;
+  emptyMessage?: string;
+}
+
+function FileMetaInfo({ file }: { file: File }) {
+  if (
+    file.file_type === "m4b" &&
+    file.audiobook_duration_seconds != null &&
+    file.audiobook_duration_seconds > 0
+  ) {
+    return (
+      <span className="text-xs text-muted-foreground">
+        {formatDuration(file.audiobook_duration_seconds)}
+      </span>
+    );
+  }
+
+  if (
+    (file.file_type === "cbz" || file.file_type === "pdf") &&
+    file.page_count != null &&
+    file.page_count > 0
+  ) {
+    return (
+      <span className="text-xs text-muted-foreground">
+        {file.page_count} page{file.page_count !== 1 ? "s" : ""}
+      </span>
+    );
+  }
+
+  return null;
+}
+
+export function FileListSection({
+  libraryId,
+  query,
+  title,
+  emptyMessage,
+}: FileListSectionProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+  const offset = (currentPage - 1) * ITEMS_PER_PAGE;
+  const total = query.data?.total ?? 0;
+  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
+
+  const handlePageChange = (page: number) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (page === 1) {
+        params.delete("page");
+      } else {
+        params.set("page", page.toString());
+      }
+      return params;
+    });
+  };
+
+  if (query.isLoading) {
+    return (
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold mb-4">{title}</h2>
+        <LoadingSpinner />
+      </section>
+    );
+  }
+
+  if (total === 0) {
+    return (
+      <section className="mb-10">
+        <h2 className="text-xl font-semibold mb-4">{title}</h2>
+        <div className="text-center py-8 text-muted-foreground">
+          {emptyMessage ?? "No files found."}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mb-10">
+      <h2 className="text-xl font-semibold mb-4">{title}</h2>
+
+      <div className="mb-4 text-sm text-muted-foreground">
+        Showing {offset + 1}-{Math.min(offset + ITEMS_PER_PAGE, total)} of{" "}
+        {total} files
+      </div>
+
+      <div className="space-y-2 mb-6 md:mb-8">
+        {query.data?.items.map((file) => (
+          <Link
+            className="flex items-center gap-3 rounded-md border p-2 hover:bg-muted/50 transition-colors"
+            key={file.id}
+            to={`/libraries/${libraryId}/books/${file.book_id}`}
+          >
+            <div className="w-12 shrink-0">
+              <FileCoverThumbnail
+                cacheKey={query.dataUpdatedAt}
+                className="w-full"
+                file={file}
+                interactive={false}
+              />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium truncate">
+                {file.name || getFilename(file.filepath)}
+              </p>
+              <p className="text-xs text-muted-foreground truncate">
+                {file.book?.title ?? "Unknown Book"}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <FileMetaInfo file={file} />
+              <Badge variant="outline">{file.file_type?.toUpperCase()}</Badge>
+            </div>
+          </Link>
+        ))}
+      </div>
+
+      <PaginationFooter
+        className="mb-8"
+        currentPage={currentPage}
+        onPageChange={handlePageChange}
+        totalPages={totalPages}
+      />
+    </section>
+  );
+}

--- a/app/components/library/FileListSection.tsx
+++ b/app/components/library/FileListSection.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import type { File, ResourceListResponse } from "@/types";
 import { formatDuration, getFilename } from "@/utils/format";
 
-const ITEMS_PER_PAGE = 50;
+export const FILE_LIST_ITEMS_PER_PAGE = 50;
 
 interface FileListQuery {
   data: ResourceListResponse<File> | undefined;
@@ -60,9 +60,9 @@ export function FileListSection({
   const [searchParams, setSearchParams] = useSearchParams();
 
   const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
-  const offset = (currentPage - 1) * ITEMS_PER_PAGE;
+  const offset = (currentPage - 1) * FILE_LIST_ITEMS_PER_PAGE;
   const total = query.data?.total ?? 0;
-  const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
+  const totalPages = Math.ceil(total / FILE_LIST_ITEMS_PER_PAGE);
 
   const handlePageChange = (page: number) => {
     setSearchParams((prev) => {
@@ -101,8 +101,8 @@ export function FileListSection({
       <h2 className="text-xl font-semibold mb-4">{title}</h2>
 
       <div className="mb-4 text-sm text-muted-foreground">
-        Showing {offset + 1}-{Math.min(offset + ITEMS_PER_PAGE, total)} of{" "}
-        {total} files
+        Showing {offset + 1}-
+        {Math.min(offset + FILE_LIST_ITEMS_PER_PAGE, total)} of {total} files
       </div>
 
       <div className="space-y-2 mb-6 md:mb-8">

--- a/app/components/library/ResourceDetail.test.tsx
+++ b/app/components/library/ResourceDetail.test.tsx
@@ -132,6 +132,32 @@ describe("ResourceDetail", () => {
     expect(screen.getByText("1 book")).toBeInTheDocument();
   });
 
+  it("renders custom count label when provided", () => {
+    render(
+      wrap(
+        <ResourceDetail
+          {...defaultProps}
+          bookCount={5}
+          countLabel={{ singular: "file", plural: "files" }}
+        />,
+      ),
+    );
+    expect(screen.getByText("5 files")).toBeInTheDocument();
+  });
+
+  it("renders singular custom count label", () => {
+    render(
+      wrap(
+        <ResourceDetail
+          {...defaultProps}
+          bookCount={1}
+          countLabel={{ singular: "file", plural: "files" }}
+        />,
+      ),
+    );
+    expect(screen.getByText("1 file")).toBeInTheDocument();
+  });
+
   it("renders children", () => {
     render(
       wrap(

--- a/app/components/library/ResourceDetail.tsx
+++ b/app/components/library/ResourceDetail.tsx
@@ -47,6 +47,11 @@ interface DeleteConfig {
   disabled: boolean;
 }
 
+interface CountLabel {
+  singular: string;
+  plural: string;
+}
+
 interface ResourceDetailProps {
   libraryId: string;
   entityId: number;
@@ -56,6 +61,8 @@ interface ResourceDetailProps {
   sortName?: string;
   aliases: string[];
   bookCount: number;
+  /** Label for the count badge. Defaults to { singular: "book", plural: "books" } */
+  countLabel?: CountLabel;
   breadcrumbItems: BreadcrumbItem[];
   editConfig: EditConfig;
   mergeConfig: MergeConfig;
@@ -69,6 +76,8 @@ interface ResourceDetailProps {
   children?: ReactNode;
 }
 
+const DEFAULT_COUNT_LABEL: CountLabel = { singular: "book", plural: "books" };
+
 export function ResourceDetail({
   libraryId,
   entityId,
@@ -77,6 +86,7 @@ export function ResourceDetail({
   sortName,
   aliases,
   bookCount,
+  countLabel = DEFAULT_COUNT_LABEL,
   breadcrumbItems,
   editConfig,
   mergeConfig,
@@ -170,7 +180,8 @@ export function ResourceDetail({
           </p>
         )}
         <Badge variant="secondary">
-          {bookCount} book{bookCount !== 1 ? "s" : ""}
+          {bookCount}{" "}
+          {bookCount !== 1 ? countLabel.plural : countLabel.singular}
         </Badge>
       </div>
 

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -1,15 +1,8 @@
-import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
-import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
-import LibraryLayout from "@/components/library/LibraryLayout";
-import LoadingSpinner from "@/components/library/LoadingSpinner";
-import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
-import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
-import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { FileListSection } from "@/components/library/FileListSection";
+import { ResourceDetail } from "@/components/library/ResourceDetail";
 import {
   useDeleteImprint,
   useImprint,
@@ -18,40 +11,54 @@ import {
   useMergeImprint,
   useUpdateImprint,
 } from "@/hooks/queries/imprints";
-import { useLibrary } from "@/hooks/queries/libraries";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import type { File } from "@/types";
+
+const ITEMS_PER_PAGE = 50;
 
 const ImprintDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const imprintId = id ? parseInt(id, 10) : undefined;
 
-  const libraryQuery = useLibrary(libraryId);
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+
   const imprintQuery = useImprint(imprintId);
-
   usePageTitle(imprintQuery.data?.name ?? "Imprint");
-  const imprintFilesQuery = useImprintFiles(imprintId);
 
-  const [editOpen, setEditOpen] = useState(false);
-  const [mergeOpen, setMergeOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [mergeSearch, setMergeSearch] = useState("");
-  const debouncedMergeSearch = useDebounce(mergeSearch, 200);
+  const imprintFilesQuery = useImprintFiles(
+    imprintId,
+    {
+      limit: ITEMS_PER_PAGE,
+      offset: (currentPage - 1) * ITEMS_PER_PAGE,
+    },
+    { enabled: Boolean(imprintId) },
+  );
 
   const updateImprintMutation = useUpdateImprint();
   const mergeImprintMutation = useMergeImprint();
   const deleteImprintMutation = useDeleteImprint();
 
+  const [mergeSearchRaw, setMergeSearchRaw] = useState("");
+  const mergeSearch = useDebounce(mergeSearchRaw, 200);
+
+  // Pre-fetch the imprint list as soon as library_id is available so the
+  // merge dialog opens instantly without a loading flash.
   const imprintsListQuery = useImprintsList(
     {
       library_id: imprintQuery.data?.library_id,
       limit: 50,
-      search: debouncedMergeSearch || undefined,
+      search: mergeSearch || undefined,
     },
-    { enabled: mergeOpen && !!imprintQuery.data?.library_id },
+    { enabled: !!imprintQuery.data?.library_id },
   );
+
+  const imprint = imprintQuery.data;
+  const aliases = imprint
+    ? ((imprint.aliases as unknown as string[]) ?? [])
+    : [];
+  const fileCount = imprint?.file_count ?? 0;
 
   const handleEdit = async (data: { name: string; aliases?: string[] }) => {
     if (!imprintId) return;
@@ -59,7 +66,6 @@ const ImprintDetail = () => {
       imprintId,
       payload: { name: data.name, aliases: data.aliases },
     });
-    setEditOpen(false);
   };
 
   const handleMerge = async (sourceId: number) => {
@@ -68,184 +74,61 @@ const ImprintDetail = () => {
       targetId: imprintId,
       sourceId,
     });
-    setMergeOpen(false);
   };
 
   const handleDelete = async () => {
     if (!imprintId) return;
     await deleteImprintMutation.mutateAsync({ imprintId });
-    setDeleteOpen(false);
     navigate(`/libraries/${libraryId}/imprints`);
   };
 
-  if (imprintQuery.isLoading) {
-    return (
-      <LibraryLayout>
-        <LoadingSpinner />
-      </LibraryLayout>
-    );
-  }
-
-  if (!imprintQuery.isSuccess || !imprintQuery.data) {
-    return (
-      <LibraryLayout>
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold mb-4">Imprint Not Found</h1>
-          <p className="text-muted-foreground">
-            The imprint you're looking for doesn't exist or may have been
-            removed.
-          </p>
-        </div>
-      </LibraryLayout>
-    );
-  }
-
-  const imprint = imprintQuery.data;
-  const aliases = (imprint.aliases as unknown as string[]) ?? [];
-  const fileCount = imprint.file_count ?? 0;
-  const canDelete = fileCount === 0;
-
-  const getFileName = (file: File) => {
-    const parts = file.filepath.split("/");
-    return parts[parts.length - 1];
-  };
-
   return (
-    <LibraryLayout>
-      <LibraryBreadcrumbs
-        items={[
-          { label: "Imprints", to: `/libraries/${libraryId}/imprints` },
-          { label: imprint.name },
-        ]}
-        libraryId={libraryId!}
-        libraryName={libraryQuery.data?.name}
-      />
-
-      {/* Imprint Header */}
-      <div className="mb-6 md:mb-8">
-        <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-2xl font-semibold min-w-0 break-words">
-            {imprint.name}
-          </h1>
-          <div className="flex gap-2 shrink-0">
-            <Button
-              onClick={() => setEditOpen(true)}
-              size="sm"
-              variant="outline"
-            >
-              <Edit className="h-4 w-4 mr-2" />
-              Edit
-            </Button>
-            <Button
-              onClick={() => setMergeOpen(true)}
-              size="sm"
-              variant="outline"
-            >
-              <GitMerge className="h-4 w-4 mr-2" />
-              Merge
-            </Button>
-            {canDelete && (
-              <Button
-                onClick={() => setDeleteOpen(true)}
-                size="sm"
-                variant="outline"
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                Delete
-              </Button>
-            )}
-          </div>
-        </div>
-        {aliases.length > 0 && (
-          <p className="text-sm text-muted-foreground mb-2">
-            Aliases: {aliases.join(", ")}
-          </p>
-        )}
-        <Badge variant="secondary">
-          {fileCount} file{fileCount !== 1 ? "s" : ""}
-        </Badge>
-      </div>
-
-      {/* Files with this Imprint */}
-      {fileCount > 0 && (
-        <section className="mb-10">
-          <h2 className="text-xl font-semibold mb-4">Files</h2>
-          {imprintFilesQuery.isLoading && <LoadingSpinner />}
-          {imprintFilesQuery.isSuccess && (
-            <div className="space-y-3">
-              {imprintFilesQuery.data.items.map((file) => (
-                <div
-                  className="border-l-4 border-l-primary pl-4 py-2"
-                  key={file.id}
-                >
-                  <div className="flex items-center justify-between gap-4">
-                    <div className="min-w-0 flex-1">
-                      <Link
-                        className="font-medium hover:underline block truncate"
-                        to={`/libraries/${libraryId}/books/${file.book_id}`}
-                      >
-                        {file.book?.title ?? "Unknown Book"}
-                      </Link>
-                      <p className="text-sm text-muted-foreground truncate">
-                        {getFileName(file)}
-                      </p>
-                    </div>
-                    <Badge variant="outline">
-                      {file.file_type?.toUpperCase()}
-                    </Badge>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* No Files */}
-      {fileCount === 0 && (
-        <div className="text-center py-8 text-muted-foreground">
-          This imprint has no associated files.
-        </div>
-      )}
-
-      <MetadataEditDialog
-        aliases={aliases}
-        entityName={imprint.name}
-        entityType="imprint"
-        isPending={updateImprintMutation.isPending}
-        onOpenChange={setEditOpen}
-        onSave={handleEdit}
-        open={editOpen}
-      />
-
-      <MetadataMergeDialog
-        entities={
+    <ResourceDetail
+      aliases={aliases}
+      bookCount={fileCount}
+      breadcrumbItems={[
+        { label: "Imprints", to: `/libraries/${libraryId}/imprints` },
+        { label: imprint?.name ?? "" },
+      ]}
+      countLabel={{ singular: "file", plural: "files" }}
+      deleteConfig={{
+        isPending: deleteImprintMutation.isPending,
+        onDelete: handleDelete,
+        disabled: fileCount > 0,
+      }}
+      editConfig={{
+        isPending: updateImprintMutation.isPending,
+        onSave: handleEdit,
+      }}
+      entityId={imprintId!}
+      entityType="imprint"
+      isLoading={imprintQuery.isLoading}
+      libraryId={libraryId!}
+      mergeConfig={{
+        entities:
           imprintsListQuery.data?.items.map((imp) => ({
             id: imp.id,
             name: imp.name,
             count: imp.file_count ?? 0,
-          })) ?? []
-        }
-        entityType="imprint"
-        isLoadingEntities={imprintsListQuery.isLoading}
-        isPending={mergeImprintMutation.isPending}
-        onMerge={handleMerge}
-        onOpenChange={setMergeOpen}
-        onSearch={setMergeSearch}
-        open={mergeOpen}
-        targetId={imprintId!}
-        targetName={imprint.name}
+          })) ?? [],
+        isLoadingEntities: imprintsListQuery.isLoading,
+        isPending: mergeImprintMutation.isPending,
+        onMerge: handleMerge,
+        onSearch: setMergeSearchRaw,
+      }}
+      name={imprint?.name ?? ""}
+      notFound={
+        !imprintQuery.isLoading && (!imprintQuery.isSuccess || !imprint)
+      }
+      notFoundLabel="Imprint Not Found"
+    >
+      <FileListSection
+        emptyMessage="This imprint has no associated files."
+        libraryId={libraryId!}
+        query={imprintFilesQuery}
+        title="Files"
       />
-
-      <MetadataDeleteDialog
-        entityName={imprint.name}
-        entityType="imprint"
-        isPending={deleteImprintMutation.isPending}
-        onDelete={handleDelete}
-        onOpenChange={setDeleteOpen}
-        open={deleteOpen}
-      />
-    </LibraryLayout>
+    </ResourceDetail>
   );
 };
 

--- a/app/components/pages/ImprintDetail.tsx
+++ b/app/components/pages/ImprintDetail.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
-import { FileListSection } from "@/components/library/FileListSection";
+import {
+  FILE_LIST_ITEMS_PER_PAGE,
+  FileListSection,
+} from "@/components/library/FileListSection";
 import { ResourceDetail } from "@/components/library/ResourceDetail";
 import {
   useDeleteImprint,
@@ -13,8 +16,6 @@ import {
 } from "@/hooks/queries/imprints";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
-
-const ITEMS_PER_PAGE = 50;
 
 const ImprintDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
@@ -30,8 +31,8 @@ const ImprintDetail = () => {
   const imprintFilesQuery = useImprintFiles(
     imprintId,
     {
-      limit: ITEMS_PER_PAGE,
-      offset: (currentPage - 1) * ITEMS_PER_PAGE,
+      limit: FILE_LIST_ITEMS_PER_PAGE,
+      offset: (currentPage - 1) * FILE_LIST_ITEMS_PER_PAGE,
     },
     { enabled: Boolean(imprintId) },
   );

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -1,16 +1,8 @@
-import { Edit, GitMerge, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
-import LibraryBreadcrumbs from "@/components/library/LibraryBreadcrumbs";
-import LibraryLayout from "@/components/library/LibraryLayout";
-import LoadingSpinner from "@/components/library/LoadingSpinner";
-import { MetadataDeleteDialog } from "@/components/library/MetadataDeleteDialog";
-import { MetadataEditDialog } from "@/components/library/MetadataEditDialog";
-import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { useLibrary } from "@/hooks/queries/libraries";
+import { FileListSection } from "@/components/library/FileListSection";
+import { ResourceDetail } from "@/components/library/ResourceDetail";
 import {
   useDeletePublisher,
   useMergePublisher,
@@ -21,37 +13,52 @@ import {
 } from "@/hooks/queries/publishers";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import type { File } from "@/types";
+
+const ITEMS_PER_PAGE = 50;
 
 const PublisherDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const publisherId = id ? parseInt(id, 10) : undefined;
 
-  const libraryQuery = useLibrary(libraryId);
+  const currentPage = parseInt(searchParams.get("page") ?? "1", 10);
+
   const publisherQuery = usePublisher(publisherId);
-
   usePageTitle(publisherQuery.data?.name ?? "Publisher");
-  const publisherFilesQuery = usePublisherFiles(publisherId);
 
-  const [editOpen, setEditOpen] = useState(false);
-  const [mergeOpen, setMergeOpen] = useState(false);
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const [mergeSearch, setMergeSearch] = useState("");
-  const debouncedMergeSearch = useDebounce(mergeSearch, 200);
+  const publisherFilesQuery = usePublisherFiles(
+    publisherId,
+    {
+      limit: ITEMS_PER_PAGE,
+      offset: (currentPage - 1) * ITEMS_PER_PAGE,
+    },
+    { enabled: Boolean(publisherId) },
+  );
 
   const updatePublisherMutation = useUpdatePublisher();
   const mergePublisherMutation = useMergePublisher();
   const deletePublisherMutation = useDeletePublisher();
 
+  const [mergeSearchRaw, setMergeSearchRaw] = useState("");
+  const mergeSearch = useDebounce(mergeSearchRaw, 200);
+
+  // Pre-fetch the publisher list as soon as library_id is available so the
+  // merge dialog opens instantly without a loading flash.
   const publishersListQuery = usePublishersList(
     {
       library_id: publisherQuery.data?.library_id,
       limit: 50,
-      search: debouncedMergeSearch || undefined,
+      search: mergeSearch || undefined,
     },
-    { enabled: mergeOpen && !!publisherQuery.data?.library_id },
+    { enabled: !!publisherQuery.data?.library_id },
   );
+
+  const publisher = publisherQuery.data;
+  const aliases = publisher
+    ? ((publisher.aliases as unknown as string[]) ?? [])
+    : [];
+  const fileCount = publisher?.file_count ?? 0;
 
   const handleEdit = async (data: { name: string; aliases?: string[] }) => {
     if (!publisherId) return;
@@ -59,7 +66,6 @@ const PublisherDetail = () => {
       publisherId,
       payload: { name: data.name, aliases: data.aliases },
     });
-    setEditOpen(false);
   };
 
   const handleMerge = async (sourceId: number) => {
@@ -68,184 +74,61 @@ const PublisherDetail = () => {
       targetId: publisherId,
       sourceId,
     });
-    setMergeOpen(false);
   };
 
   const handleDelete = async () => {
     if (!publisherId) return;
     await deletePublisherMutation.mutateAsync({ publisherId });
-    setDeleteOpen(false);
     navigate(`/libraries/${libraryId}/publishers`);
   };
 
-  if (publisherQuery.isLoading) {
-    return (
-      <LibraryLayout>
-        <LoadingSpinner />
-      </LibraryLayout>
-    );
-  }
-
-  if (!publisherQuery.isSuccess || !publisherQuery.data) {
-    return (
-      <LibraryLayout>
-        <div className="text-center">
-          <h1 className="text-2xl font-semibold mb-4">Publisher Not Found</h1>
-          <p className="text-muted-foreground">
-            The publisher you're looking for doesn't exist or may have been
-            removed.
-          </p>
-        </div>
-      </LibraryLayout>
-    );
-  }
-
-  const publisher = publisherQuery.data;
-  const aliases = (publisher.aliases as unknown as string[]) ?? [];
-  const fileCount = publisher.file_count ?? 0;
-  const canDelete = fileCount === 0;
-
-  const getFileName = (file: File) => {
-    const parts = file.filepath.split("/");
-    return parts[parts.length - 1];
-  };
-
   return (
-    <LibraryLayout>
-      <LibraryBreadcrumbs
-        items={[
-          { label: "Publishers", to: `/libraries/${libraryId}/publishers` },
-          { label: publisher.name },
-        ]}
-        libraryId={libraryId!}
-        libraryName={libraryQuery.data?.name}
-      />
-
-      {/* Publisher Header */}
-      <div className="mb-6 md:mb-8">
-        <div className="flex items-start justify-between gap-4 mb-2">
-          <h1 className="text-2xl font-semibold min-w-0 break-words">
-            {publisher.name}
-          </h1>
-          <div className="flex gap-2 shrink-0">
-            <Button
-              onClick={() => setEditOpen(true)}
-              size="sm"
-              variant="outline"
-            >
-              <Edit className="h-4 w-4 mr-2" />
-              Edit
-            </Button>
-            <Button
-              onClick={() => setMergeOpen(true)}
-              size="sm"
-              variant="outline"
-            >
-              <GitMerge className="h-4 w-4 mr-2" />
-              Merge
-            </Button>
-            {canDelete && (
-              <Button
-                onClick={() => setDeleteOpen(true)}
-                size="sm"
-                variant="outline"
-              >
-                <Trash2 className="h-4 w-4 mr-2" />
-                Delete
-              </Button>
-            )}
-          </div>
-        </div>
-        {aliases.length > 0 && (
-          <p className="text-sm text-muted-foreground mb-2">
-            Aliases: {aliases.join(", ")}
-          </p>
-        )}
-        <Badge variant="secondary">
-          {fileCount} file{fileCount !== 1 ? "s" : ""}
-        </Badge>
-      </div>
-
-      {/* Files with this Publisher */}
-      {fileCount > 0 && (
-        <section className="mb-10">
-          <h2 className="text-xl font-semibold mb-4">Files</h2>
-          {publisherFilesQuery.isLoading && <LoadingSpinner />}
-          {publisherFilesQuery.isSuccess && (
-            <div className="space-y-3">
-              {publisherFilesQuery.data.items.map((file) => (
-                <div
-                  className="border-l-4 border-l-primary pl-4 py-2"
-                  key={file.id}
-                >
-                  <div className="flex items-center justify-between gap-4">
-                    <div className="min-w-0 flex-1">
-                      <Link
-                        className="font-medium hover:underline block truncate"
-                        to={`/libraries/${libraryId}/books/${file.book_id}`}
-                      >
-                        {file.book?.title ?? "Unknown Book"}
-                      </Link>
-                      <p className="text-sm text-muted-foreground truncate">
-                        {getFileName(file)}
-                      </p>
-                    </div>
-                    <Badge variant="outline">
-                      {file.file_type?.toUpperCase()}
-                    </Badge>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* No Files */}
-      {fileCount === 0 && (
-        <div className="text-center py-8 text-muted-foreground">
-          This publisher has no associated files.
-        </div>
-      )}
-
-      <MetadataEditDialog
-        aliases={aliases}
-        entityName={publisher.name}
-        entityType="publisher"
-        isPending={updatePublisherMutation.isPending}
-        onOpenChange={setEditOpen}
-        onSave={handleEdit}
-        open={editOpen}
-      />
-
-      <MetadataMergeDialog
-        entities={
+    <ResourceDetail
+      aliases={aliases}
+      bookCount={fileCount}
+      breadcrumbItems={[
+        { label: "Publishers", to: `/libraries/${libraryId}/publishers` },
+        { label: publisher?.name ?? "" },
+      ]}
+      countLabel={{ singular: "file", plural: "files" }}
+      deleteConfig={{
+        isPending: deletePublisherMutation.isPending,
+        onDelete: handleDelete,
+        disabled: fileCount > 0,
+      }}
+      editConfig={{
+        isPending: updatePublisherMutation.isPending,
+        onSave: handleEdit,
+      }}
+      entityId={publisherId!}
+      entityType="publisher"
+      isLoading={publisherQuery.isLoading}
+      libraryId={libraryId!}
+      mergeConfig={{
+        entities:
           publishersListQuery.data?.items.map((p) => ({
             id: p.id,
             name: p.name,
             count: p.file_count ?? 0,
-          })) ?? []
-        }
-        entityType="publisher"
-        isLoadingEntities={publishersListQuery.isLoading}
-        isPending={mergePublisherMutation.isPending}
-        onMerge={handleMerge}
-        onOpenChange={setMergeOpen}
-        onSearch={setMergeSearch}
-        open={mergeOpen}
-        targetId={publisherId!}
-        targetName={publisher.name}
+          })) ?? [],
+        isLoadingEntities: publishersListQuery.isLoading,
+        isPending: mergePublisherMutation.isPending,
+        onMerge: handleMerge,
+        onSearch: setMergeSearchRaw,
+      }}
+      name={publisher?.name ?? ""}
+      notFound={
+        !publisherQuery.isLoading && (!publisherQuery.isSuccess || !publisher)
+      }
+      notFoundLabel="Publisher Not Found"
+    >
+      <FileListSection
+        emptyMessage="This publisher has no associated files."
+        libraryId={libraryId!}
+        query={publisherFilesQuery}
+        title="Files"
       />
-
-      <MetadataDeleteDialog
-        entityName={publisher.name}
-        entityType="publisher"
-        isPending={deletePublisherMutation.isPending}
-        onDelete={handleDelete}
-        onOpenChange={setDeleteOpen}
-        open={deleteOpen}
-      />
-    </LibraryLayout>
+    </ResourceDetail>
   );
 };
 

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
-import { FileListSection } from "@/components/library/FileListSection";
+import {
+  FILE_LIST_ITEMS_PER_PAGE,
+  FileListSection,
+} from "@/components/library/FileListSection";
 import { ResourceDetail } from "@/components/library/ResourceDetail";
 import {
   useDeletePublisher,
@@ -13,8 +16,6 @@ import {
 } from "@/hooks/queries/publishers";
 import { useDebounce } from "@/hooks/useDebounce";
 import { usePageTitle } from "@/hooks/usePageTitle";
-
-const ITEMS_PER_PAGE = 50;
 
 const PublisherDetail = () => {
   const { id, libraryId } = useParams<{ id: string; libraryId: string }>();
@@ -30,8 +31,8 @@ const PublisherDetail = () => {
   const publisherFilesQuery = usePublisherFiles(
     publisherId,
     {
-      limit: ITEMS_PER_PAGE,
-      offset: (currentPage - 1) * ITEMS_PER_PAGE,
+      limit: FILE_LIST_ITEMS_PER_PAGE,
+      offset: (currentPage - 1) * FILE_LIST_ITEMS_PER_PAGE,
     },
     { enabled: Boolean(publisherId) },
   );


### PR DESCRIPTION
Closes #240

## Summary
- Built `FileListSection` component: paginated file list with cover thumbnails, file name/book title, file type badge, duration/page count, 50 items per page
- Added `interactive` prop to `FileCoverThumbnail` (default `true`) to conditionally apply hover/cursor styles — file list rows pass `interactive={false}`
- Added `countLabel` prop to `ResourceDetail` (default book/books) so publishers/imprints can display "X file(s)"
- Migrated `PublisherDetail` and `ImprintDetail` from ~250-line inline implementations to thin wrappers using `ResourceDetail` + `FileListSection`
- Merge entity list is now eagerly pre-fetched (matching GenreDetail pattern) instead of lazily fetched on dialog open

## Test plan
- FileCoverThumbnail applies interactive styles by default and when explicitly true
- FileCoverThumbnail removes interactive styles when interactive is false
- ResourceDetail renders custom count label (singular and plural)
- FileListSection renders section title, file rows with name/book title/type badge
- FileListSection renders duration for audio files and page count for CBZ/PDF
- FileListSection renders empty state, loading spinner, showing count text
- FileListSection renders each row as a link to the parent book
- FileListSection falls back to filename when file has no name