### PR TITLE
[Backend] Use newest file instead of primary file for sort coalesce queries

### DIFF
--- a/pkg/sortspec/sql.go
+++ b/pkg/sortspec/sql.go
@@ -80,13 +80,13 @@ func OrderClauses(levels []SortLevel) []OrderClause {
 			out = append(out, nullsLast("b.created_at", l.Direction))
 
 		case FieldDateReleased:
-			out = append(out, nullsLast(primaryFileCoalesce("release_date"), l.Direction))
+			out = append(out, nullsLast(newestFileCoalesce("release_date"), l.Direction))
 
 		case FieldPageCount:
-			out = append(out, nullsLast(primaryFileCoalesce("page_count"), l.Direction))
+			out = append(out, nullsLast(newestFileCoalesce("page_count"), l.Direction))
 
 		case FieldDuration:
-			out = append(out, nullsLast(primaryFileCoalesce("audiobook_duration_seconds"), l.Direction))
+			out = append(out, nullsLast(newestFileCoalesce("audiobook_duration_seconds"), l.Direction))
 		}
 	}
 	return out
@@ -105,18 +105,19 @@ func nullsLast(expr string, dir Direction) OrderClause {
 	}
 }
 
-// primaryFileCoalesce returns an SQL snippet that reads `field` from
-// the book's primary file, falling back to any file on the book with
-// a non-NULL value for that field.
+// newestFileCoalesce returns an SQL snippet that reads `field` from
+// the book's newest file (by f.id DESC), falling back to any file on
+// the book with a non-NULL value for that field (also newest first).
+// Newer editions are more likely to have the metadata the user cares about.
 //
 //	COALESCE(
-//	  (SELECT f.<field> FROM files f WHERE f.id = b.primary_file_id),
-//	  (SELECT f.<field> FROM files f WHERE f.book_id = b.id AND f.<field> IS NOT NULL ORDER BY f.id LIMIT 1)
+//	  (SELECT f.<field> FROM files f WHERE f.book_id = b.id ORDER BY f.id DESC LIMIT 1),
+//	  (SELECT f.<field> FROM files f WHERE f.book_id = b.id AND f.<field> IS NOT NULL ORDER BY f.id DESC LIMIT 1)
 //	)
