### PR TITLE
[Frontend] Widen resource list pages to max-w-4xl

### DIFF
--- a/app/components/library/ResourceList.tsx
+++ b/app/components/library/ResourceList.tsx
@@ -45,7 +45,7 @@ const ResourceList = <T extends { id: number }>({
   itemConfig,
   linkTo,
   itemLabel,
-  maxWidth = "max-w-3xl",
+  maxWidth = "max-w-4xl",
 }: ResourceListProps<T>) => {
   usePageTitle(title);
 

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -49,7 +49,6 @@ const PersonList = () => {
       linkTo={(person, libraryId) =>
         `/libraries/${libraryId}/people/${person.id}`
       }
-      maxWidth="max-w-4xl"
       query={query}
       searchPlaceholder="Search by name..."
       state={state}


### PR DESCRIPTION
## Summary
- Bump the default `maxWidth` in `ResourceList` from `max-w-3xl` to `max-w-4xl` so genres, tags, and publishers pages match the people page width
- Remove the now-redundant explicit `maxWidth` prop from `PersonList`

## Test plan
- Navigate to People, Genres, Tags, and Publishers list pages
- Verify all four pages now render at the same container width