### PR TITLE
[Fix] Move alias auto-add-on-rename to frontend and fix SyncAliases duplicate conflict

### DIFF
--- a/app/components/library/MetadataEditDialog.test.tsx
+++ b/app/components/library/MetadataEditDialog.test.tsx
@@ -519,6 +519,215 @@ describe("MetadataEditDialog", () => {
     });
   });
 
+  describe("auto-alias on rename", () => {
+    it("should auto-add initial name as alias when name changes", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={[]}
+            entityName="Foobar"
+            entityType="person"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={vi.fn()}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name to "Foo"
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+
+      // "Foobar" should auto-appear as an alias chip
+      expect(screen.getByText("Foobar")).toBeInTheDocument();
+    });
+
+    it("should remove auto-added alias when name changes back to initial", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={[]}
+            entityName="Foobar"
+            entityType="person"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={vi.fn()}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name to "Foo" — auto-alias appears
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+      expect(screen.getByText("Foobar")).toBeInTheDocument();
+
+      // Change name back to "Foobar" — auto-alias should disappear
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foobar");
+
+      // The auto-alias "Foobar" should be removed
+      const chips = screen.queryAllByRole("button", {
+        name: /remove alias/i,
+      });
+      expect(chips).toHaveLength(0);
+    });
+
+    it("should not duplicate alias when initial name was already an existing alias", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Foobar"]}
+            entityName="Foobar"
+            entityType="person"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={vi.fn()}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name to "Foo" — should not add a duplicate "Foobar"
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+
+      // Should still have exactly one "Foobar" chip
+      const chips = screen.getAllByRole("button", { name: /remove alias/i });
+      expect(chips).toHaveLength(1);
+    });
+
+    it("should not remove pre-existing alias when name changes back to initial", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Foobar"]}
+            entityName="Foobar"
+            entityType="person"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={vi.fn()}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name to "Foo" then back to "Foobar"
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foobar");
+
+      // The pre-existing "Foobar" alias should still be there
+      expect(screen.getByText("Foobar")).toBeInTheDocument();
+    });
+
+    it("should include auto-added alias in save payload", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={[]}
+            entityName="Foobar"
+            entityType="series"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "Foo",
+            aliases: ["Foobar"],
+          }),
+        );
+      });
+    });
+
+    it("should handle case-insensitive duplicate when auto-adding alias", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["foobar"]}
+            entityName="Foobar"
+            entityType="person"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={vi.fn()}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("foobar")).toBeInTheDocument();
+      });
+
+      // Change name to "Foo" — should not add "Foobar" since "foobar" exists (case-insensitive)
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+
+      const chips = screen.getAllByRole("button", { name: /remove alias/i });
+      expect(chips).toHaveLength(1);
+    });
+  });
+
   describe("hasChanges comparison against initial state", () => {
     it("should compute hasChanges against initial values, not live props", async () => {
       // This test exposes the bug: hasChanges compares form values against

--- a/app/components/library/MetadataEditDialog.tsx
+++ b/app/components/library/MetadataEditDialog.tsx
@@ -1,5 +1,5 @@
 import { Loader2, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { SortNameInput } from "@/components/common/SortNameInput";
 import { Badge } from "@/components/ui/badge";
@@ -71,6 +71,11 @@ export function MetadataEditDialog({
 
   const hasSortName = entityType === "person" || entityType === "series";
 
+  // Track the name when the dialog opened and whether it was already an alias,
+  // so we can auto-add/remove it when the user renames the entity.
+  const initialNameRef = useRef("");
+  const initialNameWasAliasRef = useRef(false);
+
   // Track previous open state to detect open transitions.
   // Start with false so that if dialog starts open, we detect it as "just opened".
   const prevOpenRef = useRef(false);
@@ -109,7 +114,45 @@ export function MetadataEditDialog({
       aliases: [...initialAliases],
     });
     setChangesSaved(false);
+
+    // Store the initial name and whether it was already an alias
+    initialNameRef.current = initialName;
+    initialNameWasAliasRef.current = initialAliases.some(
+      (a) => a.toLowerCase() === initialName.toLowerCase(),
+    );
   }, [open, entityName, sortName, sortNameSource, entityType, aliases]);
+
+  // Auto-add/remove the initial name as an alias when the name changes.
+  // When the user renames away from the initial name, the old name auto-appears
+  // as an alias so it's preserved for search. When they rename back, the
+  // auto-added alias is removed (but pre-existing aliases are kept).
+  const handleNameChange = useCallback((newName: string) => {
+    setName(newName);
+
+    const initName = initialNameRef.current;
+    if (!initName) return;
+
+    const nameMovedAway = newName.toLowerCase() !== initName.toLowerCase();
+    const nameMovedBack = !nameMovedAway;
+
+    setEditAliases((prev) => {
+      const alreadyPresent = prev.some(
+        (a) => a.toLowerCase() === initName.toLowerCase(),
+      );
+
+      if (nameMovedAway && !alreadyPresent) {
+        // Auto-add the initial name as an alias
+        return [...prev, initName];
+      }
+
+      if (nameMovedBack && alreadyPresent && !initialNameWasAliasRef.current) {
+        // Remove the auto-added alias (but only if it wasn't pre-existing)
+        return prev.filter((a) => a.toLowerCase() !== initName.toLowerCase());
+      }
+
+      return prev;
+    });
+  }, []);
 
   const handleAddAlias = () => {
     const trimmed = aliasInput.trim();
@@ -201,7 +244,7 @@ export function MetadataEditDialog({
             <Label htmlFor="name">Name</Label>
             <Input
               id="name"
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => handleNameChange(e.target.value)}
               value={name}
             />
           </div>

--- a/app/components/library/PublisherEditDialog.test.tsx
+++ b/app/components/library/PublisherEditDialog.test.tsx
@@ -1,0 +1,180 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { PublisherEditDialog } from "./PublisherEditDialog";
+
+const createUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+// Mock useFormDialogClose hook
+vi.mock("@/hooks/useFormDialogClose", () => ({
+  useFormDialogClose: (
+    _open: boolean,
+    onOpenChange: (open: boolean) => void,
+  ) => ({
+    requestClose: () => onOpenChange(false),
+  }),
+}));
+
+// Mock EntityCombobox to avoid complex dependency chain
+vi.mock("@/components/common/EntityCombobox", () => ({
+  EntityCombobox: () => <div data-testid="entity-combobox" />,
+}));
+
+describe("PublisherEditDialog", () => {
+  const createQueryClient = () =>
+    new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+  const defaultProps = {
+    open: true,
+    onOpenChange: vi.fn(),
+    entityName: "Foobar",
+    aliases: [] as string[],
+    onSave: vi.fn(),
+    isPending: false,
+    useParentSearch: vi.fn(),
+  };
+
+  describe("auto-alias on rename", () => {
+    it("should auto-add initial name as alias when name changes", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog {...defaultProps} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name to "Foo"
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+
+      // "Foobar" should auto-appear as an alias chip
+      expect(screen.getByText("Foobar")).toBeInTheDocument();
+    });
+
+    it("should remove auto-added alias when name changes back to initial", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog {...defaultProps} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name to "Foo" — auto-alias appears
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+      expect(screen.getByText("Foobar")).toBeInTheDocument();
+
+      // Change name back to "Foobar" — auto-alias should disappear
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foobar");
+
+      const chips = screen.queryAllByRole("button", {
+        name: /remove alias/i,
+      });
+      expect(chips).toHaveLength(0);
+    });
+
+    it("should not duplicate alias when initial name was already an existing alias", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog {...defaultProps} aliases={["Foobar"]} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name to "Foo" — should not add a duplicate
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+
+      const chips = screen.getAllByRole("button", { name: /remove alias/i });
+      expect(chips).toHaveLength(1);
+    });
+
+    it("should not remove pre-existing alias when name changes back to initial", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog {...defaultProps} aliases={["Foobar"]} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name to "Foo" then back to "Foobar"
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foobar");
+
+      // Pre-existing alias should still be there
+      expect(screen.getByText("Foobar")).toBeInTheDocument();
+    });
+
+    it("should include auto-added alias in save payload", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog {...defaultProps} onSave={onSave} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Change name
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Foo");
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "Foo",
+            aliases: ["Foobar"],
+          }),
+        );
+      });
+    });
+  });
+});

