### PR TITLE
[Fix] Invalidate publisher hierarchy cache on delete and merge mutations

### DIFF
--- a/app/hooks/queries/publishers.test.ts
+++ b/app/hooks/queries/publishers.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 import { QueryKey as BooksQueryKey } from "./books";
 import {
   QueryKey,
+  useDeletePublisher,
   useMergePublisher,
   useSetChildPublisher,
   useUpdatePublisher,
@@ -275,6 +276,86 @@ describe("useUpdatePublisher", () => {
     await waitFor(() => {
       expect(
         client.getQueryState([QueryKey.RetrievePublisher, 2])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+});
+
+describe("useDeletePublisher", () => {
+  it("invalidates RetrievePublisher and PublisherFiles query families on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 2], {
+      id: 2,
+      children: [{ id: 1, name: "Child", file_count: 3 }],
+      descendant_ids: [1],
+      descendant_file_count: 3,
+    });
+    client.setQueryData(
+      [QueryKey.PublisherFiles, 2, { limit: 50, offset: 0 }],
+      { items: [], total: 3 },
+    );
+
+    const { result } = renderHook(() => useDeletePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ publisherId: 1 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 2])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState([
+          QueryKey.PublisherFiles,
+          2,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
+});
+
+describe("useMergePublisher", () => {
+  it("invalidates RetrievePublisher and PublisherFiles for non-target publishers on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 3], {
+      id: 3,
+      children: [{ id: 2, name: "Source", file_count: 5 }],
+      descendant_ids: [2],
+      descendant_file_count: 5,
+    });
+    client.setQueryData(
+      [QueryKey.PublisherFiles, 3, { limit: 50, offset: 0 }],
+      { items: [], total: 5 },
+    );
+
+    const { result } = renderHook(() => useMergePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 3])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState([
+          QueryKey.PublisherFiles,
+          3,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
       ).toBe(true);
     });
   });

--- a/app/hooks/queries/publishers.test.ts
+++ b/app/hooks/queries/publishers.test.ts
@@ -92,6 +92,44 @@ describe("useMergePublisher", () => {
       client.getQueryState([BooksQueryKey.RetrieveBook, 10])?.isInvalidated,
     ).toBe(true);
   });
+
+  it("invalidates RetrievePublisher and PublisherFiles for non-target publishers on success", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    client.setQueryData([QueryKey.RetrievePublisher, 3], {
+      id: 3,
+      children: [{ id: 2, name: "Source", file_count: 5 }],
+      descendant_ids: [2],
+      descendant_file_count: 5,
+    });
+    client.setQueryData(
+      [QueryKey.PublisherFiles, 3, { limit: 50, offset: 0 }],
+      { items: [], total: 5 },
+    );
+
+    const { result } = renderHook(() => useMergePublisher(), {
+      wrapper: makeWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
+    });
+
+    await waitFor(() => {
+      expect(
+        client.getQueryState([QueryKey.RetrievePublisher, 3])?.isInvalidated,
+      ).toBe(true);
+      expect(
+        client.getQueryState([
+          QueryKey.PublisherFiles,
+          3,
+          { limit: 50, offset: 0 },
+        ])?.isInvalidated,
+      ).toBe(true);
+    });
+  });
 });
 
 describe("useUpdatePublisher", () => {
@@ -314,46 +352,6 @@ describe("useDeletePublisher", () => {
         client.getQueryState([
           QueryKey.PublisherFiles,
           2,
-          { limit: 50, offset: 0 },
-        ])?.isInvalidated,
-      ).toBe(true);
-    });
-  });
-});
-
-describe("useMergePublisher", () => {
-  it("invalidates RetrievePublisher and PublisherFiles for non-target publishers on success", async () => {
-    const client = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
-
-    client.setQueryData([QueryKey.RetrievePublisher, 3], {
-      id: 3,
-      children: [{ id: 2, name: "Source", file_count: 5 }],
-      descendant_ids: [2],
-      descendant_file_count: 5,
-    });
-    client.setQueryData(
-      [QueryKey.PublisherFiles, 3, { limit: 50, offset: 0 }],
-      { items: [], total: 5 },
-    );
-
-    const { result } = renderHook(() => useMergePublisher(), {
-      wrapper: makeWrapper(client),
-    });
-
-    await act(async () => {
-      await result.current.mutateAsync({ targetId: 1, sourceId: 2 });
-    });
-
-    await waitFor(() => {
-      expect(
-        client.getQueryState([QueryKey.RetrievePublisher, 3])?.isInvalidated,
-      ).toBe(true);
-      expect(
-        client.getQueryState([
-          QueryKey.PublisherFiles,
-          3,
           { limit: 50, offset: 0 },
         ])?.isInvalidated,
       ).toBe(true);

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -163,6 +163,7 @@ export const useDeletePublisher = () => {
       return API.request<void>("DELETE", `/publishers/${publisherId}`);
     },
     onSuccess: () => {
+      invalidatePublisherHierarchyQueries(queryClient);
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListPublishers] });
       // Invalidate book queries since they display publisher info on files
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
@@ -186,15 +187,9 @@ export const useMergePublisher = () => {
         source_id: sourceId,
       });
     },
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.RetrievePublisher, variables.targetId],
-      });
+    onSuccess: () => {
+      invalidatePublisherHierarchyQueries(queryClient);
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListPublishers] });
-      // Invalidate detail-page file list since files moved from source to target
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.PublisherFiles, variables.targetId],
-      });
       // Invalidate book queries since they display publisher info on files
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.ListBooks] });
       queryClient.invalidateQueries({ queryKey: [BooksQueryKey.RetrieveBook] });


### PR DESCRIPTION
## Summary
- `useDeletePublisher` now calls `invalidatePublisherHierarchyQueries` so deleting a child publisher invalidates its parent's cached detail and file queries
- `useMergePublisher` now calls `invalidatePublisherHierarchyQueries` instead of targeted invalidations for just the target, so the source's parent hierarchy is also refreshed
- Added tests for both mutations verifying that non-target/non-deleted publisher caches are invalidated

## Test plan
- Seed a parent publisher's detail cache, delete a child publisher, verify parent's `RetrievePublisher` and `PublisherFiles` queries are invalidated
- Seed a third publisher's detail cache (parent of the source), merge source into target, verify the third publisher's queries are invalidated
- All 10 existing publisher query tests continue to pass