### PR TITLE
[Frontend] Make publisher name a clickable link in file detail views

### DIFF
--- a/app/components/files/FileDetailsTab.test.tsx
+++ b/app/components/files/FileDetailsTab.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { type File } from "@/types";
+
+import FileDetailsTab from "./FileDetailsTab";
+
+vi.mock("@/hooks/queries/plugins", () => ({
+  usePluginIdentifierTypes: () => ({ data: undefined }),
+}));
+
+function wrap(ui: React.ReactNode, libraryId = "1") {
+  return (
+    <MemoryRouter
+      initialEntries={[`/libraries/${libraryId}/books/10/files/100`]}
+    >
+      <Routes>
+        <Route
+          element={ui}
+          path="/libraries/:libraryId/books/:bookId/files/:fileId"
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function makeFile(overrides: Partial<File> = {}): File {
+  return {
+    id: 100,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    book_id: 10,
+    filepath: "/library/book/file.epub",
+    file_type: "epub",
+    file_role: "main",
+    filesize_bytes: 1024,
+    ...overrides,
+  } as File;
+}
+
+describe("FileDetailsTab", () => {
+  describe("publisher link", () => {
+    it("renders publisher name as a link to the publisher detail page", () => {
+      const file = makeFile({
+        publisher_id: 42,
+        publisher: {
+          id: 42,
+          created_at: "2024-01-01T00:00:00Z",
+          updated_at: "2024-01-01T00:00:00Z",
+          library_id: 1,
+          name: "Penguin Books",
+          aliases: [],
+          file_count: 5,
+        },
+      });
+
+      render(wrap(<FileDetailsTab file={file} />, "1"));
+
+      const link = screen.getByRole("link", { name: "Penguin Books" });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/libraries/1/publishers/42");
+    });
+
+    it("does not render publisher section when file has no publisher", () => {
+      const file = makeFile();
+
+      render(wrap(<FileDetailsTab file={file} />));
+
+      expect(screen.queryByText("Publisher")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/app/components/files/FileDetailsTab.tsx
+++ b/app/components/files/FileDetailsTab.tsx
@@ -169,7 +169,14 @@ const FileDetailsTab = ({ file }: FileDetailsTabProps) => {
       {file.publisher && (
         <div className="text-sm">
           <p className="font-semibold">Publisher</p>
-          <p className="text-muted-foreground">{file.publisher.name}</p>
+          <p>
+            <Link
+              className="text-muted-foreground hover:underline"
+              to={`/libraries/${libraryId}/publishers/${file.publisher.id}`}
+            >
+              {file.publisher.name}
+            </Link>
+          </p>
         </div>
       )}
 

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -597,7 +597,12 @@ const FileRow = ({
               {file.publisher && (
                 <>
                   <span className="text-muted-foreground">Publisher</span>
-                  <span>{file.publisher.name}</span>
+                  <Link
+                    className="hover:underline"
+                    to={`/libraries/${libraryId}/publishers/${file.publisher.id}`}
+                  >
+                    {file.publisher.name}
+                  </Link>
                 </>
               )}
               {file.release_date && (


### PR DESCRIPTION
Closes #288

## Summary
- Changed the publisher name from plain text to a clickable `<Link>` in two locations where file-level publisher metadata is displayed: the expandable file details section on BookDetail and the dedicated FileDetailsTab
- Both links navigate to the publisher's detail page scoped to the current library
- Link styling follows existing patterns: `hover:underline` in BookDetail (matching narrator links), `text-muted-foreground hover:underline` in FileDetailsTab (preserving existing muted color)

## Test plan
- Publisher name renders as a link to `/libraries/:libraryId/publishers/:id` when file has a publisher (unit test)
- Publisher section is omitted when file has no publisher (unit test)
- No backend changes needed; the File type already includes the publisher relation with id and name