--- a/app/components/library/PublisherEditDialog.tsx
+++ b/app/components/library/PublisherEditDialog.tsx
@@ -1,5 +1,5 @@
 import { Loader2, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   EntityCombobox,
@@ -64,6 +64,11 @@ export function PublisherEditDialog({
     parentId: number | null;
   } | null>(null);
 
+  // Track the name when the dialog opened and whether it was already an alias,
+  // so we can auto-add/remove it when the user renames the entity.
+  const initialNameRef = useRef("");
+  const initialNameWasAliasRef = useRef(false);
+
   const prevOpenRef = useRef(false);
 
   useEffect(() => {
@@ -92,7 +97,43 @@ export function PublisherEditDialog({
       aliases: [...initialAliases],
       parentId: parentId ?? null,
     });
+
+    // Store the initial name and whether it was already an alias
+    initialNameRef.current = initialName;
+    initialNameWasAliasRef.current = initialAliases.some(
+      (a) => a.toLowerCase() === initialName.toLowerCase(),
+    );
   }, [open, entityName, aliases, parentId, parentName]);
+
+  // Auto-add/remove the initial name as an alias when the name changes.
+  // When the user renames away from the initial name, the old name auto-appears
+  // as an alias so it's preserved for search. When they rename back, the
+  // auto-added alias is removed (but pre-existing aliases are kept).
+  const handleNameChange = useCallback((newName: string) => {
+    setName(newName);
+
+    const initName = initialNameRef.current;
+    if (!initName) return;
+
+    const nameMovedAway = newName.toLowerCase() !== initName.toLowerCase();
+    const nameMovedBack = !nameMovedAway;
+
+    setEditAliases((prev) => {
+      const alreadyPresent = prev.some(
+        (a) => a.toLowerCase() === initName.toLowerCase(),
+      );
+
+      if (nameMovedAway && !alreadyPresent) {
+        return [...prev, initName];
+      }
+
+      if (nameMovedBack && alreadyPresent && !initialNameWasAliasRef.current) {
+        return prev.filter((a) => a.toLowerCase() !== initName.toLowerCase());
+      }
+
+      return prev;
+    });
+  }, []);
 
   const handleAddAlias = () => {
     const trimmed = aliasInput.trim();
@@ -168,7 +209,7 @@ export function PublisherEditDialog({
             <Label htmlFor="publisher-name">Name</Label>
             <Input
               id="publisher-name"
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => handleNameChange(e.target.value)}
               value={name}
             />
           </div>

--- a/pkg/aliases/service.go
+++ b/pkg/aliases/service.go
@@ -239,10 +239,12 @@ func (svc *Service) SyncAliases(ctx context.Context, cfg ResourceConfig, resourc
 		if trimmed == "" {
 			continue
 		}
-		if !currentSet[strings.ToLower(trimmed)] {
+		lower := strings.ToLower(trimmed)
+		if !currentSet[lower] {
 			if err := svc.AddAlias(ctx, cfg, resourceID, trimmed, libraryID); err != nil {
 				return err
 			}
+			currentSet[lower] = true
 		}
 	}
 

--- a/pkg/aliases/service_test.go
+++ b/pkg/aliases/service_test.go
@@ -363,6 +363,43 @@ func TestTransferAliasesOnMerge_NoAliases(t *testing.T) {
 	assert.Equal(t, []string{"Sci-Fi"}, aliases)
 }
 
+func TestSyncAliases_DuplicatesInDesiredList(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+
+	// Sync with duplicates in the desired list — should not error
+	err := svc.SyncAliases(ctx, GenreConfig, genre.ID, lib.ID, []string{"Sci-Fi", "Sci-Fi"})
+	require.NoError(t, err)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"Sci-Fi"}, aliases)
+}
+
+func TestSyncAliases_DuplicatesInDesiredListCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	svc := NewService(db)
+
+	lib := createTestLibrary(t, db)
+	genre := createTestGenre(t, db, "Science Fiction", lib.ID)
+
+	// Sync with case-insensitive duplicates — should not error
+	err := svc.SyncAliases(ctx, GenreConfig, genre.ID, lib.ID, []string{"Sci-Fi", "sci-fi"})
+	require.NoError(t, err)
+
+	aliases, err := svc.ListAliases(ctx, GenreConfig, genre.ID)
+	require.NoError(t, err)
+	// Should have exactly one alias (the first occurrence wins)
+	assert.Len(t, aliases, 1)
+}
+
 func TestAddAlias_ReturnsValidationError(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -135,7 +135,6 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	nameChanged := false
-	var oldName string
 	if params.Name != nil && *params.Name != genre.Name {
 		newName := strings.TrimSpace(*params.Name)
 		if newName == "" {
@@ -174,8 +173,6 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
-		// Simple rename — capture old name before mutation
-		oldName = genre.Name
 		genre.Name = newName
 		opts := UpdateGenreOptions{Columns: []string{"name"}}
 		err = h.genreService.UpdateGenre(ctx, genre, opts)
@@ -187,18 +184,8 @@ func (h *handler) update(c echo.Context) error {
 
 	// Sync aliases if provided
 	if params.Aliases != nil {
-		syncList := params.Aliases
-		if nameChanged {
-			syncList = append(syncList, oldName)
-		}
-		if err := h.aliasService.SyncAliases(ctx, aliases.GenreConfig, id, genre.LibraryID, syncList); err != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.GenreConfig, id, genre.LibraryID, params.Aliases); err != nil {
 			return errors.WithStack(err)
-		}
-	} else if nameChanged {
-		_ = h.aliasService.RemoveAlias(ctx, aliases.GenreConfig, id, genre.Name)
-		log := logger.FromContext(ctx)
-		if err := h.aliasService.AddAlias(ctx, aliases.GenreConfig, id, oldName, genre.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"genre_id": id, "old_name": oldName, "error": err.Error()})
 		}
 	}
 

--- a/pkg/genres/handlers_test.go
+++ b/pkg/genres/handlers_test.go
@@ -86,7 +86,7 @@ func patchGenre(t *testing.T, h *handler, genreID int, payload UpdateGenrePayloa
 	return rec
 }
 
-func TestUpdateGenre_RenameAddsOldNameAsAlias(t *testing.T) {
+func TestUpdateGenre_RenameWithoutAliasesDoesNotAutoAdd(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	ctx := context.Background()
@@ -96,8 +96,30 @@ func TestUpdateGenre_RenameAddsOldNameAsAlias(t *testing.T) {
 	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
 	require.NoError(t, h.genreService.CreateGenre(ctx, genre))
 
+	// Rename without sending aliases — backend should NOT auto-add old name
 	newName := "Sci-Fi"
 	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &newName})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)
+	require.NoError(t, err)
+	assert.Empty(t, aliasList, "backend should not auto-add old name as alias; frontend handles this")
+}
+
+func TestUpdateGenre_RenameWithAliasesIncludingOldName(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(t, db)
+
+	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
+	require.NoError(t, h.genreService.CreateGenre(ctx, genre))
+
+	// Rename and send old name in aliases (as the frontend now does)
+	newName := "Sci-Fi"
+	aliasPayload := []string{"Science Fiction"}
+	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &newName, Aliases: aliasPayload})
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)
@@ -105,7 +127,7 @@ func TestUpdateGenre_RenameAddsOldNameAsAlias(t *testing.T) {
 	assert.Contains(t, aliasList, "Science Fiction")
 }
 
