### PR TITLE
[Feature] Descendant-inclusive file filtering by publisher

### DIFF
--- a/pkg/publishers/handlers_test.go
+++ b/pkg/publishers/handlers_test.go
@@ -389,6 +389,130 @@ func TestList_ResponseUsesItemsKey(t *testing.T) {
 	assert.Len(t, items, 2)
 }
 
+func TestFiles_IncludesDescendantPublisherFiles(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	// Create publisher hierarchy: parent -> child
+	parent := seedPublisherWithFiles(t, db, lib, "Parent Corp", []string{"parent-f1"})
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child Imprint", ParentID: &parent.ID}
+	_, err := db.NewInsert().Model(child).Exec(ctx)
+	require.NoError(t, err)
+
+	// Add files to the child publisher
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Child Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Child Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	childFile := &models.File{
+		LibraryID:     lib.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/child-f1.epub",
+		FilesizeBytes: 1,
+		PublisherID:   &child.ID,
+	}
+	_, err = db.NewInsert().Model(childFile).Exec(ctx)
+	require.NoError(t, err)
+
+	// Request files for the parent publisher
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(parent.ID))
+
+	err = h.files(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var total int
+	err = json.Unmarshal(resp["total"], &total)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total, "parent publisher should show files from self + child")
+
+	var items []json.RawMessage
+	err = json.Unmarshal(resp["items"], &items)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+}
+
+func TestRetrieve_FileCountIncludesDescendants(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	// Create hierarchy: root -> child with files on both
+	root := seedPublisherWithFiles(t, db, lib, "Root Publisher", []string{"root-file"})
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child Publisher", ParentID: &root.ID}
+	_, err := db.NewInsert().Model(child).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Child Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Child Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	childFile := &models.File{
+		LibraryID:     lib.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/child-pub-file.epub",
+		FilesizeBytes: 1,
+		PublisherID:   &child.ID,
+	}
+	_, err = db.NewInsert().Model(childFile).Exec(ctx)
+	require.NoError(t, err)
+
+	// Request the root publisher detail
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(root.ID))
+
+	err = h.retrieve(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	var fileCount int
+	err = json.Unmarshal(resp["file_count"], &fileCount)
+	require.NoError(t, err)
+	assert.Equal(t, 2, fileCount, "file_count should include descendant publisher files")
+}
+
 func TestUpdate_RenameTriggersmerge_ParentIDStillApplied(t *testing.T) {
 	t.Parallel()
 	db := setupHandlerTestDB(t)

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -228,22 +228,22 @@ func (svc *Service) DeletePublisher(ctx context.Context, publisherID int) error 
 	})
 }
 
-// GetFileCount returns the count of files with this publisher.
+// GetFileCount returns the count of files with this publisher and all its descendants.
 func (svc *Service) GetFileCount(ctx context.Context, publisherID int) (int, error) {
 	count, err := svc.db.NewSelect().
 		Model((*models.File)(nil)).
-		Where("publisher_id = ?", publisherID).
+		Where("publisher_id IN ("+descendantIDsSubquery()+")", publisherID).
 		Count(ctx)
 	return count, errors.WithStack(err)
 }
 
