### PR TITLE
Fix #285: Changing a publisher's parent leaves cached parent children stale

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -58,7 +58,7 @@ When a mutation modifies a resource (update/delete/merge), invalidate related qu
 
 **Cross-resource invalidation is required**: When metadata entities (genres, tags, series, people, publishers) are modified, also invalidate `ListBooks` and `RetrieveBook` queries since books display this metadata.
 
-**Hierarchy changes must invalidate both old and new parents**: For hierarchical metadata such as publishers, mutations that reparent a node (`parent_id` edits, "set child" actions) must invalidate the detail queries for both the previous parent and the new parent. Invalidating only the edited node leaves cached `children` / descendant counts stale on the parent detail pages.
+**Hierarchy changes must invalidate publisher detail + file query families**: For hierarchical metadata such as publishers, mutations that reparent a node (`parent_id` edits, "set child" actions) affect descendant-inclusive detail/file data for the moved node, both sides of the move, and any cached ancestors. Invalidate the `RetrievePublisher` and `PublisherFiles` query families for hierarchy changes rather than only the edited node.
 
 **Pattern:**
 ```typescript

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -58,6 +58,8 @@ When a mutation modifies a resource (update/delete/merge), invalidate related qu
 
 **Cross-resource invalidation is required**: When metadata entities (genres, tags, series, people, publishers) are modified, also invalidate `ListBooks` and `RetrieveBook` queries since books display this metadata.
 
+**Hierarchy changes must invalidate both old and new parents**: For hierarchical metadata such as publishers, mutations that reparent a node (`parent_id` edits, "set child" actions) must invalidate the detail queries for both the previous parent and the new parent. Invalidating only the edited node leaves cached `children` / descendant counts stale on the parent detail pages.
+
 **Pattern:**
 ```typescript
 import { QueryKey as BooksQueryKey } from "./books";

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -119,13 +119,17 @@ const PublisherDetail = () => {
 
   const handleEdit = async (data: PublisherEditData) => {
     if (!publisherId) return;
+    const payload: PublisherEditData = {
+      name: data.name,
+      aliases: data.aliases,
+    };
+    if (data.parent_id !== undefined) {
+      payload.parent_id = data.parent_id;
+    }
+
     await updatePublisherMutation.mutateAsync({
       publisherId,
-      payload: {
-        name: data.name,
-        aliases: data.aliases,
-        parent_id: data.parent_id,
-      },
+      payload,
     });
   };
 

--- a/app/hooks/queries/publishers.test.ts
+++ b/app/hooks/queries/publishers.test.ts
@@ -200,6 +200,53 @@ describe("useUpdatePublisher", () => {
     });
   });
 
