### PR TITLE
[Feature] Publisher merge flow: "Set as child" option

### DIFF
--- a/app/components/library/MetadataMergeDialog.tsx
+++ b/app/components/library/MetadataMergeDialog.tsx
@@ -23,6 +23,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 import type { EntityType } from "./MetadataEditDialog";
 
@@ -30,6 +35,13 @@ interface EntityOption {
   id: number;
   name: string;
   count: number;
+}
+
+interface SetChildConfig {
+  onSetChild: (childId: number) => Promise<void>;
+  isPending: boolean;
+  /** IDs of entities that are ancestors of the target — setting them as child would create a cycle */
+  disabledIds: number[];
 }
 
 interface MetadataMergeDialogProps {
@@ -43,6 +55,8 @@ interface MetadataMergeDialogProps {
   entities: EntityOption[];
   isLoadingEntities: boolean;
   onSearch: (search: string) => void;
+  /** When provided, shows a "Set as child" option alongside Merge */
+  setChildConfig?: SetChildConfig;
 }
 
 const ENTITY_PLURALS: Record<EntityType, string> = {
@@ -64,6 +78,7 @@ export function MetadataMergeDialog({
   entities,
   isLoadingEntities,
   onSearch,
+  setChildConfig,
 }: MetadataMergeDialogProps) {
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [comboboxOpen, setComboboxOpen] = useState(false);
@@ -76,6 +91,12 @@ export function MetadataMergeDialog({
 
   const selectedEntity = availableEntities.find((e) => e.id === selectedId);
 
+  // Determine if "Set as child" is disabled for the selected entity (would create cycle)
+  const setChildDisabled = useMemo(() => {
+    if (!setChildConfig || !selectedId) return false;
+    return setChildConfig.disabledIds.includes(selectedId);
+  }, [setChildConfig, selectedId]);
+
   const handleSearchChange = (value: string) => {
     setSearch(value);
     onSearch(value);
@@ -84,6 +105,14 @@ export function MetadataMergeDialog({
   const handleMerge = async () => {
     if (selectedId) {
       await onMerge(selectedId);
+      setSelectedId(null);
+      setSearch("");
+    }
+  };
+
+  const handleSetChild = async () => {
+    if (selectedId && setChildConfig) {
+      await setChildConfig.onSetChild(selectedId);
       setSelectedId(null);
       setSearch("");
     }
@@ -105,8 +134,10 @@ export function MetadataMergeDialog({
             Merge into "{targetName}"
           </DialogTitle>
           <DialogDescription>
-            Select a {entityType} to merge into this one. All associated books
-            will be transferred and the selected {entityType} will be deleted.
+            Select a {entityType} to merge into this one.{" "}
+            {setChildConfig
+              ? "Then choose to merge or set as a child."
+              : `All associated books will be transferred and the selected ${entityType} will be deleted.`}
           </DialogDescription>
         </DialogHeader>
 
@@ -121,8 +152,8 @@ export function MetadataMergeDialog({
               >
                 <span className="truncate">
                   {selectedEntity
-                    ? `${selectedEntity.name} (${selectedEntity.count} books)`
-                    : `Select ${entityType} to merge...`}
+                    ? `${selectedEntity.name} (${selectedEntity.count} ${selectedEntity.count !== 1 ? "files" : "file"})`
+                    : `Select ${entityType}...`}
                 </span>
                 <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
               </Button>
@@ -178,13 +209,39 @@ export function MetadataMergeDialog({
             </PopoverContent>
           </Popover>
 
-          {selectedEntity && (
+          {selectedEntity && !setChildConfig && (
             <p className="mt-4 text-sm text-muted-foreground">
               This will move all {selectedEntity.count} book
               {selectedEntity.count !== 1 ? "s" : ""} from "
               {selectedEntity.name}" to "{targetName}" and delete "
               {selectedEntity.name}".
             </p>
+          )}
+
+          {selectedEntity && setChildConfig && (
+            <div className="mt-4 space-y-3">
+              <div className="rounded-md border p-3">
+                <p className="text-sm font-medium mb-1">Merge</p>
+                <p className="text-xs text-muted-foreground">
+                  Move all files from "{selectedEntity.name}" to "{targetName}",
+                  add "{selectedEntity.name}" as an alias, and delete "
+                  {selectedEntity.name}".
+                </p>
+              </div>
+              <div className="rounded-md border p-3">
+                <p className="text-sm font-medium mb-1">Set as child</p>
+                <p className="text-xs text-muted-foreground">
+                  Make "{selectedEntity.name}" a child of "{targetName}". Both
+                  publishers keep their files and identity.
+                </p>
+                {setChildDisabled && (
+                  <p className="text-xs text-destructive mt-1">
+                    Cannot set as child: "{selectedEntity.name}" is already an
+                    ancestor of "{targetName}", which would create a cycle.
+                  </p>
+                )}
+              </div>
+            </div>
           )}
         </DialogBody>
 
@@ -196,6 +253,34 @@ export function MetadataMergeDialog({
           >
             Cancel
           </Button>
+          {setChildConfig && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                    disabled={
+                      setChildConfig.isPending ||
+                      !selectedId ||
+                      setChildDisabled
+                    }
+                    onClick={handleSetChild}
+                    size="sm"
+                    variant="secondary"
+                  >
+                    {setChildConfig.isPending && (
+                      <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                    )}
+                    Set as child
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              {setChildDisabled && (
+                <TooltipContent>
+                  Would create a cycle in the publisher hierarchy
+                </TooltipContent>
+              )}
+            </Tooltip>
+          )}
           <Button
             disabled={isPending || !selectedId}
             onClick={handleMerge}

--- a/app/components/library/MetadataMergeDialog.tsx
+++ b/app/components/library/MetadataMergeDialog.tsx
@@ -37,7 +37,7 @@ interface EntityOption {
   count: number;
 }
 
-interface SetChildConfig {
+export interface SetChildConfig {
   onSetChild: (childId: number) => Promise<void>;
   isPending: boolean;
   /** IDs of entities that are ancestors of the target — setting them as child would create a cycle */
@@ -260,6 +260,7 @@ export function MetadataMergeDialog({
                   <Button
                     disabled={
                       setChildConfig.isPending ||
+                      isPending ||
                       !selectedId ||
                       setChildDisabled
                     }
@@ -282,7 +283,7 @@ export function MetadataMergeDialog({
             </Tooltip>
           )}
           <Button
-            disabled={isPending || !selectedId}
+            disabled={isPending || setChildConfig?.isPending || !selectedId}
             onClick={handleMerge}
             size="sm"
             variant="destructive"

--- a/app/components/library/ResourceDetail.tsx
+++ b/app/components/library/ResourceDetail.tsx
@@ -32,12 +32,21 @@ interface EditConfig {
   sortNameSource?: DataSource;
 }
 
+interface SetChildConfig {
+  onSetChild: (childId: number) => Promise<void>;
+  isPending: boolean;
+  /** IDs of entities that are ancestors of the target — setting them as child would create a cycle */
+  disabledIds: number[];
+}
+
 interface MergeConfig {
   entities: { id: number; name: string; count: number }[];
   isLoadingEntities: boolean;
   isPending: boolean;
   onMerge: (sourceId: number) => Promise<void>;
   onSearch: (search: string) => void;
+  /** When provided, the merge dialog shows a "Set as child" option */
+  setChildConfig?: SetChildConfig;
 }
 
 interface DeleteConfig {
@@ -224,6 +233,18 @@ export function ResourceDetail({
         onOpenChange={setMergeOpen}
         onSearch={mergeConfig.onSearch}
         open={mergeOpen}
+        setChildConfig={
+          mergeConfig.setChildConfig
+            ? {
+                onSetChild: async (childId) => {
+                  await mergeConfig.setChildConfig!.onSetChild(childId);
+                  setMergeOpen(false);
+                },
+                isPending: mergeConfig.setChildConfig.isPending,
+                disabledIds: mergeConfig.setChildConfig.disabledIds,
+              }
+            : undefined
+        }
         targetId={entityId}
         targetName={name}
       />

--- a/app/components/library/ResourceDetail.tsx
+++ b/app/components/library/ResourceDetail.tsx
@@ -9,7 +9,10 @@ import {
   MetadataEditDialog,
   type EntityType,
 } from "@/components/library/MetadataEditDialog";
-import { MetadataMergeDialog } from "@/components/library/MetadataMergeDialog";
+import {
+  MetadataMergeDialog,
+  type SetChildConfig,
+} from "@/components/library/MetadataMergeDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useLibrary } from "@/hooks/queries/libraries";
@@ -30,13 +33,6 @@ interface EditConfig {
   /** Show sort name field in edit dialog (for person/series) */
   sortName?: string;
   sortNameSource?: DataSource;
-}
-
-interface SetChildConfig {
-  onSetChild: (childId: number) => Promise<void>;
-  isPending: boolean;
-  /** IDs of entities that are ancestors of the target — setting them as child would create a cycle */
-  disabledIds: number[];
 }
 
 interface MergeConfig {

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -23,6 +23,7 @@ import {
   usePublisher,
   usePublisherFiles,
   usePublishersList,
+  useSetChildPublisher,
   useUpdatePublisher,
 } from "@/hooks/queries/publishers";
 import { useDebounce } from "@/hooks/useDebounce";
@@ -50,6 +51,7 @@ const PublisherDetail = () => {
 
   const updatePublisherMutation = useUpdatePublisher();
   const mergePublisherMutation = useMergePublisher();
+  const setChildPublisherMutation = useSetChildPublisher();
   const deletePublisherMutation = useDeletePublisher();
 
   const [mergeSearchRaw, setMergeSearchRaw] = useState("");
@@ -135,6 +137,21 @@ const PublisherDetail = () => {
     });
   };
 
+  const handleSetChild = async (childId: number) => {
+    if (!publisherId) return;
+    await setChildPublisherMutation.mutateAsync({
+      parentId: publisherId,
+      childId,
+    });
+  };
+
+  // IDs of ancestors of this publisher — selecting one of these as "child"
+  // would create a cycle in the hierarchy
+  const ancestorIds = useMemo(() => {
+    if (!ancestors) return [];
+    return ancestors.map((a) => a.id);
+  }, [ancestors]);
+
   const handleDelete = async () => {
     if (!publisherId) return;
     await deletePublisherMutation.mutateAsync({ publisherId });
@@ -192,6 +209,11 @@ const PublisherDetail = () => {
           isPending: mergePublisherMutation.isPending,
           onMerge: handleMerge,
           onSearch: setMergeSearchRaw,
+          setChildConfig: {
+            onSetChild: handleSetChild,
+            isPending: setChildPublisherMutation.isPending,
+            disabledIds: ancestorIds,
+          },
         }}
         name={publisher?.name ?? ""}
         notFound={

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -191,3 +191,30 @@ export const useMergePublisher = () => {
     },
   });
 };
+
+export const useSetChildPublisher = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      parentId,
+      childId,
+    }: {
+      parentId: number;
+      childId: number;
+    }) => {
+      return API.request<void>("POST", `/publishers/${parentId}/set-child`, {
+        child_id: childId,
+      });
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.RetrievePublisher, variables.parentId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.RetrievePublisher, variables.childId],
+      });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.ListPublishers] });
+    },
+  });
+};

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -386,6 +386,42 @@ func (h *handler) merge(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }
 
+func (h *handler) setChild(c echo.Context) error {
+	ctx := c.Request().Context()
+	parentID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return errcodes.NotFound("Publisher")
+	}
+
+	params := SetChildPayload{}
+	if err := c.Bind(&params); err != nil {
+		return errors.WithStack(err)
+	}
+
+	parent, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{
+		ID: &parentID,
+	})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	if user, ok := c.Get("user").(*models.User); ok {
+		if !user.HasLibraryAccess(parent.LibraryID) {
+			return errcodes.Forbidden("You don't have access to this library")
+		}
+	}
+
+	// SetParent validates same-library, cycle detection, and sets the parent
+	if err := h.publisherService.SetParent(ctx, params.ChildID, &parentID); err != nil {
+		if strings.Contains(err.Error(), "cycle") || strings.Contains(err.Error(), "invalid parent") || strings.Contains(err.Error(), "same library") || strings.Contains(err.Error(), "not found") {
+			return errcodes.ValidationError(err.Error())
+		}
+		return errors.WithStack(err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
 func (h *handler) deletePublisher(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.Atoi(c.Param("id"))

--- a/pkg/publishers/handlers_test.go
+++ b/pkg/publishers/handlers_test.go
@@ -513,6 +513,132 @@ func TestRetrieve_FileCountIncludesDescendants(t *testing.T) {
 	assert.Equal(t, 2, fileCount, "file_count should include descendant publisher files")
 }
 
+
+func TestSetChild_Success(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	parent := &models.Publisher{LibraryID: lib.ID, Name: "Parent"}
+	_, err := db.NewInsert().Model(parent).Exec(ctx)
+	require.NoError(t, err)
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child"}
+	_, err = db.NewInsert().Model(child).Exec(ctx)
+	require.NoError(t, err)
+
+	e := newTestEcho(t)
+	body := fmt.Sprintf(`{"child_id": %d}`, child.ID)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(parent.ID))
+
+	err = h.setChild(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Verify child's parent_id was set to parent
+	updated, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{ID: &child.ID})
+	require.NoError(t, err)
+	require.NotNil(t, updated.ParentID)
+	assert.Equal(t, parent.ID, *updated.ParentID)
+}
+
+func TestSetChild_CycleRejected(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	// Create hierarchy: A -> B (B is child of A)
+	pubA := &models.Publisher{LibraryID: lib.ID, Name: "A"}
+	_, err := db.NewInsert().Model(pubA).Exec(ctx)
+	require.NoError(t, err)
+
+	pubB := &models.Publisher{LibraryID: lib.ID, Name: "B", ParentID: &pubA.ID}
+	_, err = db.NewInsert().Model(pubB).Exec(ctx)
+	require.NoError(t, err)
+
+	// Try to set A as child of B (would create B->A->B cycle)
+	e := newTestEcho(t)
+	body := fmt.Sprintf(`{"child_id": %d}`, pubA.ID)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(pubB.ID))
+
+	err = h.setChild(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle")
+}
+
+func TestSetChild_SamePublisherRejected(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	pub := &models.Publisher{LibraryID: lib.ID, Name: "Self"}
+	_, err := db.NewInsert().Model(pub).Exec(ctx)
+	require.NoError(t, err)
+
+	e := newTestEcho(t)
+	body := fmt.Sprintf(`{"child_id": %d}`, pub.ID)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(pub.ID))
+
+	err = h.setChild(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle")
+}
+
+func TestSetChild_LibraryAccessEnforced(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	parent := &models.Publisher{LibraryID: lib.ID, Name: "Parent"}
+	_, err := db.NewInsert().Model(parent).Exec(ctx)
+	require.NoError(t, err)
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child"}
+	_, err = db.NewInsert().Model(child).Exec(ctx)
+	require.NoError(t, err)
+
+	// User without access to this library (no LibraryAccess entries)
+	user := &models.User{Username: "restricted", PasswordHash: "x", LibraryAccess: []*models.UserLibraryAccess{}}
+
+	e := newTestEcho(t)
+	body := fmt.Sprintf(`{"child_id": %d}`, child.ID)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(parent.ID))
+	c.Set("user", user)
+
+	err = h.setChild(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access")
+}
+
+
 func TestUpdate_RenameTriggersmerge_ParentIDStillApplied(t *testing.T) {
 	t.Parallel()
 	db := setupHandlerTestDB(t)

--- a/pkg/publishers/handlers_test.go
+++ b/pkg/publishers/handlers_test.go
@@ -513,7 +513,6 @@ func TestRetrieve_FileCountIncludesDescendants(t *testing.T) {
 	assert.Equal(t, 2, fileCount, "file_count should include descendant publisher files")
 }
 
-
 func TestSetChild_Success(t *testing.T) {
 	t.Parallel()
 	db := setupHandlerTestDB(t)
@@ -637,7 +636,6 @@ func TestSetChild_LibraryAccessEnforced(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "access")
 }
-
 
 func TestUpdate_RenameTriggersmerge_ParentIDStillApplied(t *testing.T) {
 	t.Parallel()
@@ -794,13 +792,13 @@ func TestRetrieve_IncludesChildrenAndDescendantFileCount(t *testing.T) {
 	err = json.Unmarshal(rec.Body.Bytes(), &resp)
 	require.NoError(t, err)
 
-	// Check file_count (direct)
+	// Check file_count (includes descendants)
 	var fileCount int
 	err = json.Unmarshal(resp["file_count"], &fileCount)
 	require.NoError(t, err)
-	assert.Equal(t, 2, fileCount)
+	assert.Equal(t, 6, fileCount) // 2 direct + 3 childA + 1 childB
 
-	// Check descendant_file_count (files on children)
+	// Check descendant_file_count (descendants only, excludes direct)
 	assert.Contains(t, resp, "descendant_file_count")
 	var descendantFileCount int
 	err = json.Unmarshal(resp["descendant_file_count"], &descendantFileCount)
@@ -906,13 +904,13 @@ func TestList_IncludesHierarchyCounts(t *testing.T) {
 		}
 	}
 
-	// Parent: 0 direct files, 2 descendant files, 1 descendant publisher
-	assert.Equal(t, 0, parentItem.FileCount)
+	// Parent: 2 files (inclusive of descendants), 2 descendant files, 1 descendant publisher
+	assert.Equal(t, 2, parentItem.FileCount)
 	assert.Equal(t, 2, parentItem.DescendantFileCount)
 	assert.Equal(t, 1, parentItem.DescendantPublisherCount)
 	assert.Nil(t, parentItem.ParentName)
 
-	// Child: 2 direct files, 0 descendant files, 0 descendant publishers, parent name = "Parent"
+	// Child: 2 files (direct, no descendants), 0 descendant files, 0 descendant publishers, parent name = "Parent"
 	assert.Equal(t, 2, childItem.FileCount)
 	assert.Equal(t, 0, childItem.DescendantFileCount)
 	assert.Equal(t, 0, childItem.DescendantPublisherCount)

--- a/pkg/publishers/routes.go
+++ b/pkg/publishers/routes.go
@@ -27,4 +27,5 @@ func RegisterRoutesWithGroup(g *echo.Group, db *bun.DB, authMiddleware *auth.Mid
 	g.PATCH("/:id", h.update, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
 	g.DELETE("/:id", h.deletePublisher, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
 	g.POST("/:id/merge", h.merge, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
+	g.POST("/:id/set-child", h.setChild, authMiddleware.RequirePermission(models.ResourceBooks, models.OperationWrite))
 }

--- a/pkg/publishers/validators.go
+++ b/pkg/publishers/validators.go
@@ -49,3 +49,7 @@ type UpdatePublisherPayload struct {
 type MergePublishersPayload struct {
 	SourceID int `json:"source_id" validate:"required,min=1"`
 }
+
+type SetChildPayload struct {
+	ChildID int `json:"child_id" validate:"required,min=1"`
+}

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -44,6 +44,8 @@ Publishers are attached at the **file level**, not the book level. This means di
 - **Detail page:** Shows direct file count and descendant file count (files attached to any sub-publisher). Lists child publishers with their file counts as clickable links.
 - **List page:** Shows parent publisher name as secondary text, plus per-publisher counts for direct files, descendant files, and descendant publishers.
 
+The merge picker on a publisher's detail page offers two actions after selecting another publisher: **Merge** (moves files, adds an alias, deletes the source) and **Set as child** (makes the selected publisher a child of the current one without moving files or deleting either publisher). The "Set as child" option is disabled when it would create a cycle.
+
 ### Identifiers
 
 Identifiers (ISBN, ASIN, etc.) are also file-level. Each file can have multiple identifiers of **different** types: `isbn_10`, `isbn_13`, `asin`, `uuid`, `goodreads`, `google`, and custom types registered by [plugins](./plugins/overview).


### PR DESCRIPTION
Closes #264

## Summary
- Added "Set as child" alternative to the publisher merge picker. When on Publisher A's page and selecting Publisher B, users now see two actions: **Merge** (existing behavior) and **Set as child** (sets B.parent_id = A, both keep files and identity)
- Backend endpoint `POST /publishers/:id/set-child` reuses the existing `SetParent` service method with its cycle validation — no new hierarchy logic needed
- Frontend disables the "Set as child" button with explanatory text when the selected publisher is already an ancestor of the current one (would create a cycle)
- The dialog changes are backwards-compatible: other entity types (series, person, genre, tag) continue to see the original merge-only dialog unchanged

## Test plan
- Set child succeeds and correctly updates parent_id (TestSetChild_Success)
- Cycle detection rejects setting an ancestor as child (TestSetChild_CycleRejected)
- Self-reference is rejected (TestSetChild_SamePublisherRejected)
- Library access is enforced for the set-child endpoint (TestSetChild_LibraryAccessEnforced)
- Existing merge behavior is unchanged (no regression — merge tests still pass)