### PR TITLE
[Fix] Reset merge dialog search state

### DIFF
--- a/app/components/library/MetadataMergeDialog.test.tsx
+++ b/app/components/library/MetadataMergeDialog.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { MetadataMergeDialog } from "./MetadataMergeDialog";
+
+const entities = [
+  { id: 10, name: "Dutton Books", count: 3 },
+  { id: 20, name: "Ace Books", count: 2 },
+];
+
+describe("MetadataMergeDialog", () => {
+  it("clears parent search after a merge succeeds", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onMerge = vi.fn().mockResolvedValue(undefined);
+    const onSearch = vi.fn();
+
+    render(
+      <MetadataMergeDialog
+        entities={entities}
+        entityType="publisher"
+        isLoadingEntities={false}
+        isPending={false}
+        onMerge={onMerge}
+        onOpenChange={vi.fn()}
+        onSearch={onSearch}
+        open={true}
+        targetId={30}
+        targetName="Target Publisher"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(
+      screen.getByPlaceholderText("Search publishers..."),
+      "Dutton",
+    );
+    await user.click(screen.getByText("Dutton Books"));
+    await user.click(screen.getByRole("button", { name: "Merge" }));
+
+    await waitFor(() => {
+      expect(onMerge).toHaveBeenCalledWith(10);
+    });
+    expect(onSearch).toHaveBeenLastCalledWith("");
+  });
+
+  it("clears parent search when the dialog closes without merging", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const onOpenChange = vi.fn();
+    const onSearch = vi.fn();
+
+    render(
+      <MetadataMergeDialog
+        entities={entities}
+        entityType="publisher"
+        isLoadingEntities={false}
+        isPending={false}
+        onMerge={vi.fn()}
+        onOpenChange={onOpenChange}
+        onSearch={onSearch}
+        open={true}
+        targetId={30}
+        targetName="Target Publisher"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(
+      screen.getByPlaceholderText("Search publishers..."),
+      "Dutton",
+    );
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSearch).toHaveBeenLastCalledWith("");
+  });
+});

--- a/app/components/library/MetadataMergeDialog.tsx
+++ b/app/components/library/MetadataMergeDialog.tsx
@@ -114,6 +114,7 @@ export function MetadataMergeDialog({
     }
     setSelectedId(null);
     setSearch("");
+    onSearch("");
     if (setChildConfig) setAction("merge");
   };
 
@@ -121,6 +122,7 @@ export function MetadataMergeDialog({
     if (!isOpen) {
       setSelectedId(null);
       setSearch("");
+      onSearch("");
       if (setChildConfig) setAction("merge");
     }
     onOpenChange(isOpen);


### PR DESCRIPTION
## Summary

- Reset the parent merge-search value when `MetadataMergeDialog` clears its local search after a successful confirm or dialog close.
- Add focused coverage for merge success and cancel-close reset behavior.

Fixes #277.

## Validation

- `pnpm exec vitest run app/components/library/MetadataMergeDialog.test.tsx` passed, 2 tests.
- `pnpm exec prettier --check app/components/library/MetadataMergeDialog.tsx app/components/library/MetadataMergeDialog.test.tsx` passed.
- `pnpm exec eslint --max-warnings 0 app/components/library/MetadataMergeDialog.tsx app/components/library/MetadataMergeDialog.test.tsx` passed.
- `git diff --check HEAD~1 HEAD` passed.
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30` found no leaks.

Not run: full `mise check:quiet`, because `mise` is not available in this local environment. Broader type-dependent checks also need the gitignored `app/types/generated/*` files; a local `tygo`/Go dependency warmup did not complete in this fresh worktree.
