### PR TITLE
[Fix] Clean up orphaned file and book children when parent book row is missing

### DIFF
--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -1747,6 +1747,44 @@ func (svc *Service) DeleteBooksByIDs(ctx context.Context, bookIDs []int) error {
 	return errors.WithStack(err)
 }
 
+// DeleteOrphanedBookChildren removes all child rows (files, authors, book_series,
+// book_genres, book_tags, list_books) that reference a book_id whose book row no
+// longer exists. File-scoped children (narrators, identifiers, chapters, fingerprints)
+// cascade from file deletion via FK. This handles the case where a book row was
+// previously deleted without FK enforcement, leaving orphaned children behind.
+func (svc *Service) DeleteOrphanedBookChildren(ctx context.Context, bookID int) error {
+	// Delete files first — their FK children (narrators, identifiers, chapters,
+	// fingerprints) cascade automatically.
+	_, err := svc.db.NewDelete().
+		Model((*models.File)(nil)).
+		Where("book_id = ?", bookID).
+		Exec(ctx)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	// Delete book-scoped join rows that may remain from before FK enforcement.
+	// With FK enforcement ON, deleting these rows with a non-existent book_id is
+	// safe — they are orphans by definition.
+	if _, err = svc.db.NewDelete().Model((*models.Author)(nil)).Where("book_id = ?", bookID).Exec(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+	if _, err = svc.db.NewDelete().Model((*models.BookSeries)(nil)).Where("book_id = ?", bookID).Exec(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+	if _, err = svc.db.NewDelete().Model((*models.BookGenre)(nil)).Where("book_id = ?", bookID).Exec(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+	if _, err = svc.db.NewDelete().Model((*models.BookTag)(nil)).Where("book_id = ?", bookID).Exec(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+	if _, err = svc.db.NewDelete().Model((*models.ListBook)(nil)).Where("book_id = ?", bookID).Exec(ctx); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
 // PromoteNextPrimaryFile selects the best remaining file for a book and sets it as
 // primary_file_id. Main files are preferred over supplements; among equal roles,
 // the oldest file (by created_at) wins. If no files remain, primary_file_id is set

--- a/pkg/worker/scan_orphans.go
+++ b/pkg/worker/scan_orphans.go
@@ -5,8 +5,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/fileutils"
 	"github.com/shishobooks/shisho/pkg/joblogs"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -133,6 +135,22 @@ func (w *Worker) cleanupOrphanedFiles(
 		// The parallel scan may have added new files to this book since existingFiles was loaded.
 		book, err := w.bookService.RetrieveBook(ctx, books.RetrieveBookOptions{ID: &bookID})
 		if err != nil {
+			// If the book row is already gone (e.g., deleted without FK cascade before
+			// FK enforcement was enabled), clean up the orphaned file rows and any
+			// remaining book-scoped children directly.
+			var errCode *errcodes.Error
+			if errors.As(err, &errCode) && errCode.Code == "not_found" {
+				jobLog.Info("book row already missing, cleaning up orphaned children", logger.Data{"book_id": bookID})
+				if w.searchService != nil {
+					if delErr := w.searchService.DeleteFromBookIndex(ctx, bookID); delErr != nil {
+						jobLog.Warn("failed to remove missing book from search index", logger.Data{"book_id": bookID, "error": delErr.Error()})
+					}
+				}
+				if delErr := w.bookService.DeleteOrphanedBookChildren(ctx, bookID); delErr != nil {
+					jobLog.Warn("failed to delete orphaned book children", logger.Data{"book_id": bookID, "error": delErr.Error()})
+				}
+				continue
+			}
 			jobLog.Warn("failed to retrieve orphaned book", logger.Data{"book_id": bookID, "error": err.Error()})
 			continue
 		}

--- a/pkg/worker/scan_orphans_test.go
+++ b/pkg/worker/scan_orphans_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -273,6 +274,135 @@ func TestCleanupOrphanedFiles_FullOrphan_NewMainFileAddedDuringScan(t *testing.T
 	require.Len(t, remainingFiles, 1)
 	assert.Equal(t, newFile.ID, remainingFiles[0].ID)
 	assert.Equal(t, models.FileRoleMain, remainingFiles[0].FileRole)
+}
+
+func TestCleanupOrphanedFiles_MissingBookRow(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	// Create a book directory with one EPUB (so we get a book, file, and author)
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Ghost Book")
+	testgen.GenerateEPUB(t, bookDir, "ghost.epub", testgen.EPUBOptions{
+		Title:   "Ghost Book",
+		Authors: []string{"Author"},
+	})
+
+	// Run initial scan to populate book, file, author rows
+	err := tc.runScan()
+	require.NoError(t, err)
+
+	allBooks := tc.listBooks()
+	require.Len(t, allBooks, 1)
+	bookID := allBooks[0].ID
+
+	files := tc.listFiles()
+	require.Len(t, files, 1)
+	fileID := files[0].ID
+
+	// Verify authors exist for this book
+	var authorCount int
+	authorCount, err = tc.db.NewSelect().TableExpr("authors").Where("book_id = ?", bookID).Count(tc.ctx)
+	require.NoError(t, err)
+	require.Positive(t, authorCount, "book should have authors after scan")
+
+	// Simulate the orphaned state: delete the book row WITHOUT cascade
+	// (FK off prevents cascade from firing, leaving file and author rows orphaned)
+	_, err = tc.db.Exec("PRAGMA foreign_keys = OFF")
+	require.NoError(t, err)
+	_, err = tc.db.NewDelete().Model((*models.Book)(nil)).Where("id = ?", bookID).Exec(tc.ctx)
+	require.NoError(t, err)
+	_, err = tc.db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	// Verify the orphaned state: file still exists, book is gone
+	remainingFiles := tc.listFiles()
+	require.Len(t, remainingFiles, 1, "file should remain after non-cascading book delete")
+	remainingBooks := tc.listBooks()
+	require.Empty(t, remainingBooks, "book should be gone")
+
+	// Build existingFiles from the orphaned file row
+	existingFiles := []*models.File{remainingFiles[0]}
+
+	// No files in scannedPaths = all orphaned (simulates file deleted from disk)
+	scannedPaths := map[string]struct{}{}
+
+	library, err := tc.libraryService.RetrieveLibrary(tc.ctx, libraries.RetrieveLibraryOptions{ID: intPtr(1)})
+	require.NoError(t, err)
+
+	log := logger.FromContext(tc.ctx)
+	jobLog := tc.jobLogService.NewJobLogger(tc.ctx, 0, log)
+	tc.worker.cleanupOrphanedFiles(tc.ctx, existingFiles, scannedPaths, library, jobLog)
+
+	// Assert: orphaned file row should be deleted
+	afterFiles := tc.listFiles()
+	assert.Empty(t, afterFiles, "orphaned file row should be deleted when parent book is missing")
+
+	// Assert: file-scoped children should also be gone (narrators, identifiers cascade from file delete)
+	var narratorCount int
+	narratorCount, err = tc.db.NewSelect().TableExpr("narrators").Where("file_id = ?", fileID).Count(tc.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, narratorCount, "narrators for orphaned file should be gone")
+
+	// Assert: book-scoped children should also be gone
+	authorCount, err = tc.db.NewSelect().TableExpr("authors").Where("book_id = ?", bookID).Count(tc.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, authorCount, "authors for missing book should be cleaned up")
+}
+
+func TestCleanupOrphanedFiles_MissingBookRow_SubsequentScanIsClean(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	// Create a book with a file
+	bookDir := testgen.CreateSubDir(t, libraryPath, "[Author] Vanished Book")
+	testgen.GenerateEPUB(t, bookDir, "vanished.epub", testgen.EPUBOptions{
+		Title:   "Vanished Book",
+		Authors: []string{"Author"},
+	})
+
+	err := tc.runScan()
+	require.NoError(t, err)
+	require.Len(t, tc.listBooks(), 1)
+	require.Len(t, tc.listFiles(), 1)
+
+	bookID := tc.listBooks()[0].ID
+
+	// Delete book row without cascade, AND remove the file from disk
+	// (simulates the state where a previous scan or bug deleted the book row
+	// but left the file row, and the file is also no longer on disk)
+	_, err = tc.db.Exec("PRAGMA foreign_keys = OFF")
+	require.NoError(t, err)
+	_, err = tc.db.NewDelete().Model((*models.Book)(nil)).Where("id = ?", bookID).Exec(tc.ctx)
+	require.NoError(t, err)
+	_, err = tc.db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	// Remove the file from disk so the scan doesn't try to recreate it
+	require.NoError(t, os.RemoveAll(bookDir))
+
+	// First scan should clean up the orphan
+	err = tc.runScan()
+	require.NoError(t, err)
+
+	assert.Empty(t, tc.listFiles(), "orphaned file should be cleaned up by scan")
+
+	// Second scan should be completely clean (no orphans to process)
+	err = tc.runScan()
+	require.NoError(t, err)
+
+	assert.Empty(t, tc.listFiles(), "no files should remain after second scan")
+
+	// Verify no FK violations remain
+	var authorCount int
+	authorCount, err = tc.db.NewSelect().TableExpr("authors").Where("book_id = ?", bookID).Count(tc.ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, authorCount, "no orphaned authors should remain")
 }
 
 func intPtr(i int) *int {


### PR DESCRIPTION
Closes #283

## Summary
- When scan orphan cleanup detected all main files for a book were orphaned and tried to retrieve the parent book, a "not found" error caused the cleanup to skip that book entirely, leaving orphaned file rows and book-scoped children indefinitely
- The fix detects the not-found case and directly cleans up the orphaned file rows (which cascades to file-scoped children via FK) plus any remaining book-scoped children (authors, book_series, book_genres, book_tags, list_books) that may linger from before FK enforcement was enabled
- The log message changes from a warning ("failed to retrieve orphaned book") to an info ("book row already missing, cleaning up orphaned children") for the not-found case, so hourly scans won't produce noisy repeated warnings

## Test plan
- Orphaned file rows with missing parent book are deleted by cleanup
- File-scoped children (narrators) are cascade-deleted when orphaned file is removed
- Book-scoped children (authors) for missing book_id are cleaned up
- Subsequent scans after cleanup are clean with no repeated warnings
- All 5 existing orphan cleanup tests continue to pass