### PR TITLE
[Feature] Publisher hierarchy: children list + counts

### DIFF
--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -1,5 +1,10 @@
 import { useMemo, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 
 import {
   FILE_LIST_ITEMS_PER_PAGE,
@@ -10,6 +15,7 @@ import {
   type PublisherEditData,
 } from "@/components/library/PublisherEditDialog";
 import { ResourceDetail } from "@/components/library/ResourceDetail";
+import { Badge } from "@/components/ui/badge";
 import { useParentPublisherSearch } from "@/hooks/queries/entity-search";
 import {
   useDeletePublisher,
@@ -65,6 +71,8 @@ const PublisherDetail = () => {
     ? ((publisher.aliases as unknown as string[]) ?? [])
     : [];
   const fileCount = publisher?.file_count ?? 0;
+  const descendantFileCount = publisher?.descendant_file_count ?? 0;
+  const children = publisher?.children ?? [];
 
   // Compute exclusion list for parent publisher search (self + descendants)
   const descendantIds = publisher?.descendant_ids;
@@ -163,6 +171,14 @@ const PublisherDetail = () => {
         }}
         entityId={publisherId!}
         entityType="publisher"
+        extraBadges={
+          descendantFileCount > 0 ? (
+            <Badge variant="secondary">
+              {descendantFileCount}{" "}
+              {descendantFileCount === 1 ? "file" : "files"} in sub-publishers
+            </Badge>
+          ) : undefined
+        }
         isLoading={publisherQuery.isLoading}
         libraryId={libraryId!}
         mergeConfig={{
@@ -184,6 +200,27 @@ const PublisherDetail = () => {
         notFoundLabel="Publisher Not Found"
         onEditClick={() => setEditOpen(true)}
       >
+        {children.length > 0 && (
+          <section className="mb-10">
+            <h2 className="text-xl font-semibold mb-4">Child Publishers</h2>
+            <div className="space-y-1">
+              {children.map((child) => (
+                <Link
+                  className="flex items-center justify-between p-3 rounded-md hover:bg-muted/50 transition-colors"
+                  key={child.id}
+                  to={`/libraries/${libraryId}/publishers/${child.id}`}
+                >
+                  <span className="font-medium">{child.name}</span>
+                  <Badge variant="secondary">
+                    {child.file_count}{" "}
+                    {child.file_count === 1 ? "file" : "files"}
+                  </Badge>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
         <FileListSection
           emptyMessage="This publisher has no associated files."
           libraryId={libraryId!}

--- a/app/components/pages/PublishersList.tsx
+++ b/app/components/pages/PublishersList.tsx
@@ -1,25 +1,51 @@
 import ResourceList from "@/components/library/ResourceList";
-import { usePublishersList } from "@/hooks/queries/publishers";
+import {
+  usePublishersList,
+  type PublisherListItem,
+} from "@/hooks/queries/publishers";
 import { useResourceListState } from "@/hooks/useResourceListState";
-import type { Publisher } from "@/types";
 
 const PublishersList = () => {
   const state = useResourceListState();
   const query = usePublishersList(state.queryParams);
 
   return (
-    <ResourceList<Publisher>
+    <ResourceList<PublisherListItem>
       itemConfig={(publisher) => {
         const fileCount = publisher.file_count ?? 0;
+        const descendantFileCount = publisher.descendant_file_count ?? 0;
+        const descendantPublisherCount =
+          publisher.descendant_publisher_count ?? 0;
+
+        const badges = [
+          {
+            label: fileCount === 1 ? "file" : "files",
+            count: fileCount,
+          },
+        ];
+
+        if (descendantFileCount > 0) {
+          badges.push({
+            label: descendantFileCount === 1 ? "sub-file" : "sub-files",
+            count: descendantFileCount,
+          });
+        }
+
+        if (descendantPublisherCount > 0) {
+          badges.push({
+            label:
+              descendantPublisherCount === 1
+                ? "sub-publisher"
+                : "sub-publishers",
+            count: descendantPublisherCount,
+          });
+        }
+
         return {
           name: publisher.name,
+          secondaryText: publisher.parent_name ?? undefined,
           aliases: publisher.aliases.map((a) => a.name),
-          badges: [
-            {
-              label: fileCount === 1 ? "file" : "files",
-              count: fileCount,
-            },
-          ],
+          badges,
         };
       }}
       itemLabel="publishers"

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -19,18 +19,32 @@ export interface PublisherAncestor {
   name: string;
 }
 
-export interface PublisherDetail extends Publisher {
+export interface PublisherChild {
+  id: number;
+  name: string;
+  file_count: number;
+}
+
+export interface PublisherDetail extends Omit<Publisher, "children"> {
   ancestors: PublisherAncestor[];
   descendant_ids: number[];
+  children: PublisherChild[];
+  descendant_file_count: number;
 }
+
+export interface PublisherListItem extends Publisher {
+  descendant_file_count: number;
+  descendant_publisher_count: number;
+  parent_name: string | null;
+}
+
+export type ListPublishersData = ResourceListResponse<PublisherListItem>;
 
 export enum QueryKey {
   ListPublishers = "ListPublishers",
   RetrievePublisher = "RetrievePublisher",
   PublisherFiles = "PublisherFiles",
 }
-
-export type ListPublishersData = ResourceListResponse<Publisher>;
 
 export const usePublishersList = (
   query: ListPublishersQuery = {},

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -66,13 +66,35 @@ func (h *handler) retrieve(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	children, err := h.publisherService.GetChildren(ctx, id)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	type childResponse struct {
+		ID        int    `json:"id"`
+		Name      string `json:"name"`
+		FileCount int    `json:"file_count"`
+	}
+	childList := make([]childResponse, len(children))
+	for i, ch := range children {
+		childList[i] = childResponse{ID: ch.ID, Name: ch.Name, FileCount: ch.FileCount}
+	}
+
+	descendantFileCount, err := h.publisherService.GetDescendantFileCount(ctx, id)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
 	response := struct {
 		*models.Publisher
-		FileCount     int                `json:"file_count"`
-		Aliases       []string           `json:"aliases"`
-		Ancestors     []ancestorResponse `json:"ancestors"`
-		DescendantIDs []int              `json:"descendant_ids"`
-	}{publisher, fileCount, aliasList, ancestorList, descendantIDs}
+		FileCount           int                `json:"file_count"`
+		DescendantFileCount int                `json:"descendant_file_count"`
+		Aliases             []string           `json:"aliases"`
+		Ancestors           []ancestorResponse `json:"ancestors"`
+		DescendantIDs       []int              `json:"descendant_ids"`
+		Children            []childResponse    `json:"children"`
+	}{publisher, fileCount, descendantFileCount, aliasList, ancestorList, descendantIDs, childList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -107,14 +129,40 @@ func (h *handler) list(c echo.Context) error {
 
 	type PublisherWithCount struct {
 		*models.Publisher
-		FileCount int      `json:"file_count"`
-		Aliases   []string `json:"aliases"`
+		FileCount                int      `json:"file_count"`
+		DescendantFileCount      int      `json:"descendant_file_count"`
+		DescendantPublisherCount int      `json:"descendant_publisher_count"`
+		ParentName               *string  `json:"parent_name"`
+		Aliases                  []string `json:"aliases"`
 	}
+
+	// Build a lookup map of publisher ID -> name for parent resolution
+	publisherNameMap := make(map[int]string, len(publishers))
+	for _, p := range publishers {
+		publisherNameMap[p.ID] = p.Name
+	}
+
 	result := make([]PublisherWithCount, len(publishers))
 	for i, p := range publishers {
 		fileCount, _ := h.publisherService.GetFileCount(ctx, p.ID)
+		descendantFileCount, _ := h.publisherService.GetDescendantFileCount(ctx, p.ID)
+		descendantPublisherCount, _ := h.publisherService.GetDescendantPublisherCount(ctx, p.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PublisherConfig, p.ID)
-		result[i] = PublisherWithCount{p, fileCount, aliasList}
+
+		var parentName *string
+		if p.ParentID != nil {
+			if name, ok := publisherNameMap[*p.ParentID]; ok {
+				parentName = &name
+			} else {
+				// Parent might not be in the current page; look it up
+				parent, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{ID: p.ParentID})
+				if err == nil {
+					parentName = &parent.Name
+				}
+			}
+		}
+
+		result[i] = PublisherWithCount{p, fileCount, descendantFileCount, descendantPublisherCount, parentName, aliasList}
 	}
 
 	response := map[string]any{

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -81,7 +81,7 @@ func (h *handler) retrieve(c echo.Context) error {
 		childList[i] = childResponse{ID: ch.ID, Name: ch.Name, FileCount: ch.FileCount}
 	}
 
-	descendantFileCount, err := h.publisherService.GetDescendantFileCount(ctx, id)
+	descendantFileCount, err := h.publisherService.GetFileCountForPublisherIDs(ctx, descendantIDs)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -145,8 +145,9 @@ func (h *handler) list(c echo.Context) error {
 	result := make([]PublisherWithCount, len(publishers))
 	for i, p := range publishers {
 		fileCount, _ := h.publisherService.GetFileCount(ctx, p.ID)
-		descendantFileCount, _ := h.publisherService.GetDescendantFileCount(ctx, p.ID)
-		descendantPublisherCount, _ := h.publisherService.GetDescendantPublisherCount(ctx, p.ID)
+		descendantIDs, _ := h.publisherService.GetDescendantIDs(ctx, p.ID)
+		descendantFileCount, _ := h.publisherService.GetFileCountForPublisherIDs(ctx, descendantIDs)
+		descendantPublisherCount := len(descendantIDs)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PublisherConfig, p.ID)
 
 		var parentName *string

--- a/pkg/publishers/handlers_test.go
+++ b/pkg/publishers/handlers_test.go
@@ -452,7 +452,6 @@ func TestRetrieve_IncludesChildrenAndDescendantFileCount(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create files: 2 direct on parent, 3 on childA, 1 on childB
-	seedPublisherWithFiles(t, db, lib, "direct_parent", nil)
 	// Use the actual publisher IDs for file creation
 	book := &models.Book{
 		LibraryID:       lib.ID,

--- a/pkg/publishers/handlers_test.go
+++ b/pkg/publishers/handlers_test.go
@@ -431,3 +431,242 @@ func TestUpdate_RenameTriggersmerge_ParentIDStillApplied(t *testing.T) {
 	require.NotNil(t, updated.ParentID, "parent_id should be set on merge target")
 	assert.Equal(t, parent.ID, *updated.ParentID)
 }
+
+func TestRetrieve_IncludesChildrenAndDescendantFileCount(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	parent := &models.Publisher{LibraryID: lib.ID, Name: "Parent"}
+	_, err := db.NewInsert().Model(parent).Exec(ctx)
+	require.NoError(t, err)
+
+	childA := &models.Publisher{LibraryID: lib.ID, Name: "ChildA", ParentID: &parent.ID}
+	_, err = db.NewInsert().Model(childA).Exec(ctx)
+	require.NoError(t, err)
+
+	childB := &models.Publisher{LibraryID: lib.ID, Name: "ChildB", ParentID: &parent.ID}
+	_, err = db.NewInsert().Model(childB).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create files: 2 direct on parent, 3 on childA, 1 on childB
+	seedPublisherWithFiles(t, db, lib, "direct_parent", nil)
+	// Use the actual publisher IDs for file creation
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Direct Parent Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Direct Parent Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		file := &models.File{
+			LibraryID:     lib.ID,
+			BookID:        book.ID,
+			FileType:      models.FileTypeEPUB,
+			FileRole:      models.FileRoleMain,
+			Filepath:      fmt.Sprintf("/tmp/parent_file_%d.epub", i),
+			FilesizeBytes: 1,
+			PublisherID:   &parent.ID,
+		}
+		_, err = db.NewInsert().Model(file).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	book2 := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "ChildA Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "ChildA Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book2).Exec(ctx)
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		file := &models.File{
+			LibraryID:     lib.ID,
+			BookID:        book2.ID,
+			FileType:      models.FileTypeEPUB,
+			FileRole:      models.FileRoleMain,
+			Filepath:      fmt.Sprintf("/tmp/childA_file_%d.epub", i),
+			FilesizeBytes: 1,
+			PublisherID:   &childA.ID,
+		}
+		_, err = db.NewInsert().Model(file).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	book3 := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "ChildB Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "ChildB Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book3).Exec(ctx)
+	require.NoError(t, err)
+
+	file := &models.File{
+		LibraryID:     lib.ID,
+		BookID:        book3.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      "/tmp/childB_file_0.epub",
+		FilesizeBytes: 1,
+		PublisherID:   &childB.ID,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(parent.ID))
+
+	err = h.retrieve(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp map[string]json.RawMessage
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	// Check file_count (direct)
+	var fileCount int
+	err = json.Unmarshal(resp["file_count"], &fileCount)
+	require.NoError(t, err)
+	assert.Equal(t, 2, fileCount)
+
+	// Check descendant_file_count (files on children)
+	assert.Contains(t, resp, "descendant_file_count")
+	var descendantFileCount int
+	err = json.Unmarshal(resp["descendant_file_count"], &descendantFileCount)
+	require.NoError(t, err)
+	assert.Equal(t, 4, descendantFileCount) // 3 + 1
+
+	// Check children
+	assert.Contains(t, resp, "children")
+	var children []struct {
+		ID        int    `json:"id"`
+		Name      string `json:"name"`
+		FileCount int    `json:"file_count"`
+	}
+	err = json.Unmarshal(resp["children"], &children)
+	require.NoError(t, err)
+	require.Len(t, children, 2)
+	assert.Equal(t, "ChildA", children[0].Name)
+	assert.Equal(t, 3, children[0].FileCount)
+	assert.Equal(t, "ChildB", children[1].Name)
+	assert.Equal(t, 1, children[1].FileCount)
+}
+
+func TestList_IncludesHierarchyCounts(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	parent := &models.Publisher{LibraryID: lib.ID, Name: "Parent"}
+	_, err := db.NewInsert().Model(parent).Exec(ctx)
+	require.NoError(t, err)
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child", ParentID: &parent.ID}
+	_, err = db.NewInsert().Model(child).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create files on child
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Child Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Child Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	for i := 0; i < 2; i++ {
+		file := &models.File{
+			LibraryID:     lib.ID,
+			BookID:        book.ID,
+			FileType:      models.FileTypeEPUB,
+			FileRole:      models.FileRoleMain,
+			Filepath:      fmt.Sprintf("/tmp/list_child_file_%d.epub", i),
+			FilesizeBytes: 1,
+			PublisherID:   &child.ID,
+		}
+		_, err = db.NewInsert().Model(file).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = h.list(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Items []struct {
+			ID                       int     `json:"id"`
+			Name                     string  `json:"name"`
+			FileCount                int     `json:"file_count"`
+			DescendantFileCount      int     `json:"descendant_file_count"`
+			DescendantPublisherCount int     `json:"descendant_publisher_count"`
+			ParentName               *string `json:"parent_name"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, 2, resp.Total)
+
+	// Find parent and child in response (sorted by name: Child, Parent)
+	var parentItem, childItem struct {
+		ID                       int     `json:"id"`
+		Name                     string  `json:"name"`
+		FileCount                int     `json:"file_count"`
+		DescendantFileCount      int     `json:"descendant_file_count"`
+		DescendantPublisherCount int     `json:"descendant_publisher_count"`
+		ParentName               *string `json:"parent_name"`
+	}
+	for _, item := range resp.Items {
+		if item.Name == "Parent" {
+			parentItem = item
+		} else {
+			childItem = item
+		}
+	}
+
+	// Parent: 0 direct files, 2 descendant files, 1 descendant publisher
+	assert.Equal(t, 0, parentItem.FileCount)
+	assert.Equal(t, 2, parentItem.DescendantFileCount)
+	assert.Equal(t, 1, parentItem.DescendantPublisherCount)
+	assert.Nil(t, parentItem.ParentName)
+
+	// Child: 2 direct files, 0 descendant files, 0 descendant publishers, parent name = "Parent"
+	assert.Equal(t, 2, childItem.FileCount)
+	assert.Equal(t, 0, childItem.DescendantFileCount)
+	assert.Equal(t, 0, childItem.DescendantPublisherCount)
+	require.NotNil(t, childItem.ParentName)
+	assert.Equal(t, "Parent", *childItem.ParentName)
+}

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -486,13 +486,19 @@ func (svc *Service) GetDescendantFileCount(ctx context.Context, publisherID int)
 	if err != nil {
 		return 0, err
 	}
-	if len(descendantIDs) == 0 {
+	return svc.GetFileCountForPublisherIDs(ctx, descendantIDs)
+}
+
+// GetFileCountForPublisherIDs returns the count of files attached to any of the
+// given publisher IDs. Useful when descendant IDs have already been computed.
+func (svc *Service) GetFileCountForPublisherIDs(ctx context.Context, publisherIDs []int) (int, error) {
+	if len(publisherIDs) == 0 {
 		return 0, nil
 	}
 
 	count, err := svc.db.NewSelect().
 		Model((*models.File)(nil)).
-		Where("publisher_id IN (?)", bun.List(descendantIDs)).
+		Where("publisher_id IN (?)", bun.List(publisherIDs)).
 		Count(ctx)
 	return count, errors.WithStack(err)
 }

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -461,6 +461,52 @@ func (svc *Service) GetAncestors(ctx context.Context, publisherID int) ([]*model
 	return ancestors, nil
 }
 
+// GetChildren returns the direct children of a publisher with their file counts.
+func (svc *Service) GetChildren(ctx context.Context, publisherID int) ([]*models.Publisher, error) {
+	var children []*models.Publisher
+
+	err := svc.db.NewSelect().
+		Model(&children).
+		Where("pub.parent_id = ?", publisherID).
+		ColumnExpr("pub.*").
+		ColumnExpr("(SELECT COUNT(*) FROM files WHERE files.publisher_id = pub.id) AS file_count").
+		Order("pub.name ASC").
+		Scan(ctx)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return children, nil
+}
+
+// GetDescendantFileCount returns the count of files attached to any descendant
+// of the given publisher (not including the publisher's own direct files).
+func (svc *Service) GetDescendantFileCount(ctx context.Context, publisherID int) (int, error) {
+	descendantIDs, err := svc.GetDescendantIDs(ctx, publisherID)
+	if err != nil {
+		return 0, err
+	}
+	if len(descendantIDs) == 0 {
+		return 0, nil
+	}
+
+	count, err := svc.db.NewSelect().
+		Model((*models.File)(nil)).
+		Where("publisher_id IN (?)", bun.List(descendantIDs)).
+		Count(ctx)
+	return count, errors.WithStack(err)
+}
+
+// GetDescendantPublisherCount returns the count of all publishers in the
+// subtree rooted at publisherID (not including the publisher itself).
+func (svc *Service) GetDescendantPublisherCount(ctx context.Context, publisherID int) (int, error) {
+	descendantIDs, err := svc.GetDescendantIDs(ctx, publisherID)
+	if err != nil {
+		return 0, err
+	}
+	return len(descendantIDs), nil
+}
+
 // GetDescendantIDs returns all descendant IDs of a publisher (children,
 // grandchildren, etc.) using a breadth-first traversal.
 func (svc *Service) GetDescendantIDs(ctx context.Context, publisherID int) ([]int, error) {

--- a/pkg/publishers/service_test.go
+++ b/pkg/publishers/service_test.go
@@ -3,6 +3,7 @@ package publishers
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -555,4 +556,170 @@ func TestListPublishers_SearchMatchesAliases(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 1, "Should find publisher by alias 'PRH'")
 	assert.Equal(t, "Penguin Random House", results[0].Name)
+}
+
+// createFilesForPublisher creates a book and the specified number of files
+// associated with the given publisher.
+func createFilesForPublisher(t *testing.T, db *bun.DB, lib *models.Library, publisherID int, count int) {
+	t.Helper()
+	ctx := context.Background()
+
+	book := &models.Book{
+		LibraryID:       lib.ID,
+		Title:           "Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err := db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	for i := 0; i < count; i++ {
+		file := &models.File{
+			LibraryID:     lib.ID,
+			BookID:        book.ID,
+			FileType:      models.FileTypeEPUB,
+			FileRole:      models.FileRoleMain,
+			Filepath:      fmt.Sprintf("/tmp/pub%d_file%d.epub", publisherID, i),
+			FilesizeBytes: 1,
+			PublisherID:   &publisherID,
+		}
+		_, err = db.NewInsert().Model(file).Exec(ctx)
+		require.NoError(t, err)
+	}
+}
+
+func TestGetChildren_ReturnsDirectChildrenWithFileCount(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	parent := &models.Publisher{LibraryID: lib.ID, Name: "Parent"}
+	err := svc.CreatePublisher(ctx, parent)
+	require.NoError(t, err)
+
+	childA := &models.Publisher{LibraryID: lib.ID, Name: "ChildA", ParentID: &parent.ID}
+	err = svc.CreatePublisher(ctx, childA)
+	require.NoError(t, err)
+
+	childB := &models.Publisher{LibraryID: lib.ID, Name: "ChildB", ParentID: &parent.ID}
+	err = svc.CreatePublisher(ctx, childB)
+	require.NoError(t, err)
+
+	// Grandchild should NOT appear in children of parent
+	grandchild := &models.Publisher{LibraryID: lib.ID, Name: "Grandchild", ParentID: &childA.ID}
+	err = svc.CreatePublisher(ctx, grandchild)
+	require.NoError(t, err)
+
+	// Create files for children
+	createFilesForPublisher(t, db, lib, childA.ID, 3)
+	createFilesForPublisher(t, db, lib, childB.ID, 1)
+
+	children, err := svc.GetChildren(ctx, parent.ID)
+	require.NoError(t, err)
+	require.Len(t, children, 2)
+
+	// Children should be ordered by name
+	assert.Equal(t, "ChildA", children[0].Name)
+	assert.Equal(t, 3, children[0].FileCount)
+	assert.Equal(t, "ChildB", children[1].Name)
+	assert.Equal(t, 1, children[1].FileCount)
+}
+
+func TestGetChildren_NoChildren(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	leaf := &models.Publisher{LibraryID: lib.ID, Name: "Leaf"}
+	err := svc.CreatePublisher(ctx, leaf)
+	require.NoError(t, err)
+
+	children, err := svc.GetChildren(ctx, leaf.ID)
+	require.NoError(t, err)
+	assert.Empty(t, children)
+}
+
+func TestGetDescendantFileCount_CountsAllDescendantFiles(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	root := &models.Publisher{LibraryID: lib.ID, Name: "Root"}
+	err := svc.CreatePublisher(ctx, root)
+	require.NoError(t, err)
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child", ParentID: &root.ID}
+	err = svc.CreatePublisher(ctx, child)
+	require.NoError(t, err)
+
+	grandchild := &models.Publisher{LibraryID: lib.ID, Name: "Grandchild", ParentID: &child.ID}
+	err = svc.CreatePublisher(ctx, grandchild)
+	require.NoError(t, err)
+
+	// Create files at different levels
+	createFilesForPublisher(t, db, lib, child.ID, 2)
+	createFilesForPublisher(t, db, lib, grandchild.ID, 3)
+
+	count, err := svc.GetDescendantFileCount(ctx, root.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 5, count) // 2 + 3
+
+	// Child's descendants have 3 files (grandchild only)
+	count, err = svc.GetDescendantFileCount(ctx, child.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	// Grandchild has no descendants
+	count, err = svc.GetDescendantFileCount(ctx, grandchild.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestGetDescendantPublisherCount_CountsAllDescendantPublishers(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+
+	root := &models.Publisher{LibraryID: lib.ID, Name: "Root"}
+	err := svc.CreatePublisher(ctx, root)
+	require.NoError(t, err)
+
+	childA := &models.Publisher{LibraryID: lib.ID, Name: "ChildA", ParentID: &root.ID}
+	err = svc.CreatePublisher(ctx, childA)
+	require.NoError(t, err)
+
+	childB := &models.Publisher{LibraryID: lib.ID, Name: "ChildB", ParentID: &root.ID}
+	err = svc.CreatePublisher(ctx, childB)
+	require.NoError(t, err)
+
+	grandchild := &models.Publisher{LibraryID: lib.ID, Name: "Grandchild", ParentID: &childA.ID}
+	err = svc.CreatePublisher(ctx, grandchild)
+	require.NoError(t, err)
+
+	count, err := svc.GetDescendantPublisherCount(ctx, root.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count) // childA + childB + grandchild
+
+	count, err = svc.GetDescendantPublisherCount(ctx, childA.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count) // grandchild only
+
+	count, err = svc.GetDescendantPublisherCount(ctx, childB.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count) // no children
 }

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -36,9 +36,13 @@ Genres and tags are simple labels attached to books. The distinction is semantic
 
 ### Publishers
 
-Publishers are attached at the **file level**, not the book level. This means different editions of the same book can have different publishers. Publishers support a `parent_id` field for future hierarchy support (e.g., imprints as children of parent publishers).
+Publishers are attached at the **file level**, not the book level. This means different editions of the same book can have different publishers. Publishers support a hierarchical structure for organizing imprints and parent companies.
 
 **Publisher hierarchy.** Publishers can be organized into a parent-child hierarchy. Set a parent publisher from the publisher edit dialog to express relationships like "Dutton" is a child of "Penguin Random House". The publisher detail page displays the full ancestor chain as clickable breadcrumbs. Cycles are rejected (you cannot make A a child of B if B is already a descendant of A). The parent combobox in the edit dialog automatically excludes the publisher itself and all its descendants to prevent invalid selections.
+
+**Hierarchy in the UI:**
+- **Detail page:** Shows direct file count and descendant file count (files attached to any sub-publisher). Lists child publishers with their file counts as clickable links.
+- **List page:** Shows parent publisher name as secondary text, plus per-publisher counts for direct files, descendant files, and descendant publishers.
 
 ### Identifiers
 


### PR DESCRIPTION
Closes #262

## Summary
- Added backend service methods (`GetChildren`, `GetDescendantFileCount`, `GetDescendantPublisherCount`) using breadth-first traversal of the publisher tree
- Updated publisher detail endpoint to return children list (id + name + direct file count) and descendant file count
- Updated publisher list endpoint to return descendant file count, descendant publisher count, and parent name per publisher
- Publisher detail page shows a "Child Publishers" section with clickable links and file count badges, plus a descendant file count badge
- Publishers list page shows parent name as secondary text and descendant file/publisher count badges (hidden when 0)
- Updated docs to describe the new hierarchy UI features

## Test plan
- Direct children returned with file counts, sorted by name (service_test.go)
- No children returns empty list (service_test.go)
- Descendant file count aggregates recursively across the subtree (service_test.go)
- Descendant publisher count covers all levels (service_test.go)
- Retrieve endpoint includes children and descendant_file_count (handlers_test.go)
- List endpoint includes hierarchy counts and parent_name (handlers_test.go)
- Root publisher with no children shows 0 for descendant counts (no confusing UI)
- All checks pass: Go lint, Go tests, ESLint, Prettier, TypeScript, vitest, mise check:quiet