### PR TITLE
[Fix] Fold pending alias input into save payload without requiring Enter

### DIFF
--- a/app/components/library/MetadataEditDialog.test.tsx
+++ b/app/components/library/MetadataEditDialog.test.tsx
@@ -728,6 +728,221 @@ describe("MetadataEditDialog", () => {
     });
   });
 
+  describe("pending alias input on save (no Enter)", () => {
+    it("should include pending alias text in save payload without pressing Enter", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={[]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Name")).toBeInTheDocument();
+      });
+
+      // Type alias without pressing Enter
+      const aliasInput = screen.getByPlaceholderText(
+        "Type alias and press Enter",
+      );
+      await user.type(aliasInput, "Sci-Fi");
+
+      // Save button should be enabled because pending alias counts as a change
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith({
+          name: "Science Fiction",
+          aliases: ["Sci-Fi"],
+        });
+      });
+    });
+
+    it("should include pending alias alongside existing aliases on save", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Sci-Fi"]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+      });
+
+      // Type another alias without pressing Enter
+      const aliasInput = screen.getByPlaceholderText("Add another...");
+      await user.type(aliasInput, "SF");
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith({
+          name: "Science Fiction",
+          aliases: ["Sci-Fi", "SF"],
+        });
+      });
+    });
+
+    it("should ignore whitespace-only pending alias on save", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Sci-Fi"]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+      });
+
+      // Type whitespace in alias input
+      const aliasInput = screen.getByPlaceholderText("Add another...");
+      await user.type(aliasInput, "   ");
+
+      // Change name to make save possible
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Sci-Fi Genre");
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            aliases: expect.not.arrayContaining(["   "]),
+          }),
+        );
+      });
+    });
+
+    it("should not duplicate existing alias on save (case-insensitive)", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={["Sci-Fi"]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={onSave}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Sci-Fi")).toBeInTheDocument();
+      });
+
+      // Type duplicate alias (different case) without pressing Enter
+      const aliasInput = screen.getByPlaceholderText("Add another...");
+      await user.type(aliasInput, "sci-fi");
+
+      // Change name to make save possible (since duplicate alias won't count as change).
+      // Renaming away from "Science Fiction" auto-adds it as an alias.
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "Sci-Fi Genre");
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalled();
+        const savedAliases = onSave.mock.calls[0][0].aliases;
+        // "Sci-Fi" (original) + "Science Fiction" (auto-added on rename) = 2 aliases.
+        // Pending "sci-fi" should NOT be added as a third (case-insensitive duplicate).
+        expect(savedAliases).toEqual(["Sci-Fi", "Science Fiction"]);
+      });
+    });
+
+    it("should enable Save when only pending alias input is the change", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MetadataEditDialog
+            aliases={[]}
+            entityName="Science Fiction"
+            entityType="genre"
+            isPending={false}
+            onOpenChange={vi.fn()}
+            onSave={vi.fn()}
+            open={true}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Name")).toBeInTheDocument();
+      });
+
+      // Save should be disabled initially
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      expect(saveButton).toBeDisabled();
+
+      // Type alias text without Enter
+      const aliasInput = screen.getByPlaceholderText(
+        "Type alias and press Enter",
+      );
+      await user.type(aliasInput, "Sci-Fi");
+
+      // Save should now be enabled
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+    });
+  });
+
   describe("hasChanges comparison against initial state", () => {
     it("should compute hasChanges against initial values, not live props", async () => {
       // This test exposes the bug: hasChanges compares form values against

--- a/app/components/library/MetadataEditDialog.tsx
+++ b/app/components/library/MetadataEditDialog.tsx
@@ -175,26 +175,6 @@ export function MetadataEditDialog({
     }
   };
 
-  const handleSubmit = async () => {
-    setServerError(null);
-    try {
-      const data: { name: string; sort_name?: string; aliases?: string[] } = {
-        name,
-      };
-      if (hasSortName) {
-        data.sort_name = editSortName;
-      }
-      data.aliases = resolvedAliases;
-      await onSave(data);
-      setChangesSaved(true);
-      requestClose();
-    } catch (err) {
-      if (err instanceof Error) {
-        setServerError(err.message);
-      }
-    }
-  };
-
   // Resolve pending alias input into the effective alias list for comparison
   const resolvedAliases = useMemo(
     () => resolveAliases(editAliases, aliasInput),
@@ -234,6 +214,26 @@ export function MetadataEditDialog({
   ]);
 
   const { requestClose } = useFormDialogClose(open, onOpenChange, hasChanges);
+
+  const handleSubmit = async () => {
+    setServerError(null);
+    try {
+      const data: { name: string; sort_name?: string; aliases?: string[] } = {
+        name,
+      };
+      if (hasSortName) {
+        data.sort_name = editSortName;
+      }
+      data.aliases = resolvedAliases;
+      await onSave(data);
+      setChangesSaved(true);
+      requestClose();
+    } catch (err) {
+      if (err instanceof Error) {
+        setServerError(err.message);
+      }
+    }
+  };
 
   return (
     <FormDialog hasChanges={hasChanges} onOpenChange={onOpenChange} open={open}>

--- a/app/components/library/MetadataEditDialog.tsx
+++ b/app/components/library/MetadataEditDialog.tsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
 import { DataSourceManual, type DataSource } from "@/types";
+import { resolveAliases } from "@/utils/aliases";
 import { forPerson, forTitle } from "@/utils/sortname";
 
 export type EntityType = "person" | "series" | "genre" | "tag" | "publisher";
@@ -183,7 +184,7 @@ export function MetadataEditDialog({
       if (hasSortName) {
         data.sort_name = editSortName;
       }
-      data.aliases = editAliases;
+      data.aliases = resolveAliases(editAliases, aliasInput);
       await onSave(data);
       setChangesSaved(true);
       requestClose();
@@ -193,6 +194,12 @@ export function MetadataEditDialog({
       }
     }
   };
+
+  // Resolve pending alias input into the effective alias list for comparison
+  const resolvedAliases = useMemo(
+    () => resolveAliases(editAliases, aliasInput),
+    [editAliases, aliasInput],
+  );
 
   const hasChanges = useMemo(() => {
     if (changesSaved) return false;
@@ -208,8 +215,8 @@ export function MetadataEditDialog({
     const effectiveSortName =
       editSortName || (generateSort ? generateSort(name) : "");
     const aliasesChanged =
-      editAliases.length !== initialValues.aliases.length ||
-      editAliases.some((a, i) => a !== initialValues.aliases[i]);
+      resolvedAliases.length !== initialValues.aliases.length ||
+      resolvedAliases.some((a, i) => a !== initialValues.aliases[i]);
     // Compare against stored initial values, not live props
     return (
       name !== initialValues.name ||
@@ -223,7 +230,7 @@ export function MetadataEditDialog({
     changesSaved,
     initialValues,
     entityType,
-    editAliases,
+    resolvedAliases,
   ]);
 
   const { requestClose } = useFormDialogClose(open, onOpenChange, hasChanges);

--- a/app/components/library/MetadataEditDialog.tsx
+++ b/app/components/library/MetadataEditDialog.tsx
@@ -184,7 +184,7 @@ export function MetadataEditDialog({
       if (hasSortName) {
         data.sort_name = editSortName;
       }
-      data.aliases = resolveAliases(editAliases, aliasInput);
+      data.aliases = resolvedAliases;
       await onSave(data);
       setChangesSaved(true);
       requestClose();

--- a/app/components/library/PublisherEditDialog.test.tsx
+++ b/app/components/library/PublisherEditDialog.test.tsx
@@ -42,6 +42,160 @@ describe("PublisherEditDialog", () => {
     useParentSearch: vi.fn(),
   };
 
+  describe("pending alias input on save (no Enter)", () => {
+    it("should include pending alias text in save payload without pressing Enter", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog {...defaultProps} onSave={onSave} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Type alias without pressing Enter
+      const aliasInput = screen.getByPlaceholderText(
+        "Type alias and press Enter",
+      );
+      await user.type(aliasInput, "Foo Publishing");
+
+      // Save should be enabled
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: "Foobar",
+            aliases: ["Foo Publishing"],
+          }),
+        );
+      });
+    });
+
+    it("should include pending alias alongside existing aliases on save", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog
+            {...defaultProps}
+            aliases={["Foo Press"]}
+            onSave={onSave}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Foo Press")).toBeInTheDocument();
+      });
+
+      // Type another alias without pressing Enter
+      const aliasInput = screen.getByPlaceholderText("Add another...");
+      await user.type(aliasInput, "Foo Publishing");
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            aliases: ["Foo Press", "Foo Publishing"],
+          }),
+        );
+      });
+    });
+
+    it("should not duplicate existing alias on save (case-insensitive)", async () => {
+      const user = createUser();
+      const onSave = vi.fn().mockResolvedValue(undefined);
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog
+            {...defaultProps}
+            aliases={["Foo Press"]}
+            onSave={onSave}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Foo Press")).toBeInTheDocument();
+      });
+
+      // Type duplicate alias (different case) without Enter
+      const aliasInput = screen.getByPlaceholderText("Add another...");
+      await user.type(aliasInput, "foo press");
+
+      // Change name to make save possible
+      const nameInput = screen.getByLabelText("Name");
+      await user.clear(nameInput);
+      await user.type(nameInput, "FooBar Inc");
+
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      await user.click(saveButton);
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(
+          expect.objectContaining({
+            aliases: expect.arrayContaining(["Foo Press"]),
+          }),
+        );
+        // Should not have duplicated
+        const callAliases = onSave.mock.calls[0][0].aliases;
+        expect(
+          callAliases.filter((a: string) => a.toLowerCase() === "foo press"),
+        ).toHaveLength(1);
+      });
+    });
+
+    it("should enable Save when only pending alias input is the change", async () => {
+      const user = createUser();
+      const queryClient = createQueryClient();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PublisherEditDialog {...defaultProps} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("Foobar")).toBeInTheDocument();
+      });
+
+      // Save should be disabled initially
+      const saveButton = screen.getByRole("button", { name: /save/i });
+      expect(saveButton).toBeDisabled();
+
+      // Type alias text without Enter
+      const aliasInput = screen.getByPlaceholderText(
+        "Type alias and press Enter",
+      );
+      await user.type(aliasInput, "Foo Publishing");
+
+      // Save should now be enabled
+      await waitFor(() => {
+        expect(saveButton).not.toBeDisabled();
+      });
+    });
+  });
+
   describe("auto-alias on rename", () => {
     it("should auto-add initial name as alias when name changes", async () => {
       const user = createUser();

--- a/app/components/library/PublisherEditDialog.tsx
+++ b/app/components/library/PublisherEditDialog.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { PublisherIdOption } from "@/hooks/queries/entity-search";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
+import { resolveAliases } from "@/utils/aliases";
 
 export interface PublisherEditData {
   name: string;
@@ -161,15 +162,21 @@ export function PublisherEditDialog({
       ? selectedParent.id
       : (parentId ?? null);
 
+  // Resolve pending alias input into the effective alias list for comparison
+  const resolvedAliases = useMemo(
+    () => resolveAliases(editAliases, aliasInput),
+    [editAliases, aliasInput],
+  );
+
   const hasChanges = useMemo(() => {
     if (changesSaved) return false;
     if (!initialValues) return false;
     const aliasesChanged =
-      editAliases.length !== initialValues.aliases.length ||
-      editAliases.some((a, i) => a !== initialValues.aliases[i]);
+      resolvedAliases.length !== initialValues.aliases.length ||
+      resolvedAliases.some((a, i) => a !== initialValues.aliases[i]);
     const parentChanged = currentParentId !== initialValues.parentId;
     return name !== initialValues.name || aliasesChanged || parentChanged;
-  }, [name, changesSaved, initialValues, editAliases, currentParentId]);
+  }, [name, changesSaved, initialValues, resolvedAliases, currentParentId]);
 
   const { requestClose } = useFormDialogClose(open, onOpenChange, hasChanges);
 
@@ -178,7 +185,7 @@ export function PublisherEditDialog({
     try {
       const data: PublisherEditData = {
         name,
-        aliases: editAliases,
+        aliases: resolveAliases(editAliases, aliasInput),
       };
       // Only send parent_id if it changed
       if (initialValues && currentParentId !== initialValues.parentId) {

--- a/app/components/library/PublisherEditDialog.tsx
+++ b/app/components/library/PublisherEditDialog.tsx
@@ -185,7 +185,7 @@ export function PublisherEditDialog({
     try {
       const data: PublisherEditData = {
         name,
-        aliases: resolveAliases(editAliases, aliasInput),
+        aliases: resolvedAliases,
       };
       // Only send parent_id if it changed
       if (initialValues && currentParentId !== initialValues.parentId) {

--- a/app/utils/aliases.test.ts
+++ b/app/utils/aliases.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveAliases } from "./aliases";
+
+describe("resolveAliases", () => {
+  it("returns committed aliases unchanged when pending input is empty", () => {
+    expect(resolveAliases(["Sci-Fi", "SF"], "")).toEqual(["Sci-Fi", "SF"]);
+  });
+
+  it("returns committed aliases unchanged when pending input is whitespace-only", () => {
+    expect(resolveAliases(["Sci-Fi"], "   ")).toEqual(["Sci-Fi"]);
+  });
+
+  it("appends trimmed pending input to committed aliases", () => {
+    expect(resolveAliases(["Sci-Fi"], "  SF  ")).toEqual(["Sci-Fi", "SF"]);
+  });
+
+  it("appends pending input when committed list is empty", () => {
+    expect(resolveAliases([], "New Alias")).toEqual(["New Alias"]);
+  });
+
+  it("does not add pending input that duplicates an existing alias (case-insensitive)", () => {
+    expect(resolveAliases(["Sci-Fi"], "sci-fi")).toEqual(["Sci-Fi"]);
+  });
+
+  it("does not add pending input that duplicates an existing alias (different case)", () => {
+    expect(resolveAliases(["SF"], "sf")).toEqual(["SF"]);
+  });
+
+  it("handles empty committed list with whitespace-only pending input", () => {
+    expect(resolveAliases([], "   ")).toEqual([]);
+  });
+});

--- a/app/utils/aliases.ts
+++ b/app/utils/aliases.ts
@@ -1,0 +1,17 @@
+/**
+ * Fold pending alias input into a committed alias list.
+ *
+ * Trims whitespace, ignores empty/whitespace-only input, and skips
+ * case-insensitive duplicates of existing aliases.
+ */
+export function resolveAliases(
+  committed: string[],
+  pendingInput: string,
+): string[] {
+  const trimmed = pendingInput.trim();
+  if (!trimmed) return committed;
+  if (committed.some((a) => a.toLowerCase() === trimmed.toLowerCase())) {
+    return committed;
+  }
+  return [...committed, trimmed];
+}

--- a/e2e/alias.spec.ts
+++ b/e2e/alias.spec.ts
@@ -3,10 +3,11 @@
  *
  * Covers:
  * 1. Adding aliases via the edit dialog — persists and is visible on reopen.
- * 2. Removing an alias via the edit dialog — no longer present after save.
- * 3. Merging two series — source name becomes alias of the target.
- * 4. Renaming a series — old name becomes alias.
- * 5. Autocomplete search matches aliases — searching by alias in the book
+ * 2. Saving an alias without pressing Enter — pending input is folded in on save.
+ * 3. Removing an alias via the edit dialog — no longer present after save.
+ * 4. Merging two series — source name becomes alias of the target.
+ * 5. Renaming a series — old name becomes alias.
+ * 6. Autocomplete search matches aliases — searching by alias in the book
  *    edit dialog returns the canonical resource.
  *
  * Running:
@@ -126,6 +127,59 @@ test.describe("Alias workflows", () => {
     const data = (await resp.json()) as { aliases: string[] };
     expect(data.aliases).toContain("FS");
     expect(data.aliases).toContain("The Fantasy Saga");
+  });
+
+  test("saving alias without pressing Enter persists the alias", async ({
+    page,
+    apiContext,
+  }) => {
+    // Create a series via test API.
+    const seriesResp = await apiContext.post("/test/series", {
+      data: { libraryId: testData.libraryId, name: "No-Enter Alias Test" },
+    });
+    const series = (await seriesResp.json()) as { id: number };
+
+    await login(page);
+    await page.goto(`/libraries/${testData.libraryId}/series/${series.id}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(
+      page.locator("h1").filter({ hasText: "No-Enter Alias Test" }),
+    ).toBeVisible();
+
+    // Open edit dialog.
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(
+      dialog.getByRole("heading", { name: "Edit Series" }),
+    ).toBeVisible();
+
+    // Type an alias but do NOT press Enter — just click Save directly.
+    await dialog.getByLabel("Aliases").fill("No Enter Alias");
+
+    // Save — wait for the PATCH response.
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.url().includes(`/api/series/${series.id}`) &&
+          r.request().method() === "PATCH" &&
+          r.ok(),
+      ),
+      dialog.getByRole("button", { name: "Save" }).click(),
+    ]);
+
+    // Reopen the edit dialog to verify alias persisted.
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const dialog2 = page.getByRole("dialog");
+    await expect(
+      dialog2.getByRole("heading", { name: "Edit Series" }),
+    ).toBeVisible();
+    await expect(dialog2.getByText("No Enter Alias")).toBeVisible();
+
+    // Also verify via API.
+    const resp = await page.request.get(`/api/series/${series.id}`);
+    const data = (await resp.json()) as { aliases: string[] };
+    expect(data.aliases).toContain("No Enter Alias");
   });
 
   test("removing an alias via edit dialog removes it", async ({

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -111,7 +111,7 @@ This resolution happens transparently in all contexts — library scans, plugin 
 
 ### Managing Aliases
 
-**Edit dialog.** Open the edit dialog for any resource (person, series, genre, tag, or publisher). Below the name field, a chip input lets you add and remove aliases. Type a name and press Enter to add it; click the × on a chip to remove it.
+**Edit dialog.** Open the edit dialog for any resource (person, series, genre, tag, or publisher). Below the name field, a chip input lets you add and remove aliases. Type a name and press Enter to add it as a chip, or simply click Save — any text still in the alias input is automatically included when you save. Click the × on a chip to remove it.
 
 **Automatic creation on merge.** When you merge two resources, the source resource's name automatically becomes an alias of the target. Any existing aliases on the source transfer to the target as well, so no previously-working name mappings are lost.
 


### PR DESCRIPTION
Closes #286

## Summary
- Typing an alias and clicking Save without pressing Enter now includes the pending text in the save payload, instead of silently discarding it
- Extracted a shared `resolveAliases` utility (`app/utils/aliases.ts`) that trims whitespace, ignores empty input, and skips case-insensitive duplicates -- used by both `MetadataEditDialog` and `PublisherEditDialog`
- The `hasChanges` computation now factors in pending alias input, so typing a valid alias immediately enables the Save button even without pressing Enter

## Test plan
- 7 unit tests for the `resolveAliases` utility covering all edge cases (empty, whitespace, trim, duplicate, case-insensitive)
- 5 component tests for MetadataEditDialog verifying pending alias inclusion, whitespace handling, duplicate prevention, and Save button enablement
- 4 component tests for PublisherEditDialog covering the same behaviors
- 1 E2E test that types an alias, clicks Save without Enter, reopens the dialog, and verifies persistence via both UI and API
- Updated docs at `website/docs/metadata.md` to describe the new behavior