### PR TITLE
[Fix] Render series number badge when series_number is 0

### DIFF
--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -329,7 +329,7 @@ export function BookEditDialog({
         .filter((s) => s.name.trim())
         .map((s) => ({
           name: s.name,
-          number: s.number ? parseFloat(s.number) : undefined,
+          number: s.number !== "" ? parseFloat(s.number) : undefined,
           series_number_unit: s.unit !== "" ? s.unit : undefined,
         }));
     }

--- a/app/components/library/BookItem.test.tsx
+++ b/app/components/library/BookItem.test.tsx
@@ -40,6 +40,134 @@ function makeBook(overrides: Partial<Book> = {}): Book {
   } as Book;
 }
 
+describe("BookItem — Series number badge", () => {
+  const seriesId = 42;
+
+  it("shows badge when series_number is 0", () => {
+    const book = makeBook({
+      book_series: [
+        {
+          id: 1,
+          book_id: 1,
+          series_id: seriesId,
+          series_number: 0,
+        } as never,
+      ],
+      files: [
+        {
+          id: 10,
+          file_role: FileRoleMain,
+          file_type: "epub",
+          reviewed: true,
+        } as never,
+      ],
+    });
+    render(wrap(<BookItem book={book} libraryId="1" seriesId={seriesId} />));
+    // The badge should be a <span> with specific classes, containing "0"
+    const badge = screen.getByText("0", { selector: "span" });
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toContain("bg-primary");
+  });
+
+  it("shows badge when series_number is a positive number", () => {
+    const book = makeBook({
+      book_series: [
+        {
+          id: 1,
+          book_id: 1,
+          series_id: seriesId,
+          series_number: 3,
+        } as never,
+      ],
+      files: [
+        {
+          id: 10,
+          file_role: FileRoleMain,
+          file_type: "epub",
+          reviewed: true,
+        } as never,
+      ],
+    });
+    render(wrap(<BookItem book={book} libraryId="1" seriesId={seriesId} />));
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("hides badge when series_number is null", () => {
+    const book = makeBook({
+      book_series: [
+        {
+          id: 1,
+          book_id: 1,
+          series_id: seriesId,
+          series_number: null,
+        } as never,
+      ],
+      files: [
+        {
+          id: 10,
+          file_role: FileRoleMain,
+          file_type: "epub",
+          reviewed: true,
+        } as never,
+      ],
+    });
+    render(wrap(<BookItem book={book} libraryId="1" seriesId={seriesId} />));
+    // The formatted output of null is "", so there should be no badge content
+    // We check that "0" or any number text isn't rendered as a badge
+    const title = screen.getByText("Test Book");
+    // The title container should not have leading-[1.6] class
+    expect(title.className).not.toContain("leading-[1.6]");
+  });
+
+  it("hides badge when series_number is undefined", () => {
+    const book = makeBook({
+      book_series: [
+        {
+          id: 1,
+          book_id: 1,
+          series_id: seriesId,
+        } as never,
+      ],
+      files: [
+        {
+          id: 10,
+          file_role: FileRoleMain,
+          file_type: "epub",
+          reviewed: true,
+        } as never,
+      ],
+    });
+    render(wrap(<BookItem book={book} libraryId="1" seriesId={seriesId} />));
+    const title = screen.getByText("Test Book");
+    expect(title.className).not.toContain("leading-[1.6]");
+  });
+
+  it("applies leading-[1.6] class when series_number is 0", () => {
+    const book = makeBook({
+      book_series: [
+        {
+          id: 1,
+          book_id: 1,
+          series_id: seriesId,
+          series_number: 0,
+        } as never,
+      ],
+      files: [
+        {
+          id: 10,
+          file_role: FileRoleMain,
+          file_type: "epub",
+          reviewed: true,
+        } as never,
+      ],
+    });
+    render(wrap(<BookItem book={book} libraryId="1" seriesId={seriesId} />));
+    const title = screen.getByText("Test Book");
+    // The parent div that has leading-[1.6] is the closest ancestor with that class
+    expect(title.closest("div")?.className).toContain("leading-[1.6]");
+  });
+});
+
 describe("BookItem — Needs review badge", () => {
   it("shows badge when a main file has reviewed=false", () => {
     const book = makeBook({

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -297,11 +297,11 @@ const BookItem = ({
             <div
               className={cn(
                 "mt-2 group-hover:underline text-sm font-bold line-clamp-2",
-                seriesNumber && "leading-[1.6]",
+                seriesNumber != null && "leading-[1.6]",
               )}
               ref={titleRef}
             >
-              {seriesNumber && (
+              {seriesNumber != null && (
                 <span className="inline-flex items-center justify-center align-text-top min-w-5 h-[18px] px-[5px] bg-primary text-primary-foreground rounded text-[11px] font-extrabold tabular-nums tracking-tight mr-1.5">
                   {formatSeriesNumber(
                     seriesNumber,

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -1110,7 +1110,7 @@ export function IdentifyReviewForm({
         .filter((s) => s.name.trim())
         .map((s) => ({
           name: s.name,
-          number: s.number ? parseFloat(s.number) : undefined,
+          number: s.number !== "" ? parseFloat(s.number) : undefined,
           series_number_unit: s.unit !== "" ? s.unit : undefined,
         }));
     }

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1246,7 +1246,7 @@ const BookDetail = () => {
                       >
                         {bs.series?.name ?? "Unknown Series"}
                       </Link>
-                      {bs.series_number && (
+                      {bs.series_number != null && (
                         <Badge className="text-xs" variant="outline">
                           {formatSeriesNumber(
                             bs.series_number,


### PR DESCRIPTION
Closes #253

## Summary
- Series number badge was not rendering when `series_number` is `0` because `{seriesNumber && (...)}` short-circuits on falsy values in JS
- Replaced truthiness guards with explicit nullish checks (`!= null`) in `BookItem.tsx` (series detail page) and `BookDetail.tsx` (book detail page)
- The `leading-[1.6]` line-height class conditional was also guarded by the same truthiness check and is now fixed
- `formatSeriesNumber` was already correct and needed no changes

## Test plan
- Badge renders with correct formatted value when `series_number` is `0`
- Badge renders for positive series numbers (regression check)
- Badge hidden when `series_number` is `null`
- Badge hidden when `series_number` is `undefined`
- `leading-[1.6]` class applied when `series_number` is `0`