### PR TITLE
[Docs] Unified publisher hierarchy — ADR and CONTEXT.md update

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,13 +33,11 @@ A category classification for a book (e.g., "Science Fiction").
 A user-defined label for a book, more granular than genre.
 
 **Publisher**:
-The publishing entity for a file.
-
-**Imprint**:
-A branded subdivision of a publisher, associated with a file.
+A publishing entity associated with a file. Publishers form a hierarchy via an optional parent relationship — a publisher can have one parent and many children. An imprint, a division, and a conglomerate are all represented as publishers at different levels of the tree. A file references exactly one publisher (at any level of the hierarchy); ancestor publishers are derived by walking up the tree.
+_Avoid_: imprint (as a separate concept — imprints are just publishers with a parent)
 
 **Alias**:
-An alternative name for a resource (series, person, genre, tag, publisher, or imprint) that resolves to the canonical resource during name-based lookups. Aliases are library-scoped and case-insensitive. A resource can have many aliases; each alias belongs to exactly one resource.
+An alternative name for a resource (series, person, genre, tag, or publisher) that resolves to the canonical resource during name-based lookups. Aliases are library-scoped and case-insensitive. A resource can have many aliases; each alias belongs to exactly one resource.
 _Avoid_: synonym, alternate name, variant
 
 **Primary Name**:
@@ -62,11 +60,12 @@ A `.metadata.json` file placed alongside a book or file that provides metadata o
 
 ## Relationships
 
-- A **Library** contains many **Books**, **Series**, **Persons**, **Genres**, **Tags**, **Publishers**, and **Imprints**
+- A **Library** contains many **Books**, **Series**, **Persons**, **Genres**, **Tags**, and **Publishers**
 - A **Book** has one or more **Files**
 - A **Book** has many **Genres**, **Tags**, **Authors** (persons), and **Series**
-- A **File** has at most one **Publisher**, at most one **Imprint**, and many **Narrators** (persons)
-- A **Resource** (series, person, genre, tag, publisher, imprint) has many **Aliases**
+- A **File** has at most one **Publisher** and many **Narrators** (persons)
+- A **Publisher** has at most one parent **Publisher** and many child **Publishers** (self-referential hierarchy)
+- A **Resource** (series, person, genre, tag, publisher) has many **Aliases**
 - An **Alias** belongs to exactly one resource and is unique within its resource type and library
 
 ## Example dialogue
@@ -80,4 +79,4 @@ A `.metadata.json` file placed alongside a book or file that provides metadata o
 ## Flagged ambiguities
 
 - The database table for persons is `persons`, but the URL path uses `people` and the Go package is `pkg/people`. The domain term is **Person**.
-- **Publisher** and **Imprint** are file-level metadata, not book-level. This differs from series/genre/tag/author which are book-level.
+- **Publisher** is file-level metadata, not book-level. This differs from series/genre/tag/author which are book-level.

--- a/docs/adr/0001-per-resource-alias-tables.md
+++ b/docs/adr/0001-per-resource-alias-tables.md
@@ -4,6 +4,8 @@ We considered two storage models for aliases: a single polymorphic `aliases` tab
 
 We chose per-resource tables because they allow natural foreign keys with `ON DELETE CASCADE`, alias-to-alias uniqueness enforced by a simple DB unique index per table, and straightforward lookup queries (each `FindOrCreate` only JOINs its own alias table). Cross-table uniqueness (alias vs. primary name) requires application-level validation either way, but per-resource tables avoid the additional complexity of a discriminator column and `WHERE resource_type = ?` filters on every query. The approach also matches the existing codebase pattern where each resource type has its own service, handlers, and migrations.
 
+Note: `imprint_aliases` was removed in ADR 0002 (unified publisher hierarchy). The imprint concept was folded into publishers.
+
 ## Considered Options
 
 - **Polymorphic table**: Fewer tables, but uniqueness constraints require application-level enforcement or SQLite triggers. Foreign keys can't reference multiple parent tables. Queries need a `WHERE resource_type = ?` filter on every access.

--- a/docs/adr/0001-per-resource-alias-tables.md
+++ b/docs/adr/0001-per-resource-alias-tables.md
@@ -4,7 +4,7 @@ We considered two storage models for aliases: a single polymorphic `aliases` tab
 
 We chose per-resource tables because they allow natural foreign keys with `ON DELETE CASCADE`, alias-to-alias uniqueness enforced by a simple DB unique index per table, and straightforward lookup queries (each `FindOrCreate` only JOINs its own alias table). Cross-table uniqueness (alias vs. primary name) requires application-level validation either way, but per-resource tables avoid the additional complexity of a discriminator column and `WHERE resource_type = ?` filters on every query. The approach also matches the existing codebase pattern where each resource type has its own service, handlers, and migrations.
 
