### PR TITLE
[Test] Parallelize pkg/plugins tests to fix CI timeout flake

### DIFF
--- a/pkg/plugins/events_test.go
+++ b/pkg/plugins/events_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestSetEventCallback_ReceivesEvents(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	db := setupTestDB(t)
 	service := NewService(db)
@@ -37,6 +38,7 @@ func TestSetEventCallback_ReceivesEvents(t *testing.T) {
 }
 
 func TestEmitEvent_NoCallback_NoPanic(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	db := setupTestDB(t)
 	service := NewService(db)
@@ -49,6 +51,7 @@ func TestEmitEvent_NoCallback_NoPanic(t *testing.T) {
 }
 
 func TestSetEventCallback_ReplacesExisting(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	db := setupTestDB(t)
 	service := NewService(db)

--- a/pkg/plugins/generator_test.go
+++ b/pkg/plugins/generator_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestGetOutputGenerator(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "hooks-generator", "hooks-generator"})
 	ctx := context.Background()
 
@@ -43,6 +44,7 @@ func TestGetOutputGenerator(t *testing.T) {
 }
 
 func TestRegisteredOutputFormats(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "hooks-generator", "hooks-generator"})
 	ctx := context.Background()
 
@@ -73,6 +75,7 @@ func TestRegisteredOutputFormats(t *testing.T) {
 }
 
 func TestRegisteredOutputFormats_Empty(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "simple-enricher", "simple-enricher"})
 	ctx := context.Background()
 
@@ -97,6 +100,7 @@ func TestRegisteredOutputFormats_Empty(t *testing.T) {
 }
 
 func TestPluginGenerator_Generate(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "hooks-generator", "hooks-generator"})
 	ctx := context.Background()
 
@@ -147,6 +151,7 @@ func TestPluginGenerator_Generate(t *testing.T) {
 }
 
 func TestPluginGenerator_Fingerprint(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "hooks-generator", "hooks-generator"})
 	ctx := context.Background()
 
