### PR TITLE
[Frontend] Remove primary file concept from frontend

### DIFF
--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -49,7 +49,7 @@ import {
 import { isBookNeedsReview } from "@/utils/book";
 import { isCoverLoaded, markCoverLoaded } from "@/utils/coverCache";
 import { getCoverFileType, selectCoverFile } from "@/utils/coverSelection";
-import { getPrimaryFileType } from "@/utils/primaryFile";
+import { hasAnyCBZFile } from "@/utils/hasAnyCBZFile";
 import { formatSeriesNumber } from "@/utils/seriesNumber";
 
 interface BookItemProps {
@@ -107,7 +107,7 @@ const BookItem = ({
     : undefined;
   const seriesNumber = seriesEntry?.series_number;
   const seriesNumberUnit = seriesEntry?.series_number_unit;
-  const primaryFileType = getPrimaryFileType(book);
+  const anyCBZ = hasAnyCBZFile(book);
 
   const aspectClass = getAspectRatioClass(coverAspectRatio, book.files);
   const coverUrl = cacheKey
@@ -306,7 +306,7 @@ const BookItem = ({
                   {formatSeriesNumber(
                     seriesNumber,
                     seriesNumberUnit,
-                    primaryFileType,
+                    anyCBZ ? "cbz" : null,
                   )}
                 </span>
               )}

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -65,7 +65,7 @@ import { cn, isPageBasedFileType } from "@/libraries/utils";
 import { AuthorRoleWriter, FileTypeCBZ, type Book, type File } from "@/types";
 import { AUTHOR_ROLES, getAuthorRoleLabel } from "@/utils/authorRoles";
 import { formatDuration, formatMetadataFieldLabel } from "@/utils/format";
-import { getPrimaryFileType } from "@/utils/primaryFile";
+import { hasAnyCBZFile } from "@/utils/hasAnyCBZFile";
 import { formatSeriesNumber } from "@/utils/seriesNumber";
 
 import {
@@ -424,7 +424,7 @@ export function IdentifyReviewForm({
   onHasChangesChange,
 }: IdentifyReviewFormProps) {
   const file = findFile(book, fileId);
-  const primaryFileType = getPrimaryFileType(book);
+  const anyCBZ = hasAnyCBZFile(book);
   const applyMutation = usePluginApply();
   const { data: pluginIdentifierTypes } = usePluginIdentifierTypes();
 
@@ -1437,7 +1437,7 @@ export function IdentifyReviewForm({
                             (s) =>
                               `${s.name}${
                                 s.number
-                                  ? ` ${formatSeriesNumber(parseFloat(s.number), s.unit || null, primaryFileType)}`
+                                  ? ` ${formatSeriesNumber(parseFloat(s.number), s.unit || null, anyCBZ ? "cbz" : null)}`
                                   : ""
                               }`,
                           )

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -75,13 +75,10 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
 
     for (const bookId of selectedBookIds) {
       const book = allBooks.find((b) => b.id === bookId);
-      if (!book?.primary_file_id) continue;
-      const primaryFile = book.files?.find(
-        (f) => f.id === book.primary_file_id,
-      );
-      if (primaryFile) {
-        fileIds.push(primaryFile.id);
-        totalSize += primaryFile.filesize_bytes ?? 0;
+      const firstMain = book?.files?.find((f) => f.file_role === "main");
+      if (firstMain) {
+        fileIds.push(firstMain.id);
+        totalSize += firstMain.filesize_bytes ?? 0;
       }
     }
 

--- a/app/components/library/identify-utils.test.ts
+++ b/app/components/library/identify-utils.test.ts
@@ -240,7 +240,6 @@ describe("pickInitialFile", () => {
   it("returns undefined when there are no main files", () => {
     const result = pickInitialFile({
       files: [file(1, { file_role: "supplement" })],
-      primary_file_id: undefined,
     } as unknown as Book);
     expect(result).toBeUndefined();
   });
@@ -251,37 +250,21 @@ describe("pickInitialFile", () => {
       file(2, { reviewed: false }),
       file(3, { reviewed: true }),
     ];
-    expect(
-      pickInitialFile({ files, primary_file_id: 1 } as unknown as Book)?.id,
-    ).toBe(2);
+    expect(pickInitialFile({ files } as unknown as Book)?.id).toBe(2);
   });
 
   it("treats reviewed=undefined as non-reviewed", () => {
     const files = [file(1, { reviewed: true }), file(2)];
-    expect(
-      pickInitialFile({ files, primary_file_id: 1 } as unknown as Book)?.id,
-    ).toBe(2);
+    expect(pickInitialFile({ files } as unknown as Book)?.id).toBe(2);
   });
 
-  it("prefers primary when all reviewed equal", () => {
+  it("falls back to first when all reviewed equal", () => {
     const files = [file(1), file(2), file(3)];
-    expect(
-      pickInitialFile({ files, primary_file_id: 2 } as unknown as Book)?.id,
-    ).toBe(2);
+    expect(pickInitialFile({ files } as unknown as Book)?.id).toBe(1);
   });
 
-  it("falls back to first when primary not set", () => {
+  it("falls back to first when all are reviewed", () => {
     const files = [file(10, { reviewed: true }), file(20, { reviewed: true })];
-    expect(
-      pickInitialFile({ files, primary_file_id: undefined } as unknown as Book)
-        ?.id,
-    ).toBe(10);
-  });
-
-  it("falls back to first when primary id does not match any main file", () => {
-    const files = [file(1), file(2)];
-    expect(
-      pickInitialFile({ files, primary_file_id: 99 } as unknown as Book)?.id,
-    ).toBe(1);
+    expect(pickInitialFile({ files } as unknown as Book)?.id).toBe(10);
   });
 });

--- a/app/components/library/identify-utils.ts
+++ b/app/components/library/identify-utils.ts
@@ -14,8 +14,7 @@ export interface IdentifierEntry {
  *
  * 1. If some main files are reviewed and others aren't, prefer a non-reviewed
  *    one (`reviewed !== true` covers both `false` and `undefined`).
- * 2. Otherwise prefer the book's primary file if set.
- * 3. Otherwise the first main file.
+ * 2. Otherwise the first main file.
  *
  * Returns `undefined` when there are no main files. */
 export function pickInitialFile(book: Book): File | undefined {
@@ -26,10 +25,6 @@ export function pickInitialFile(book: Book): File | undefined {
   if (hasReviewed && hasNonReviewed) {
     const nonReviewed = mains.find((f) => f.reviewed !== true);
     if (nonReviewed) return nonReviewed;
-  }
-  if (book.primary_file_id != null) {
-    const primary = mains.find((f) => f.id === book.primary_file_id);
-    if (primary) return primary;
   }
   return mains[0];
 }

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -12,7 +12,6 @@ import {
   MoreVertical,
   RefreshCw,
   Search,
-  Star,
   Trash2,
   X,
 } from "lucide-react";
@@ -67,7 +66,6 @@ import {
   useDeleteFile,
   useResyncBook,
   useResyncFile,
-  useSetPrimaryFile,
 } from "@/hooks/queries/books";
 import { useLibrary } from "@/hooks/queries/libraries";
 import { usePluginIdentifierTypes } from "@/hooks/queries/plugins";
@@ -94,8 +92,8 @@ import {
   formatIdentifierType,
   getFilename,
 } from "@/utils/format";
+import { hasAnyCBZFile } from "@/utils/hasAnyCBZFile";
 import { getIdentifierUrl } from "@/utils/identifiers";
-import { getPrimaryFileType } from "@/utils/primaryFile";
 import { formatSeriesNumber } from "@/utils/seriesNumber";
 
 interface DownloadError {
@@ -132,10 +130,6 @@ interface FileRowProps {
   cacheKey?: number;
   onDeleteFile: () => void;
   isDeletingFile: boolean;
-  isPrimary?: boolean;
-  showPrimaryBadge?: boolean;
-  onSetPrimary?: () => void;
-  isSettingPrimary?: boolean;
 }
 
 const FileRow = ({
@@ -162,10 +156,6 @@ const FileRow = ({
   cacheKey,
   onDeleteFile,
   isDeletingFile,
-  isPrimary = false,
-  showPrimaryBadge = false,
-  onSetPrimary,
-  isSettingPrimary = false,
 }: FileRowProps) => {
   const showChevron = hasExpandableMetadata && !isSupplement;
   const { data: pluginIdentifierTypes } = usePluginIdentifierTypes();
@@ -222,7 +212,7 @@ const FileRow = ({
 
       {/* Content area */}
       <div className="flex-1 min-w-0 space-y-1">
-        {/* Primary row: badge, name, stats, actions */}
+        {/* Main row: badge, name, stats, actions */}
         <div className="flex items-center gap-2">
           {/* File type badge */}
           <Badge
@@ -240,14 +230,6 @@ const FileRow = ({
           >
             {file.name || getFilename(file.filepath)}
           </Link>
-
-          {/* Primary badge */}
-          {showPrimaryBadge && isPrimary && (
-            <span className="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-500">
-              <Star className="h-3 w-3 fill-current" />
-              Primary
-            </span>
-          )}
 
           {/* Stats and actions - desktop only (inline) */}
           <div className="hidden md:flex items-center gap-3 text-xs text-muted-foreground shrink-0">
@@ -378,18 +360,6 @@ const FileRow = ({
                   <RefreshCw className="h-4 w-4 mr-2" />
                   Rescan file
                 </DropdownMenuItem>
-                {onSetPrimary && !isPrimary && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      disabled={isSettingPrimary}
-                      onClick={onSetPrimary}
-                    >
-                      <Star className="h-4 w-4 mr-2" />
-                      Set as primary
-                    </DropdownMenuItem>
-                  </>
-                )}
                 {onMoveFile && (
                   <>
                     <DropdownMenuSeparator />
@@ -535,18 +505,6 @@ const FileRow = ({
                 <RefreshCw className="h-4 w-4 mr-2" />
                 Rescan file
               </DropdownMenuItem>
-              {onSetPrimary && !isPrimary && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    disabled={isSettingPrimary}
-                    onClick={onSetPrimary}
-                  >
-                    <Star className="h-4 w-4 mr-2" />
-                    Set as primary
-                  </DropdownMenuItem>
-                </>
-              )}
               <DropdownMenuItem
                 className="text-destructive focus:text-destructive"
                 disabled={isDeletingFile}
@@ -708,7 +666,6 @@ const BookDetail = () => {
   const resyncBookMutation = useResyncBook();
   const deleteBookMutation = useDeleteBook();
   const deleteFileMutation = useDeleteFile();
-  const setPrimaryFileMutation = useSetPrimaryFile();
   const setBookReviewMutation = useSetBookReview();
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [addToListOpen, setAddToListOpen] = useState(false);
@@ -976,22 +933,6 @@ const BookDetail = () => {
     }
   };
 
-  const handleSetPrimaryFile = (fileId: number) => {
-    const book = bookQuery.data;
-    if (!book) return;
-    setPrimaryFileMutation.mutate(
-      { bookId: book.id, fileId },
-      {
-        onSuccess: () => {
-          toast.success("Primary file updated");
-        },
-        onError: (error) => {
-          toast.error(error.message || "Failed to set primary file");
-        },
-      },
-    );
-  };
-
   if (bookQuery.isLoading) {
     return (
       <LibraryLayout>
@@ -1015,8 +956,8 @@ const BookDetail = () => {
 
   const book = bookQuery.data;
 
-  // Determine primary file type for series number display
-  const primaryFileType = getPrimaryFileType(book);
+  // Check if any file is CBZ for series number display formatting
+  const anyCBZ = hasAnyCBZFile(book);
 
   // Separate main files and supplements
   const mainFiles =
@@ -1249,7 +1190,7 @@ const BookDetail = () => {
                           {formatSeriesNumber(
                             bs.series_number,
                             bs.series_number_unit,
-                            primaryFileType,
+                            anyCBZ ? "cbz" : null,
                           )}
                         </Badge>
                       )}
@@ -1375,10 +1316,8 @@ const BookDetail = () => {
                     isDownloading={downloadingFileId === file.id}
                     isExpanded={expandedFileIds.has(file.id)}
                     isFileSelected={selectedFileIds.has(file.id)}
-                    isPrimary={book.primary_file_id === file.id}
                     isResyncing={resyncingFileId === file.id}
                     isSelectMode={isFileSelectMode}
-                    isSettingPrimary={setPrimaryFileMutation.isPending}
                     key={file.id}
                     libraryDownloadPreference={
                       libraryQuery.data?.download_format_preference
@@ -1395,14 +1334,8 @@ const BookDetail = () => {
                     onEdit={() => setEditingFile(file)}
                     onMoveFile={() => setSingleFileMoveId(file.id)}
                     onRescan={() => setRescanFileId(file.id)}
-                    onSetPrimary={
-                      mainFiles.length > 1
-                        ? () => handleSetPrimaryFile(file.id)
-                        : undefined
-                    }
                     onToggleExpand={() => toggleFileExpanded(file.id)}
                     onToggleSelect={() => toggleFileSelection(file.id)}
-                    showPrimaryBadge={mainFiles.length > 1}
                   />
                 ))}
               </div>

--- a/app/hooks/queries/books.ts
+++ b/app/hooks/queries/books.ts
@@ -300,28 +300,4 @@ export const useDeleteBooks = () => {
   });
 };
 
-interface SetPrimaryFileMutationVariables {
-  bookId: number;
-  fileId: number;
-}
-
-export const useSetPrimaryFile = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation<Book, ShishoAPIError, SetPrimaryFileMutationVariables>({
-    mutationFn: ({ bookId, fileId }) => {
-      return API.request(
-        "PUT",
-        `/books/${bookId}/primary-file`,
-        { file_id: fileId },
-        null,
-      );
-    },
-    onSuccess: (data: Book) => {
-      queryClient.invalidateQueries({ queryKey: [QueryKey.ListBooks] });
-      queryClient.setQueryData([QueryKey.RetrieveBook, String(data.id)], data);
-    },
-  });
-};
-
 export * from "./resync";

--- a/app/utils/hasAnyCBZFile.test.ts
+++ b/app/utils/hasAnyCBZFile.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type { Book } from "@/types";
+
+import { hasAnyCBZFile } from "./hasAnyCBZFile";
+
+function makeBook(overrides: Partial<Book> = {}): Book {
+  return {
+    id: 1,
+    title: "Test",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    library_id: 1,
+    ...overrides,
+  } as Book;
+}
+
+describe("hasAnyCBZFile", () => {
+  it("returns true when at least one file is CBZ", () => {
+    const book = makeBook({
+      files: [
+        { id: 1, file_type: "epub" } as never,
+        { id: 2, file_type: "cbz" } as never,
+      ],
+    });
+    expect(hasAnyCBZFile(book)).toBe(true);
+  });
+
+  it("returns false when no files are CBZ", () => {
+    const book = makeBook({
+      files: [
+        { id: 1, file_type: "epub" } as never,
+        { id: 2, file_type: "m4b" } as never,
+      ],
+    });
+    expect(hasAnyCBZFile(book)).toBe(false);
+  });
+
+  it("returns false when book has no files", () => {
+    const book = makeBook({ files: [] });
+    expect(hasAnyCBZFile(book)).toBe(false);
+  });
+
+  it("returns false when files is undefined", () => {
+    const book = makeBook({ files: undefined });
+    expect(hasAnyCBZFile(book)).toBe(false);
+  });
+
+  it("returns true when all files are CBZ", () => {
+    const book = makeBook({
+      files: [
+        { id: 1, file_type: "cbz" } as never,
+        { id: 2, file_type: "cbz" } as never,
+      ],
+    });
+    expect(hasAnyCBZFile(book)).toBe(true);
+  });
+});

--- a/app/utils/hasAnyCBZFile.ts
+++ b/app/utils/hasAnyCBZFile.ts
@@ -1,0 +1,10 @@
+import { FileTypeCBZ, type Book } from "@/types";
+
+/**
+ * Returns true if the book has at least one file with file_type "cbz".
+ * Used to determine whether series numbers should use CBZ formatting
+ * (e.g., "Vol. 5", "Ch. 42") instead of bare numbers.
+ */
+export function hasAnyCBZFile(book: Book): boolean {
+  return book.files?.some((f) => f.file_type === FileTypeCBZ) ?? false;
+}

--- a/app/utils/primaryFile.ts
+++ b/app/utils/primaryFile.ts
@@ -1,9 +1,0 @@
-import type { Book } from "@/types";
-
-export function getPrimaryFileType(book: Book): string | null {
-  const primary =
-    (book.primary_file_id != null
-      ? book.files?.find((f) => f.id === book.primary_file_id)
-      : null) ?? book.files?.[0];
-  return primary?.file_type ?? null;
-}


### PR DESCRIPTION
Closes #290

## Summary
- Replaced `getPrimaryFileType` with `hasAnyCBZFile` — a new utility that checks if any file on a book is CBZ, used to determine series number formatting ("Vol. 5" / "Ch. 42")
- Removed the "Primary" badge from file list items, the "Set as primary" context menu option, the `useSetPrimaryFile` mutation hook, and deleted `app/utils/primaryFile.ts`
- Updated `pickInitialFile` to fall back to the first main file instead of preferring the primary file, and `SelectionToolbar` bulk download to use the first main file instead of the primary file

## Notes
- The `isPrimaryFile` variable name persists in `identify-decisions.ts` and `IdentifyReviewForm.tsx`, but its meaning has shifted from "is this the book's designated primary file" to "is this a single-main-file book". No code reads `book.primary_file_id` anymore.
- The `primary_file_id` field remains in the generated TypeScript types (from the Go backend), which is expected since the backend still returns it during the transition period per the issue description.

## Test plan
- hasAnyCBZFile returns true when at least one file is CBZ, false when none are CBZ, files are empty, or undefined
- pickInitialFile falls back to first main file when all reviewed states are equal
- Book-changed fields default OFF when book has multiple main files, ON when single main file
- File-level fields default ON regardless of main file count