+  it("invalidates the previous and new parent publisher file queries when parent_id changes", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 1], {
+      id: 1,
+      parent_id: 2,
+    });
+    client.setQueryData(
+      [QueryKey.PublisherFiles, 2, { limit: 50, offset: 0 }],
+      { items: [], total: 1 },
+    );
+    client.setQueryData(
+      [QueryKey.PublisherFiles, 3, { limit: 50, offset: 0 }],
+      { items: [], total: 0 },
+    );
+
+    const { result } = renderHook(() => useUpdatePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        publisherId: 1,
+        payload: { parent_id: 3 },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([
+          QueryKey.PublisherFiles,
+          2,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState([
+          QueryKey.PublisherFiles,
+          3,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
   it("invalidates the previous parent publisher detail query when parent_id is cleared", async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -234,7 +281,7 @@ describe("useUpdatePublisher", () => {
 });
 
 describe("useSetChildPublisher", () => {
-  it("invalidates the previous and new parent publisher detail queries when reparenting a child", async () => {
+  it("invalidates the previous and new parent detail and file queries without a cached child detail query", async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -247,10 +294,52 @@ describe("useSetChildPublisher", () => {
       id: 2,
       children: [{ id: 3, name: "Child", file_count: 0 }],
     });
-    client.setQueryData([QueryKey.RetrievePublisher, 3], {
-      id: 3,
-      parent_id: 2,
+    client.setQueryData([QueryKey.ListPublishers, { library_id: 10 }], {
+      items: [
+        {
+          id: 1,
+          name: "New Parent",
+          library_id: 10,
+          aliases: [],
+          file_count: 0,
+          descendant_file_count: 1,
+          descendant_publisher_count: 1,
+          parent_id: null,
+          parent_name: null,
+        },
+        {
+          id: 2,
+          name: "Old Parent",
+          library_id: 10,
+          aliases: [],
+          file_count: 0,
+          descendant_file_count: 1,
+          descendant_publisher_count: 1,
+          parent_id: null,
+          parent_name: null,
+        },
+        {
+          id: 3,
+          name: "Child",
+          library_id: 10,
+          aliases: [],
+          file_count: 1,
+          descendant_file_count: 0,
+          descendant_publisher_count: 0,
+          parent_id: 2,
+          parent_name: "Old Parent",
+        },
+      ],
+      total: 3,
     });
+    client.setQueryData(
+      [QueryKey.PublisherFiles, 1, { limit: 50, offset: 0 }],
+      { items: [], total: 0 },
+    );
+    client.setQueryData(
+      [QueryKey.PublisherFiles, 2, { limit: 50, offset: 0 }],
+      { items: [], total: 1 },
+    );
 
     const { result } = renderHook(() => useSetChildPublisher(), {
       wrapper: makeWrapper(client),
@@ -271,7 +360,18 @@ describe("useSetChildPublisher", () => {
         client.getQueryState([QueryKey.RetrievePublisher, 2])?.isInvalidated,
       ).toBe(true);
       expect(
-        client.getQueryState([QueryKey.RetrievePublisher, 3])?.isInvalidated,
+        client.getQueryState([
+          QueryKey.PublisherFiles,
+          1,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState([
+          QueryKey.PublisherFiles,
+          2,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
       ).toBe(true);
     });
   });

--- a/app/hooks/queries/publishers.test.ts
+++ b/app/hooks/queries/publishers.test.ts
@@ -4,7 +4,7 @@ import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { QueryKey as BooksQueryKey } from "./books";
-import { QueryKey, useMergePublisher } from "./publishers";
+import { QueryKey, useMergePublisher, useUpdatePublisher } from "./publishers";
 
 vi.mock("@/libraries/api", async () => {
   const actual = await vi.importActual<object>("@/libraries/api");
@@ -85,5 +85,110 @@ describe("useMergePublisher", () => {
     expect(
       client.getQueryState([BooksQueryKey.RetrieveBook, 10])?.isInvalidated,
     ).toBe(true);
+  });
+});
+
+describe("useUpdatePublisher", () => {
+  it("invalidates the new parent publisher detail query when parent_id is set", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 1], {
+      id: 1,
+      parent_id: null,
+    });
+    client.setQueryData([QueryKey.RetrievePublisher, 2], {
+      id: 2,
+      children: [],
+    });
+
+    const { result } = renderHook(() => useUpdatePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        publisherId: 1,
+        payload: { parent_id: 2 },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 1])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 2])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  it("invalidates the previous parent publisher detail query when parent_id changes", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 1], {
+      id: 1,
+      parent_id: 2,
+    });
+    client.setQueryData([QueryKey.RetrievePublisher, 2], {
+      id: 2,
+      children: [{ id: 1, name: "Child", file_count: 0 }],
+    });
+    client.setQueryData([QueryKey.RetrievePublisher, 3], {
+      id: 3,
+      children: [],
+    });
+
+    const { result } = renderHook(() => useUpdatePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        publisherId: 1,
+        payload: { parent_id: 3 },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 2])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+
+  it("invalidates the previous parent publisher detail query when parent_id is cleared", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 1], {
+      id: 1,
+      parent_id: 2,
+    });
+    client.setQueryData([QueryKey.RetrievePublisher, 2], {
+      id: 2,
+      children: [{ id: 1, name: "Child", file_count: 0 }],
+    });
+
+    const { result } = renderHook(() => useUpdatePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        publisherId: 1,
+        payload: { parent_id: null },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 2])?.isInvalidated,
+      ).toBe(true);
+    });
   });
 });

--- a/app/hooks/queries/publishers.test.ts
+++ b/app/hooks/queries/publishers.test.ts
@@ -4,7 +4,12 @@ import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { QueryKey as BooksQueryKey } from "./books";
-import { QueryKey, useMergePublisher, useUpdatePublisher } from "./publishers";
+import {
+  QueryKey,
+  useMergePublisher,
+  useSetChildPublisher,
+  useUpdatePublisher,
+} from "./publishers";
 
 vi.mock("@/libraries/api", async () => {
   const actual = await vi.importActual<object>("@/libraries/api");
@@ -89,6 +94,41 @@ describe("useMergePublisher", () => {
 });
 
 describe("useUpdatePublisher", () => {
+  it("does not invalidate parent publisher detail queries when parent_id is unchanged", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 1], {
+      id: 1,
+      parent_id: 2,
+    });
+    client.setQueryData([QueryKey.RetrievePublisher, 2], {
+      id: 2,
+      children: [{ id: 1, name: "Child", file_count: 0 }],
+    });
+
+    const { result } = renderHook(() => useUpdatePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        publisherId: 1,
+        payload: { name: "Updated name", parent_id: undefined },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 1])?.isInvalidated,
+      ).toBe(true);
+    });
+    expect(
+      client.getQueryState([QueryKey.RetrievePublisher, 2])?.isInvalidated,
+    ).not.toBe(true);
+  });
+
   it("invalidates the new parent publisher detail query when parent_id is set", async () => {
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -188,6 +228,50 @@ describe("useUpdatePublisher", () => {
     await waitFor(() => {
       expect(
         client.getQueryState([QueryKey.RetrievePublisher, 2])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+});
+
+describe("useSetChildPublisher", () => {
+  it("invalidates the previous and new parent publisher detail queries when reparenting a child", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 1], {
+      id: 1,
+      children: [],
+    });
+    client.setQueryData([QueryKey.RetrievePublisher, 2], {
+      id: 2,
+      children: [{ id: 3, name: "Child", file_count: 0 }],
+    });
+    client.setQueryData([QueryKey.RetrievePublisher, 3], {
+      id: 3,
+      parent_id: 2,
+    });
+
+    const { result } = renderHook(() => useSetChildPublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        parentId: 1,
+        childId: 3,
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 1])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 2])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 3])?.isInvalidated,
       ).toBe(true);
     });
   });

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -2,6 +2,7 @@ import {
   useMutation,
   useQuery,
   useQueryClient,
+  type QueryClient,
   type UseQueryOptions,
 } from "@tanstack/react-query";
 