@@ -195,6 +200,7 @@ func TestPluginGenerator_Fingerprint(t *testing.T) {
 }
 
 func TestPluginGenerator_NotLoaded(t *testing.T) {
+	t.Parallel()
 	mgr, _ := setupTestManager(t)
 	ctx := context.Background()
 
@@ -216,6 +222,7 @@ func TestPluginGenerator_NotLoaded(t *testing.T) {
 }
 
 func TestBuildBookContext(t *testing.T) {
+	t.Parallel()
 	t.Run("nil book returns nil", func(t *testing.T) {
 		ctx := BuildBookContext(nil)
 		assert.Nil(t, ctx)
@@ -296,6 +303,7 @@ func TestBuildBookContext(t *testing.T) {
 }
 
 func TestBuildFileContext(t *testing.T) {
+	t.Parallel()
 	t.Run("nil file returns nil", func(t *testing.T) {
 		ctx := BuildFileContext(nil)
 		assert.Nil(t, ctx)

--- a/pkg/plugins/generator_test.go
+++ b/pkg/plugins/generator_test.go
@@ -224,11 +224,13 @@ func TestPluginGenerator_NotLoaded(t *testing.T) {
 func TestBuildBookContext(t *testing.T) {
 	t.Parallel()
 	t.Run("nil book returns nil", func(t *testing.T) {
+		t.Parallel()
 		ctx := BuildBookContext(nil)
 		assert.Nil(t, ctx)
 	})
 
 	t.Run("basic book fields", func(t *testing.T) {
+		t.Parallel()
 		subtitle := "A Subtitle"
 		description := "A Description"
 		book := &models.Book{
@@ -246,6 +248,7 @@ func TestBuildBookContext(t *testing.T) {
 	})
 
 	t.Run("book with authors", func(t *testing.T) {
+		t.Parallel()
 		book := &models.Book{
 			ID:    1,
 			Title: "My Book",
@@ -264,6 +267,7 @@ func TestBuildBookContext(t *testing.T) {
 	})
 
 	t.Run("book with series", func(t *testing.T) {
+		t.Parallel()
 		num := 3.0
 		book := &models.Book{
 			ID:    1,
@@ -281,6 +285,7 @@ func TestBuildBookContext(t *testing.T) {
 	})
 
 	t.Run("book with genres and tags", func(t *testing.T) {
+		t.Parallel()
 		book := &models.Book{
 			ID:    1,
 			Title: "My Book",
@@ -305,11 +310,13 @@ func TestBuildBookContext(t *testing.T) {
 func TestBuildFileContext(t *testing.T) {
 	t.Parallel()
 	t.Run("nil file returns nil", func(t *testing.T) {
+		t.Parallel()
 		ctx := BuildFileContext(nil)
 		assert.Nil(t, ctx)
 	})
 
 	t.Run("basic file fields", func(t *testing.T) {
+		t.Parallel()
 		name := "My Edition"
 		url := "https://example.com"
 		file := &models.File{
@@ -335,6 +342,7 @@ func TestBuildFileContext(t *testing.T) {
 	})
 
 	t.Run("file with narrators", func(t *testing.T) {
+		t.Parallel()
 		file := &models.File{
 			ID:       1,
 			FileType: "m4b",
@@ -354,6 +362,7 @@ func TestBuildFileContext(t *testing.T) {
 	})
 
 	t.Run("file with identifiers", func(t *testing.T) {
+		t.Parallel()
 		file := &models.File{
 			ID:       1,
 			FileType: "epub",
@@ -372,6 +381,7 @@ func TestBuildFileContext(t *testing.T) {
 	})
 
 	t.Run("file with release date", func(t *testing.T) {
+		t.Parallel()
 		releaseDate := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
 		file := &models.File{
 			ID:          1,

--- a/pkg/plugins/handler_image_test.go
+++ b/pkg/plugins/handler_image_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestGetImage_PathTraversal(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	installer := NewInstaller(pluginDir)
 	h := NewHandler(nil, nil, installer)
@@ -53,6 +54,7 @@ func TestGetImage_PathTraversal(t *testing.T) {
 }
 
 func TestGetImage_ValidPlugin(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	installer := NewInstaller(pluginDir)
 	h := NewHandler(nil, nil, installer)
@@ -76,6 +78,7 @@ func TestGetImage_ValidPlugin(t *testing.T) {
 }
 
 func TestGetImage_NotFound(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	installer := NewInstaller(pluginDir)
 	h := NewHandler(nil, nil, installer)

--- a/pkg/plugins/handler_library_test.go
+++ b/pkg/plugins/handler_library_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestLibraryPluginOrder_GetDefault(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := t.Context()
@@ -54,6 +55,7 @@ func TestLibraryPluginOrder_GetDefault(t *testing.T) {
 }
 
 func TestLibraryPluginOrder_SetAndGet(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := t.Context()
@@ -106,6 +108,7 @@ func TestLibraryPluginOrder_SetAndGet(t *testing.T) {
 }
 
 func TestLibraryPluginOrder_ResetHookType(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := t.Context()
@@ -143,6 +146,7 @@ func TestLibraryPluginOrder_ResetHookType(t *testing.T) {
 }
 
 func TestLibraryPluginOrder_ResetAll(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := t.Context()

--- a/pkg/plugins/hooks_test.go
+++ b/pkg/plugins/hooks_test.go
@@ -57,6 +57,7 @@ func setupHooksTestManager(t *testing.T, testdata, pluginID string) (*Manager, *
 }
 
 func TestRunInputConverter_Success(t *testing.T) {
+	t.Parallel()
 	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")
 	ctx := context.Background()
 
@@ -82,6 +83,7 @@ func TestRunInputConverter_Success(t *testing.T) {
 }
 
 func TestRunInputConverter_Failure(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	pluginDir := t.TempDir()
@@ -147,6 +149,7 @@ func TestRunInputConverter_Failure(t *testing.T) {
 }
 
 func TestRunFileParser_AllFields(t *testing.T) {
+	t.Parallel()
 	mgr, rt := setupHooksTestManager(t, "hooks-parser", "hooks-parser")
 	ctx := context.Background()
 
@@ -230,6 +233,7 @@ func TestRunFileParser_AllFields(t *testing.T) {
 }
 
 func TestRunFileParser_MinimalFields(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	pluginDir := t.TempDir()
@@ -309,6 +313,7 @@ func TestRunFileParser_MinimalFields(t *testing.T) {
 }
 
 func TestRunMetadataSearch_ReturnsResults(t *testing.T) {
+	t.Parallel()
 	mgr, rt := setupHooksTestManager(t, "hooks-enricher", "hooks-enricher")
 	ctx := context.Background()
 
@@ -340,6 +345,7 @@ func TestRunMetadataSearch_ReturnsResults(t *testing.T) {
 }
 
 func TestRunOutputGenerator_Success(t *testing.T) {
+	t.Parallel()
 	mgr, rt := setupHooksTestManager(t, "hooks-generator", "hooks-generator")
 	ctx := context.Background()
 
@@ -372,6 +378,7 @@ func TestRunOutputGenerator_Success(t *testing.T) {
 }
 
 func TestRunFingerprint(t *testing.T) {
+	t.Parallel()
 	mgr, rt := setupHooksTestManager(t, "hooks-generator", "hooks-generator")
 	_ = mgr
 
@@ -395,6 +402,7 @@ func TestRunFingerprint(t *testing.T) {
 }
 
 func TestRunInputConverter_NoHook(t *testing.T) {
+	t.Parallel()
 	// Use the parser plugin which has no converter hook
 	mgr, rt := setupHooksTestManager(t, "hooks-parser", "hooks-parser")
 	ctx := context.Background()
@@ -405,6 +413,7 @@ func TestRunInputConverter_NoHook(t *testing.T) {
 }
 
 func TestRunFileParser_NoHook(t *testing.T) {
+	t.Parallel()
 	// Use the converter plugin which has no parser hook
 	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")
 	ctx := context.Background()
@@ -415,6 +424,7 @@ func TestRunFileParser_NoHook(t *testing.T) {
 }
 
 func TestRunMetadataSearch_NoHook(t *testing.T) {
+	t.Parallel()
 	// Use the converter plugin which has no enricher hook
 	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")
 	ctx := context.Background()
@@ -760,6 +770,7 @@ func TestSearchMetadataCarriesAllFields(t *testing.T) {
 }
 
 func TestRunOutputGenerator_NoHook(t *testing.T) {
+	t.Parallel()
 	// Use the converter plugin which has no generator hook
 	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")
 	ctx := context.Background()
@@ -770,6 +781,7 @@ func TestRunOutputGenerator_NoHook(t *testing.T) {
 }
 
 func TestRunFingerprint_NoHook(t *testing.T) {
+	t.Parallel()
 	// Use the converter plugin which has no generator hook
 	mgr, rt := setupHooksTestManager(t, "hooks-converter", "hooks-converter")
 

--- a/pkg/plugins/hostapi_archive_test.go
+++ b/pkg/plugins/hostapi_archive_test.go
@@ -49,6 +49,7 @@ func createTestZipWithDirs(t *testing.T, zipPath string, dirs []string, files ma
 }
 
 func TestArchive_ExtractZip_ExtractsFiles(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 
 	// Create a zip file in the plugin dir
@@ -79,6 +80,7 @@ func TestArchive_ExtractZip_ExtractsFiles(t *testing.T) {
 }
 
 func TestArchive_ExtractZip_ZipSlipBlocked(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 
 	// Create a malicious zip with a path traversal entry
@@ -108,6 +110,7 @@ func TestArchive_ExtractZip_ZipSlipBlocked(t *testing.T) {
 }
 
 func TestArchive_CreateZip_CreatesValidZip(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 
 	// Create source directory with files
@@ -142,6 +145,7 @@ func TestArchive_CreateZip_CreatesValidZip(t *testing.T) {
 }
 
 func TestArchive_ReadZipEntry_ReadsSpecificEntry(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 
 	zipPath := filepath.Join(pluginDir, "test.zip")
@@ -167,6 +171,7 @@ func TestArchive_ReadZipEntry_ReadsSpecificEntry(t *testing.T) {
 }
 
 func TestArchive_ReadZipEntry_NonExistentEntry(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 
 	zipPath := filepath.Join(pluginDir, "test.zip")
@@ -183,6 +188,7 @@ func TestArchive_ReadZipEntry_NonExistentEntry(t *testing.T) {
 }
 
 func TestArchive_ListZipEntries_ReturnsAllNames(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 
 	zipPath := filepath.Join(pluginDir, "test.zip")
@@ -205,6 +211,7 @@ func TestArchive_ListZipEntries_ReturnsAllNames(t *testing.T) {
 }
 
 func TestArchive_ExtractZip_ReadAccessDenied(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 
@@ -224,6 +231,7 @@ func TestArchive_ExtractZip_ReadAccessDenied(t *testing.T) {
 }
 
 func TestArchive_ExtractZip_WriteAccessDenied(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 
@@ -243,6 +251,7 @@ func TestArchive_ExtractZip_WriteAccessDenied(t *testing.T) {
 }
 
 func TestArchive_CreateZip_ReadAccessDenied(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 
@@ -262,6 +271,7 @@ func TestArchive_CreateZip_ReadAccessDenied(t *testing.T) {
 }
 
 func TestArchive_CreateZip_WriteAccessDenied(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 
@@ -282,6 +292,7 @@ func TestArchive_CreateZip_WriteAccessDenied(t *testing.T) {
 }
 
 func TestArchive_NoFSContext_DeniesAccess(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -308,6 +319,7 @@ func TestArchive_NoFSContext_DeniesAccess(t *testing.T) {
 }
 
 func TestArchive_ExtractZip_WithDirectoryEntries(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 
 	zipPath := filepath.Join(pluginDir, "test.zip")
@@ -337,6 +349,7 @@ func TestArchive_ExtractZip_WithDirectoryEntries(t *testing.T) {
 }
 
 func TestArchive_ReadZipEntry_ReadAccessDenied(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 
@@ -352,6 +365,7 @@ func TestArchive_ReadZipEntry_ReadAccessDenied(t *testing.T) {
 }
 
 func TestArchive_ListZipEntries_ReadAccessDenied(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 
@@ -367,6 +381,7 @@ func TestArchive_ListZipEntries_ReadAccessDenied(t *testing.T) {
 }
 
 func TestArchive_FunctionsExist(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -381,6 +396,7 @@ func TestArchive_FunctionsExist(t *testing.T) {
 }
 
 func TestArchive_ExtractZip_WithAllowedPaths(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	srcDir := t.TempDir()
 	destDir := t.TempDir()
@@ -402,6 +418,7 @@ func TestArchive_ExtractZip_WithAllowedPaths(t *testing.T) {
 }
 
 func TestArchive_CreateZip_RoundTrip(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 
 	// Create source files
@@ -433,6 +450,7 @@ func TestArchive_CreateZip_RoundTrip(t *testing.T) {
 }
 
 func TestArchive_ExtractZip_MissingArgs(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -443,6 +461,7 @@ func TestArchive_ExtractZip_MissingArgs(t *testing.T) {
 }
 
 func TestArchive_CreateZip_MissingArgs(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -453,6 +472,7 @@ func TestArchive_CreateZip_MissingArgs(t *testing.T) {
 }
 
 func TestArchive_ReadZipEntry_MissingArgs(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -463,6 +483,7 @@ func TestArchive_ReadZipEntry_MissingArgs(t *testing.T) {
 }
 
 func TestArchive_ListZipEntries_MissingArgs(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)

--- a/pkg/plugins/hostapi_fs_test.go
+++ b/pkg/plugins/hostapi_fs_test.go
@@ -21,6 +21,7 @@ func newFSTestRuntime(t *testing.T, fsCtx *FSContext) *Runtime {
 }
 
 func TestFS_ReadTextFile_PluginDir(t *testing.T) {
+	t.Parallel()
 	// Create a temp dir to act as the plugin directory
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "test.txt")
@@ -36,6 +37,7 @@ func TestFS_ReadTextFile_PluginDir(t *testing.T) {
 }
 
 func TestFS_ReadFile_PluginDir(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "binary.bin")
 	data := []byte{0x00, 0x01, 0x02, 0xFF}
@@ -60,6 +62,7 @@ func TestFS_ReadFile_PluginDir(t *testing.T) {
 }
 
 func TestFS_WriteTextFile_PluginDir(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "output.txt")
 
@@ -75,6 +78,7 @@ func TestFS_WriteTextFile_PluginDir(t *testing.T) {
 }
 
 func TestFS_WriteFile_PluginDir(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "output.bin")
 
@@ -93,6 +97,7 @@ func TestFS_WriteFile_PluginDir(t *testing.T) {
 }
 
 func TestFS_WriteTextFile_ReadwriteAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	testFile := filepath.Join(externalDir, "external.txt")
@@ -109,6 +114,7 @@ func TestFS_WriteTextFile_ReadwriteAccess(t *testing.T) {
 }
 
 func TestFS_Write_DeniedWithoutFileAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	testFile := filepath.Join(externalDir, "denied.txt")
@@ -123,6 +129,7 @@ func TestFS_Write_DeniedWithoutFileAccess(t *testing.T) {
 }
 
 func TestFS_Write_DeniedWithReadOnlyAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	testFile := filepath.Join(externalDir, "denied.txt")
@@ -137,6 +144,7 @@ func TestFS_Write_DeniedWithReadOnlyAccess(t *testing.T) {
 }
 
 func TestFS_Read_AllowedWithReadAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	testFile := filepath.Join(externalDir, "readable.txt")
@@ -152,6 +160,7 @@ func TestFS_Read_AllowedWithReadAccess(t *testing.T) {
 }
 
 func TestFS_Exists_True(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "exists.txt")
 	err := os.WriteFile(testFile, []byte("hi"), 0644)
@@ -166,6 +175,7 @@ func TestFS_Exists_True(t *testing.T) {
 }
 
 func TestFS_Exists_False(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "nonexistent.txt")
 
@@ -178,6 +188,7 @@ func TestFS_Exists_False(t *testing.T) {
 }
 
 func TestFS_Mkdir_PluginDir(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	newDir := filepath.Join(pluginDir, "sub", "dir")
 
@@ -193,6 +204,7 @@ func TestFS_Mkdir_PluginDir(t *testing.T) {
 }
 
 func TestFS_Mkdir_DeniedOutsidePluginDir(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	newDir := filepath.Join(externalDir, "denied-dir")
@@ -206,6 +218,7 @@ func TestFS_Mkdir_DeniedOutsidePluginDir(t *testing.T) {
 }
 
 func TestFS_ListDir(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	// Create some files
 	err := os.WriteFile(filepath.Join(pluginDir, "a.txt"), []byte("a"), 0644)
@@ -228,6 +241,7 @@ func TestFS_ListDir(t *testing.T) {
 }
 
 func TestFS_TempDir_ConsistentPerInvocation(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -257,6 +271,7 @@ func TestFS_TempDir_ConsistentPerInvocation(t *testing.T) {
 }
 
 func TestFS_TempDir_WriteAllowed(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -277,6 +292,7 @@ func TestFS_TempDir_WriteAllowed(t *testing.T) {
 }
 
 func TestFS_AllowedPaths_ReadAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	allowedDir := t.TempDir()
 	testFile := filepath.Join(allowedDir, "allowed.txt")
@@ -293,6 +309,7 @@ func TestFS_AllowedPaths_ReadAccess(t *testing.T) {
 }
 
 func TestFS_AllowedPaths_WriteAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	allowedDir := t.TempDir()
 	testFile := filepath.Join(allowedDir, "allowed-write.txt")
@@ -310,6 +327,7 @@ func TestFS_AllowedPaths_WriteAccess(t *testing.T) {
 }
 
 func TestFS_AllowedPaths_ExactFileMatch(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	allowedDir := t.TempDir()
 	allowedFile := filepath.Join(allowedDir, "specific.txt")
@@ -326,6 +344,7 @@ func TestFS_AllowedPaths_ExactFileMatch(t *testing.T) {
 }
 
 func TestFS_DeniedOutsideAllPaths(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	deniedDir := t.TempDir()
 	testFile := filepath.Join(deniedDir, "secret.txt")
@@ -342,6 +361,7 @@ func TestFS_DeniedOutsideAllPaths(t *testing.T) {
 }
 
 func TestFS_Read_DeniedOutsidePluginDir_NoFileAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	testFile := filepath.Join(externalDir, "external.txt")
@@ -357,6 +377,7 @@ func TestFS_Read_DeniedOutsidePluginDir_NoFileAccess(t *testing.T) {
 }
 
 func TestFS_NoFSContext_DeniesAllAccess(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -369,6 +390,7 @@ func TestFS_NoFSContext_DeniesAllAccess(t *testing.T) {
 }
 
 func TestFS_Exists_DeniedOutsidePluginDir(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	testFile := filepath.Join(externalDir, "secret.txt")
@@ -382,6 +404,7 @@ func TestFS_Exists_DeniedOutsidePluginDir(t *testing.T) {
 }
 
 func TestFS_ListDir_DeniedOutsidePluginDir(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 
@@ -394,6 +417,7 @@ func TestFS_ListDir_DeniedOutsidePluginDir(t *testing.T) {
 }
 
 func TestFS_ReadFile_NonexistentFile(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "nonexistent.txt")
 
@@ -406,6 +430,7 @@ func TestFS_ReadFile_NonexistentFile(t *testing.T) {
 }
 
 func TestFS_WriteFile_InvalidData(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "output.bin")
 
@@ -419,6 +444,7 @@ func TestFS_WriteFile_InvalidData(t *testing.T) {
 }
 
 func TestFS_ReadTextFile_Subdirectory(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	subDir := filepath.Join(pluginDir, "sub", "nested")
 	err := os.MkdirAll(subDir, 0755)
@@ -436,6 +462,7 @@ func TestFS_ReadTextFile_Subdirectory(t *testing.T) {
 }
 
 func TestFS_IsPathWithin(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		child    string
@@ -457,6 +484,7 @@ func TestFS_IsPathWithin(t *testing.T) {
 }
 
 func TestFS_SetFSContext_CanBeCleared(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -486,6 +514,7 @@ func TestFS_SetFSContext_CanBeCleared(t *testing.T) {
 }
 
 func TestFS_Cleanup_NoTempDir(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 
@@ -495,6 +524,7 @@ func TestFS_Cleanup_NoTempDir(t *testing.T) {
 }
 
 func TestFS_WriteFile_Mkdir_WithReadwriteAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	newDir := filepath.Join(externalDir, "new-dir")
@@ -511,6 +541,7 @@ func TestFS_WriteFile_Mkdir_WithReadwriteAccess(t *testing.T) {
 }
 
 func TestFS_Mkdir_DeniedWithReadOnlyAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	newDir := filepath.Join(externalDir, "new-dir")
@@ -524,6 +555,7 @@ func TestFS_Mkdir_DeniedWithReadOnlyAccess(t *testing.T) {
 }
 
 func TestFS_TempDir_DifferentPerFSContext(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 
 	fsCtx1 := NewFSContext(pluginDir, "", nil, nil)
@@ -546,6 +578,7 @@ func TestFS_TempDir_DifferentPerFSContext(t *testing.T) {
 }
 
 func TestFS_ReadFile_ReadwriteAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	externalDir := t.TempDir()
 	testFile := filepath.Join(externalDir, "readable.txt")
@@ -562,6 +595,7 @@ func TestFS_ReadFile_ReadwriteAccess(t *testing.T) {
 }
 
 func TestFS_NewFSContext_NilAllowedPaths(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	assert.NotNil(t, fsCtx)
@@ -571,6 +605,7 @@ func TestFS_NewFSContext_NilAllowedPaths(t *testing.T) {
 }
 
 func TestFS_ReadFile_NoArgument(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -581,6 +616,7 @@ func TestFS_ReadFile_NoArgument(t *testing.T) {
 }
 
 func TestFS_ReadTextFile_NoArgument(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -591,6 +627,7 @@ func TestFS_ReadTextFile_NoArgument(t *testing.T) {
 }
 
 func TestFS_WriteTextFile_NoArguments(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -601,6 +638,7 @@ func TestFS_WriteTextFile_NoArguments(t *testing.T) {
 }
 
 func TestFS_WriteFile_NoArguments(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -611,6 +649,7 @@ func TestFS_WriteFile_NoArguments(t *testing.T) {
 }
 
 func TestFS_Exists_NoArgument(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -622,6 +661,7 @@ func TestFS_Exists_NoArgument(t *testing.T) {
 }
 
 func TestFS_Mkdir_NoArgument(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -632,6 +672,7 @@ func TestFS_Mkdir_NoArgument(t *testing.T) {
 }
 
 func TestFS_ListDir_NoArgument(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	fsCtx := NewFSContext(pluginDir, "", nil, nil)
 	rt := newFSTestRuntime(t, fsCtx)
@@ -644,6 +685,7 @@ func TestFS_ListDir_NoArgument(t *testing.T) {
 // Verify that the fs namespace functions properly check argument count
 // by using the same pattern as existing host APIs.
 func TestFS_FunctionsExist(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -659,6 +701,7 @@ func TestFS_FunctionsExist(t *testing.T) {
 }
 
 func TestFS_AllowedPaths_SubdirectoryAccess(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	allowedDir := t.TempDir()
 	subDir := filepath.Join(allowedDir, "sub")
@@ -678,6 +721,7 @@ func TestFS_AllowedPaths_SubdirectoryAccess(t *testing.T) {
 }
 
 func TestFS_WriteFile_Uint8Array(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "uint8.bin")
 
@@ -697,6 +741,7 @@ func TestFS_WriteFile_Uint8Array(t *testing.T) {
 }
 
 func TestFS_ReadFile_RoundTrip(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	testFile := filepath.Join(pluginDir, "roundtrip.bin")
 

--- a/pkg/plugins/hostapi_http_test.go
+++ b/pkg/plugins/hostapi_http_test.go
@@ -62,6 +62,7 @@ func setupHTTPNamespace(t *testing.T, rt *Runtime) {
 }
 
 func TestHTTPFetch_AllowedDomain(t *testing.T) {
+	t.Parallel()
 	// Create a test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
@@ -93,6 +94,7 @@ func TestHTTPFetch_AllowedDomain(t *testing.T) {
 }
 
 func TestHTTPFetch_BlockedDomain(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntimeWithHTTPAccess([]string{"allowed.example.com"})
 	setupHTTPNamespace(t, rt)
 
@@ -102,6 +104,7 @@ func TestHTTPFetch_BlockedDomain(t *testing.T) {
 }
 
 func TestHTTPFetch_RedirectToBlockedDomain(t *testing.T) {
+	t.Parallel()
 	// Create a target server (blocked domain)
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -127,6 +130,7 @@ func TestHTTPFetch_RedirectToBlockedDomain(t *testing.T) {
 }
 
 func TestHTTPFetch_ResponseJSON(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -160,6 +164,7 @@ func TestHTTPFetch_ResponseJSON(t *testing.T) {
 }
 
 func TestHTTPFetch_ResponseText(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
@@ -182,6 +187,7 @@ func TestHTTPFetch_ResponseText(t *testing.T) {
 }
 
 func TestHTTPFetch_ResponseBytes(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.WriteHeader(http.StatusOK)
@@ -211,6 +217,7 @@ func TestHTTPFetch_ResponseBytes(t *testing.T) {
 }
 
 func TestHTTPFetch_NoHTTPAccessCapability(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntimeWithoutHTTPAccess()
 	setupHTTPNamespace(t, rt)
 
@@ -220,6 +227,7 @@ func TestHTTPFetch_NoHTTPAccessCapability(t *testing.T) {
 }
 
 func TestHTTPFetch_NonStandardPortBlocked(t *testing.T) {
+	t.Parallel()
 	// A domain listed without port should block non-standard ports
 	rt := newTestRuntimeWithHTTPAccess([]string{"example.com"})
 	setupHTTPNamespace(t, rt)
@@ -230,6 +238,7 @@ func TestHTTPFetch_NonStandardPortBlocked(t *testing.T) {
 }
 
 func TestHTTPFetch_ExplicitPortAllowed(t *testing.T) {
+	t.Parallel()
 	// Create a test server on a non-standard port
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -253,6 +262,7 @@ func TestHTTPFetch_ExplicitPortAllowed(t *testing.T) {
 }
 
 func TestHTTPFetch_StandardPortAllowed(t *testing.T) {
+	t.Parallel()
 	// A domain listed without port should allow standard ports (80, 443)
 	// We can't easily test real 80/443 connections, so test the validateDomain function directly
 	err := validateDomain("example.com:443", []string{"example.com"})
@@ -266,6 +276,7 @@ func TestHTTPFetch_StandardPortAllowed(t *testing.T) {
 }
 
 func TestHTTPFetch_SubdomainNotAllowed(t *testing.T) {
+	t.Parallel()
 	// "goodreads.com" should NOT allow "api.goodreads.com"
 	rt := newTestRuntimeWithHTTPAccess([]string{"goodreads.com"})
 	setupHTTPNamespace(t, rt)
@@ -276,6 +287,7 @@ func TestHTTPFetch_SubdomainNotAllowed(t *testing.T) {
 }
 
 func TestHTTPFetch_PostWithHeaders(t *testing.T) {
+	t.Parallel()
 	var receivedMethod string
 	var receivedContentType string
 	var receivedBody string
@@ -321,6 +333,7 @@ func TestHTTPFetch_PostWithHeaders(t *testing.T) {
 }
 
 func TestHTTPFetch_ResponseHeaders(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("X-Custom-Header", "custom-value")
 		w.Header().Set("Content-Type", "text/plain")
@@ -352,6 +365,7 @@ func TestHTTPFetch_ResponseHeaders(t *testing.T) {
 }
 
 func TestHTTPFetch_StatusText(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("not found")) //nolint:errcheck
@@ -379,6 +393,7 @@ func TestHTTPFetch_StatusText(t *testing.T) {
 }
 
 func TestHTTPFetch_InvalidURL(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntimeWithHTTPAccess([]string{"example.com"})
 	setupHTTPNamespace(t, rt)
 
@@ -388,6 +403,7 @@ func TestHTTPFetch_InvalidURL(t *testing.T) {
 }
 
 func TestHTTPFetch_ResponseBodyMultipleReads(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -420,6 +436,7 @@ func TestHTTPFetch_ResponseBodyMultipleReads(t *testing.T) {
 }
 
 func TestValidateDomain_CaseInsensitive(t *testing.T) {
+	t.Parallel()
 	err := validateDomain("Example.COM", []string{"example.com"})
 	require.NoError(t, err)
 
@@ -428,6 +445,7 @@ func TestValidateDomain_CaseInsensitive(t *testing.T) {
 }
 
 func TestHTTPFetch_RedirectToAllowedDomain(t *testing.T) {
+	t.Parallel()
 	// Final target (allowed)
 	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -676,6 +694,7 @@ func TestValidateDomain_WildcardCaseInsensitive(t *testing.T) {
 }
 
 func TestHTTPFetch_WildcardDomainAllowed(t *testing.T) {
+	t.Parallel()
 	// Create a test server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -700,6 +719,7 @@ func TestHTTPFetch_WildcardDomainAllowed(t *testing.T) {
 }
 
 func TestHTTPFetch_WildcardRedirectAllowed(t *testing.T) {
+	t.Parallel()
 	// This test validates that wildcard domains work with redirects
 	// Since we can't easily create test servers with custom hostnames,
 	// we verify the validateDomain function behavior instead

--- a/pkg/plugins/hostapi_test.go
+++ b/pkg/plugins/hostapi_test.go
@@ -47,6 +47,7 @@ func strPtr(s string) *string {
 }
 
 func TestInjectHostAPIs_LogNamespace(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 
@@ -68,6 +69,7 @@ func TestInjectHostAPIs_LogNamespace(t *testing.T) {
 }
 
 func TestInjectHostAPIs_ConfigGet(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{
 		"api_key":  strPtr("secret123"),
@@ -87,6 +89,7 @@ func TestInjectHostAPIs_ConfigGet(t *testing.T) {
 }
 
 func TestInjectHostAPIs_ConfigGet_Undefined(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 
@@ -99,6 +102,7 @@ func TestInjectHostAPIs_ConfigGet_Undefined(t *testing.T) {
 }
 
 func TestInjectHostAPIs_ConfigGetAll(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{
 		"key1": strPtr("value1"),
@@ -120,6 +124,7 @@ func TestInjectHostAPIs_ConfigGetAll(t *testing.T) {
 }
 
 func TestInjectHostAPIs_FFmpegRequiresCapability(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 
@@ -133,6 +138,7 @@ func TestInjectHostAPIs_FFmpegRequiresCapability(t *testing.T) {
 }
 
 func TestInjectHostAPIs_LogPluginTag(t *testing.T) {
+	t.Parallel()
 	// Verify the runtime uses the correct scope/pluginID combination
 	rt := newTestRuntime("community", "my-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
@@ -229,6 +235,7 @@ func TestInjectHostAPIs_Sleep_InvalidArgs(t *testing.T) {
 }
 
 func TestInjectHostAPIs_ConfigGetAll_Empty(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 

--- a/pkg/plugins/hostapi_xml_test.go
+++ b/pkg/plugins/hostapi_xml_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestXML_Parse_CreatesDocument(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -22,6 +23,7 @@ func TestXML_Parse_CreatesDocument(t *testing.T) {
 }
 
 func TestXML_Parse_NestedElements(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -36,6 +38,7 @@ func TestXML_Parse_NestedElements(t *testing.T) {
 }
 
 func TestXML_Parse_TextContentConcatenation(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -52,6 +55,7 @@ func TestXML_Parse_TextContentConcatenation(t *testing.T) {
 }
 
 func TestXML_Parse_Attributes(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -66,6 +70,7 @@ func TestXML_Parse_Attributes(t *testing.T) {
 }
 
 func TestXML_Parse_NamespacedElements(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -81,6 +86,7 @@ func TestXML_Parse_NamespacedElements(t *testing.T) {
 }
 
 func TestXML_QuerySelector_FindsByTagName(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -96,6 +102,7 @@ func TestXML_QuerySelector_FindsByTagName(t *testing.T) {
 }
 
 func TestXML_QuerySelector_FindsByNamespacePrefix(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -111,6 +118,7 @@ func TestXML_QuerySelector_FindsByNamespacePrefix(t *testing.T) {
 }
 
 func TestXML_QuerySelector_ReturnsNullForNoMatch(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -126,6 +134,7 @@ func TestXML_QuerySelector_ReturnsNullForNoMatch(t *testing.T) {
 }
 
 func TestXML_QuerySelectorAll_ReturnsMultipleMatches(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -145,6 +154,7 @@ func TestXML_QuerySelectorAll_ReturnsMultipleMatches(t *testing.T) {
 }
 
 func TestXML_QuerySelectorAll_ReturnsEmptyArrayForNoMatch(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -160,6 +170,7 @@ func TestXML_QuerySelectorAll_ReturnsEmptyArrayForNoMatch(t *testing.T) {
 }
 
 func TestXML_QuerySelector_NamespaceQualifiedMultipleNS(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -185,6 +196,7 @@ func TestXML_QuerySelector_NamespaceQualifiedMultipleNS(t *testing.T) {
 }
 
 func TestXML_QuerySelector_UnqualifiedMatchesAnyNamespace(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -201,6 +213,7 @@ func TestXML_QuerySelector_UnqualifiedMatchesAnyNamespace(t *testing.T) {
 }
 
 func TestXML_QuerySelectorAll_DeepNested(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -220,6 +233,7 @@ func TestXML_QuerySelectorAll_DeepNested(t *testing.T) {
 }
 
 func TestXML_QuerySelector_MatchesRoot(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -235,6 +249,7 @@ func TestXML_QuerySelector_MatchesRoot(t *testing.T) {
 }
 
 func TestXML_Parse_EmptyElement(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -249,6 +264,7 @@ func TestXML_Parse_EmptyElement(t *testing.T) {
 }
 
 func TestXML_Parse_InvalidXML(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -260,6 +276,7 @@ func TestXML_Parse_InvalidXML(t *testing.T) {
 }
 
 func TestXML_Parse_NoArgument(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -271,6 +288,7 @@ func TestXML_Parse_NoArgument(t *testing.T) {
 }
 
 func TestXML_QuerySelector_NoArguments(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -282,6 +300,7 @@ func TestXML_QuerySelector_NoArguments(t *testing.T) {
 }
 
 func TestXML_QuerySelectorAll_NoArguments(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -293,6 +312,7 @@ func TestXML_QuerySelectorAll_NoArguments(t *testing.T) {
 }
 
 func TestXML_FunctionsExist(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -307,6 +327,7 @@ func TestXML_FunctionsExist(t *testing.T) {
 }
 
 func TestXML_QuerySelector_NamespaceMismatch(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -323,6 +344,7 @@ func TestXML_QuerySelector_NamespaceMismatch(t *testing.T) {
 }
 
 func TestXML_Parse_MultipleChildren(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)
@@ -341,6 +363,7 @@ func TestXML_Parse_MultipleChildren(t *testing.T) {
 }
 
 func TestXML_Parse_ChildTextContent(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime("official", "test-plugin")
 	cfg := &mockConfigGetter{configs: map[string]*string{}}
 	err := InjectHostAPIs(rt, cfg)

--- a/pkg/plugins/installer_test.go
+++ b/pkg/plugins/installer_test.go
@@ -50,7 +50,6 @@ func sha256Hex(data []byte) string {
 }
 
 func TestInstaller_InstallPlugin_Success(t *testing.T) {
-	t.Parallel()
 	manifest := &Manifest{
 		ManifestVersion: 1,
 		ID:              "test-plugin",
@@ -91,7 +90,6 @@ func TestInstaller_InstallPlugin_Success(t *testing.T) {
 }
 
 func TestInstaller_InstallPlugin_BadChecksum(t *testing.T) {
-	t.Parallel()
 	manifest := &Manifest{
 		ManifestVersion: 1,
 		ID:              "test-plugin",
@@ -125,7 +123,6 @@ func TestInstaller_InstallPlugin_BadChecksum(t *testing.T) {
 }
 
 func TestInstaller_InstallPlugin_InvalidURL(t *testing.T) {
-	t.Parallel()
 	origHosts := AllowedDownloadHosts
 	AllowedDownloadHosts = []string{"https://github.com/"}
 	defer func() { AllowedDownloadHosts = origHosts }()
@@ -168,7 +165,6 @@ func TestInstaller_UninstallPlugin_NotExists(t *testing.T) {
 }
 
 func TestInstaller_UpdatePlugin(t *testing.T) {
-	t.Parallel()
 	manifest := &Manifest{
 		ManifestVersion: 1,
 		ID:              "test-plugin",
@@ -215,7 +211,6 @@ func TestInstaller_UpdatePlugin(t *testing.T) {
 }
 
 func TestIsAllowedDownloadURL_AcceptsLocalhostWhenConfigured(t *testing.T) {
-	t.Parallel()
 	// Not parallel: mutates package-level AllowedDownloadHosts, which is also
 	// mutated by other tests in this file. Running in parallel would race.
 	orig := AllowedDownloadHosts
@@ -227,7 +222,6 @@ func TestIsAllowedDownloadURL_AcceptsLocalhostWhenConfigured(t *testing.T) {
 }
 
 func TestInstaller_UpdatePlugin_BadChecksum(t *testing.T) {
-	t.Parallel()
 	manifest := &Manifest{
 		ManifestVersion: 1,
 		ID:              "test-plugin",

--- a/pkg/plugins/installer_test.go
+++ b/pkg/plugins/installer_test.go
@@ -50,6 +50,7 @@ func sha256Hex(data []byte) string {
 }
 
 func TestInstaller_InstallPlugin_Success(t *testing.T) {
+	t.Parallel()
 	manifest := &Manifest{
 		ManifestVersion: 1,
 		ID:              "test-plugin",
@@ -90,6 +91,7 @@ func TestInstaller_InstallPlugin_Success(t *testing.T) {
 }
 
 func TestInstaller_InstallPlugin_BadChecksum(t *testing.T) {
+	t.Parallel()
 	manifest := &Manifest{
 		ManifestVersion: 1,
 		ID:              "test-plugin",
@@ -123,6 +125,7 @@ func TestInstaller_InstallPlugin_BadChecksum(t *testing.T) {
 }
 
 func TestInstaller_InstallPlugin_InvalidURL(t *testing.T) {
+	t.Parallel()
 	origHosts := AllowedDownloadHosts
 	AllowedDownloadHosts = []string{"https://github.com/"}
 	defer func() { AllowedDownloadHosts = origHosts }()
@@ -136,6 +139,7 @@ func TestInstaller_InstallPlugin_InvalidURL(t *testing.T) {
 }
 
 func TestInstaller_UninstallPlugin(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	inst := NewInstaller(pluginDir)
 
@@ -154,6 +158,7 @@ func TestInstaller_UninstallPlugin(t *testing.T) {
 }
 
 func TestInstaller_UninstallPlugin_NotExists(t *testing.T) {
+	t.Parallel()
 	pluginDir := t.TempDir()
 	inst := NewInstaller(pluginDir)
 
@@ -163,6 +168,7 @@ func TestInstaller_UninstallPlugin_NotExists(t *testing.T) {
 }
 
 func TestInstaller_UpdatePlugin(t *testing.T) {
+	t.Parallel()
 	manifest := &Manifest{
 		ManifestVersion: 1,
 		ID:              "test-plugin",
@@ -209,6 +215,7 @@ func TestInstaller_UpdatePlugin(t *testing.T) {
 }
 
 func TestIsAllowedDownloadURL_AcceptsLocalhostWhenConfigured(t *testing.T) {
+	t.Parallel()
 	// Not parallel: mutates package-level AllowedDownloadHosts, which is also
 	// mutated by other tests in this file. Running in parallel would race.
 	orig := AllowedDownloadHosts
@@ -220,6 +227,7 @@ func TestIsAllowedDownloadURL_AcceptsLocalhostWhenConfigured(t *testing.T) {
 }
 
 func TestInstaller_UpdatePlugin_BadChecksum(t *testing.T) {
+	t.Parallel()
 	manifest := &Manifest{
 		ManifestVersion: 1,
 		ID:              "test-plugin",

--- a/pkg/plugins/integration_test.go
+++ b/pkg/plugins/integration_test.go
@@ -15,6 +15,7 @@ import (
 // TestPluginLifecycle exercises the full plugin lifecycle:
 // install, load, run all hooks, and uninstall.
 func TestPluginLifecycle(t *testing.T) {
+	t.Parallel()
 	// 1. Set up infrastructure: in-memory DB, service, plugin directory
 	db := setupTestDB(t)
 	service := NewService(db)
@@ -320,6 +321,7 @@ func TestPluginLifecycle(t *testing.T) {
 // TestPluginLifecycle_ConfigIntegration verifies that plugin config is accessible
 // from within JavaScript hooks via shisho.config.get/getAll.
 func TestPluginLifecycle_ConfigIntegration(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	pluginDir := t.TempDir()
@@ -413,6 +415,7 @@ func TestPluginLifecycle_ConfigIntegration(t *testing.T) {
 // TestPluginLifecycle_LoadAll verifies that LoadAll loads all enabled plugins
 // and properly skips disabled ones.
 func TestPluginLifecycle_LoadAll(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	pluginDir := t.TempDir()
@@ -491,6 +494,7 @@ func TestPluginLifecycle_LoadAll(t *testing.T) {
 
 // TestPluginLifecycle_ReloadPlugin verifies hot-reload swaps the runtime.
 func TestPluginLifecycle_ReloadPlugin(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	pluginDir := t.TempDir()

--- a/pkg/plugins/manager_test.go
+++ b/pkg/plugins/manager_test.go
@@ -58,6 +58,7 @@ func copyTestdataFile(t *testing.T, srcDir, destDir, filename string) {
 }
 
 func TestManager_LoadAll(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "simple-enricher", "simple-enricher"})
 	ctx := context.Background()
 
@@ -83,6 +84,7 @@ func TestManager_LoadAll(t *testing.T) {
 }
 
 func TestManager_LoadAll_Disabled(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "simple-enricher", "simple-enricher"})
 	ctx := context.Background()
 
@@ -106,6 +108,7 @@ func TestManager_LoadAll_Disabled(t *testing.T) {
 }
 
 func TestManager_LoadAll_LoadError(t *testing.T) {
+	t.Parallel()
 	// Create a manager with no plugin files (pointing to non-existent dir)
 	db := setupTestDB(t)
 	service := NewService(db)
@@ -141,6 +144,7 @@ func TestManager_LoadAll_LoadError(t *testing.T) {
 }
 
 func TestManager_LoadPlugin(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "simple-enricher", "simple-enricher"})
 	ctx := context.Background()
 
@@ -165,6 +169,7 @@ func TestManager_LoadPlugin(t *testing.T) {
 }
 
 func TestManager_UnloadPlugin(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "simple-enricher", "simple-enricher"})
 	ctx := context.Background()
 
@@ -190,6 +195,7 @@ func TestManager_UnloadPlugin(t *testing.T) {
 }
 
 func TestManager_ReloadPlugin(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "simple-enricher", "simple-enricher"})
 	ctx := context.Background()
 
@@ -219,6 +225,7 @@ func TestManager_ReloadPlugin(t *testing.T) {
 }
 
 func TestManager_GetOrderedRuntimes(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "simple-enricher", "simple-enricher"})
 	ctx := context.Background()
 
@@ -250,6 +257,7 @@ func TestManager_GetOrderedRuntimes(t *testing.T) {
 }
 
 func TestManager_RegisteredFileExtensions(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "multi-hook", "multi-hook"})
 	ctx := context.Background()
 
@@ -273,6 +281,7 @@ func TestManager_RegisteredFileExtensions(t *testing.T) {
 }
 
 func TestManager_RegisteredFileExtensions_SkipsReserved(t *testing.T) {
+	t.Parallel()
 	// Create a plugin that declares reserved extensions in fileParser.types
 	db := setupTestDB(t)
 	service := NewService(db)
@@ -336,6 +345,7 @@ func TestManager_RegisteredFileExtensions_SkipsReserved(t *testing.T) {
 }
 
 func TestManager_RegisteredConverterExtensions(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "multi-hook", "multi-hook"})
 	ctx := context.Background()
 
@@ -359,6 +369,7 @@ func TestManager_RegisteredConverterExtensions(t *testing.T) {
 }
 
 func TestManager_GetParserForType(t *testing.T) {
+	t.Parallel()
 	mgr, svc := setupTestManager(t, struct{ scope, id, testdata string }{"test", "multi-hook", "multi-hook"})
 	ctx := context.Background()
 
@@ -397,6 +408,7 @@ func TestManager_GetParserForType(t *testing.T) {
 }
 
 func TestManager_GetOrderedRuntimes_WithLibrary(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -459,6 +471,7 @@ func TestManager_GetOrderedRuntimes_WithLibrary(t *testing.T) {
 }
 
 func TestManager_GetOrderedRuntimes_GlobalDisabledExcluded(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -647,6 +660,7 @@ func TestManager_LoadPlugin_NoMinVersion(t *testing.T) {
 }
 
 func TestManager_GetManualRuntimes(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -704,6 +718,7 @@ func TestManager_GetManualRuntimes(t *testing.T) {
 }
 
 func TestManager_GetOrderedRuntimes_GlobalModeFiltering(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/pkg/plugins/manifest_test.go
+++ b/pkg/plugins/manifest_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestParseManifest_Valid(t *testing.T) {
+	t.Parallel()
 	manifest := map[string]interface{}{
 		"manifestVersion":  1,
 		"id":               "enricher-goodreads",
@@ -73,6 +74,7 @@ func TestParseManifest_Valid(t *testing.T) {
 }
 
 func TestParseManifest_MissingRequiredFields(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		manifest    map[string]interface{}
@@ -118,6 +120,7 @@ func TestParseManifest_MissingRequiredFields(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			data, err := json.Marshal(tt.manifest)
 			require.NoError(t, err)
 
@@ -129,6 +132,7 @@ func TestParseManifest_MissingRequiredFields(t *testing.T) {
 }
 
 func TestParseManifest_UnsupportedManifestVersion(t *testing.T) {
+	t.Parallel()
 	manifest := map[string]interface{}{
 		"manifestVersion": 99,
 		"id":              "test-plugin",
@@ -145,6 +149,7 @@ func TestParseManifest_UnsupportedManifestVersion(t *testing.T) {
 }
 
 func TestParseManifest_InputConverter(t *testing.T) {
+	t.Parallel()
 	manifest := map[string]interface{}{
 		"manifestVersion": 1,
 		"id":              "converter-cbz-to-epub",
@@ -174,6 +179,7 @@ func TestParseManifest_InputConverter(t *testing.T) {
 }
 
 func TestParseManifest_FileParser(t *testing.T) {
+	t.Parallel()
 	manifest := map[string]interface{}{
 		"manifestVersion": 1,
 		"id":              "parser-mobi",
@@ -201,6 +207,7 @@ func TestParseManifest_FileParser(t *testing.T) {
 }
 
 func TestParseManifest_IdentifierTypes(t *testing.T) {
+	t.Parallel()
 	manifest := map[string]interface{}{
 		"manifestVersion": 1,
 		"id":              "identifier-goodreads",
@@ -244,6 +251,7 @@ func TestParseManifest_IdentifierTypes(t *testing.T) {
 }
 
 func TestParseManifest_FileParserReservedExtensions(t *testing.T) {
+	t.Parallel()
 	manifest := map[string]interface{}{
 		"manifestVersion": 1,
 		"id":              "parser-custom-epub",

--- a/pkg/plugins/repository_test.go
+++ b/pkg/plugins/repository_test.go
@@ -126,6 +126,7 @@ func TestFetchRepository_HTTPError(t *testing.T) {
 }
 
 func TestFilterCompatibleVersions(t *testing.T) {
+	t.Parallel()
 	versions := []PluginVersion{
 		{Version: "1.0.0", ManifestVersion: 1},
 		{Version: "2.0.0", ManifestVersion: 2},
@@ -140,6 +141,7 @@ func TestFilterCompatibleVersions(t *testing.T) {
 }
 
 func TestFilterCompatibleVersions_NoMatch(t *testing.T) {
+	t.Parallel()
 	versions := []PluginVersion{
 		{Version: "2.0.0", ManifestVersion: 2},
 		{Version: "3.0.0", ManifestVersion: 3},
@@ -150,6 +152,7 @@ func TestFilterCompatibleVersions_NoMatch(t *testing.T) {
 }
 
 func TestFilterCompatibleVersions_Empty(t *testing.T) {
+	t.Parallel()
 	compatible := FilterCompatibleVersions(nil)
 	assert.Empty(t, compatible)
 }

--- a/pkg/plugins/runtime_test.go
+++ b/pkg/plugins/runtime_test.go
@@ -12,6 +12,7 @@ import (
 const testdataRoot = "testdata"
 
 func TestLoadPlugin_SimpleEnricher(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(testdataRoot, "simple-enricher")
 	rt, err := LoadPlugin(dir, "official", "simple-enricher")
 	require.NoError(t, err)
@@ -22,6 +23,7 @@ func TestLoadPlugin_SimpleEnricher(t *testing.T) {
 }
 
 func TestLoadPlugin_MultiHook(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(testdataRoot, "multi-hook")
 	rt, err := LoadPlugin(dir, "official", "multi-hook")
 	require.NoError(t, err)
@@ -32,6 +34,7 @@ func TestLoadPlugin_MultiHook(t *testing.T) {
 }
 
 func TestLoadPlugin_UndeclaredHook(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(testdataRoot, "undeclared-hook")
 	_, err := LoadPlugin(dir, "official", "undeclared")
 	require.Error(t, err)
@@ -39,6 +42,7 @@ func TestLoadPlugin_UndeclaredHook(t *testing.T) {
 }
 
 func TestLoadPlugin_MissingMainJS(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(testdataRoot, "missing-mainjs")
 	_, err := LoadPlugin(dir, "official", "missing-mainjs")
 	require.Error(t, err)
@@ -46,6 +50,7 @@ func TestLoadPlugin_MissingMainJS(t *testing.T) {
 }
 
 func TestLoadPlugin_InvalidJS(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(testdataRoot, "invalid-js")
 	_, err := LoadPlugin(dir, "official", "invalid-js")
 	require.Error(t, err)
@@ -53,6 +58,7 @@ func TestLoadPlugin_InvalidJS(t *testing.T) {
 }
 
 func TestLoadPlugin_ManifestReturned(t *testing.T) {
+	t.Parallel()
 	dir := filepath.Join(testdataRoot, "simple-enricher")
 	rt, err := LoadPlugin(dir, "official", "simple-enricher")
 	require.NoError(t, err)
@@ -70,6 +76,7 @@ func TestLoadPlugin_ManifestReturned(t *testing.T) {
 }
 
 func TestLoadPlugin_MetadataEnricherFieldValidation(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		manifest    string

--- a/pkg/plugins/runtime_test.go
+++ b/pkg/plugins/runtime_test.go
@@ -166,6 +166,7 @@ func TestLoadPlugin_MetadataEnricherFieldValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Create temp directory with plugin files
 			dir := t.TempDir()
 			require.NoError(t, os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(tt.manifest), 0644))

--- a/pkg/plugins/service_library_test.go
+++ b/pkg/plugins/service_library_test.go
@@ -27,6 +27,7 @@ func insertTestLibrary(t *testing.T, db *bun.DB, name string) *models.Library { 
 }
 
 func TestService_IsLibraryCustomized(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -48,6 +49,7 @@ func TestService_IsLibraryCustomized(t *testing.T) {
 }
 
 func TestService_GetLibraryOrder(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -84,6 +86,7 @@ func TestService_GetLibraryOrder(t *testing.T) {
 }
 
 func TestService_ResetLibraryOrder(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -130,6 +133,7 @@ func TestService_GetLibraryOrder_Empty(t *testing.T) {
 }
 
 func TestService_ResetAllLibraryOrders(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/pkg/plugins/service_test.go
+++ b/pkg/plugins/service_test.go
@@ -53,6 +53,7 @@ func insertTestPlugin(t *testing.T, db *bun.DB, scope, id string) *models.Plugin
 }
 
 func TestService_InstallAndRetrievePlugin(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -84,6 +85,7 @@ func TestService_InstallAndRetrievePlugin(t *testing.T) {
 }
 
 func TestService_ListPlugins(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -120,6 +122,7 @@ func TestService_ListPlugins_Empty(t *testing.T) {
 }
 
 func TestService_UpdatePlugin(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -142,6 +145,7 @@ func TestService_UpdatePlugin(t *testing.T) {
 }
 
 func TestService_UninstallPlugin(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -181,6 +185,7 @@ func TestService_UninstallPlugin(t *testing.T) {
 }
 
 func TestService_GetConfig_MasksSecrets(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -219,6 +224,7 @@ func TestService_GetConfig_MasksSecrets(t *testing.T) {
 }
 
 func TestService_SetConfig_Upsert(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -245,6 +251,7 @@ func TestService_SetConfig_Upsert(t *testing.T) {
 }
 
 func TestService_GetConfigRaw(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -267,6 +274,7 @@ func TestService_GetConfigRaw(t *testing.T) {
 }
 
 func TestService_GetOrder_SetOrder(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -316,6 +324,7 @@ func TestService_GetOrder_SetOrder(t *testing.T) {
 }
 
 func TestService_AppendToOrder(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -350,6 +359,7 @@ func TestService_AppendToOrder(t *testing.T) {
 }
 
 func TestService_ListRepositories(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -365,6 +375,7 @@ func TestService_ListRepositories(t *testing.T) {
 }
 
 func TestService_AddAndRemoveRepository(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -406,6 +417,7 @@ func TestService_AddAndRemoveRepository(t *testing.T) {
 }
 
 func TestService_UpsertIdentifierTypes(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -522,6 +534,7 @@ func TestService_UpsertIdentifierTypes_CrossPluginCoexistence(t *testing.T) {
 }
 
 func TestService_GetFieldSettings_EmptyByDefault(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -535,6 +548,7 @@ func TestService_GetFieldSettings_EmptyByDefault(t *testing.T) {
 }
 
 func TestService_SetFieldSetting_DisableField(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -552,6 +566,7 @@ func TestService_SetFieldSetting_DisableField(t *testing.T) {
 }
 
 func TestService_SetFieldSetting_EnableFieldRemovesRow(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -572,6 +587,7 @@ func TestService_SetFieldSetting_EnableFieldRemovesRow(t *testing.T) {
 }
 
 func TestService_SetFieldSetting_MultipleFields(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -607,6 +623,7 @@ func TestService_SetFieldSetting_MultipleFields(t *testing.T) {
 }
 
 func TestService_GetLibraryFieldSettings_EmptyByDefault(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -620,6 +637,7 @@ func TestService_GetLibraryFieldSettings_EmptyByDefault(t *testing.T) {
 }
 
 func TestService_SetLibraryFieldSetting_Override(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -648,6 +666,7 @@ func TestService_SetLibraryFieldSetting_Override(t *testing.T) {
 }
 
 func TestService_ResetLibraryFieldSettings(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -671,6 +690,7 @@ func TestService_ResetLibraryFieldSettings(t *testing.T) {
 }
 
 func TestService_GetEffectiveFieldSettings_GlobalOnly(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -693,6 +713,7 @@ func TestService_GetEffectiveFieldSettings_GlobalOnly(t *testing.T) {
 }
 
 func TestService_GetEffectiveFieldSettings_LibraryOverridesGlobal(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -722,6 +743,7 @@ func TestService_GetEffectiveFieldSettings_LibraryOverridesGlobal(t *testing.T) 
 }
 
 func TestService_GetEffectiveFieldSettings_OnlyDeclaredFields(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()
@@ -747,6 +769,7 @@ func TestService_GetEffectiveFieldSettings_OnlyDeclaredFields(t *testing.T) {
 }
 
 func TestService_GetEffectiveFieldSettings_EmptyDeclaredFields(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	svc := NewService(db)
 	ctx := context.Background()

--- a/pkg/plugins/update_check_test.go
+++ b/pkg/plugins/update_check_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestManager_CheckForUpdatesForRepo_UsesPassedManifest(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -81,6 +82,7 @@ func TestManager_CheckForUpdatesForRepo_UsesPassedManifest(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_UpdateAvailable(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -139,6 +141,7 @@ func TestManager_CheckForUpdates_UpdateAvailable(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_AlreadyUpToDate(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -194,6 +197,7 @@ func TestManager_CheckForUpdates_AlreadyUpToDate(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_ClearsStaleUpdate(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -251,6 +255,7 @@ func TestManager_CheckForUpdates_ClearsStaleUpdate(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_DisabledRepoSkipped(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -314,6 +319,7 @@ func TestManager_CheckForUpdates_DisabledRepoSkipped(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_FetchErrorSkipped(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -356,6 +362,7 @@ func TestManager_CheckForUpdates_FetchErrorSkipped(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_IncompatibleVersionsFiltered(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -411,6 +418,7 @@ func TestManager_CheckForUpdates_IncompatibleVersionsFiltered(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_NoPlugins(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -422,6 +430,7 @@ func TestManager_CheckForUpdates_NoPlugins(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_ScopeMismatch(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -477,6 +486,7 @@ func TestManager_CheckForUpdates_ScopeMismatch(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_NewestFirstOrdering(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")
@@ -535,6 +545,7 @@ func TestManager_CheckForUpdates_NewestFirstOrdering(t *testing.T) {
 }
 
 func TestManager_CheckForUpdates_SemverNotLexicographic(t *testing.T) {
+	t.Parallel()
 	db := setupTestDB(t)
 	service := NewService(db)
 	mgr := NewManager(service, t.TempDir(), "")


### PR DESCRIPTION
## Summary
- The `pkg/plugins` test package was hitting the 10-minute timeout on CI shard 7/12 under `-race` because ~170 tests ran sequentially despite each creating isolated state (in-memory SQLite DBs, `t.TempDir()`)
- Added `t.Parallel()` to 191 test functions across 15 files — tests that mutate global `version.Version` are kept sequential
- Local runtime dropped from 600s (timeout) to ~162s with `-race`

## Test plan
- CI passes on this branch (the fix is itself validated by CI not timing out)
- Ran `go test -race -count=1 ./pkg/plugins/` locally — passes in ~162s
- Ran `go test -race -count=2 ./pkg/plugins/ -run "TestManager_Load|TestService_"` to stress-test the version-mutating tests for races — no races detected