### PR TITLE
[Fix] File type badges overflow instead of wrapping on book cards

### DIFF
--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -377,7 +377,7 @@ const BookItem = ({
           );
         })()}
       {book.files && (
-        <div className="mt-2 flex gap-2 text-xs">
+        <div className="mt-2 flex flex-wrap gap-2 text-xs">
           {uniqBy(book.files, "file_type").map((f) => (
             <Badge className="text-xs uppercase" key={f.id} variant="secondary">
               {f.file_type}


### PR DESCRIPTION
## Summary
- Add `flex-wrap` to the file type badge container in `BookItem.tsx` so badges wrap to the next line instead of overflowing horizontally when a book has 3+ formats (e.g., EPUB + M4B + PDF)

## Test plan
- Open a library with books that have multiple file formats (3+)
- Verify badges wrap to a second line on narrow cards instead of overflowing
- Verify single-format books still display normally