@@ -45,6 +46,22 @@ export enum QueryKey {
   RetrievePublisher = "RetrievePublisher",
   PublisherFiles = "PublisherFiles",
 }
+
+const invalidateAffectedPublisherParents = (
+  queryClient: QueryClient,
+  previousParentId?: number | null,
+  nextParentId?: number | null,
+) => {
+  const affectedParentIds = new Set(
+    [previousParentId, nextParentId].filter((id): id is number => id != null),
+  );
+
+  affectedParentIds.forEach((parentId) => {
+    queryClient.invalidateQueries({
+      queryKey: [QueryKey.RetrievePublisher, parentId],
+    });
+  });
+};
 
 export const usePublishersList = (
   query: ListPublishersQuery = {},
@@ -142,18 +159,12 @@ export const useUpdatePublisher = () => {
       queryClient.invalidateQueries({
         queryKey: [QueryKey.RetrievePublisher, variables.publisherId],
       });
-      if ("parent_id" in variables.payload) {
-        const affectedParentIds = new Set(
-          [previousParentId, variables.payload.parent_id].filter(
-            (id): id is number => id != null,
-          ),
+      if (variables.payload.parent_id !== undefined) {
+        invalidateAffectedPublisherParents(
+          queryClient,
+          previousParentId,
+          variables.payload.parent_id,
         );
-
-        affectedParentIds.forEach((parentId) => {
-          queryClient.invalidateQueries({
-            queryKey: [QueryKey.RetrievePublisher, parentId],
-          });
-        });
       }
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListPublishers] });
       // Invalidate book queries since they display publisher info on files
@@ -226,12 +237,19 @@ export const useSetChildPublisher = () => {
       });
     },
     onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.RetrievePublisher, variables.parentId],