-func TestUpdateGenre_RenamePreservesExistingAliases(t *testing.T) {
+func TestUpdateGenre_RenameWithAliasesPreservesExisting(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	ctx := context.Background()
@@ -121,17 +143,19 @@ func TestUpdateGenre_RenamePreservesExistingAliases(t *testing.T) {
 	).Exec(ctx)
 	require.NoError(t, err)
 
+	// Frontend sends full desired alias list including old name and existing aliases
 	newName := "Sci-Fi"
-	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &newName})
+	aliasPayload := []string{"SF", "Science Fiction"}
+	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &newName, Aliases: aliasPayload})
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)
 	require.NoError(t, err)
-	assert.Contains(t, aliasList, "Science Fiction", "old name should be added as alias")
+	assert.Contains(t, aliasList, "Science Fiction", "old name should be in aliases")
 	assert.Contains(t, aliasList, "SF", "existing alias should be preserved")
 }
 
-func TestUpdateGenre_SequentialRenames_NoDuplicateAliases(t *testing.T) {
+func TestUpdateGenre_SequentialRenames_FrontendSendsAliases(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	ctx := context.Background()
@@ -141,12 +165,14 @@ func TestUpdateGenre_SequentialRenames_NoDuplicateAliases(t *testing.T) {
 	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
 	require.NoError(t, h.genreService.CreateGenre(ctx, genre))
 
+	// First rename: frontend sends old name as alias
 	nameB := "Sci-Fi"
-	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &nameB})
+	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &nameB, Aliases: []string{"Science Fiction"}})
 	require.Equal(t, http.StatusOK, rec.Code)
 
