### PR TITLE
[Fix] Prefer whole-numbered books for series cover over prequels

### DIFF
--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -788,7 +788,9 @@ func (svc *Service) UpdateFile(ctx context.Context, file *models.File, opts Upda
 	return nil
 }
 
-// GetFirstBookInSeriesByID returns the first book in a series, ordered by series number.
+// GetFirstBookInSeriesByID returns the first book in a series, preferring
+// whole-numbered entries (1, 2, …) over fractional ones (0.5, 1.5, …) so
+// that prequels don't become the series cover when a main entry exists.
 func (svc *Service) GetFirstBookInSeriesByID(ctx context.Context, seriesID int) (*models.Book, error) {
 	var book models.Book
 
@@ -798,7 +800,7 @@ func (svc *Service) GetFirstBookInSeriesByID(ctx context.Context, seriesID int) 
 		Relation("Files").
 		Join("INNER JOIN book_series bs ON bs.book_id = b.id").
 		Where("bs.series_id = ?", seriesID).
-		Order("bs.series_number ASC", "b.title ASC").
+		OrderExpr("CASE WHEN bs.series_number = CAST(bs.series_number AS INTEGER) THEN 0 ELSE 1 END ASC, bs.series_number ASC, b.title ASC").
 		Limit(1).
 		Scan(ctx)
 	if err != nil {

--- a/pkg/books/service_first_book_test.go
+++ b/pkg/books/service_first_book_test.go
@@ -1,0 +1,185 @@
+package books
+
+import (
+	"context"
+	"testing"
+
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func seedSeriesBooks(t *testing.T, db *bun.DB, library *models.Library, seriesID int, entries []struct {
+	Title        string
+	SeriesNumber *float64
+}) []*models.Book {
+	t.Helper()
+	ctx := context.Background()
+
+	var books []*models.Book
+	for i, e := range entries {
+		book := &models.Book{
+			LibraryID:       library.ID,
+			Title:           e.Title,
+			TitleSource:     models.DataSourceFilepath,
+			SortTitle:       e.Title,
+			SortTitleSource: models.DataSourceFilepath,
+			AuthorSource:    models.DataSourceFilepath,
+			Filepath:        t.TempDir(),
+		}
+		_, err := db.NewInsert().Model(book).Exec(ctx)
+		require.NoError(t, err)
+
+		bs := &models.BookSeries{
+			BookID:       book.ID,
+			SeriesID:     seriesID,
+			SeriesNumber: e.SeriesNumber,
+			SortOrder:    i + 1,
+		}
+		_, err = db.NewInsert().Model(bs).Exec(ctx)
+		require.NoError(t, err)
+
+		file := &models.File{
+			LibraryID:     library.ID,
+			BookID:        book.ID,
+			FileType:      models.FileTypeEPUB,
+			FileRole:      models.FileRoleMain,
+			Filepath:      "/fake/" + e.Title + ".epub",
+			FilesizeBytes: 100,
+		}
+		_, err = db.NewInsert().Model(file).Exec(ctx)
+		require.NoError(t, err)
+
+		books = append(books, book)
+	}
+	return books
+}
+
+func ptrFloat64(v float64) *float64 { return &v }
+
+func TestGetFirstBookInSeriesByID_PrefersWholeNumberOverPrequel(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, _ := setupTestLibraryAndBook(t, db) // creates library + a throwaway book
+
+	series := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Test Series",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "Test Series",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err := db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+
+	books := seedSeriesBooks(t, db, library, series.ID, []struct {
+		Title        string
+		SeriesNumber *float64
+	}{
+		{Title: "Prequel", SeriesNumber: ptrFloat64(0.5)},
+		{Title: "Book One", SeriesNumber: ptrFloat64(1)},
+		{Title: "Book Two", SeriesNumber: ptrFloat64(2)},
+	})
+
+	svc := NewService(db)
+	first, err := svc.GetFirstBookInSeriesByID(ctx, series.ID)
+	require.NoError(t, err)
+	assert.Equal(t, books[1].ID, first.ID, "should pick Book One (1) over Prequel (0.5)")
+}
+
+func TestGetFirstBookInSeriesByID_FallsBackToFractionalWhenNoWholeNumbers(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, _ := setupTestLibraryAndBook(t, db)
+
+	series := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Novellas",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "Novellas",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err := db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+
+	books := seedSeriesBooks(t, db, library, series.ID, []struct {
+		Title        string
+		SeriesNumber *float64
+	}{
+		{Title: "Novella 0.5", SeriesNumber: ptrFloat64(0.5)},
+		{Title: "Novella 1.5", SeriesNumber: ptrFloat64(1.5)},
+	})
+
+	svc := NewService(db)
+	first, err := svc.GetFirstBookInSeriesByID(ctx, series.ID)
+	require.NoError(t, err)
+	assert.Equal(t, books[0].ID, first.ID, "should pick the earliest fractional (0.5) when no whole numbers exist")
+}
+
+func TestGetFirstBookInSeriesByID_PicksLowestWholeNumber(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, _ := setupTestLibraryAndBook(t, db)
+
+	series := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Normal Series",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "Normal Series",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err := db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+
+	books := seedSeriesBooks(t, db, library, series.ID, []struct {
+		Title        string
+		SeriesNumber *float64
+	}{
+		{Title: "Book One", SeriesNumber: ptrFloat64(1)},
+		{Title: "Book Two", SeriesNumber: ptrFloat64(2)},
+		{Title: "Book Three", SeriesNumber: ptrFloat64(3)},
+	})
+
+	svc := NewService(db)
+	first, err := svc.GetFirstBookInSeriesByID(ctx, series.ID)
+	require.NoError(t, err)
+	assert.Equal(t, books[0].ID, first.ID, "should pick the first whole number (1)")
+}
+
+func TestGetFirstBookInSeriesByID_NullSeriesNumberTreatedAsFractional(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, _ := setupTestLibraryAndBook(t, db)
+
+	series := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Mixed",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "Mixed",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err := db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+
+	books := seedSeriesBooks(t, db, library, series.ID, []struct {
+		Title        string
+		SeriesNumber *float64
+	}{
+		{Title: "Unnumbered", SeriesNumber: nil},
+		{Title: "Book One", SeriesNumber: ptrFloat64(1)},
+	})
+
+	svc := NewService(db)
+	first, err := svc.GetFirstBookInSeriesByID(ctx, series.ID)
+	require.NoError(t, err)
+	assert.Equal(t, books[1].ID, first.ID, "should prefer Book One (whole) over unnumbered (nil)")
+}


### PR DESCRIPTION
## Summary
- Series covers previously used the lowest `series_number` entry, which caused prequels (e.g., 0.5) to become the series cover image instead of the first main entry (1.0)
- The ordering in `GetFirstBookInSeriesByID` now sorts whole-numbered entries before fractional/NULL ones, only falling back to fractional numbers when no whole-numbered books exist
- Added 4 test cases covering: prequel vs whole number, fractional-only fallback, lowest-whole-number selection, and NULL series number handling

## Test plan
- Series with books numbered 0.5, 1, 2 should use book 1's cover
- Series with only fractional entries (0.5, 1.5) should use the lowest (0.5)
- Series with only whole-numbered entries should use the lowest
- Books with NULL series number should not be preferred over whole-numbered entries