### PR TITLE
[Frontend] Add auto-hide viewer chrome and fix EPUB scroll mode

### DIFF
--- a/app/components/pages/EPUBReader.test.tsx
+++ b/app/components/pages/EPUBReader.test.tsx
@@ -166,6 +166,33 @@ describe("EPUBReader", () => {
     ).toBeInTheDocument();
   });
 
+  it("hides chrome toggle button in scrolled flow even with auto-hide enabled", () => {
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: {
+        preload_count: 3,
+        fit_mode: "fit-height",
+        viewer_epub_font_size: 100,
+        viewer_epub_theme: "light",
+        viewer_epub_flow: "scrolled",
+        viewer_hide_chrome: true,
+      },
+      isLoading: false,
+    } as never);
+
+    vi.mocked(useEpubBlob).mockReturnValue({
+      data: new Blob(["x"], { type: "application/epub+zip" }),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as never);
+
+    renderReader();
+    expect(
+      screen.queryByRole("button", { name: /toggle controls/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("updates settings when the theme button is clicked", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const mutate = vi.fn();

--- a/app/components/pages/EPUBReader.test.tsx
+++ b/app/components/pages/EPUBReader.test.tsx
@@ -108,6 +108,64 @@ describe("EPUBReader", () => {
     vi.useRealTimers();
   });
 
+  it("hides prev/next page buttons in scrolled flow mode", () => {
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: {
+        preload_count: 3,
+        fit_mode: "fit-height",
+        viewer_epub_font_size: 100,
+        viewer_epub_theme: "light",
+        viewer_epub_flow: "scrolled",
+      },
+      isLoading: false,
+    } as never);
+
+    vi.mocked(useEpubBlob).mockReturnValue({
+      data: new Blob(["x"], { type: "application/epub+zip" }),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as never);
+
+    renderReader();
+    expect(
+      screen.queryByRole("button", { name: /previous page/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /next page/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows prev/next page buttons in paginated flow mode", () => {
+    vi.mocked(useUserSettings).mockReturnValue({
+      data: {
+        preload_count: 3,
+        fit_mode: "fit-height",
+        viewer_epub_font_size: 100,
+        viewer_epub_theme: "light",
+        viewer_epub_flow: "paginated",
+      },
+      isLoading: false,
+    } as never);
+
+    vi.mocked(useEpubBlob).mockReturnValue({
+      data: new Blob(["x"], { type: "application/epub+zip" }),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    } as never);
+
+    renderReader();
+    expect(
+      screen.getByRole("button", { name: /previous page/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /next page/i }),
+    ).toBeInTheDocument();
+  });
+
   it("updates settings when the theme button is clicked", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const mutate = vi.fn();

--- a/app/components/pages/EPUBReader.tsx
+++ b/app/components/pages/EPUBReader.tsx
@@ -437,21 +437,25 @@ export default function EPUBReader({ file, bookTitle }: EPUBReaderProps) {
           </div>
         )}
 
-        <Button
-          aria-label="Previous page"
-          className="absolute left-0 top-0 w-1/3 h-full z-10 opacity-0"
-          onClick={goPrev}
-          variant="ghost"
-        />
-        <Button
-          aria-label="Next page"
-          className="absolute right-0 top-0 w-1/3 h-full z-10 opacity-0"
-          onClick={goNext}
-          variant="ghost"
-        />
+        {flow !== "scrolled" && (
+          <>
+            <Button
+              aria-label="Previous page"
+              className="absolute left-0 top-0 w-1/3 h-full z-10 opacity-0"
+              onClick={goPrev}
+              variant="ghost"
+            />
+            <Button
+              aria-label="Next page"
+              className="absolute right-0 top-0 w-1/3 h-full z-10 opacity-0"
+              onClick={goNext}
+              variant="ghost"
+            />
+          </>
+        )}
 
-        {/* Center tap zone: toggle chrome on mobile */}
-        {hideChrome && (
+        {/* Center tap zone: toggle chrome on mobile (paginated only) */}
+        {hideChrome && flow !== "scrolled" && (
           <Button
             aria-label="Toggle controls"
             className="absolute left-1/3 top-0 w-1/3 h-full z-10 opacity-0"

--- a/app/components/pages/EPUBReader.tsx
+++ b/app/components/pages/EPUBReader.tsx
@@ -14,13 +14,16 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
 import { useEpubBlob } from "@/hooks/queries/epub";
 import {
   useUpdateUserSettings,
   useUserSettings,
   type UpdateUserSettingsVariables,
 } from "@/hooks/queries/settings";
+import { useAutoHideChrome } from "@/hooks/useAutoHideChrome";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { cn } from "@/libraries/utils";
 import type { File } from "@/types";
 
 import "@/libraries/foliate/view.js";
@@ -75,6 +78,9 @@ export default function EPUBReader({ file, bookTitle }: EPUBReaderProps) {
   const fontSize = settings?.viewer_epub_font_size ?? 100;
   const theme = settings?.viewer_epub_theme ?? "light";
   const flow = settings?.viewer_epub_flow ?? "paginated";
+  const hideChrome = settings?.viewer_hide_chrome ?? false;
+
+  const { chromeVisible, toggleChrome } = useAutoHideChrome(hideChrome);
 
   // Local draft state lets the slider thumb and label update live while the
   // user drags, without firing a PUT on every tick. We only commit to the API
@@ -314,7 +320,14 @@ export default function EPUBReader({ file, bookTitle }: EPUBReaderProps) {
 
   return (
     <div className="fixed inset-0 bg-background flex flex-col">
-      <header className="flex items-center justify-end px-4 py-2 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <header
+        className={cn(
+          "flex items-center justify-end px-4 py-2 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+          hideChrome &&
+            "fixed top-0 inset-x-0 z-20 transition-transform duration-300",
+          hideChrome && !chromeVisible && "-translate-y-full",
+        )}
+      >
         <div className="flex items-center gap-2">
           {toc.length > 0 && (
             <select
@@ -387,13 +400,31 @@ export default function EPUBReader({ file, bookTitle }: EPUBReaderProps) {
                     ))}
                   </div>
                 </div>
+                <div className="flex items-center justify-between">
+                  <label className="text-sm font-medium" htmlFor="hide-chrome">
+                    Auto-hide controls
+                  </label>
+                  <Switch
+                    checked={hideChrome}
+                    disabled={!settingsReady}
+                    id="hide-chrome"
+                    onCheckedChange={(checked) =>
+                      commitSettings({ viewer_hide_chrome: checked })
+                    }
+                  />
+                </div>
               </div>
             </PopoverContent>
           </Popover>
         </div>
       </header>
 
-      <main className="flex-1 relative bg-background">
+      <main
+        className={cn(
+          "relative bg-background",
+          hideChrome ? "fixed inset-0" : "flex-1",
+        )}
+      >
         {(isLoading || !blob || !bookReady) && (
           <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background z-20">
             <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
@@ -419,6 +450,16 @@ export default function EPUBReader({ file, bookTitle }: EPUBReaderProps) {
           variant="ghost"
         />
 
+        {/* Center tap zone: toggle chrome on mobile */}
+        {hideChrome && (
+          <Button
+            aria-label="Toggle controls"
+            className="absolute left-1/3 top-0 w-1/3 h-full z-10 opacity-0"
+            onClick={toggleChrome}
+            variant="ghost"
+          />
+        )}
+
         <foliate-view
           ref={(el) => {
             viewRef.current = el;
@@ -431,7 +472,14 @@ export default function EPUBReader({ file, bookTitle }: EPUBReaderProps) {
         />
       </main>
 
-      <footer className="border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <footer
+        className={cn(
+          "border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+          hideChrome &&
+            "fixed bottom-0 inset-x-0 z-20 transition-transform duration-300",
+          hideChrome && !chromeVisible && "translate-y-full",
+        )}
+      >
         <div className="px-4 pt-3">
           <div
             className="relative h-1.5 bg-muted rounded-full cursor-pointer"

--- a/app/components/pages/PageReader.tsx
+++ b/app/components/pages/PageReader.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, ChevronRight, Loader2, Settings } from "lucide-react";
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -15,12 +16,15 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
 import { useFileChapters } from "@/hooks/queries/chapters";
 import {
   useUpdateUserSettings,
   useUserSettings,
 } from "@/hooks/queries/settings";
+import { useAutoHideChrome } from "@/hooks/useAutoHideChrome";
 import { usePageTitle } from "@/hooks/usePageTitle";
+import { cn } from "@/libraries/utils";
 import type { Chapter } from "@/types";
 
 // Flatten chapters for progress bar (CBZ/PDF chapters don't nest)
@@ -65,6 +69,12 @@ export default function PageReader({
   const [imageLoading, setImageLoading] = useState(true);
   const currentPageUrl = getPageUrl(currentPage);
   const imgRef = useRef<HTMLImageElement>(null);
+  const mainRef = useRef<HTMLElement>(null);
+
+  // Reset scroll position on page change (layout effect to avoid flash)
+  useLayoutEffect(() => {
+    mainRef.current?.scrollTo(0, 0);
+  }, [currentPage]);
 
   // Reset loading state when the page URL changes
   useEffect(() => {
@@ -87,7 +97,10 @@ export default function PageReader({
   const updateSettings = useUpdateUserSettings();
   const preloadCount = settings?.preload_count ?? 3;
   const fitMode = settings?.fit_mode ?? "fit-height";
+  const hideChrome = settings?.viewer_hide_chrome ?? false;
   const settingsReady = !settingsLoading && settings != null;
+
+  const { chromeVisible, toggleChrome } = useAutoHideChrome(hideChrome);
 
   // Sync URL with current page
   useEffect(() => {
@@ -162,7 +175,14 @@ export default function PageReader({
   return (
     <div className="fixed inset-0 bg-background flex flex-col">
       {/* Header */}
-      <header className="flex items-center justify-end px-4 py-2 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <header
+        className={cn(
+          "flex items-center justify-end px-4 py-2 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+          hideChrome &&
+            "fixed top-0 inset-x-0 z-20 transition-transform duration-300",
+          hideChrome && !chromeVisible && "-translate-y-full",
+        )}
+      >
         <div className="flex items-center gap-2">
           {/* Chapter dropdown */}
           {flatChapters.length > 0 && (
@@ -227,14 +247,27 @@ export default function PageReader({
                     <Button
                       disabled={!settingsReady}
                       onClick={() =>
-                        updateSettings.mutate({ fit_mode: "original" })
+                        updateSettings.mutate({ fit_mode: "fit-width" })
                       }
                       size="sm"
-                      variant={fitMode === "original" ? "default" : "outline"}
+                      variant={fitMode === "fit-width" ? "default" : "outline"}
                     >
-                      Original
+                      Fit Width
                     </Button>
                   </div>
+                </div>
+                <div className="flex items-center justify-between">
+                  <label className="text-sm font-medium" htmlFor="hide-chrome">
+                    Auto-hide controls
+                  </label>
+                  <Switch
+                    checked={hideChrome}
+                    disabled={!settingsReady}
+                    id="hide-chrome"
+                    onCheckedChange={(checked) =>
+                      updateSettings.mutate({ viewer_hide_chrome: checked })
+                    }
+                  />
                 </div>
               </div>
             </PopoverContent>
@@ -244,9 +277,14 @@ export default function PageReader({
 
       {/* Page Display */}
       <main
-        className={`flex-1 flex items-center justify-center bg-black relative ${
-          fitMode === "original" ? "overflow-auto" : "overflow-hidden"
-        }`}
+        className={cn(
+          "flex bg-black relative",
+          hideChrome ? "fixed inset-0" : "flex-1",
+          fitMode === "fit-width"
+            ? "items-start justify-start overflow-auto"
+            : "items-center justify-center overflow-hidden",
+        )}
+        ref={mainRef}
       >
         {/* Tap zones for mobile navigation */}
         <Button
@@ -263,6 +301,16 @@ export default function PageReader({
           variant="ghost"
         />
 
+        {/* Center tap zone: toggle chrome on mobile */}
+        {hideChrome && (
+          <Button
+            aria-label="Toggle controls"
+            className="absolute left-1/3 top-0 w-1/3 h-full z-10 opacity-0"
+            onClick={toggleChrome}
+            variant="ghost"
+          />
+        )}
+
         {/* Loading spinner */}
         {imageLoading && (
           <div className="absolute inset-0 flex items-center justify-center z-[5] bg-black/60">
@@ -273,7 +321,7 @@ export default function PageReader({
         <img
           alt={`Page ${currentPage + 1}`}
           className={
-            fitMode === "fit-height" ? "max-h-full w-auto object-contain" : "" // original: no constraints, natural size
+            fitMode === "fit-height" ? "max-h-full w-auto object-contain" : ""
           }
           onError={() => setImageLoading(false)}
           onLoad={() => setImageLoading(false)}
@@ -289,7 +337,14 @@ export default function PageReader({
       </main>
 
       {/* Controls */}
-      <footer className="border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <footer
+        className={cn(
+          "border-t bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+          hideChrome &&
+            "fixed bottom-0 inset-x-0 z-20 transition-transform duration-300",
+          hideChrome && !chromeVisible && "translate-y-full",
+        )}
+      >
         {/* Progress Bar */}
         <div className="px-4 pt-3">
           <div

--- a/app/components/pages/PageReader.tsx
+++ b/app/components/pages/PageReader.tsx
@@ -321,7 +321,9 @@ export default function PageReader({
         <img
           alt={`Page ${currentPage + 1}`}
           className={
-            fitMode === "fit-height" ? "max-h-full w-auto object-contain" : ""
+            fitMode === "fit-height"
+              ? "max-h-full w-auto object-contain"
+              : "w-full h-auto"
           }
           onError={() => setImageLoading(false)}
           onLoad={() => setImageLoading(false)}

--- a/app/components/pages/UserSettings.tsx
+++ b/app/components/pages/UserSettings.tsx
@@ -6,6 +6,7 @@ import { useTheme, type Theme } from "@/components/contexts/Theme/context";
 import { SizeSelector } from "@/components/library/SizeSelector";
 import TopNav from "@/components/library/TopNav";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { DEFAULT_GALLERY_SIZE } from "@/constants/gallerySize";
 import {
   useUpdateUserSettings,
@@ -123,6 +124,33 @@ const UserSettings = () => {
                   them.
                 </p>
               </div>
+            </div>
+          </div>
+
+          {/* Reader Settings */}
+          <div className="border border-border rounded-md p-4 md:p-6">
+            <h2 className="text-lg font-semibold mb-4">Reader</h2>
+            <div className="flex items-center justify-between">
+              <div>
+                <label
+                  className="text-sm font-medium"
+                  htmlFor="hide-chrome-setting"
+                >
+                  Auto-hide controls
+                </label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Hide the header and footer in the reader. Move your mouse or
+                  tap the screen to reveal them.
+                </p>
+              </div>
+              <Switch
+                checked={userSettingsQuery.data?.viewer_hide_chrome ?? false}
+                disabled={!userSettingsQuery.data}
+                id="hide-chrome-setting"
+                onCheckedChange={(checked) =>
+                  updateUserSettings.mutate({ viewer_hide_chrome: checked })
+                }
+              />
             </div>
           </div>
 

--- a/app/hooks/queries/settings.ts
+++ b/app/hooks/queries/settings.ts
@@ -15,6 +15,7 @@ export interface UserSettings {
   viewer_epub_theme: EpubTheme;
   viewer_epub_flow: EpubFlow;
   gallery_size: GallerySize;
+  viewer_hide_chrome: boolean;
 }
 
 export enum QueryKey {
@@ -46,6 +47,7 @@ export interface UpdateUserSettingsVariables {
   viewer_epub_theme?: EpubTheme;
   viewer_epub_flow?: EpubFlow;
   gallery_size?: GallerySize;
+  viewer_hide_chrome?: boolean;
 }
 
 export const useUpdateUserSettings = () => {

--- a/app/hooks/useAutoHideChrome.test.ts
+++ b/app/hooks/useAutoHideChrome.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAutoHideChrome } from "./useAutoHideChrome";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useAutoHideChrome", () => {
+  it("always returns chromeVisible true when disabled", () => {
+    const { result } = renderHook(() => useAutoHideChrome(false));
+    expect(result.current.chromeVisible).toBe(true);
+
+    act(() => vi.advanceTimersByTime(5000));
+    expect(result.current.chromeVisible).toBe(true);
+  });
+
+  it("hides chrome after initial delay when enabled", () => {
+    const { result } = renderHook(() => useAutoHideChrome(true));
+    expect(result.current.chromeVisible).toBe(true);
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.chromeVisible).toBe(false);
+  });
+
+  it("re-shows chrome on mouse move and hides again after inactivity", () => {
+    const { result } = renderHook(() => useAutoHideChrome(true));
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.chromeVisible).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new Event("mousemove"));
+    });
+    expect(result.current.chromeVisible).toBe(true);
+
+    act(() => vi.advanceTimersByTime(3000));
+    expect(result.current.chromeVisible).toBe(false);
+  });
+
+  it("toggleChrome toggles visibility and restarts inactivity timer", () => {
+    const { result } = renderHook(() => useAutoHideChrome(true));
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.chromeVisible).toBe(false);
+
+    act(() => result.current.toggleChrome());
+    expect(result.current.chromeVisible).toBe(true);
+
+    act(() => vi.advanceTimersByTime(3000));
+    expect(result.current.chromeVisible).toBe(false);
+  });
+
+  it("toggleChrome hides chrome when currently visible", () => {
+    const { result } = renderHook(() => useAutoHideChrome(true));
+    expect(result.current.chromeVisible).toBe(true);
+
+    act(() => result.current.toggleChrome());
+    expect(result.current.chromeVisible).toBe(false);
+  });
+
+  it("toggleChrome is a no-op when disabled", () => {
+    const { result } = renderHook(() => useAutoHideChrome(false));
+    act(() => result.current.toggleChrome());
+    expect(result.current.chromeVisible).toBe(true);
+  });
+
+  it("resets to visible when switching from enabled to disabled", () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAutoHideChrome(enabled),
+      { initialProps: { enabled: true } },
+    );
+
+    act(() => vi.advanceTimersByTime(2000));
+    expect(result.current.chromeVisible).toBe(false);
+
+    rerender({ enabled: false });
+    expect(result.current.chromeVisible).toBe(true);
+  });
+});

--- a/app/hooks/useAutoHideChrome.ts
+++ b/app/hooks/useAutoHideChrome.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const INITIAL_HIDE_DELAY = 2000;
+const INACTIVITY_HIDE_DELAY = 3000;
+
+export function useAutoHideChrome(enabled: boolean) {
+  const [visible, setVisible] = useState(true);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setVisible(true);
+      return;
+    }
+
+    const startHideTimer = (delay: number) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setVisible(false), delay);
+    };
+
+    const handleMouseMove = () => {
+      setVisible(true);
+      startHideTimer(INACTIVITY_HIDE_DELAY);
+    };
+
+    startHideTimer(INITIAL_HIDE_DELAY);
+    window.addEventListener("mousemove", handleMouseMove);
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [enabled]);
+
+  const toggleChrome = useCallback(() => {
+    if (!enabled) return;
+    setVisible((v) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (!v) {
+        timerRef.current = setTimeout(
+          () => setVisible(false),
+          INACTIVITY_HIDE_DELAY,
+        );
+      }
+      return !v;
+    });
+  }, [enabled]);
+
+  return { chromeVisible: !enabled || visible, toggleChrome };
+}

--- a/pkg/migrations/20260512000000_add_viewer_hide_chrome.go
+++ b/pkg/migrations/20260512000000_add_viewer_hide_chrome.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`
+			ALTER TABLE user_settings ADD COLUMN viewer_hide_chrome BOOLEAN NOT NULL DEFAULT FALSE
+		`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec(`
+			UPDATE user_settings SET viewer_fit_mode = 'fit-width' WHERE viewer_fit_mode = 'original'
+		`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`
+			UPDATE user_settings SET viewer_fit_mode = 'original' WHERE viewer_fit_mode = 'fit-width'
+		`)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		_, err = db.Exec("ALTER TABLE user_settings DROP COLUMN viewer_hide_chrome")
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/user_settings.go
+++ b/pkg/models/user_settings.go
@@ -7,9 +7,9 @@ import (
 )
 
 const (
-	//tygo:emit export type FitMode = typeof FitModeHeight | typeof FitModeOriginal;
-	FitModeHeight   = "fit-height"
-	FitModeOriginal = "original"
+	//tygo:emit export type FitMode = typeof FitModeHeight | typeof FitModeWidth;
+	FitModeHeight = "fit-height"
+	FitModeWidth  = "fit-width"
 )
 
 const (
@@ -46,6 +46,7 @@ type UserSettings struct {
 	EpubTheme          string    `bun:"viewer_epub_theme,notnull,default:'light'" json:"viewer_epub_theme" tstype:"EpubTheme"`
 	EpubFlow           string    `bun:"viewer_epub_flow,notnull,default:'paginated'" json:"viewer_epub_flow" tstype:"EpubFlow"`
 	GallerySize        string    `bun:",notnull,default:'m'" json:"gallery_size" tstype:"GallerySize"`
+	ViewerHideChrome   bool      `bun:",notnull,default:false" json:"viewer_hide_chrome"`
 }
 
 // DefaultUserSettings returns a UserSettings with default values.
@@ -57,5 +58,6 @@ func DefaultUserSettings() *UserSettings {
 		EpubTheme:          EpubThemeLight,
 		EpubFlow:           EpubFlowPaginated,
 		GallerySize:        GallerySizeMedium,
+		ViewerHideChrome:   false,
 	}
 }

--- a/pkg/settings/handlers.go
+++ b/pkg/settings/handlers.go
@@ -33,6 +33,7 @@ func (h *handler) getUserSettings(c echo.Context) error {
 		EpubTheme:    settings.EpubTheme,
 		EpubFlow:     settings.EpubFlow,
 		GallerySize:  settings.GallerySize,
+		HideChrome:   settings.ViewerHideChrome,
 	})
 }
 
@@ -55,7 +56,7 @@ func (h *handler) updateUserSettings(c echo.Context) error {
 		return errcodes.ValidationError("preload_count must be between 1 and 10")
 	}
 	if payload.FitMode != nil && !IsValidFitMode(*payload.FitMode) {
-		return errcodes.ValidationError("fit_mode must be 'fit-height' or 'original'")
+		return errcodes.ValidationError("fit_mode must be 'fit-height' or 'fit-width'")
 	}
 	if payload.EpubFontSize != nil && (*payload.EpubFontSize < 50 || *payload.EpubFontSize > 200) {
 		return errcodes.ValidationError("viewer_epub_font_size must be between 50 and 200")
@@ -83,5 +84,6 @@ func (h *handler) updateUserSettings(c echo.Context) error {
 		EpubTheme:    settings.EpubTheme,
 		EpubFlow:     settings.EpubFlow,
 		GallerySize:  settings.GallerySize,
+		HideChrome:   settings.ViewerHideChrome,
 	})
 }

--- a/pkg/settings/service.go
+++ b/pkg/settings/service.go
@@ -50,6 +50,7 @@ type UserSettingsUpdate struct {
 	EpubTheme    *string
 	EpubFlow     *string
 	GallerySize  *string
+	HideChrome   *bool
 }
 
 // UpdateUserSettings applies a partial update to a user's settings,
@@ -99,6 +100,9 @@ func (svc *Service) UpdateUserSettings(
 		if update.GallerySize != nil {
 			current.GallerySize = *update.GallerySize
 		}
+		if update.HideChrome != nil {
+			current.ViewerHideChrome = *update.HideChrome
+		}
 
 		now := time.Now()
 		current.UserID = userID
@@ -117,6 +121,7 @@ func (svc *Service) UpdateUserSettings(
 			Set("viewer_epub_theme = EXCLUDED.viewer_epub_theme").
 			Set("viewer_epub_flow = EXCLUDED.viewer_epub_flow").
 			Set("gallery_size = EXCLUDED.gallery_size").
+			Set("viewer_hide_chrome = EXCLUDED.viewer_hide_chrome").
 			Returning("*").
 			Exec(ctx)
 		if err != nil {

--- a/pkg/settings/user_service_test.go
+++ b/pkg/settings/user_service_test.go
@@ -29,7 +29,7 @@ func TestUpdateUserSettings_PersistsEpubFields(t *testing.T) {
 	svc := NewService(db)
 
 	preload := 5
-	fitMode := "original"
+	fitMode := "fit-width"
 	fontSize := 140
 	theme := models.EpubThemeSepia
 	flow := models.EpubFlowScrolled
@@ -70,7 +70,7 @@ func TestUpdateUserSettings_PartialUpdateDoesNotClobber(t *testing.T) {
 
 	// Seed all five fields to known non-default values.
 	preload := 7
-	fitMode := "original"
+	fitMode := "fit-width"
 	fontSize := 130
 	theme := models.EpubThemeDark
 	flow := models.EpubFlowScrolled
@@ -90,7 +90,7 @@ func TestUpdateUserSettings_PartialUpdateDoesNotClobber(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 7, updated.ViewerPreloadCount)
-	assert.Equal(t, "original", updated.ViewerFitMode)
+	assert.Equal(t, "fit-width", updated.ViewerFitMode)
 	assert.Equal(t, 130, updated.EpubFontSize)
 	assert.Equal(t, models.EpubThemeSepia, updated.EpubTheme)
 	assert.Equal(t, models.EpubFlowScrolled, updated.EpubFlow)

--- a/pkg/settings/validators.go
+++ b/pkg/settings/validators.go
@@ -18,6 +18,7 @@ type UserSettingsPayload struct {
 	EpubTheme    *string `json:"viewer_epub_theme,omitempty"`
 	EpubFlow     *string `json:"viewer_epub_flow,omitempty"`
 	GallerySize  *string `json:"gallery_size,omitempty"`
+	HideChrome   *bool   `json:"viewer_hide_chrome,omitempty"`
 }
 
 // UserSettingsResponse is the response for user settings.
@@ -28,11 +29,12 @@ type UserSettingsResponse struct {
 	EpubTheme    string `json:"viewer_epub_theme"`
 	EpubFlow     string `json:"viewer_epub_flow"`
 	GallerySize  string `json:"gallery_size"`
+	HideChrome   bool   `json:"viewer_hide_chrome"`
 }
 
 // ValidFitModes returns all valid fit mode values.
 func ValidFitModes() []string {
-	return []string{models.FitModeHeight, models.FitModeOriginal}
+	return []string{models.FitModeHeight, models.FitModeWidth}
 }
 
 // IsValidFitMode returns true if the fit mode is valid.

--- a/website/docs/supported-formats.md
+++ b/website/docs/supported-formats.md
@@ -22,7 +22,7 @@ fingerprints (cover pHash, text SimHash, etc.) — see
 
 ## Comics
 
-- **CBZ** — Full [metadata extraction](./metadata#cbz) from ComicInfo.xml including title, authors, series, cover art, and language
+- **CBZ** — Full [metadata extraction](./metadata#cbz) from ComicInfo.xml including title, authors, series, cover art, and language. Includes an in-app viewer with fit-width/fit-height modes and auto-hide controls
 
 ## Downloads
 

--- a/website/docs/supported-formats.md
+++ b/website/docs/supported-formats.md
@@ -13,8 +13,8 @@ fingerprints (cover pHash, text SimHash, etc.) — see
 
 ## Ebooks
 
-- **EPUB** — Full [metadata extraction](./metadata#epub) including title, authors, series, description, cover art, language, and more. Includes an in-app reader with font size, theme, and flow controls
-- **PDF** — Full [metadata extraction](./metadata#pdf) including title, authors, description, cover art, page count, language, and chapter extraction from PDF bookmarks. Includes an in-app viewer with page-by-page reading
+- **EPUB** — Full [metadata extraction](./metadata#epub) including title, authors, series, description, cover art, language, and more. Includes an in-app reader with font size, theme, flow (paginated or scrolled), and auto-hide controls
+- **PDF** — Full [metadata extraction](./metadata#pdf) including title, authors, description, cover art, page count, language, and chapter extraction from PDF bookmarks. Includes an in-app viewer with fit-width/fit-height modes and auto-hide controls
 
 ## Audiobooks
 


### PR DESCRIPTION
## Summary
- Add auto-hide controls setting for EPUB and PDF readers — header/footer slide away after 2s of inactivity, reappear on mouse move, and toggle via center tap zone on mobile
- Rename "Original" fit mode to "Fit Width" with a data migration for existing user settings
- Fix EPUB scroll mode: invisible prev/next page buttons (z-10, covering the full reading area) were intercepting all wheel and touch events, preventing native scrolling from reaching the paginator's shadow DOM

## Test plan
- Open an EPUB, enable "Auto-hide controls" in settings — verify chrome hides after 2s and reappears on mouse move
- In paginated mode, verify center tap zone toggles chrome visibility
- Switch to scrolled flow mode — verify scrolling works with mouse wheel and touch
- Switch back to paginated mode — verify prev/next tap zones still work
- Open a PDF/CBZ, verify auto-hide works and fit-width/fit-height modes are correct
- Run `npx vitest run app/components/pages/EPUBReader.test.tsx` — 7 tests pass