### PR TITLE
[Fix] Invalidate detail-page list queries after metadata entity merges

### DIFF
--- a/app/hooks/queries/genres.test.ts
+++ b/app/hooks/queries/genres.test.ts
@@ -1,0 +1,85 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { QueryKey as BooksQueryKey } from "./books";
+import { QueryKey, useMergeGenre } from "./genres";
+
+vi.mock("@/libraries/api", async () => {
+  const actual = await vi.importActual<object>("@/libraries/api");
+  return {
+    ...actual,
+    API: {
+      request: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+const makeWrapper = (client: QueryClient) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  return Wrapper;
+};
+
+describe("useMergeGenre", () => {
+  it("invalidates GenreBooks for the target id on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.GenreBooks, 1, { limit: 50, offset: 0 }], {
+      items: [],
+      total: 0,
+    });
+
+    const { result } = renderHook(() => useMergeGenre(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.GenreBooks, 1, { limit: 50, offset: 0 }])
+          ?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  it("invalidates RetrieveGenre, ListGenres, and book queries on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrieveGenre, 1], { id: 1 });
+    client.setQueryData([QueryKey.ListGenres, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.ListBooks, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.RetrieveBook, 10], { id: 10 });
+
+    const { result } = renderHook(() => useMergeGenre(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrieveGenre, 1])?.isInvalidated,
+      ).toBe(true);
+    });
+    expect(client.getQueryState([QueryKey.ListGenres, {}])?.isInvalidated).toBe(
+      true,
+    );
+    expect(
+      client.getQueryState([BooksQueryKey.ListBooks, {}])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState([BooksQueryKey.RetrieveBook, 10])?.isInvalidated,
+    ).toBe(true);
+  });
+});

--- a/app/hooks/queries/genres.ts
+++ b/app/hooks/queries/genres.ts
@@ -145,6 +145,10 @@ export const useMergeGenre = () => {
         queryKey: [QueryKey.RetrieveGenre, variables.targetId],
       });
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListGenres] });
+      // Invalidate detail-page book list since books moved from source to target
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.GenreBooks, variables.targetId],
+      });
       // Invalidate book queries since they display genre info
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });

--- a/app/hooks/queries/imprints.test.ts
+++ b/app/hooks/queries/imprints.test.ts
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { QueryKey as BooksQueryKey } from "./books";
+import { QueryKey, useMergeImprint } from "./imprints";
+
+vi.mock("@/libraries/api", async () => {
+  const actual = await vi.importActual<object>("@/libraries/api");
+  return {
+    ...actual,
+    API: {
+      request: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+const makeWrapper = (client: QueryClient) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  return Wrapper;
+};
+
+describe("useMergeImprint", () => {
+  it("invalidates ImprintFiles for the target id on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.ImprintFiles, 1, { limit: 50, offset: 0 }], {
+      items: [],
+      total: 0,
+    });
+
+    const { result } = renderHook(() => useMergeImprint(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([
+          QueryKey.ImprintFiles,
+          1,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  it("invalidates RetrieveImprint, ListImprints, and book queries on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrieveImprint, 1], { id: 1 });
+    client.setQueryData([QueryKey.ListImprints, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.ListBooks, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.RetrieveBook, 10], { id: 10 });
+
+    const { result } = renderHook(() => useMergeImprint(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrieveImprint, 1])?.isInvalidated,
+      ).toBe(true);
+    });
+    expect(
+      client.getQueryState([QueryKey.ListImprints, {}])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState([BooksQueryKey.ListBooks, {}])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState([BooksQueryKey.RetrieveBook, 10])?.isInvalidated,
+    ).toBe(true);
+  });
+});

--- a/app/hooks/queries/imprints.ts
+++ b/app/hooks/queries/imprints.ts
@@ -147,6 +147,10 @@ export const useMergeImprint = () => {
         queryKey: [QueryKey.RetrieveImprint, variables.targetId],
       });
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListImprints] });
+      // Invalidate detail-page file list since files moved from source to target
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.ImprintFiles, variables.targetId],
+      });
       // Invalidate book queries since they display imprint info on files
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });

--- a/app/hooks/queries/people.test.ts
+++ b/app/hooks/queries/people.test.ts
@@ -1,0 +1,123 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { QueryKey as BooksQueryKey } from "./books";
+import { QueryKey, useMergePerson } from "./people";
+import { QueryKey as SearchQueryKey } from "./search";
+
+vi.mock("@/libraries/api", async () => {
+  const actual = await vi.importActual<object>("@/libraries/api");
+  return {
+    ...actual,
+    API: {
+      request: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+const makeWrapper = (client: QueryClient) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  return Wrapper;
+};
+
+describe("useMergePerson", () => {
+  it("invalidates PersonAuthoredBooks for the target id on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData(
+      [QueryKey.PersonAuthoredBooks, 1, { limit: 50, offset: 0 }],
+      { items: [], total: 0 },
+    );
+
+    const { result } = renderHook(() => useMergePerson(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([
+          QueryKey.PersonAuthoredBooks,
+          1,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  it("invalidates PersonNarratedFiles for the target id on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData(
+      [QueryKey.PersonNarratedFiles, 1, { limit: 50, offset: 0 }],
+      { items: [], total: 0 },
+    );
+
+    const { result } = renderHook(() => useMergePerson(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([
+          QueryKey.PersonNarratedFiles,
+          1,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  it("invalidates RetrievePerson, ListPeople, book queries, and global search on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePerson, 1], { id: 1 });
+    client.setQueryData([QueryKey.ListPeople, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.ListBooks, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.RetrieveBook, 10], { id: 10 });
+    client.setQueryData([SearchQueryKey.GlobalSearch, "test"], []);
+
+    const { result } = renderHook(() => useMergePerson(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePerson, 1])?.isInvalidated,
+      ).toBe(true);
+    });
+    expect(client.getQueryState([QueryKey.ListPeople, {}])?.isInvalidated).toBe(
+      true,
+    );
+    expect(
+      client.getQueryState([BooksQueryKey.ListBooks, {}])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState([BooksQueryKey.RetrieveBook, 10])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState([SearchQueryKey.GlobalSearch, "test"])
+        ?.isInvalidated,
+    ).toBe(true);
+  });
+});

--- a/app/hooks/queries/people.ts
+++ b/app/hooks/queries/people.ts
@@ -175,6 +175,13 @@ export const useMergePerson = () => {
         queryKey: [QueryKey.RetrievePerson, variables.targetId],
       });
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListPeople] });
+      // Invalidate detail-page lists since books/files moved from source to target
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.PersonAuthoredBooks, variables.targetId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.PersonNarratedFiles, variables.targetId],
+      });
       // Invalidate book queries since they display author/narrator info
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });

--- a/app/hooks/queries/publishers.test.ts
+++ b/app/hooks/queries/publishers.test.ts
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { QueryKey as BooksQueryKey } from "./books";
+import { QueryKey, useMergePublisher } from "./publishers";
+
+vi.mock("@/libraries/api", async () => {
+  const actual = await vi.importActual<object>("@/libraries/api");
+  return {
+    ...actual,
+    API: {
+      request: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+const makeWrapper = (client: QueryClient) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  return Wrapper;
+};
+
+describe("useMergePublisher", () => {
+  it("invalidates PublisherFiles for the target id on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    // Seed the detail-page file list cache for the target publisher.
+    client.setQueryData(
+      [QueryKey.PublisherFiles, 1, { limit: 50, offset: 0 }],
+      { items: [], total: 0 },
+    );
+
+    const { result } = renderHook(() => useMergePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([
+          QueryKey.PublisherFiles,
+          1,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  it("invalidates RetrievePublisher, ListPublishers, and book queries on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 1], { id: 1 });
+    client.setQueryData([QueryKey.ListPublishers, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.ListBooks, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.RetrieveBook, 10], { id: 10 });
+
+    const { result } = renderHook(() => useMergePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 1])?.isInvalidated,
+      ).toBe(true);
+    });
+    expect(
+      client.getQueryState([QueryKey.ListPublishers, {}])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState([BooksQueryKey.ListBooks, {}])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState([BooksQueryKey.RetrieveBook, 10])?.isInvalidated,
+    ).toBe(true);
+  });
+});

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -157,6 +157,10 @@ export const useMergePublisher = () => {
         queryKey: [QueryKey.RetrievePublisher, variables.targetId],
       });
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListPublishers] });
+      // Invalidate detail-page file list since files moved from source to target
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.PublisherFiles, variables.targetId],
+      });
       // Invalidate book queries since they display publisher info on files
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });

