### PR TITLE
[Feature] Allow creating new parent publisher from edit dialog

### DIFF
--- a/app/components/library/PublisherEditDialog.test.tsx
+++ b/app/components/library/PublisherEditDialog.test.tsx
@@ -18,9 +18,15 @@ vi.mock("@/hooks/useFormDialogClose", () => ({
   }),
 }));
 
-// Mock EntityCombobox to avoid complex dependency chain
+// Mock EntityCombobox to capture onChange and simulate selections.
+// The mock renders buttons that tests can click to trigger onChange with
+// either an existing option or a __create payload.
+let capturedOnChange: ((next: unknown) => void) | null = null;
 vi.mock("@/components/common/EntityCombobox", () => ({
-  EntityCombobox: () => <div data-testid="entity-combobox" />,
+  EntityCombobox: ({ onChange }: { onChange: (next: unknown) => void }) => {
+    capturedOnChange = onChange;
+    return <div data-testid="entity-combobox" />;
+  },
 }));
 
 describe("PublisherEditDialog", () => {
@@ -175,6 +181,78 @@ describe("PublisherEditDialog", () => {
           }),
         );
       });
+    });
+  });
+
+  describe("create parent publisher", () => {
+    it("should send parent_name when creating a new parent publisher", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog {...defaultProps} onSave={onSave} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Simulate selecting a __create option from the combobox
+      expect(capturedOnChange).not.toBeNull();
+      capturedOnChange!({ __create: "New Parent Corp" });
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "Foobar",
+            parent_name: "New Parent Corp",
+          }),
+        );
+      });
+      // Should NOT include parent_id when creating by name
+      const callArgs = onSave.mock.calls[0][0];
+      expect(callArgs.parent_id).toBeUndefined();
+    });
+
+    it("should send parent_id when selecting an existing parent", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog {...defaultProps} onSave={onSave} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Simulate selecting an existing publisher
+      expect(capturedOnChange).not.toBeNull();
+      capturedOnChange!({ id: 42, name: "Existing Parent", file_count: 5 });
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "Foobar",
+            parent_id: 42,
+          }),
+        );
+      });
+      // Should NOT include parent_name when selecting an existing parent
+      const callArgs = onSave.mock.calls[0][0];
+      expect(callArgs.parent_name).toBeUndefined();
     });
   });
 });

