### PR TITLE
[Fix] Truncate OPDS authors to first entry for KOReader

### DIFF
--- a/pkg/opds/handlers.go
+++ b/pkg/opds/handlers.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
@@ -862,8 +863,28 @@ func (h *handler) bookCover(c echo.Context) error {
 	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio)
 }
 
+// isKOReader returns true when the request comes from KOReader's OPDS client.
+func isKOReader(c echo.Context) bool {
+	return strings.Contains(c.Request().UserAgent(), "KOReader")
+}
+
+// truncateFeedAuthors keeps only the first author per entry. KOReader's
+// XML parser treats <author> as a scalar (last element wins), so
+// multiple elements cause it to show only the last author.
+func truncateFeedAuthors(feed *Feed) {
+	for i := range feed.Entries {
+		if len(feed.Entries[i].Authors) > 1 {
+			feed.Entries[i].Authors = feed.Entries[i].Authors[:1]
+		}
+	}
+}
+
 // respondXML sends an XML response with the correct content type.
 func respondXML(c echo.Context, data interface{}) error {
+	if feed, ok := data.(*Feed); ok && isKOReader(c) {
+		truncateFeedAuthors(feed)
+	}
+
 	c.Response().Header().Set(echo.HeaderContentType, MimeTypeAtom+"; charset=utf-8")
 	c.Response().WriteHeader(http.StatusOK)
 

--- a/pkg/opds/handlers_koreader_test.go
+++ b/pkg/opds/handlers_koreader_test.go
@@ -40,6 +40,11 @@ func TestTruncateFeedAuthors(t *testing.T) {
 			authors:         nil,
 			expectedAuthors: nil,
 		},
+		{
+			name:            "empty authors unchanged",
+			authors:         []Author{},
+			expectedAuthors: []Author{},
+		},
 	}
 
 	for _, tt := range tests {
@@ -102,7 +107,7 @@ func TestIsKOReader(t *testing.T) {
 	}
 }
 
-func TestRespondXML_KOReaderConcatsAuthors(t *testing.T) {
+func TestRespondXML_KOReaderTruncatesAuthors(t *testing.T) {
 	t.Parallel()
 
 	feed := &Feed{

--- a/pkg/opds/handlers_koreader_test.go
+++ b/pkg/opds/handlers_koreader_test.go
@@ -1,0 +1,180 @@
+package opds
+
+import (
+	"encoding/xml"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncateFeedAuthors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		authors         []Author
+		expectedAuthors []Author
+	}{
+		{
+			name:            "single author unchanged",
+			authors:         []Author{{Name: "Alice"}},
+			expectedAuthors: []Author{{Name: "Alice"}},
+		},
+		{
+			name:            "multiple authors keeps first only",
+			authors:         []Author{{Name: "Alice"}, {Name: "Bob"}},
+			expectedAuthors: []Author{{Name: "Alice"}},
+		},
+		{
+			name:            "three authors keeps first only",
+			authors:         []Author{{Name: "Alice"}, {Name: "Bob"}, {Name: "Charlie"}},
+			expectedAuthors: []Author{{Name: "Alice"}},
+		},
+		{
+			name:            "no authors unchanged",
+			authors:         nil,
+			expectedAuthors: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			feed := &Feed{
+				Entries: []Entry{
+					{
+						ID:      "urn:test:1",
+						Title:   "Test Book",
+						Authors: tt.authors,
+					},
+				},
+			}
+			truncateFeedAuthors(feed)
+			assert.Equal(t, tt.expectedAuthors, feed.Entries[0].Authors)
+		})
+	}
+}
+
+func TestIsKOReader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		userAgent string
+		expected  bool
+	}{
+		{
+			name:      "KOReader user agent",
+			userAgent: "KOReader/2024.04 (Linux)",
+			expected:  true,
+		},
+		{
+			name:      "KOReader case variant",
+			userAgent: "koreader/2024.04",
+			expected:  false,
+		},
+		{
+			name:      "non-KOReader user agent",
+			userAgent: "Mozilla/5.0",
+			expected:  false,
+		},
+		{
+			name:      "empty user agent",
+			userAgent: "",
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("User-Agent", tt.userAgent)
+			c := e.NewContext(req, httptest.NewRecorder())
+			assert.Equal(t, tt.expected, isKOReader(c))
+		})
+	}
+}
+
+func TestRespondXML_KOReaderConcatsAuthors(t *testing.T) {
+	t.Parallel()
+
+	feed := &Feed{
+		Xmlns:   AtomNS,
+		ID:      "urn:test:feed",
+		Title:   "Test Feed",
+		Updated: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Entries: []Entry{
+			{
+				ID:    "urn:test:1",
+				Title: "Multi-Author Book",
+				Authors: []Author{
+					{Name: "First Author"},
+					{Name: "Second Author"},
+				},
+			},
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("User-Agent", "KOReader/2024.04 (Linux)")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := respondXML(c, feed)
+	require.NoError(t, err)
+
+	var parsed Feed
+	err = xml.Unmarshal(rec.Body.Bytes(), &parsed)
+	require.NoError(t, err)
+
+	require.Len(t, parsed.Entries, 1)
+	require.Len(t, parsed.Entries[0].Authors, 1)
+	assert.Equal(t, "First Author", parsed.Entries[0].Authors[0].Name)
+}
+
+func TestRespondXML_NonKOReaderKeepsSeparateAuthors(t *testing.T) {
+	t.Parallel()
+
+	feed := &Feed{
+		Xmlns:   AtomNS,
+		ID:      "urn:test:feed",
+		Title:   "Test Feed",
+		Updated: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Entries: []Entry{
+			{
+				ID:    "urn:test:1",
+				Title: "Multi-Author Book",
+				Authors: []Author{
+					{Name: "First Author"},
+					{Name: "Second Author"},
+				},
+			},
+		},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := respondXML(c, feed)
+	require.NoError(t, err)
+
+	var parsed Feed
+	err = xml.Unmarshal(rec.Body.Bytes(), &parsed)
+	require.NoError(t, err)
+
+	require.Len(t, parsed.Entries, 1)
+	require.Len(t, parsed.Entries[0].Authors, 2)
+	assert.Equal(t, "First Author", parsed.Entries[0].Authors[0].Name)
+	assert.Equal(t, "Second Author", parsed.Entries[0].Authors[1].Name)
+}


### PR DESCRIPTION
## Summary
- KOReader's OPDS XML parser treats `<author>` as a scalar — when multiple `<author>` elements are present, the last one overwrites all previous ones, so multi-author books only show the last author
- Detect KOReader via `User-Agent` header and truncate the author list to just the first (primary) author
- Other OPDS clients continue to receive spec-correct separate `<author>` elements

## Test plan
- Connect KOReader to the OPDS feed and verify multi-author books show the first author
- Verify a non-KOReader OPDS client still receives all authors as separate `<author>` elements
- Run `go test ./pkg/opds/` — new tests cover `truncateFeedAuthors`, `isKOReader`, and the `respondXML` integration for both KOReader and non-KOReader user agents