### PR TITLE
[Frontend] Replace isPrimaryFile gate with source-priority check in identify review defaults

### DIFF
--- a/app/components/library/IdentifyReviewForm.test.tsx
+++ b/app/components/library/IdentifyReviewForm.test.tsx
@@ -14,6 +14,7 @@ import {
 import { Dialog } from "@/components/ui/dialog";
 import type { PluginSearchResult } from "@/hooks/queries/plugins";
 import {
+  DataSourceFilepath,
   DataSourceManual,
   FileRoleMain,
   FileTypeEPUB,
@@ -303,10 +304,11 @@ describe("IdentifyReviewForm component", () => {
   it("omits unchecked fields from the apply payload", async () => {
     const user = createUser();
     renderForm({
-      // Single-file book → primary, so book-changed defaults ON.
+      // Low-priority sources → book-changed defaults ON.
       book: makeBook({
         title: "Old Title",
-        // Authors are also "changed" because the result proposes a new author.
+        title_source: DataSourceFilepath,
+        author_source: DataSourceFilepath,
       }),
       result: makeResult({
         title: "New Title",
@@ -314,7 +316,7 @@ describe("IdentifyReviewForm component", () => {
       }),
     });
 
-    // Title checkbox should be checked by default (book-changed on primary).
+    // Title checkbox should be checked by default (low-priority source).
     const titleCheckbox = screen.getByRole("checkbox", {
       name: /apply title/i,
     });
@@ -334,18 +336,13 @@ describe("IdentifyReviewForm component", () => {
     expect(payload.fields.authors).toEqual([{ name: "New Author" }]);
   });
 
-  it("defaults book-changed fields OFF on a non-primary file", async () => {
+  it("defaults book-changed fields OFF when source is high-priority", async () => {
     const user = createUser();
-    // Two main files, primary is the OTHER one.
-    const file1 = makeFile({ id: 1, filepath: "/test/book1.epub" });
-    const file2 = makeFile({ id: 2, filepath: "/test/book2.epub" });
     renderForm({
       book: makeBook({
         title: "Old Title",
-        primary_file_id: 1,
-        files: [file1, file2],
+        title_source: DataSourceManual, // high-priority → default OFF
       }),
-      fileId: 2, // identifying the non-primary file
       result: makeResult({ title: "New Title" }),
     });
 
@@ -361,16 +358,12 @@ describe("IdentifyReviewForm component", () => {
     expect(titleCheckbox).toHaveAttribute("data-state", "unchecked");
   });
 
-  it("defaults book-changed fields ON when identifying the primary file", () => {
-    const file1 = makeFile({ id: 1, filepath: "/test/book1.epub" });
-    const file2 = makeFile({ id: 2, filepath: "/test/book2.epub" });
+  it("defaults book-changed fields ON when source is low-priority", () => {
     renderForm({
       book: makeBook({
         title: "Old Title",
-        primary_file_id: 1,
-        files: [file1, file2],
+        title_source: DataSourceFilepath, // low-priority → default ON
       }),
-      fileId: 1,
       result: makeResult({ title: "New Title" }),
     });
 
@@ -380,16 +373,15 @@ describe("IdentifyReviewForm component", () => {
     expect(titleCheckbox).toHaveAttribute("data-state", "checked");
   });
 
-  it("defaults file-level fields ON regardless of primary status", () => {
-    const file1 = makeFile({ id: 1 });
-    const file2 = makeFile({
-      id: 2,
-      filepath: "/test/book2.epub",
-      release_date: "2020-01-01T00:00:00Z",
-    });
+  it("defaults file-level fields ON regardless of source", () => {
     renderForm({
-      book: makeBook({ primary_file_id: 1, files: [file1, file2] }),
-      fileId: 2, // non-primary
+      book: makeBook({
+        files: [
+          makeFile({
+            release_date: "2020-01-01T00:00:00Z",
+          }),
+        ],
+      }),
       result: makeResult({ release_date: "2024-06-15" }),
     });
 
@@ -402,7 +394,12 @@ describe("IdentifyReviewForm component", () => {
   it("section-level checkbox toggles all child rows", async () => {
     const user = createUser();
     renderForm({
-      book: makeBook({ title: "Old Title" }),
+      book: makeBook({
+        title: "Old Title",
+        title_source: DataSourceFilepath,
+        author_source: DataSourceFilepath,
+        genre_source: DataSourceFilepath,
+      }),
       result: makeResult({
         title: "New Title",
         authors: [{ name: "New Author" }],
@@ -417,9 +414,9 @@ describe("IdentifyReviewForm component", () => {
     const sectionCheckbox = screen.getByRole("checkbox", {
       name: /apply all book fields/i,
     });
-    // Title/authors/genres default ON, but other book fields (subtitle,
-    // series, tags, description) are unchanged → off. Aggregate is
-    // indeterminate. Clicking indeterminate sets all to true.
+    // Title/authors/genres default ON (low-priority source), but other book
+    // fields (subtitle, series, tags, description) are unchanged → off.
+    // Aggregate is indeterminate. Clicking indeterminate sets all to true.
     expect(sectionCheckbox).toHaveAttribute("data-state", "indeterminate");
     await user.click(sectionCheckbox);
     expect(sectionCheckbox).toHaveAttribute("data-state", "checked");
@@ -484,7 +481,11 @@ describe("IdentifyReviewForm component", () => {
   it("hides unchanged rows in the default Changed filter, shows them in All", async () => {
     const user = createUser();
     renderForm({
-      book: makeBook({ title: "Old Title", subtitle: "" }),
+      book: makeBook({
+        title: "Old Title",
+        title_source: DataSourceFilepath, // low-priority → defaults ON
+        subtitle: "",
+      }),
       result: makeResult({ title: "New Title" }),
     });
 
@@ -509,7 +510,10 @@ describe("IdentifyReviewForm component", () => {
   it("disables row inputs when the apply checkbox is unchecked", async () => {
     const user = createUser();
     renderForm({
-      book: makeBook({ title: "Old Title" }),
+      book: makeBook({
+        title: "Old Title",
+        title_source: DataSourceFilepath, // low-priority → defaults ON
+      }),
       result: makeResult({ title: "New Title" }),
     });
 
@@ -530,7 +534,10 @@ describe("IdentifyReviewForm component", () => {
   it("Restore suggestions resets the form", async () => {
     const user = createUser();
     renderForm({
-      book: makeBook({ title: "Old Title" }),
+      book: makeBook({
+        title: "Old Title",
+        title_source: DataSourceFilepath, // low-priority → defaults ON
+      }),
       result: makeResult({ title: "New Title" }),
     });
 

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -450,20 +450,28 @@ export function IdentifyReviewForm({
 
   const [filterMode, setFilterMode] = useState<"changed" | "all">("changed");
 
-  // The "primary file" gate for book-level changed-field defaults. A book
-  // with no explicit primary_file_id and a single MAIN file is treated as
-  // primary; this avoids surprising "nothing applies" defaults on freshly
-  // scanned single-file books. Supplements never count toward this — a
-  // book with one main + one supplement is still effectively single-main.
-  const isPrimaryFile = useMemo(() => {
-    const mainCount = (book.files ?? []).filter(
-      (f) => f.file_role === "main",
-    ).length;
-    if (book.primary_file_id == null) {
-      return mainCount <= 1;
-    }
-    return file?.id === book.primary_file_id;
-  }, [book.primary_file_id, book.files, file?.id]);
+  // Map each book-level field key to its current data source on the book.
+  // Used by defaultDecision to determine whether the plugin value should
+  // default ON (low-priority source) or OFF (high-priority source).
+  const bookFieldSource: Record<BookFieldKey, string | undefined> = useMemo(
+    () => ({
+      title: book.title_source || undefined,
+      subtitle: book.subtitle_source ?? undefined,
+      authors: book.author_source || undefined,
+      series: undefined, // No series_source field on the book model.
+      genres: book.genre_source ?? undefined,
+      tags: book.tag_source ?? undefined,
+      description: book.description_source ?? undefined,
+    }),
+    [
+      book.title_source,
+      book.subtitle_source,
+      book.author_source,
+      book.genre_source,
+      book.tag_source,
+      book.description_source,
+    ],
+  );
 
   // ---- Extract current values ----
   const currentAuthors: AuthorEntry[] = useMemo(
@@ -855,17 +863,19 @@ export function IdentifyReviewForm({
         out[k] = false;
         continue;
       }
+      const scope = fieldScope(k);
       out[k] = defaultDecision({
-        scope: fieldScope(k),
+        scope,
         status: initialFieldStatus[k],
-        isPrimaryFile,
+        fieldSource:
+          scope === "book" ? bookFieldSource[k as BookFieldKey] : undefined,
       });
     }
     return out;
     // isDisabled is stable for the component's lifetime (closes over
     // disabledFieldsRaw which is derived from result.disabled_fields).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialFieldStatus, isPrimaryFile]);
+  }, [initialFieldStatus, bookFieldSource]);
 
   const [decisions, setDecisions] =
     useState<Record<FieldKey, boolean>>(initialDecisions);
@@ -888,7 +898,7 @@ export function IdentifyReviewForm({
       const desired = defaultDecision({
         scope: "file",
         status: initialFieldStatus.cover,
-        isPrimaryFile,
+        fieldSource: undefined,
       });
       setDecisions((prev) =>
         prev.cover === desired ? prev : { ...prev, cover: desired },
@@ -899,12 +909,7 @@ export function IdentifyReviewForm({
     // value at effect commit, which is what we want. Intentionally omitted
     // from deps to avoid re-running on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    hasCoverChoice,
-    initialFieldStatus.cover,
-    isPrimaryFile,
-    userCoverSelection,
-  ]);
+  }, [hasCoverChoice, initialFieldStatus.cover, userCoverSelection]);
 
   const setDecision = (k: FieldKey, v: boolean) => {
     if (isDisabled(k)) return;

--- a/app/components/library/identify-decisions.test.ts
+++ b/app/components/library/identify-decisions.test.ts
@@ -3,66 +3,163 @@ import { describe, expect, it } from "vitest";
 import { aggregateDecisions, defaultDecision } from "./identify-decisions";
 
 describe("defaultDecision", () => {
-  it("returns true for new book-level fields regardless of primary status", () => {
+  it("returns true for new book-level fields regardless of source", () => {
     expect(
-      defaultDecision({ scope: "book", status: "new", isPrimaryFile: false }),
+      defaultDecision({ scope: "book", status: "new", fieldSource: "manual" }),
     ).toBe(true);
-    expect(
-      defaultDecision({ scope: "book", status: "new", isPrimaryFile: true }),
-    ).toBe(true);
-  });
-
-  it("returns true for changed book-level fields on primary file", () => {
     expect(
       defaultDecision({
         scope: "book",
-        status: "changed",
-        isPrimaryFile: true,
+        status: "new",
+        fieldSource: "filepath",
       }),
     ).toBe(true);
-  });
-
-  it("returns false for changed book-level fields on non-primary file", () => {
     expect(
       defaultDecision({
         scope: "book",
-        status: "changed",
-        isPrimaryFile: false,
+        status: "new",
+        fieldSource: undefined,
       }),
-    ).toBe(false);
-  });
-
-  it("returns true for any non-unchanged file-level field", () => {
-    expect(
-      defaultDecision({ scope: "file", status: "new", isPrimaryFile: false }),
-    ).toBe(true);
-    expect(
-      defaultDecision({
-        scope: "file",
-        status: "changed",
-        isPrimaryFile: false,
-      }),
-    ).toBe(true);
-    expect(
-      defaultDecision({ scope: "file", status: "new", isPrimaryFile: true }),
     ).toBe(true);
   });
 
-  it("returns false for unchanged fields regardless of scope or primary", () => {
+  it("returns false for unchanged fields regardless of scope or source", () => {
     expect(
       defaultDecision({
         scope: "book",
         status: "unchanged",
-        isPrimaryFile: true,
+        fieldSource: "filepath",
       }),
     ).toBe(false);
     expect(
       defaultDecision({
         scope: "file",
         status: "unchanged",
-        isPrimaryFile: false,
+        fieldSource: undefined,
       }),
     ).toBe(false);
+  });
+
+  it("returns true for any non-unchanged file-level field regardless of source", () => {
+    expect(
+      defaultDecision({
+        scope: "file",
+        status: "new",
+        fieldSource: "manual",
+      }),
+    ).toBe(true);
+    expect(
+      defaultDecision({
+        scope: "file",
+        status: "changed",
+        fieldSource: "plugin",
+      }),
+    ).toBe(true);
+    expect(
+      defaultDecision({
+        scope: "file",
+        status: "changed",
+        fieldSource: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns ON for changed book-level fields with filepath source", () => {
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "filepath",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns ON for changed book-level fields with file metadata source", () => {
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "file_metadata",
+      }),
+    ).toBe(true);
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "epub_metadata",
+      }),
+    ).toBe(true);
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "cbz_metadata",
+      }),
+    ).toBe(true);
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "m4b_metadata",
+      }),
+    ).toBe(true);
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "pdf_metadata",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns OFF for changed book-level fields with manual source", () => {
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "manual",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns OFF for changed book-level fields with sidecar source", () => {
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "sidecar",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns OFF for changed book-level fields with plugin source", () => {
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "plugin",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns OFF for changed book-level fields with plugin-specific source", () => {
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: "plugin:shisho/goodreads-metadata",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns ON for changed book-level fields with missing/unknown source", () => {
+    expect(
+      defaultDecision({
+        scope: "book",
+        status: "changed",
+        fieldSource: undefined,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/app/components/library/identify-decisions.ts
+++ b/app/components/library/identify-decisions.ts
@@ -1,3 +1,8 @@
+import {
+  DataSourceFileMetadataPriority,
+  DataSourcePluginPrefix,
+} from "@/types";
+
 import type { FieldStatus } from "./identify-utils";
 
 export type FieldScope = "book" | "file";
@@ -5,7 +10,41 @@ export type FieldScope = "book" | "file";
 export interface FieldDecisionInput {
   scope: FieldScope;
   status: FieldStatus;
-  isPrimaryFile: boolean;
+  /** The data source of the field's current value (e.g. "manual", "filepath").
+   *  Used for book-level changed fields to decide whether the plugin value
+   *  should default ON (low-priority source) or OFF (high-priority source). */
+  fieldSource: string | undefined;
+}
+
+/** Source priority lookup matching the backend's `GetDataSourcePriority`.
+ *  Sources at or above `DataSourceFileMetadataPriority` (3) are considered
+ *  low-priority and the plugin's value should default ON. */
+const SOURCE_PRIORITY: Record<string, number> = {
+  manual: 0,
+  sidecar: 1,
+  plugin: 2,
+  file_metadata: 3,
+  existing_cover: 3,
+  epub_metadata: 3,
+  cbz_metadata: 3,
+  m4b_metadata: 3,
+  pdf_metadata: 3,
+  filepath: 4,
+};
+
+function getSourcePriority(source: string | undefined): number {
+  if (source == null) return DataSourceFileMetadataPriority;
+  const p = SOURCE_PRIORITY[source];
+  if (p != null) return p;
+  if (source.startsWith(DataSourcePluginPrefix)) return 2;
+  // Unknown source — treat as low-priority so the plugin value defaults ON.
+  return DataSourceFileMetadataPriority;
+}
+
+/** Whether a field's current source is low-priority (file metadata or filepath),
+ *  meaning the plugin's value should default ON for book-level changed fields. */
+function isLowPrioritySource(source: string | undefined): boolean {
+  return getSourcePriority(source) >= DataSourceFileMetadataPriority;
 }
 
 /** Default per-field checkbox state at dialog open.
@@ -13,20 +52,22 @@ export interface FieldDecisionInput {
  * - File-level fields: ON whenever there's something to apply (each file has
  *   its own copy, so applying the plugin's value carries no shared-data risk).
  * - Book-level new: ON (no current value to overwrite).
- * - Book-level changed: ON only on the primary file (avoids non-canonical
- *   files clobbering shared book metadata — the "second-identify" case).
+ * - Book-level changed: ON when the field's current value came from a
+ *   low-priority source (filepath or file metadata); OFF when it came from
+ *   a high-priority source (manual, sidecar, or plugin).
  * - Unchanged: OFF.
  *
  */
 export function defaultDecision({
   scope,
   status,
-  isPrimaryFile,
+  fieldSource,
 }: FieldDecisionInput): boolean {
   if (status === "unchanged") return false;
   if (scope === "file") return true;
   if (status === "new") return true;
-  return isPrimaryFile;
+  // Book-level changed: check source priority.
+  return isLowPrioritySource(fieldSource);
 }
 
 /** Combine child decisions into a section-level (or global) state.


### PR DESCRIPTION
Closes #291

## Summary

- Replaced the `isPrimaryFile` gate in `defaultDecision` with a `fieldSource` parameter that checks data source priority. Book-level changed fields from low-priority sources (filepath, file metadata) now default ON, while fields from high-priority sources (manual, sidecar, plugin) default OFF. Missing/unknown sources default ON.
- The `IdentifyReviewForm` component now reads each book field's `*_source` property from the book model and passes it to `defaultDecision`, removing the `isPrimaryFile` computation entirely.
- The `series` book field has no `series_source` column, so it maps to `undefined` which defaults ON (correct conservative behavior). The source priority lookup mirrors the backend's `GetDataSourcePriority` in `pkg/models/data-source.go`.

## Test plan

- Unit tests cover all source-priority combinations: filepath, file metadata (epub/cbz/m4b/pdf), manual, sidecar, plugin, plugin-specific, and missing/unknown sources
- Component tests verify book-changed fields default OFF with high-priority source and ON with low-priority source
- Component tests verify file-level fields default ON regardless of source
- TypeScript compiles cleanly