-func primaryFileCoalesce(field string) string {
+func newestFileCoalesce(field string) string {
 	return fmt.Sprintf(
 		`COALESCE(
-            (SELECT f.%[1]s FROM files f WHERE f.id = b.primary_file_id),
-            (SELECT f.%[1]s FROM files f WHERE f.book_id = b.id AND f.%[1]s IS NOT NULL ORDER BY f.id LIMIT 1)
+            (SELECT f.%[1]s FROM files f WHERE f.book_id = b.id ORDER BY f.id DESC LIMIT 1),
+            (SELECT f.%[1]s FROM files f WHERE f.book_id = b.id AND f.%[1]s IS NOT NULL ORDER BY f.id DESC LIMIT 1)
         )`, field)
 }

--- a/pkg/sortspec/sql_test.go
+++ b/pkg/sortspec/sql_test.go
@@ -55,22 +55,52 @@ func TestOrderClauses_SeriesExpandsToTwo(t *testing.T) {
 	assert.NotContains(t, got[1].Expression, "ORDER BY bs.series_number ASC, bs.id ASC")
 }
 
-func TestOrderClauses_PrimaryFileFallback(t *testing.T) {
+func TestOrderClauses_NewestFileFallback(t *testing.T) {
 	t.Parallel()
 
 	got := OrderClauses([]SortLevel{
 		{Field: FieldPageCount, Direction: DirAsc},
 	})
 
-	// page_count uses the COALESCE(primary file, any file with value)
-	// pattern. The generated SQL must reference b.primary_file_id and
-	// b.id as correlated subquery columns.
+	// page_count uses the COALESCE(newest file, any file with value)
+	// pattern. The generated SQL must prefer the newest file (f.id DESC)
+	// and must NOT reference b.primary_file_id.
 	assert.Len(t, got, 1)
 	assert.Contains(t, got[0].Expression, "COALESCE")
-	assert.Contains(t, got[0].Expression, "b.primary_file_id")
+	assert.NotContains(t, got[0].Expression, "primary_file_id")
+	assert.Contains(t, got[0].Expression, "f.id DESC")
 	assert.Contains(t, got[0].Expression, "b.id")
 	assert.Contains(t, got[0].Expression, "page_count")
 	assert.Contains(t, got[0].Expression, "ASC")
+}
+
+func TestOrderClauses_NewestFileCoalesce_AllFields(t *testing.T) {
+	t.Parallel()
+
+	// All file-level sort fields (date_released, page_count, duration)
+	// must use the newest-file coalesce and must not reference primary_file_id.
+	tests := []struct {
+		field   string
+		dbField string
+	}{
+		{FieldDateReleased, "release_date"},
+		{FieldPageCount, "page_count"},
+		{FieldDuration, "audiobook_duration_seconds"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.field, func(t *testing.T) {
+			t.Parallel()
+			got := OrderClauses([]SortLevel{
+				{Field: tt.field, Direction: DirDesc},
+			})
+			assert.Len(t, got, 1)
+			assert.Contains(t, got[0].Expression, "COALESCE")
+			assert.NotContains(t, got[0].Expression, "primary_file_id")
+			assert.Contains(t, got[0].Expression, "f.id DESC")
+			assert.Contains(t, got[0].Expression, tt.dbField)
+		})
+	}
 }
 
 func TestOrderClauses_MultiLevel(t *testing.T) {

--- a/website/docs/gallery-sort.md
+++ b/website/docs/gallery-sort.md
@@ -25,11 +25,11 @@ A dot on the Sort button means your current sort differs from your saved default
 | Author | Primary author's name (books with no author sort to the end) |
 | Series | Primary series name, then series number within each series (the within-series order is always ascending — "Stormlight #1 before #2" — even when you pick **Series, descending**, which only flips the series-name ordering) |
 | Date added | When the book was first scanned into the library |
-| Date released | Release date from the primary file's metadata |
-| Page count | Page count from the primary file |
-| Duration | Audiobook duration from the primary file |
+| Date released | Release date from the newest file's metadata |
+| Page count | Page count from the newest file |
+| Duration | Audiobook duration from the newest file |
 
-For Date released, Page count, and Duration: if the primary file doesn't have a value, Shisho falls back to any other file on the book that does. Books with no value on any of their files sort to the end, regardless of ascending/descending.
+For Date released, Page count, and Duration: the value comes from the book's newest file (newer editions are more likely to have accurate metadata). If the newest file doesn't have a value, Shisho falls back to the newest file that does. Books with no value on any of their files sort to the end, regardless of ascending/descending.
 
 ## URL-addressable sorts
 


### PR DESCRIPTION
Closes #292

## Summary
- Replaced `primaryFileCoalesce` with `newestFileCoalesce` in `pkg/sortspec/sql.go` so file-level sort fields (release_date, page_count, audiobook_duration_seconds) pull metadata from the newest file (`f.id DESC`) instead of from `b.primary_file_id`
- The COALESCE structure is preserved: first subquery gets the value from the newest file, second subquery falls back to the newest file that has a non-NULL value for the field, so books missing the field on all files still sort to the end via NULLS LAST
- Part of the `primary_file_id` removal parent issue (#289)

## Test plan
- `TestOrderClauses_NewestFileFallback` verifies page_count sort uses `f.id DESC` and does not reference `primary_file_id`
- `TestOrderClauses_NewestFileCoalesce_AllFields` covers all three file-level sort fields (date_released, page_count, duration) to ensure they all use newest-file coalesce with `f.id DESC` and no `primary_file_id`