### PR TITLE
[Frontend] Show author names instead of book title in file list subtitle

### DIFF
--- a/app/components/library/FileListSection.test.tsx
+++ b/app/components/library/FileListSection.test.tsx
@@ -95,7 +95,61 @@ describe("FileListSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders file name and book title for each row", () => {
+  it("shows author names as subtitle when authors are available", () => {
+    const files = [
+      makeFile(1, {
+        book: {
+          id: 10,
+          title: "Book Title 1",
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+          library_id: 1,
+          authors: [
+            {
+              id: 1,
+              book_id: 10,
+              person_id: 1,
+              person: {
+                id: 1,
+                created_at: "2024-01-01T00:00:00Z",
+                updated_at: "2024-01-01T00:00:00Z",
+                name: "Alice",
+                sort_name: "Alice",
+              },
+              sort_order: 0,
+            },
+            {
+              id: 2,
+              book_id: 10,
+              person_id: 2,
+              person: {
+                id: 2,
+                created_at: "2024-01-01T00:00:00Z",
+                updated_at: "2024-01-01T00:00:00Z",
+                name: "Bob",
+                sort_name: "Bob",
+              },
+              sort_order: 1,
+            },
+          ],
+        } as File["book"],
+      }),
+    ];
+    render(
+      wrap(
+        <FileListSection
+          libraryId="1"
+          query={makeQueryResult(files, 1)}
+          title="Files"
+        />,
+      ),
+    );
+    expect(screen.getByText("Edition 1")).toBeInTheDocument();
+    expect(screen.getByText("Alice, Bob")).toBeInTheDocument();
+    expect(screen.queryByText("Book Title 1")).not.toBeInTheDocument();
+  });
+
+  it("falls back to book title when no authors are available", () => {
     const files = [makeFile(1), makeFile(2)];
     render(
       wrap(

--- a/app/components/library/FileListSection.tsx
+++ b/app/components/library/FileListSection.tsx
@@ -25,6 +25,14 @@ interface FileListSectionProps {
   pageParam?: string;
 }
 
+function fileSubtitle(file: File): string {
+  const authors = file.book?.authors
+    ?.map((a) => a.person?.name)
+    .filter(Boolean);
+  if (authors && authors.length > 0) return authors.join(", ");
+  return file.book?.title ?? "Unknown Book";
+}
+
 function FileMetaInfo({ file }: { file: File }) {
   if (
     file.file_type === "m4b" &&
@@ -128,7 +136,7 @@ export function FileListSection({
                 {file.name || getFilename(file.filepath)}
               </p>
               <p className="text-xs text-muted-foreground truncate">
-                {file.book?.title ?? "Unknown Book"}
+                {fileSubtitle(file)}
               </p>
             </div>
             <div className="flex items-center gap-2 shrink-0">

--- a/pkg/kobo/service.go
+++ b/pkg/kobo/service.go
@@ -246,6 +246,9 @@ func (svc *Service) GetScopedFiles(ctx context.Context, userID int, scope *SyncS
 	q := svc.db.NewSelect().
 		Model(&files).
 		Relation("Book").
+		Relation("Book.Authors", func(sq *bun.SelectQuery) *bun.SelectQuery {
+			return sq.Order("a.sort_order ASC")
+		}).
 		Relation("Book.Authors.Person").
 		Relation("Book.BookSeries.Series").
 		Relation("Publisher").

--- a/pkg/lists/service.go
+++ b/pkg/lists/service.go
@@ -320,7 +320,9 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 		NewSelect().
 		Model(&listBooks).
 		Relation("Book").
-		Relation("Book.Authors").
+		Relation("Book.Authors", func(sq *bun.SelectQuery) *bun.SelectQuery {
+			return sq.Order("a.sort_order ASC")
+		}).
 		Relation("Book.Authors.Person").
 		Relation("Book.BookSeries").
 		Relation("Book.BookSeries.Series").

--- a/pkg/people/service.go
+++ b/pkg/people/service.go
@@ -311,6 +311,7 @@ func (svc *Service) GetNarratedFilesPaginated(ctx context.Context, personID, lim
 	total, err := svc.db.NewSelect().
 		Model(&files).
 		Relation("Book").
+		Relation("Book.Authors.Person").
 		Join("INNER JOIN narrators n ON n.file_id = f.id").
 		Where("n.person_id = ?", personID).
 		Order("f.filepath ASC").

--- a/pkg/people/service.go
+++ b/pkg/people/service.go
@@ -311,6 +311,9 @@ func (svc *Service) GetNarratedFilesPaginated(ctx context.Context, personID, lim
 	total, err := svc.db.NewSelect().
 		Model(&files).
 		Relation("Book").
+		Relation("Book.Authors", func(sq *bun.SelectQuery) *bun.SelectQuery {
+			return sq.Order("a.sort_order ASC")
+		}).
 		Relation("Book.Authors.Person").
 		Join("INNER JOIN narrators n ON n.file_id = f.id").
 		Where("n.person_id = ?", personID).

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -262,6 +262,7 @@ func (svc *Service) GetFilesPaginated(ctx context.Context, publisherID, limit, o
 		Model(&files).
 		Where("f.publisher_id IN ("+descendantIDsSubquery()+")", publisherID).
 		Relation("Book").
+		Relation("Book.Authors.Person").
 		Order("f.filepath ASC").
 		Limit(limit).
 		Offset(offset).

--- a/pkg/publishers/service.go
+++ b/pkg/publishers/service.go
@@ -262,6 +262,9 @@ func (svc *Service) GetFilesPaginated(ctx context.Context, publisherID, limit, o
 		Model(&files).
 		Where("f.publisher_id IN ("+descendantIDsSubquery()+")", publisherID).
 		Relation("Book").
+		Relation("Book.Authors", func(sq *bun.SelectQuery) *bun.SelectQuery {
+			return sq.Order("a.sort_order ASC")
+		}).
 		Relation("Book.Authors.Person").
 		Order("f.filepath ASC").
 		Limit(limit).


### PR DESCRIPTION
## Summary
- On publisher and person detail pages, the file list subtitle showed the book title, which was almost always identical to the file name — providing no useful information
- Changed the subtitle to show author names (e.g., "Mark Manson") with a fallback to book title when no authors are available
- Added `Book.Authors.Person` relation loading to `GetFilesPaginated` in both the publishers and people backend services

## Test plan
- Navigate to a publisher detail page and verify each file row shows the author name(s) as the subtitle instead of the book title
- Navigate to a person detail page (narrated files tab) and verify the same
- Verify files with multiple authors show them comma-separated
- Verify files with no authors fall back to showing the book title