-      });
+      const previousParentId = queryClient.getQueryData<PublisherDetail>([
+        QueryKey.RetrievePublisher,
+        variables.childId,
+      ])?.parent_id;
+
       queryClient.invalidateQueries({
         queryKey: [QueryKey.RetrievePublisher, variables.childId],
       });
+      invalidateAffectedPublisherParents(
+        queryClient,
+        previousParentId,
+        variables.parentId,
+      );
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListPublishers] });
       queryClient.invalidateQueries({
         queryKey: [QueryKey.PublisherFiles, variables.parentId],

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -134,9 +134,27 @@ export const useUpdatePublisher = () => {
       );
     },
     onSuccess: (_data, variables) => {
+      const previousParentId = queryClient.getQueryData<PublisherDetail>([
+        QueryKey.RetrievePublisher,
+        variables.publisherId,
+      ])?.parent_id;
+
       queryClient.invalidateQueries({
         queryKey: [QueryKey.RetrievePublisher, variables.publisherId],
       });
+      if ("parent_id" in variables.payload) {
+        const affectedParentIds = new Set(
+          [previousParentId, variables.payload.parent_id].filter(
+            (id): id is number => id != null,
+          ),
+        );
+
+        affectedParentIds.forEach((parentId) => {
+          queryClient.invalidateQueries({
+            queryKey: [QueryKey.RetrievePublisher, parentId],
+          });
+        });
+      }
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListPublishers] });
       // Invalidate book queries since they display publisher info on files
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -47,20 +47,9 @@ export enum QueryKey {
   PublisherFiles = "PublisherFiles",
 }
 
-const invalidateAffectedPublisherParents = (
-  queryClient: QueryClient,
-  previousParentId?: number | null,
-  nextParentId?: number | null,
-) => {
-  const affectedParentIds = new Set(
-    [previousParentId, nextParentId].filter((id): id is number => id != null),
-  );
-
-  affectedParentIds.forEach((parentId) => {
-    queryClient.invalidateQueries({
-      queryKey: [QueryKey.RetrievePublisher, parentId],
-    });
-  });
+const invalidatePublisherHierarchyQueries = (queryClient: QueryClient) => {
+  queryClient.invalidateQueries({ queryKey: [QueryKey.RetrievePublisher] });
+  queryClient.invalidateQueries({ queryKey: [QueryKey.PublisherFiles] });
 };
 
 export const usePublishersList = (
@@ -151,20 +140,12 @@ export const useUpdatePublisher = () => {
       );
     },
     onSuccess: (_data, variables) => {
-      const previousParentId = queryClient.getQueryData<PublisherDetail>([
-        QueryKey.RetrievePublisher,
-        variables.publisherId,
-      ])?.parent_id;
-
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.RetrievePublisher, variables.publisherId],
-      });
       if (variables.payload.parent_id !== undefined) {
-        invalidateAffectedPublisherParents(
-          queryClient,
-          previousParentId,
-          variables.payload.parent_id,
-        );
+        invalidatePublisherHierarchyQueries(queryClient);
+      } else {
+        queryClient.invalidateQueries({
+          queryKey: [QueryKey.RetrievePublisher, variables.publisherId],
+        });
       }
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListPublishers] });
       // Invalidate book queries since they display publisher info on files
@@ -236,24 +217,9 @@ export const useSetChildPublisher = () => {
         child_id: childId,
       });
     },
-    onSuccess: (_data, variables) => {
-      const previousParentId = queryClient.getQueryData<PublisherDetail>([
-        QueryKey.RetrievePublisher,
-        variables.childId,
-      ])?.parent_id;
-
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.RetrievePublisher, variables.childId],
-      });
-      invalidateAffectedPublisherParents(
-        queryClient,
-        previousParentId,
-        variables.parentId,
-      );
+    onSuccess: () => {
+      invalidatePublisherHierarchyQueries(queryClient);
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListPublishers] });
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.PublisherFiles, variables.parentId],
-      });
     },
   });
 };


### PR DESCRIPTION
Resolves #285

Automated implementation via afk.