### PR TITLE
[Docs] Add Preferred Cover term to domain glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -44,6 +44,10 @@ _Avoid_: synonym, alternate name, variant
 The canonical display name of a resource, shown in the UI and used as the authoritative label.
 _Avoid_: canonical name, display name
 
+**Preferred Cover**:
+A per-file designation that prioritizes one file's cover over others in the same format category (ebook or audiobook) when representing the book. At most one file per category per book can be preferred.
+_Avoid_: primary cover, default cover, canonical cover
+
 ### Workflows
 
 **Scan**:
@@ -57,10 +61,6 @@ Combining two resources of the same type into one, transferring all associations
 
 **Sidecar**:
 A `.metadata.json` file placed alongside a book or file that provides metadata overrides.
-
-**Preferred Cover**:
-A user-set flag on a file indicating that its cover should represent the book when selecting a cover from that file's type category (ebook or audiobook). At most one file per type category per book can be preferred. When no file is preferred, the default selection order applies.
-_Avoid_: primary cover, default cover, canonical cover
 
 ## Relationships
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,6 +58,10 @@ Combining two resources of the same type into one, transferring all associations
 **Sidecar**:
 A `.metadata.json` file placed alongside a book or file that provides metadata overrides.
 
+**Preferred Cover**:
+A user-set flag on a file indicating that its cover should represent the book when selecting a cover from that file's type category (ebook or audiobook). At most one file per type category per book can be preferred. When no file is preferred, the default selection order applies.
+_Avoid_: primary cover, default cover, canonical cover
+
 ## Relationships
 
 - A **Library** contains many **Books**, **Series**, **Persons**, **Genres**, **Tags**, and **Publishers**


### PR DESCRIPTION
## Summary
- Adds "Preferred Cover" to `CONTEXT.md` as domain vocabulary for the upcoming per-file-type cover source override feature (#320, #322)
- Documents the avoid-list: primary cover, default cover, canonical cover

## Test plan
- Verify the glossary entry is clear and consistent with the PRD language in #320