-// GetFiles returns all files with this publisher.
+// GetFiles returns all files with this publisher and all its descendants.
 func (svc *Service) GetFiles(ctx context.Context, publisherID int) ([]*models.File, error) {
 	var files []*models.File
 
 	err := svc.db.NewSelect().
 		Model(&files).
-		Where("f.publisher_id = ?", publisherID).
+		Where("f.publisher_id IN ("+descendantIDsSubquery()+")", publisherID).
 		Relation("Book").
 		Order("f.filepath ASC").
 		Scan(ctx)
@@ -254,13 +254,13 @@ func (svc *Service) GetFiles(ctx context.Context, publisherID int) ([]*models.Fi
 	return files, nil
 }
 
-// GetFilesPaginated returns a paginated list of files with this publisher.
+// GetFilesPaginated returns a paginated list of files with this publisher and all its descendants.
 func (svc *Service) GetFilesPaginated(ctx context.Context, publisherID, limit, offset int) ([]*models.File, int, error) {
 	var files []*models.File
 
 	total, err := svc.db.NewSelect().
 		Model(&files).
-		Where("f.publisher_id = ?", publisherID).
+		Where("f.publisher_id IN ("+descendantIDsSubquery()+")", publisherID).
 		Relation("Book").
 		Order("f.filepath ASC").
 		Limit(limit).
@@ -492,4 +492,18 @@ func (svc *Service) GetDescendantIDs(ctx context.Context, publisherID int) ([]in
 	}
 
 	return descendants, nil
+}
+
+// descendantIDsSubquery returns a raw SQL expression that computes all publisher IDs
+// in the subtree rooted at the given publisherID (inclusive of the root itself).
+// Uses a recursive CTE to traverse the publisher hierarchy.
+func descendantIDsSubquery() string {
+	return `SELECT id FROM (
+		WITH RECURSIVE publisher_tree(id) AS (
+			SELECT ?
+			UNION ALL
+			SELECT p.id FROM publishers p JOIN publisher_tree pt ON p.parent_id = pt.id
+		)
+		SELECT id FROM publisher_tree
+	)`
 }

--- a/pkg/publishers/service_test.go
+++ b/pkg/publishers/service_test.go
@@ -525,6 +525,177 @@ func TestValidateNoCycle_NonExistentParentReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "parent publisher not found")
 }
 