+	// Second rename: frontend sends both previous aliases
 	nameC := "SF"
-	rec = patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &nameC})
+	rec = patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &nameC, Aliases: []string{"Science Fiction", "Sci-Fi"}})
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)
@@ -299,7 +325,7 @@ func TestList_ResponseUsesItemsKey(t *testing.T) {
 	assert.False(t, hasGenres, "list response must NOT use 'genres' key")
 }
 
-func TestUpdateGenre_RenameBackToOriginalName(t *testing.T) {
+func TestUpdateGenre_RenameBackToOriginalName_FrontendSendsAliases(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	ctx := context.Background()
@@ -309,14 +335,15 @@ func TestUpdateGenre_RenameBackToOriginalName(t *testing.T) {
 	genre := &models.Genre{LibraryID: lib.ID, Name: "Science Fiction"}
 	require.NoError(t, h.genreService.CreateGenre(ctx, genre))
 
-	// First rename: "Science Fiction" → "Sci-Fi"
+	// First rename: "Science Fiction" → "Sci-Fi", frontend adds old name as alias
 	newName := "Sci-Fi"
-	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &newName})
+	rec := patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &newName, Aliases: []string{"Science Fiction"}})
 	require.Equal(t, http.StatusOK, rec.Code)
 
-	// Second rename back: "Sci-Fi" → "Science Fiction"
+	// Second rename back: "Sci-Fi" → "Science Fiction", frontend removes auto-added alias
+	// and adds "Sci-Fi" as new alias
 	originalName := "Science Fiction"
