### PR TITLE
Fix #277: MetadataMergeDialog doesn't reset parent search state after merge

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -51,6 +51,7 @@ Use semantic color tokens exclusively. Never use hardcoded Tailwind colors (`dar
 **IMPORTANT - List Limits:**
 - **Default list limit is 50** - All list endpoints have a max limit of 50 items per request
 - **Always use server-side search** - Never rely on client-side filtering for searchable lists; always pass search queries to the API. This ensures users can find items beyond the initial 50 loaded.
+- **Metadata merge search should clear immediately** - Merge dialogs reset their search when they close or complete. Use `useDebouncedSearch` for that query state instead of `useDebounce` so clearing to `""` updates the server-side search immediately and fast reopen cycles do not show stale filtered results.
 
 ### React Query Cache Invalidation
 

--- a/app/components/library/MetadataMergeDialog.test.tsx
+++ b/app/components/library/MetadataMergeDialog.test.tsx
@@ -48,6 +48,46 @@ describe("MetadataMergeDialog", () => {
     expect(onSearch).toHaveBeenLastCalledWith("");
   });
 
+  it("clears parent search state after setting a child", async () => {
+    const user = createUser();
+    const onSetChild = vi.fn().mockResolvedValue(undefined);
+    const onSearch = vi.fn();
+
+    render(
+      <MetadataMergeDialog
+        entities={entities}
+        entityType="publisher"
+        isLoadingEntities={false}
+        isPending={false}
+        onMerge={vi.fn()}
+        onOpenChange={vi.fn()}
+        onSearch={onSearch}
+        open={true}
+        setChildConfig={{
+          disabledIds: [],
+          isPending: false,
+          onSetChild,
+        }}
+        targetId={1}
+        targetName="Penguin"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(
+      screen.getByPlaceholderText("Search publishers..."),
+      "Dutton",
+    );
+    await user.click(screen.getByText("Dutton"));
+    await user.click(screen.getByRole("radio", { name: /Set as child/i }));
+    await user.click(screen.getByRole("button", { name: /Set as child/i }));
+
+    await waitFor(() => {
+      expect(onSetChild).toHaveBeenCalledWith(10);
+    });
+    expect(onSearch).toHaveBeenLastCalledWith("");
+  });
+
   it("clears parent search state when the dialog closes", async () => {
     const user = createUser();
     const onOpenChange = vi.fn();

--- a/app/components/library/MetadataMergeDialog.test.tsx
+++ b/app/components/library/MetadataMergeDialog.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { MetadataMergeDialog } from "./MetadataMergeDialog";
+
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+const entities = [
+  { id: 10, name: "Dutton", count: 5 },
+  { id: 20, name: "Riverhead", count: 3 },
+];
+
+describe("MetadataMergeDialog", () => {
+  it("clears parent search state after a merge", async () => {
+    const user = createUser();
+    const onMerge = vi.fn().mockResolvedValue(undefined);
+    const onSearch = vi.fn();
+
+    render(
+      <MetadataMergeDialog
+        entities={entities}
+        entityType="publisher"
+        isLoadingEntities={false}
+        isPending={false}
+        onMerge={onMerge}
+        onOpenChange={vi.fn()}
+        onSearch={onSearch}
+        open={true}
+        targetId={1}
+        targetName="Penguin"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(
+      screen.getByPlaceholderText("Search publishers..."),
+      "Dutton",
+    );
+    await user.click(screen.getByText("Dutton"));
+
+    await user.click(screen.getByRole("button", { name: "Merge" }));
+
+    await waitFor(() => {
+      expect(onMerge).toHaveBeenCalledWith(10);
+    });
+    expect(onSearch).toHaveBeenLastCalledWith("");
+  });
+
+  it("clears parent search state when the dialog closes", async () => {
+    const user = createUser();
+    const onOpenChange = vi.fn();
+    const onSearch = vi.fn();
+
+    render(
+      <MetadataMergeDialog
+        entities={entities}
+        entityType="publisher"
+        isLoadingEntities={false}
+        isPending={false}
+        onMerge={vi.fn()}
+        onOpenChange={onOpenChange}
+        onSearch={onSearch}
+        open={true}
+        targetId={1}
+        targetName="Penguin"
+      />,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(
+      screen.getByPlaceholderText("Search publishers..."),
+      "Dutton",
+    );
+    await user.keyboard("{Escape}");
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSearch).toHaveBeenLastCalledWith("");
+  });
+});

--- a/app/components/library/MetadataMergeDialog.tsx
+++ b/app/components/library/MetadataMergeDialog.tsx
@@ -105,6 +105,13 @@ export function MetadataMergeDialog({
     onSearch(value);
   };
 
+  const resetDialogState = () => {
+    setSelectedId(null);
+    setSearch("");
+    onSearch("");
+    if (setChildConfig) setAction("merge");
+  };
+
   const handleConfirm = async () => {
     if (!selectedId) return;
     if (action === "set-child" && setChildConfig) {
@@ -112,16 +119,12 @@ export function MetadataMergeDialog({
     } else {
       await onMerge(selectedId);
     }
-    setSelectedId(null);
-    setSearch("");
-    if (setChildConfig) setAction("merge");
+    resetDialogState();
   };
 
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
-      setSelectedId(null);
-      setSearch("");
-      if (setChildConfig) setAction("merge");
+      resetDialogState();
     }
     onOpenChange(isOpen);
   };

--- a/app/components/pages/GenreDetail.test.tsx
+++ b/app/components/pages/GenreDetail.test.tsx
@@ -56,16 +56,10 @@ vi.mock("@/hooks/queries/genres", () => ({
     isLoading: false,
     isSuccess: true,
   }),
-  useGenresList: ({
-    search,
-  }: {
-    search?: string;
-  }) => ({
+  useGenresList: ({ search }: { search?: string }) => ({
     data: {
       items: allGenres.filter((genre) =>
-        search
-          ? genre.name.toLowerCase().includes(search.toLowerCase())
-          : true,
+        search ? genre.name.toLowerCase().includes(search.toLowerCase()) : true,
       ),
     },
     isLoading: false,

--- a/app/components/pages/GenreDetail.test.tsx
+++ b/app/components/pages/GenreDetail.test.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import GenreDetail from "./GenreDetail";
+
+vi.mock("@/hooks/queries/libraries", () => ({
+  useLibrary: () => ({ data: { name: "My Library" } }),
+}));
+
+vi.mock("@/components/library/LibraryLayout", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/library/BookGallerySection", () => ({
+  BookGallerySection: () => <div>Books</div>,
+}));
+
+vi.mock("@/hooks/usePageTitle", () => ({
+  usePageTitle: vi.fn(),
+}));
+
+vi.mock("@/hooks/queries/settings", () => ({
+  useUserSettings: () => ({
+    data: { gallery_size: "m" },
+    isSuccess: true,
+    isError: false,
+  }),
+}));
+
+const allGenres = [
+  { id: 5, name: "Science Fiction", book_count: 3 },
+  { id: 10, name: "Dystopian", book_count: 5 },
+  { id: 20, name: "Horror", book_count: 2 },
+];
+
+vi.mock("@/hooks/queries/genres", () => ({
+  useGenre: () => ({
+    data: {
+      aliases: [],
+      book_count: 3,
+      id: 5,
+      library_id: 1,
+      name: "Science Fiction",
+    },
+    isLoading: false,
+    isSuccess: true,
+  }),
+  useGenreBooks: () => ({
+    data: { items: [], total: 0 },
+    dataUpdatedAt: 0,
+    isLoading: false,
+    isSuccess: true,
+  }),
+  useGenresList: ({
+    search,
+  }: {
+    search?: string;
+  }) => ({
+    data: {
+      items: allGenres.filter((genre) =>
+        search
+          ? genre.name.toLowerCase().includes(search.toLowerCase())
+          : true,
+      ),
+    },
+    isLoading: false,
+  }),
+  useUpdateGenre: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useMergeGenre: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useDeleteGenre: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+function renderAt(path: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            element={<GenreDetail />}
+            path="/libraries/:libraryId/genres/:id"
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("GenreDetail", () => {
+  it("shows an unfiltered merge list immediately after a fast close and reopen", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    renderAt("/libraries/1/genres/5");
+
+    await user.click(screen.getByRole("button", { name: /^merge$/i }));
+    await user.click(screen.getByRole("combobox"));
+    await user.type(screen.getByPlaceholderText("Search genres..."), "Dys");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(screen.getByText("Dystopian")).toBeInTheDocument();
+    expect(screen.queryByText("Horror")).not.toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await user.click(screen.getByRole("button", { name: /^merge$/i }));
+    await user.click(screen.getByRole("combobox"));
+
+    expect(screen.getByText("Dystopian")).toBeInTheDocument();
+    expect(screen.getByText("Horror")).toBeInTheDocument();
+  });
+});

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -16,7 +16,7 @@ import {
   useUpdateGenre,
 } from "@/hooks/queries/genres";
 import { useUserSettings } from "@/hooks/queries/settings";
-import { useDebounce } from "@/hooks/useDebounce";
+import { useDebouncedSearch } from "@/hooks/useDebouncedSearch";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { parseGallerySize } from "@/libraries/gallerySize";
 import type { GallerySize } from "@/types";
@@ -59,7 +59,7 @@ const GenreDetail = () => {
   const deleteGenreMutation = useDeleteGenre();
 
   const [mergeSearchRaw, setMergeSearchRaw] = useState("");
-  const mergeSearch = useDebounce(mergeSearchRaw, 200);
+  const mergeSearch = useDebouncedSearch(mergeSearchRaw, 200);
 
   // Fires as soon as library_id is available rather than waiting for the merge
   // dialog to open. The query is cheap (50 items, single index scan) and

--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -22,7 +22,7 @@ import {
   useUpdatePerson,
 } from "@/hooks/queries/people";
 import { useUserSettings } from "@/hooks/queries/settings";
-import { useDebounce } from "@/hooks/useDebounce";
+import { useDebouncedSearch } from "@/hooks/useDebouncedSearch";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { parseGallerySize } from "@/libraries/gallerySize";
 import type { GallerySize } from "@/types";
@@ -78,7 +78,7 @@ const PersonDetail = () => {
   const deletePersonMutation = useDeletePerson();
 
   const [mergeSearchRaw, setMergeSearchRaw] = useState("");
-  const mergeSearch = useDebounce(mergeSearchRaw, 200);
+  const mergeSearch = useDebouncedSearch(mergeSearchRaw, 200);
 
   const peopleListQuery = usePeopleList(
     {

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -26,7 +26,7 @@ import {
   useSetChildPublisher,
   useUpdatePublisher,
 } from "@/hooks/queries/publishers";
-import { useDebounce } from "@/hooks/useDebounce";
+import { useDebouncedSearch } from "@/hooks/useDebouncedSearch";
 import { usePageTitle } from "@/hooks/usePageTitle";
 
 const PublisherDetail = () => {
@@ -55,7 +55,7 @@ const PublisherDetail = () => {
   const deletePublisherMutation = useDeletePublisher();
 
   const [mergeSearchRaw, setMergeSearchRaw] = useState("");
-  const mergeSearch = useDebounce(mergeSearchRaw, 200);
+  const mergeSearch = useDebouncedSearch(mergeSearchRaw, 200);
 
   // Pre-fetch the publisher list as soon as library_id is available so the
   // merge dialog opens instantly without a loading flash.

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -26,7 +26,7 @@ import {
   useUpdateUserSettings,
   useUserSettings,
 } from "@/hooks/queries/settings";
-import { useDebounce } from "@/hooks/useDebounce";
+import { useDebouncedSearch } from "@/hooks/useDebouncedSearch";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { parseGallerySize } from "@/libraries/gallerySize";
 import type { GallerySize } from "@/types";
@@ -94,7 +94,7 @@ const SeriesDetail = () => {
   const [mergeOpen, setMergeOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [mergeSearch, setMergeSearch] = useState("");
-  const debouncedMergeSearch = useDebounce(mergeSearch, 200);
+  const debouncedMergeSearch = useDebouncedSearch(mergeSearch, 200);
 
   const updateSeriesMutation = useUpdateSeries();
   const mergeSeriesMutation = useMergeSeries();

--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -16,7 +16,7 @@ import {
   useTagsList,
   useUpdateTag,
 } from "@/hooks/queries/tags";
-import { useDebounce } from "@/hooks/useDebounce";
+import { useDebouncedSearch } from "@/hooks/useDebouncedSearch";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { parseGallerySize } from "@/libraries/gallerySize";
 import type { GallerySize } from "@/types";
@@ -59,7 +59,7 @@ const TagDetail = () => {
   const deleteTagMutation = useDeleteTag();
 
   const [mergeSearchRaw, setMergeSearchRaw] = useState("");
-  const mergeSearch = useDebounce(mergeSearchRaw, 200);
+  const mergeSearch = useDebouncedSearch(mergeSearchRaw, 200);
 
   // Fires as soon as library_id is available rather than waiting for the merge
   // dialog to open. The query is cheap (50 items, single index scan) and

--- a/app/hooks/useDebouncedSearch.ts
+++ b/app/hooks/useDebouncedSearch.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedSearch(value: string, delay: number = 300): string {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    if (value === "") {
+      setDebouncedValue("");
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -52,6 +52,8 @@ The hierarchy is **manually curated** — Shisho does not automatically infer pa
 
 The merge picker on a publisher's detail page offers two actions after selecting another publisher: **Merge** (moves files, adds an alias, deletes the source) and **Set as child** (makes the selected publisher a child of the current one without moving files or deleting either publisher). The "Set as child" option is disabled when it would create a cycle.
 
+When you close a metadata merge picker or complete a merge/set-child action, its search resets immediately. Reopening the picker starts from the full server-side result list instead of keeping the previous filtered query.
+
 ### Identifiers
 
 Identifiers (ISBN, ASIN, etc.) are also file-level. Each file can have multiple identifiers of **different** types: `isbn_10`, `isbn_13`, `asin`, `uuid`, `goodreads`, `google`, and custom types registered by [plugins](./plugins/overview).


### PR DESCRIPTION
Resolves #277

Automated implementation via afk.