+func createTestFile(t *testing.T, db *bun.DB, lib *models.Library, publisherID int, filepath string) {
+	t.Helper()
+	ctx := context.Background()
+
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err := db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     lib.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath,
+		FilesizeBytes: 1,
+		PublisherID:   &publisherID,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+}
+
+func TestGetFileCount_IncludesDescendantFiles(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	// Create hierarchy: root -> child -> grandchild
+	root := &models.Publisher{LibraryID: lib.ID, Name: "Root"}
+	err := svc.CreatePublisher(ctx, root)
+	require.NoError(t, err)
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child", ParentID: &root.ID}
+	err = svc.CreatePublisher(ctx, child)
+	require.NoError(t, err)
+
+	grandchild := &models.Publisher{LibraryID: lib.ID, Name: "Grandchild", ParentID: &child.ID}
+	err = svc.CreatePublisher(ctx, grandchild)
+	require.NoError(t, err)
+
+	// Create files for each publisher
+	createTestFile(t, db, lib, root.ID, "/tmp/root-file.epub")
+	createTestFile(t, db, lib, child.ID, "/tmp/child-file.epub")
+	createTestFile(t, db, lib, grandchild.ID, "/tmp/grandchild-file.epub")
+
+	// Root should count files from self + child + grandchild = 3
+	count, err := svc.GetFileCount(ctx, root.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	// Child should count files from self + grandchild = 2
+	count, err = svc.GetFileCount(ctx, child.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Grandchild (leaf) should count only its own files = 1
+	count, err = svc.GetFileCount(ctx, grandchild.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestGetFilesPaginated_IncludesDescendantFiles(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	// Create hierarchy: root -> child
+	root := &models.Publisher{LibraryID: lib.ID, Name: "Root"}
+	err := svc.CreatePublisher(ctx, root)
+	require.NoError(t, err)
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child", ParentID: &root.ID}
+	err = svc.CreatePublisher(ctx, child)
+	require.NoError(t, err)
+
+	// Create files
+	createTestFile(t, db, lib, root.ID, "/tmp/root-file.epub")
+	createTestFile(t, db, lib, child.ID, "/tmp/child-file.epub")
+
+	// Root paginated query should return both files
+	files, total, err := svc.GetFilesPaginated(ctx, root.ID, 50, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2, total)
+	assert.Len(t, files, 2)
+
+	// Child paginated query should return only child's file
+	files, total, err = svc.GetFilesPaginated(ctx, child.ID, 50, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+	assert.Len(t, files, 1)
+}
+
+func TestGetFilesPaginated_PaginatesCorrectlyWithDescendants(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	// Create hierarchy: root -> child
+	root := &models.Publisher{LibraryID: lib.ID, Name: "Root"}
+	err := svc.CreatePublisher(ctx, root)
+	require.NoError(t, err)
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child", ParentID: &root.ID}
+	err = svc.CreatePublisher(ctx, child)
+	require.NoError(t, err)
+
+	// Create 3 files total (1 root, 2 child)
+	createTestFile(t, db, lib, root.ID, "/tmp/a-root.epub")
+	createTestFile(t, db, lib, child.ID, "/tmp/b-child1.epub")
+	createTestFile(t, db, lib, child.ID, "/tmp/c-child2.epub")
+
+	// Page 1 of size 2 should return 2 items, total 3
+	files, total, err := svc.GetFilesPaginated(ctx, root.ID, 2, 0)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	assert.Len(t, files, 2)
+
+	// Page 2 of size 2 should return 1 item, total 3
+	files, total, err = svc.GetFilesPaginated(ctx, root.ID, 2, 2)
+	require.NoError(t, err)
+	assert.Equal(t, 3, total)
+	assert.Len(t, files, 1)
+}
+
+func TestGetFiles_IncludesDescendantFiles(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	// Create hierarchy: root -> child
+	root := &models.Publisher{LibraryID: lib.ID, Name: "Root"}
+	err := svc.CreatePublisher(ctx, root)
+	require.NoError(t, err)
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child", ParentID: &root.ID}
+	err = svc.CreatePublisher(ctx, child)
+	require.NoError(t, err)
+
+	createTestFile(t, db, lib, root.ID, "/tmp/root-file.epub")
+	createTestFile(t, db, lib, child.ID, "/tmp/child-file.epub")
+
+	// Root GetFiles should return both files
+	files, err := svc.GetFiles(ctx, root.ID)
+	require.NoError(t, err)
+	assert.Len(t, files, 2)
+
+	// Child GetFiles should return only child's file
+	files, err = svc.GetFiles(ctx, child.ID)
+	require.NoError(t, err)
+	assert.Len(t, files, 1)
+}
+
 func TestListPublishers_SearchMatchesAliases(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)


### PR DESCRIPTION
Closes #263

## Summary
- Publisher file queries (count, list, paginated) now use a recursive CTE to include files from all descendant publishers in the hierarchy
- A reusable `descendantIDsSubquery()` helper generates the recursive CTE SQL for computing the full publisher subtree (self + all descendants)
- No frontend changes needed — the publisher detail page automatically shows the expanded file set since it calls the same endpoints
- The publisher list page's per-item file count also reflects the total (direct + descendant)

## Implementation notes
- Used a recursive CTE inside a subquery rather than Bun's `WithRecursive` API because Bun wraps UNION ALL members in parentheses which is invalid CTE syntax in SQLite when the query is used as a subquery (e.g., by `ScanAndCount`'s COUNT wrapper)
- SQLite's default recursion limit (1000) applies, which is more than sufficient for practical publisher trees

## Test plan
- Root publisher file count includes files from all descendants (service_test.go:TestGetFileCount_IncludesDescendantFiles)
- Paginated file listing includes descendant publisher files (service_test.go:TestGetFilesPaginated_IncludesDescendantFiles)
- Pagination works correctly with expanded descendant result set (service_test.go:TestGetFilesPaginated_PaginatesCorrectlyWithDescendants)
- GetFiles returns files from all descendants (service_test.go:TestGetFiles_IncludesDescendantFiles)
- Files endpoint includes descendant publisher files via handler (handlers_test.go:TestFiles_IncludesDescendantPublisherFiles)
- Retrieve endpoint file_count includes descendants (handlers_test.go:TestRetrieve_FileCountIncludesDescendants)