-	rec = patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &originalName})
+	rec = patchGenre(t, h, genre.ID, UpdateGenrePayload{Name: &originalName, Aliases: []string{"Sci-Fi"}})
 	require.Equal(t, http.StatusOK, rec.Code)
 
 	aliasList, err := h.aliasService.ListAliases(ctx, aliases.GenreConfig, genre.ID)

--- a/pkg/people/handlers.go
+++ b/pkg/people/handlers.go
@@ -164,9 +164,7 @@ func (h *handler) update(c echo.Context) error {
 	opts := UpdatePersonOptions{Columns: []string{}}
 	nameChanged := false
 
-	var oldName string
 	if params.Name != nil && *params.Name != person.Name {
-		oldName = person.Name
 		nameChanged = true
 		person.Name = *params.Name
 		// Regenerate sort name when name changes (unless sort_name_source is manual)
@@ -200,20 +198,10 @@ func (h *handler) update(c echo.Context) error {
 	// Sync aliases if provided
 	aliasesChanged := false
 	if params.Aliases != nil {
-		syncList := params.Aliases
-		if nameChanged {
-			syncList = append(syncList, oldName)
-		}
-		if err := h.aliasService.SyncAliases(ctx, aliases.PersonConfig, id, person.LibraryID, syncList); err != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.PersonConfig, id, person.LibraryID, params.Aliases); err != nil {
 			return errors.WithStack(err)
 		}
 		aliasesChanged = true
-	} else if nameChanged {
-		_ = h.aliasService.RemoveAlias(ctx, aliases.PersonConfig, id, person.Name)
-		log := logger.FromContext(ctx)
-		if err := h.aliasService.AddAlias(ctx, aliases.PersonConfig, id, oldName, person.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"person_id": id, "old_name": oldName, "error": err.Error()})
-		}
 	}
 
 	// Reload the model

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -211,7 +211,6 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	nameChanged := false
-	var oldName string
 	if params.Name != nil && *params.Name != publisher.Name {
 		newName := strings.TrimSpace(*params.Name)
 		if newName == "" {
@@ -258,7 +257,6 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
-		oldName = publisher.Name
 		publisher.Name = newName
 		opts := UpdatePublisherOptions{Columns: []string{"name"}}
 		err = h.publisherService.UpdatePublisher(ctx, publisher, opts)
@@ -269,18 +267,8 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	if params.Aliases != nil {
-		syncList := params.Aliases
-		if nameChanged {
-			syncList = append(syncList, oldName)
-		}
-		if err := h.aliasService.SyncAliases(ctx, aliases.PublisherConfig, id, publisher.LibraryID, syncList); err != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.PublisherConfig, id, publisher.LibraryID, params.Aliases); err != nil {
 			return errors.WithStack(err)
-		}
-	} else if nameChanged {
-		_ = h.aliasService.RemoveAlias(ctx, aliases.PublisherConfig, id, publisher.Name)
-		log := logger.FromContext(ctx)
-		if err := h.aliasService.AddAlias(ctx, aliases.PublisherConfig, id, oldName, publisher.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"publisher_id": id, "old_name": oldName, "error": err.Error()})
 		}
 	}
 

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -146,11 +146,7 @@ func (h *handler) update(c echo.Context) error {
 	// Keep track of what's been changed
 	opts := UpdateSeriesOptions{Columns: []string{}}
 
-	var oldName string
-	nameChanged := false
 	if params.Name != nil && *params.Name != series.Name {
-		oldName = series.Name
-		nameChanged = true
 		series.Name = *params.Name
 		series.NameSource = models.DataSourceManual
 		opts.Columns = append(opts.Columns, "name", "name_source")
@@ -189,20 +185,10 @@ func (h *handler) update(c echo.Context) error {
 	// Sync aliases if provided
 	aliasesChanged := false
 	if params.Aliases != nil {
-		syncList := params.Aliases
-		if nameChanged {
-			syncList = append(syncList, oldName)
-		}
-		if err := h.aliasService.SyncAliases(ctx, aliases.SeriesConfig, id, series.LibraryID, syncList); err != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.SeriesConfig, id, series.LibraryID, params.Aliases); err != nil {
 			return errors.WithStack(err)
 		}
 		aliasesChanged = true
-	} else if nameChanged {
-		_ = h.aliasService.RemoveAlias(ctx, aliases.SeriesConfig, id, series.Name)
-		log := logger.FromContext(ctx)
-		if err := h.aliasService.AddAlias(ctx, aliases.SeriesConfig, id, oldName, series.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"series_id": id, "old_name": oldName, "error": err.Error()})
-		}
 	}
 
 	// Reload the model

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -130,7 +130,6 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	nameChanged := false
-	var oldName string
 	if params.Name != nil && *params.Name != tag.Name {
 		newName := strings.TrimSpace(*params.Name)
 		if newName == "" {
@@ -165,7 +164,6 @@ func (h *handler) update(c echo.Context) error {
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
-		oldName = tag.Name
 		tag.Name = newName
 		opts := UpdateTagOptions{Columns: []string{"name"}}
 		err = h.tagService.UpdateTag(ctx, tag, opts)
@@ -176,18 +174,8 @@ func (h *handler) update(c echo.Context) error {
 	}
 
 	if params.Aliases != nil {
-		syncList := params.Aliases
-		if nameChanged {
-			syncList = append(syncList, oldName)
-		}
-		if err := h.aliasService.SyncAliases(ctx, aliases.TagConfig, id, tag.LibraryID, syncList); err != nil {
+		if err := h.aliasService.SyncAliases(ctx, aliases.TagConfig, id, tag.LibraryID, params.Aliases); err != nil {
 			return errors.WithStack(err)
-		}
-	} else if nameChanged {
-		_ = h.aliasService.RemoveAlias(ctx, aliases.TagConfig, id, tag.Name)
-		log := logger.FromContext(ctx)
-		if err := h.aliasService.AddAlias(ctx, aliases.TagConfig, id, oldName, tag.LibraryID); err != nil {
-			log.Warn("failed to add old name as alias after rename", logger.Data{"tag_id": id, "old_name": oldName, "error": err.Error()})
 		}
 	}
 

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -115,7 +115,7 @@ This resolution happens transparently in all contexts — library scans, plugin 
 
 **Automatic creation on merge.** When you merge two resources, the source resource's name automatically becomes an alias of the target. Any existing aliases on the source transfer to the target as well, so no previously-working name mappings are lost.
 
-**Automatic creation on rename.** When you rename a resource, the old name automatically becomes an alias. Future references to the old name still resolve to the renamed resource.
+**Automatic creation on rename.** When you rename a resource in the edit dialog, the old name automatically appears as an alias chip in the alias list. You can remove it before saving if you don't want to keep it. If you change the name back to the original, the auto-added alias is removed automatically. This ensures the old name is preserved for search by default, while giving you full control.
 
 ### Uniqueness Rules
 


### PR DESCRIPTION
Closes #278

## Summary
- Moved alias auto-add-on-rename from backend to frontend: MetadataEditDialog (person, series, genre, tag) and PublisherEditDialog now auto-add the initial name to the alias list when the user renames, giving full visibility and control. Backend handlers no longer silently append the old name.
- Fixed SyncAliases duplicate conflict bug: tracks already-added aliases in `currentSet` after each `AddAlias`, preventing duplicate insert errors when the desired list contains duplicates.
- Extended the fix beyond the three resources in the issue: genres and tags had the same backend auto-add pattern and were fixed for consistency.
- Updated docs to reflect the new user-visible alias-on-rename behavior.

## Details
- Frontend auto-alias uses refs (`initialNameRef`, `initialNameWasAliasRef`) rather than state to avoid re-render loops, and a `useCallback` handler to batch `setName` + `setEditAliases` updates
- Pre-existing aliases (ones that already matched the initial name when the dialog opened) are never auto-removed, only auto-added ones are cleaned up on revert
- The `SyncAliases` defense-in-depth fix prevents the duplicate conflict even if a caller somehow sends duplicates in the desired list

## Test plan
- SyncAliases with exact duplicates in desired list does not error
- SyncAliases with case-insensitive duplicates in desired list does not error
- Auto-add initial name as alias when name changes (MetadataEditDialog)
- Auto-remove alias when name reverts to initial (MetadataEditDialog)
- No duplicate when initial name was already an existing alias (MetadataEditDialog)
- Pre-existing alias preserved when name reverts (MetadataEditDialog)
- Auto-added alias included in save payload (MetadataEditDialog)
- Case-insensitive duplicate prevention (MetadataEditDialog)
- PublisherEditDialog auto-alias (5 tests covering same behaviors)
- Backend rename without aliases does not auto-add (genre handler test)
- Backend rename with aliases syncs as sent (genre handler test)