--- a/app/hooks/queries/tags.test.ts
+++ b/app/hooks/queries/tags.test.ts
@@ -1,0 +1,85 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { QueryKey as BooksQueryKey } from "./books";
+import { QueryKey, useMergeTag } from "./tags";
+
+vi.mock("@/libraries/api", async () => {
+  const actual = await vi.importActual<object>("@/libraries/api");
+  return {
+    ...actual,
+    API: {
+      request: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+const makeWrapper = (client: QueryClient) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  return Wrapper;
+};
+
+describe("useMergeTag", () => {
+  it("invalidates TagBooks for the target id on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.TagBooks, 1, { limit: 50, offset: 0 }], {
+      items: [],
+      total: 0,
+    });
+
+    const { result } = renderHook(() => useMergeTag(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.TagBooks, 1, { limit: 50, offset: 0 }])
+          ?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  it("invalidates RetrieveTag, ListTags, and book queries on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrieveTag, 1], { id: 1 });
+    client.setQueryData([QueryKey.ListTags, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.ListBooks, {}], { items: [], total: 0 });
+    client.setQueryData([BooksQueryKey.RetrieveBook, 10], { id: 10 });
+
+    const { result } = renderHook(() => useMergeTag(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrieveTag, 1])?.isInvalidated,
+      ).toBe(true);
+    });
+    expect(client.getQueryState([QueryKey.ListTags, {}])?.isInvalidated).toBe(
+      true,
+    );
+    expect(
+      client.getQueryState([BooksQueryKey.ListBooks, {}])?.isInvalidated,
+    ).toBe(true);
+    expect(
+      client.getQueryState([BooksQueryKey.RetrieveBook, 10])?.isInvalidated,
+    ).toBe(true);
+  });
+});

--- a/app/hooks/queries/tags.ts
+++ b/app/hooks/queries/tags.ts
@@ -136,6 +136,10 @@ export const useMergeTag = () => {
         queryKey: [QueryKey.RetrieveTag, variables.targetId],
       });
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListTags] });
+      // Invalidate detail-page book list since books moved from source to target
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.TagBooks, variables.targetId],
+      });
       // Invalidate book queries since they display tag info
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });


### PR DESCRIPTION
Closes #252

## Summary
- Publisher, genre, imprint, tag, and person merge mutations now invalidate their detail-page list queries (`PublisherFiles`, `GenreBooks`, `ImprintFiles`, `TagBooks`, `PersonAuthoredBooks`, `PersonNarratedFiles`) on success, so books/files auto-refresh after a merge without a manual reload
- Mirrors the existing correct pattern in `useMergeSeries` which already invalidated `[SeriesBooks, targetId]`
- Person merge invalidates both authored books and narrated files lists since the person detail page has two sections
- Invalidating by `[QueryKey, targetId]` prefix is sufficient because pagination params come after the target id in the cache key

## Test plan
- useMergePublisher invalidates PublisherFiles for the target id on success
- useMergePublisher invalidates existing keys (RetrievePublisher, ListPublishers, book queries)
- useMergeGenre invalidates GenreBooks for the target id on success
- useMergeGenre invalidates existing keys (RetrieveGenre, ListGenres, book queries)
- useMergeImprint invalidates ImprintFiles for the target id on success
- useMergeImprint invalidates existing keys (RetrieveImprint, ListImprints, book queries)
- useMergeTag invalidates TagBooks for the target id on success
- useMergeTag invalidates existing keys (RetrieveTag, ListTags, book queries)
- useMergePerson invalidates PersonAuthoredBooks for the target id on success
- useMergePerson invalidates PersonNarratedFiles for the target id on success
- useMergePerson invalidates existing keys (RetrievePerson, ListPeople, book queries, global search)
- All tests written red-first, then green after the fix
- mise check:quiet passes (lint, test, lint:js, test:js:fast all green)