--- a/app/components/library/PublisherEditDialog.tsx
+++ b/app/components/library/PublisherEditDialog.tsx
@@ -25,6 +25,7 @@ export interface PublisherEditData {
   name: string;
   aliases?: string[];
   parent_id?: number | null;
+  parent_name?: string;
 }
 
 interface PublisherEditDialogProps {
@@ -53,8 +54,9 @@ export function PublisherEditDialog({
   const [name, setName] = useState(entityName);
   const [editAliases, setEditAliases] = useState<string[]>([]);
   const [aliasInput, setAliasInput] = useState("");
-  const [selectedParent, setSelectedParent] =
-    useState<PublisherIdOption | null>(null);
+  const [selectedParent, setSelectedParent] = useState<
+    PublisherIdOption | { __create: string } | null
+  >(null);
   const [parentCleared, setParentCleared] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
   const [changesSaved, setChangesSaved] = useState(false);
@@ -155,10 +157,17 @@ export function PublisherEditDialog({
     }
   };
 
+  // Whether the selected parent is a new publisher to create by name
+  const isCreateParent = selectedParent != null && "__create" in selectedParent;
+
+  // The effective parent ID for change detection. A __create parent counts as
+  // "changed" because it's a new value distinct from any existing numeric ID.
   const currentParentId = parentCleared
     ? null
     : selectedParent
-      ? selectedParent.id
+      ? isCreateParent
+        ? -1 // sentinel: always differs from any real ID
+        : (selectedParent as PublisherIdOption).id
       : (parentId ?? null);
 
   const hasChanges = useMemo(() => {
@@ -180,9 +189,14 @@ export function PublisherEditDialog({
         name,
         aliases: editAliases,
       };
-      // Only send parent_id if it changed
+      // Only send parent change if it actually changed
       if (initialValues && currentParentId !== initialValues.parentId) {
-        data.parent_id = currentParentId;
+        if (isCreateParent) {
+          // Creating a new parent publisher by name
+          data.parent_name = (selectedParent as { __create: string }).__create;
+        } else {
+          data.parent_id = currentParentId;
+        }
       }
       await onSave(data);
       setChangesSaved(true);
@@ -219,7 +233,6 @@ export function PublisherEditDialog({
             <div className="flex items-center gap-2">
               <div className="flex-1">
                 <EntityCombobox<PublisherIdOption>
-                  canCreate={false}
                   getOptionDescription={(p) =>
                     `${p.file_count} ${p.file_count === 1 ? "file" : "files"}`
                   }
@@ -228,7 +241,6 @@ export function PublisherEditDialog({
                   hook={useParentSearch}
                   label="Publisher"
                   onChange={(next) => {
-                    if ("__create" in next) return;
                     setSelectedParent(next);
                     setParentCleared(false);
                   }}

--- a/app/components/pages/PublisherDetail.tsx
+++ b/app/components/pages/PublisherDetail.tsx
@@ -125,7 +125,9 @@ const PublisherDetail = () => {
       name: data.name,
       aliases: data.aliases,
     };
-    if (data.parent_id !== undefined) {
+    if (data.parent_name !== undefined) {
+      payload.parent_name = data.parent_name;
+    } else if (data.parent_id !== undefined) {
       payload.parent_id = data.parent_id;
     }
 

--- a/app/hooks/queries/publishers.ts
+++ b/app/hooks/queries/publishers.ts
@@ -140,7 +140,10 @@ export const useUpdatePublisher = () => {
       );
     },
     onSuccess: (_data, variables) => {
-      if (variables.payload.parent_id !== undefined) {
+      if (
+        variables.payload.parent_id !== undefined ||
+        variables.payload.parent_name !== undefined
+      ) {
         invalidatePublisherHierarchyQueries(queryClient);
       } else {
         queryClient.invalidateQueries({

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -208,6 +208,24 @@ func (h *handler) update(c echo.Context) error {
 			}
 			return errors.WithStack(err)
 		}
+	} else if params.ParentName != nil {
+		// Resolve parent by name: find or create a publisher with the given name
+		// in the same library, then set it as the parent.
+		parentPublisher, err := h.publisherService.FindOrCreatePublisher(ctx, *params.ParentName, publisher.LibraryID)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		// Index the parent publisher in case it was just created
+		if indexErr := h.searchService.IndexPublisher(ctx, parentPublisher); indexErr != nil {
+			log := logger.FromContext(ctx)
+			log.Warn("failed to index new parent publisher", logger.Data{"publisher_id": parentPublisher.ID, "error": indexErr.Error()})
+		}
+		if err := h.publisherService.SetParent(ctx, id, &parentPublisher.ID); err != nil {
+			if strings.Contains(err.Error(), "cycle") || strings.Contains(err.Error(), "invalid parent") || strings.Contains(err.Error(), "same library") || strings.Contains(err.Error(), "not found") {
+				return errcodes.ValidationError(err.Error())
+			}
+			return errors.WithStack(err)
+		}
 	}
 
 	nameChanged := false

--- a/pkg/publishers/handlers.go
+++ b/pkg/publishers/handlers.go
@@ -199,9 +199,15 @@ func (h *handler) update(c echo.Context) error {
 		}
 	}
 
-	// Handle parent_id update before name-change/merge so that the parent_id
-	// change applies even when a rename triggers a merge (which returns early).
+	// Handle parent update before name-change/merge so that the parent change
+	// applies even when a rename triggers a merge (which returns early).
+	// resolvedParentID tracks the parent ID resolved from either path so the
+	// merge-transfer block below can use it.
+	var resolvedParentID *int
+	var parentWasSet bool
 	if params.ParentID.Set {
+		resolvedParentID = params.ParentID.Value
+		parentWasSet = true
 		if err := h.publisherService.SetParent(ctx, id, params.ParentID.Value); err != nil {
 			if strings.Contains(err.Error(), "cycle") || strings.Contains(err.Error(), "invalid parent") || strings.Contains(err.Error(), "same library") || strings.Contains(err.Error(), "not found") {
 				return errcodes.ValidationError(err.Error())
@@ -215,6 +221,8 @@ func (h *handler) update(c echo.Context) error {
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		resolvedParentID = &parentPublisher.ID
+		parentWasSet = true
 		// Index the parent publisher in case it was just created
 		if indexErr := h.searchService.IndexPublisher(ctx, parentPublisher); indexErr != nil {
 			log := logger.FromContext(ctx)
@@ -240,10 +248,10 @@ func (h *handler) update(c echo.Context) error {
 			LibraryID: &publisher.LibraryID,
 		})
 		if err == nil && existing.ID != id {
-			// If parent_id was set on the source publisher above, transfer it to the
-			// merge target so the intent is preserved.
-			if params.ParentID.Set {
-				if err := h.publisherService.SetParent(ctx, existing.ID, params.ParentID.Value); err != nil {
+			// If a parent was set on the source publisher above, transfer it to
+			// the merge target so the intent is preserved.
+			if parentWasSet {
+				if err := h.publisherService.SetParent(ctx, existing.ID, resolvedParentID); err != nil {
 					// Non-fatal: merge succeeded, log and continue
 					log := logger.FromContext(ctx)
 					log.Warn("failed to set parent on merge target", logger.Data{"publisher_id": existing.ID, "error": err.Error()})

--- a/pkg/publishers/handlers_test.go
+++ b/pkg/publishers/handlers_test.go
@@ -917,3 +917,102 @@ func TestList_IncludesHierarchyCounts(t *testing.T) {
 	require.NotNil(t, childItem.ParentName)
 	assert.Equal(t, "Parent", *childItem.ParentName)
 }
+
+func TestUpdate_SetParentByName_CreatesNewPublisher(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child"}
+	_, err := db.NewInsert().Model(child).Exec(ctx)
+	require.NoError(t, err)
+
+	// Set parent by name — the parent publisher does not exist yet
+	e := newTestEcho(t)
+	body := `{"parent_name": "New Parent"}`
+	req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(child.ID))
+
+	err = h.update(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify the parent was created and set
+	updated, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{ID: &child.ID})
+	require.NoError(t, err)
+	require.NotNil(t, updated.ParentID)
+
+	parent, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{ID: updated.ParentID})
+	require.NoError(t, err)
+	assert.Equal(t, "New Parent", parent.Name)
+	assert.Equal(t, lib.ID, parent.LibraryID)
+}
+
+func TestUpdate_SetParentByName_ReusesExistingPublisher(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	existing := &models.Publisher{LibraryID: lib.ID, Name: "Existing Parent"}
+	_, err := db.NewInsert().Model(existing).Exec(ctx)
+	require.NoError(t, err)
+
+	child := &models.Publisher{LibraryID: lib.ID, Name: "Child"}
+	_, err = db.NewInsert().Model(child).Exec(ctx)
+	require.NoError(t, err)
+
+	// Set parent by name — the publisher already exists
+	e := newTestEcho(t)
+	body := `{"parent_name": "Existing Parent"}`
+	req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(child.ID))
+
+	err = h.update(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Verify the existing publisher was reused
+	updated, err := h.publisherService.RetrievePublisher(ctx, RetrievePublisherOptions{ID: &child.ID})
+	require.NoError(t, err)
+	require.NotNil(t, updated.ParentID)
+	assert.Equal(t, existing.ID, *updated.ParentID)
+}
+
+func TestUpdate_SetParentByName_RejectsSelfReference(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+	ctx := context.Background()
+
+	// Create a publisher named "Self"
+	pub := &models.Publisher{LibraryID: lib.ID, Name: "Self"}
+	_, err := db.NewInsert().Model(pub).Exec(ctx)
+	require.NoError(t, err)
+
+	// Try to set parent by the publisher's own name — should reject as cycle
+	e := newTestEcho(t)
+	body := `{"parent_name": "Self"}`
+	req := httptest.NewRequest(http.MethodPatch, "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(pub.ID))
+
+	err = h.update(c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle")
+}

--- a/pkg/publishers/validators.go
+++ b/pkg/publishers/validators.go
@@ -41,9 +41,10 @@ func (n *NullableInt) UnmarshalJSON(data []byte) error {
 // UpdatePublisherPayload is the request body for PATCH /publishers/:id.
 // tstype is applied to the generated TypeScript type.
 type UpdatePublisherPayload struct {
-	Name     *string     `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
-	Aliases  []string    `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`
-	ParentID NullableInt `json:"parent_id,omitempty" tstype:"number | null"`
+	Name       *string     `json:"name,omitempty" validate:"omitempty,min=1,max=300"`
+	Aliases    []string    `json:"aliases,omitempty" validate:"omitempty,dive,min=1,max=300"`
+	ParentID   NullableInt `json:"parent_id,omitempty" tstype:"number | null"`
+	ParentName *string     `json:"parent_name,omitempty" validate:"omitempty,min=1,max=300"`
 }
 
 type MergePublishersPayload struct {

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -38,7 +38,7 @@ Genres and tags are simple labels attached to books. The distinction is semantic
 
 Publishers are attached at the **file level**, not the book level. This means different editions of the same book can have different publishers. A file references one publisher at whatever level of specificity is known from the source metadata.
 
-**Publisher hierarchy.** Publishers can be organized into a parent-child hierarchy to express relationships between imprints, divisions, and parent companies — they are all "publishers" at different levels of the tree. For example, "Dutton" might be a child of "Penguin Publishing Group", which is a child of "Penguin Random House". Set a parent publisher from the publisher edit dialog. The detail page displays the full ancestor chain as clickable breadcrumbs.
+**Publisher hierarchy.** Publishers can be organized into a parent-child hierarchy to express relationships between imprints, divisions, and parent companies — they are all "publishers" at different levels of the tree. For example, "Dutton" might be a child of "Penguin Publishing Group", which is a child of "Penguin Random House". Set a parent publisher from the publisher edit dialog — you can select an existing publisher or type a new name to create one on the fly. The detail page displays the full ancestor chain as clickable breadcrumbs.
 
 The hierarchy is **manually curated** — Shisho does not automatically infer parent-child relationships from metadata sources. You build the tree yourself through the edit dialog or the merge picker's "Set as child" action.
 


### PR DESCRIPTION
Closes #287

## Summary
- The publisher edit dialog's parent combobox now allows typing a new name to create a parent publisher on the fly, instead of only selecting from existing publishers
- Backend resolves the name via `FindOrCreatePublisher` (case-insensitive + alias dedup) and sends either `parent_name` (new) or `parent_id` (existing) — mutually exclusive fields on `UpdatePublisherPayload`
- Cycle/self-reference validation still applies to parent publishers created by name

## Test plan
- Backend: 3 new tests covering create-new-parent-by-name, reuse-existing-by-name, and reject-self-reference-by-name
- Frontend: 2 new tests verifying the dialog sends `parent_name` for create selections and `parent_id` for existing selections
- Existing publisher hierarchy tests continue to pass (parent_id path unchanged)