-Note: `imprint_aliases` was removed in ADR 0002 (unified publisher hierarchy). The imprint concept was folded into publishers.
+Note: `imprint_aliases` will be removed as part of ADR 0002 (unified publisher hierarchy), which folds the imprint concept into publishers.
 
 ## Considered Options
 

--- a/docs/adr/0002-unified-publisher-hierarchy.md
+++ b/docs/adr/0002-unified-publisher-hierarchy.md
@@ -1,0 +1,19 @@
+# Unified publisher hierarchy instead of separate publisher and imprint tables
+
+We had separate `publishers` and `imprints` tables with independent `publisher_id` and `imprint_id` fields on files. This caused three problems: (1) external sources like Goodreads list imprints as publishers, requiring manual correction; (2) the two fields could get out of sync since imprints are inherently tied to a publisher; (3) the publishing industry has multiple hierarchy levels (conglomerate → division → imprint) that don't map to a flat two-table model.
+
+We chose to unify into a single `publishers` table with a self-referential `parent_id` for hierarchy. Imprints, divisions, and conglomerates are all publishers at different levels of the tree. A file references exactly one publisher at whatever level of specificity is known. Ancestor publishers are derived by walking up the tree via recursive CTE.
+
+## Key decisions
+
+- **Adjacency list** (not closure table) — hierarchy is shallow (3-4 levels), SQLite supports recursive CTEs, and we don't need heavy tree queries in hot paths.
+- **Files attach at any level** — metadata sources vary in specificity; forcing leaf-node attachment would require placeholder nodes or lose data.
+- **Clean break** — `imprint` removed entirely from sidecar files, plugin SDK, and format parser outputs. No backwards-compatibility shim. Justified by 0.0.X status.
+- **Migration strategy** — copy imprints into publishers (skip on name conflict), set file's publisher to the imprint value (more specific), drop imprint tables. No auto-generated hierarchy; parent relationships are a manual curation task.
+- **Cycle prevention** — validate on write (walk ancestor chain), exclude invalid options from comboboxes.
+
+## Considered options
+
+- **Keep publisher + imprint as separate tables**: Status quo. Simple model but doesn't match industry reality, causes data sync issues, and external sources don't distinguish the two.
+- **Single publisher field, no hierarchy**: Simpler, but loses the ability to see "all books under Penguin Random House" when files are attached to specific imprints.
+- **Closure table for hierarchy**: More powerful tree queries, but more complex to maintain (insert/move operations update many rows) for marginal benefit given shallow trees.

--- a/docs/adr/0002-unified-publisher-hierarchy.md
+++ b/docs/adr/0002-unified-publisher-hierarchy.md
@@ -9,7 +9,7 @@ We chose to unify into a single `publishers` table with a self-referential `pare
 - **Adjacency list** (not closure table) — hierarchy is shallow (3-4 levels), SQLite supports recursive CTEs, and we don't need heavy tree queries in hot paths.
 - **Files attach at any level** — metadata sources vary in specificity; forcing leaf-node attachment would require placeholder nodes or lose data.
 - **Clean break** — `imprint` removed entirely from sidecar files, plugin SDK, and format parser outputs. No backwards-compatibility shim. Justified by 0.0.X status.
-- **Migration strategy** — copy imprints into publishers (skip on name conflict), set file's publisher to the imprint value (more specific), drop imprint tables. No auto-generated hierarchy; parent relationships are a manual curation task.
+- **Migration strategy** — copy imprints into publishers (skip on name conflict), copy imprint aliases into publisher aliases (skip on conflict), set file's publisher to the imprint value (more specific), drop imprint tables. No auto-generated hierarchy; parent relationships are a manual curation task.
 - **Cycle prevention** — validate on write (walk ancestor chain), exclude invalid options from comboboxes.
 
 ## Considered options


### PR DESCRIPTION
## Summary
- Add ADR 0002 documenting the decision to replace separate publisher/imprint tables with a single hierarchical publishers table
- Update CONTEXT.md to remove "Imprint" as a domain term and redefine "Publisher" with hierarchy semantics
- Add note to ADR 0001 that imprint_aliases was removed

## Test plan
- Verify CONTEXT.md accurately describes the new publisher model (hierarchy, no imprint)
- Verify ADR 0002 captures the key decisions: adjacency list, any-level attachment, clean break, migration strategy, cycle prevention
- Verify ADR 0001 note correctly references ADR 0002