### PR TITLE
[Feature] Show all main files on eReader book download page

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -83,7 +83,7 @@ Each book has an optional `PrimaryFileID` (`*int`) that designates which file is
 - `pkg/books/service.go` — Auto-promotion in `CreateFile` and `DeleteFile`
 - `pkg/books/merge.go` — Primary file handling during `MoveFilesToBook`
 - `pkg/kobo/service.go` — Syncs all Kobo-compatible main files (EPUB, CBZ) per book, not just the primary
-- `pkg/ereader/handlers.go` — Uses `PrimaryFileID` to select the default download file
+- `pkg/ereader/handlers.go` — Download page lists all main files; `getBookFileType` uses first main file for type filtering
 
 ### Cover Image System
 

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -576,35 +576,20 @@ func (h *handler) Download(c echo.Context) error {
 		return errcodes.Forbidden("Access to this book is denied")
 	}
 
-	// Get the primary file from the book's files
-	var mainFile *models.File
+	// Collect main files (exclude supplements)
+	var mainFiles []*models.File
 	for _, f := range book.Files {
-		if book.PrimaryFileID != nil && f.ID == *book.PrimaryFileID {
-			mainFile = f
-			break
+		if f.FileRole == models.FileRoleMain {
+			mainFiles = append(mainFiles, f)
 		}
 	}
-	if mainFile == nil && len(book.Files) > 0 {
-		mainFile = book.Files[0] // Fallback to first file if no primary set
-	}
-	if mainFile == nil {
+	if len(mainFiles) == 0 {
 		return errcodes.NotFound("No files available for this book")
 	}
 
 	// Detect Kobo device from User-Agent
 	userAgent := c.Request().Header.Get("User-Agent")
 	isKobo := strings.Contains(strings.ToLower(userAgent), "kobo")
-
-	// Generate download link using eReader file download route (with API key auth)
-	var downloadURL string
-	supportsKepub := mainFile.FileType == models.FileTypeEPUB || mainFile.FileType == models.FileTypeCBZ
-	if isKobo && supportsKepub {
-		// Use KePub conversion for Kobo
-		downloadURL = fmt.Sprintf("%s/file/%d/kepub", baseURL, mainFile.ID)
-	} else {
-		// Use original file
-		downloadURL = fmt.Sprintf("%s/file/%d", baseURL, mainFile.ID)
-	}
 
 	var content strings.Builder
 	content.WriteString(navBar(baseURL + "/"))
@@ -635,55 +620,13 @@ func (h *handler) Download(c echo.Context) error {
 		}
 	}
 
-	// Show file metadata
-	var metaParts []string
-
-	// File size
-	if mainFile.FilesizeBytes > 0 {
-		metaParts = append(metaParts, formatFileSize(mainFile.FilesizeBytes))
-	}
-
-	// Page count (CBZ)
-	if mainFile.PageCount != nil && *mainFile.PageCount > 0 {
-		metaParts = append(metaParts, fmt.Sprintf("%d pages", *mainFile.PageCount))
-	}
-
-	// Duration (M4B audiobooks)
-	if mainFile.AudiobookDurationSeconds != nil && *mainFile.AudiobookDurationSeconds > 0 {
-		metaParts = append(metaParts, formatDuration(*mainFile.AudiobookDurationSeconds))
-	}
-
-	// Narrators (M4B audiobooks)
-	if len(mainFile.Narrators) > 0 {
-		var narratorNames []string
-		for _, n := range mainFile.Narrators {
-			if n.Person != nil {
-				narratorNames = append(narratorNames, n.Person.Name)
-			}
-		}
-		if len(narratorNames) > 0 {
-			metaParts = append(metaParts, "Narrated by: "+strings.Join(narratorNames, ", "))
-		}
-	}
-
-	if len(metaParts) > 0 {
-		content.WriteString(fmt.Sprintf("<p><i>%s</i></p>", strings.Join(metaParts, " • ")))
-	}
-
 	if book.Description != nil && *book.Description != "" {
 		content.WriteString(fmt.Sprintf("<p>%s</p>", *book.Description))
 	}
 
-	// Show appropriate format in download link (button style for easier tapping)
-	downloadFormat := strings.ToUpper(mainFile.FileType)
-	if isKobo && supportsKepub {
-		downloadFormat = "KePub"
-	}
-	content.WriteString(fmt.Sprintf(`<p><a href="%s" class="nav-btn" style="display: inline-block;">Download %s</a></p>`, downloadURL, downloadFormat))
-
-	// Note for CBZ files about conversion time
-	if mainFile.FileType == models.FileTypeCBZ {
-		content.WriteString(`<p style="font-size: 0.9em; color: #666;"><i>Note: The download may take a moment to start while the file is being prepared.</i></p>`)
+	// Render a download entry for each main file
+	for _, f := range mainFiles {
+		content.WriteString(fileDownloadEntry(baseURL, book.Title, f, isKobo))
 	}
 
 	return c.HTML(http.StatusOK, RenderPage(content.String()))
@@ -961,30 +904,57 @@ func formatFileSize(bytes int64) string {
 	}
 }
 
-// formatDuration formats seconds into hours and minutes.
-func formatDuration(seconds float64) string {
-	totalMinutes := int(seconds / 60)
-	hours := totalMinutes / 60
-	minutes := totalMinutes % 60
-	if hours > 0 {
-		return fmt.Sprintf("%dh %dm", hours, minutes)
-	}
-	return fmt.Sprintf("%dm", minutes)
-}
-
-// getBookFileType returns the primary file type for a book.
+// getBookFileType returns the file type of the first main file for a book.
+// Supplement files are skipped. Returns empty string if no main files exist.
 func getBookFileType(book *models.Book) string {
-	if book.PrimaryFileID != nil {
-		for _, f := range book.Files {
-			if f.ID == *book.PrimaryFileID {
-				return f.FileType
-			}
+	for _, f := range book.Files {
+		if f.FileRole == models.FileRoleMain {
+			return f.FileType
 		}
 	}
-	if len(book.Files) > 0 {
-		return book.Files[0].FileType
-	}
 	return ""
+}
+
+// fileDownloadEntry renders a single file's download block with file name,
+// type badge, file size, and download link. Uses block-level elements with
+// large tap targets for eReader compatibility (no flexbox).
+func fileDownloadEntry(baseURL, bookTitle string, f *models.File, isKobo bool) string {
+	// Determine display name: file name if set, otherwise book title
+	displayName := bookTitle
+	if f.Name != nil && *f.Name != "" {
+		displayName = *f.Name
+	}
+
+	// Build download URL (KePub for Kobo when applicable)
+	supportsKepub := f.FileType == models.FileTypeEPUB || f.FileType == models.FileTypeCBZ
+	var downloadURL string
+	if isKobo && supportsKepub {
+		downloadURL = fmt.Sprintf("%s/file/%d/kepub", baseURL, f.ID)
+	} else {
+		downloadURL = fmt.Sprintf("%s/file/%d", baseURL, f.ID)
+	}
+
+	// Format label
+	downloadFormat := strings.ToUpper(f.FileType)
+	if isKobo && supportsKepub {
+		downloadFormat = "KePub"
+	}
+
+	// Build metadata line: type badge + file size
+	var metaParts []string
+	metaParts = append(metaParts, strings.ToUpper(f.FileType))
+	if f.FilesizeBytes > 0 {
+		metaParts = append(metaParts, formatFileSize(f.FilesizeBytes))
+	}
+
+	var sb strings.Builder
+	sb.WriteString(`<div style="padding: 12px 0; border-bottom: 1px solid #ccc;">`)
+	sb.WriteString(fmt.Sprintf(`<div style="font-weight: bold;">%s</div>`, displayName))
+	sb.WriteString(fmt.Sprintf(`<div style="font-size: 0.9em; color: #666; margin: 4px 0;">%s</div>`, strings.Join(metaParts, " • ")))
+	sb.WriteString(fmt.Sprintf(`<a href="%s" class="nav-btn" style="display: inline-block; margin-top: 8px;">Download %s</a>`, downloadURL, downloadFormat))
+	sb.WriteString(`</div>`)
+
+	return sb.String()
 }
 
 // filterBooksByType filters books to only include those matching the specified type.

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -952,6 +952,9 @@ func fileDownloadEntry(baseURL, bookTitle string, f *models.File, isKobo bool) s
 	sb.WriteString(fmt.Sprintf(`<div style="font-weight: bold;">%s</div>`, displayName))
 	sb.WriteString(fmt.Sprintf(`<div style="font-size: 0.9em; color: #666; margin: 4px 0;">%s</div>`, strings.Join(metaParts, " • ")))
 	sb.WriteString(fmt.Sprintf(`<a href="%s" class="nav-btn" style="display: inline-block; margin-top: 8px;">Download %s</a>`, downloadURL, downloadFormat))
+	if f.FileType == models.FileTypeCBZ {
+		sb.WriteString(`<div style="font-size: 0.9em; color: #666; margin-top: 4px;"><i>Note: The download may take a moment while the file is being prepared.</i></div>`)
+	}
 	sb.WriteString(`</div>`)
 
 	return sb.String()

--- a/pkg/ereader/handlers_download_test.go
+++ b/pkg/ereader/handlers_download_test.go
@@ -1,0 +1,507 @@
+package ereader
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/apikeys"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/libraries"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetBookFileType_UsesFirstMainFile confirms that getBookFileType
+// returns the type of the first main file (by order in the slice),
+// ignoring PrimaryFileID and supplement files.
+func TestGetBookFileType_UsesFirstMainFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		book *models.Book
+		want string
+	}{
+		{
+			name: "single main file",
+			book: &models.Book{
+				Files: []*models.File{
+					{ID: 1, FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain},
+				},
+			},
+			want: models.FileTypeEPUB,
+		},
+		{
+			name: "multiple main files returns first",
+			book: &models.Book{
+				Files: []*models.File{
+					{ID: 1, FileType: models.FileTypeCBZ, FileRole: models.FileRoleMain},
+					{ID: 2, FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain},
+				},
+			},
+			want: models.FileTypeCBZ,
+		},
+		{
+			name: "skips supplement files",
+			book: &models.Book{
+				Files: []*models.File{
+					{ID: 1, FileType: models.FileTypePDF, FileRole: models.FileRoleSupplement},
+					{ID: 2, FileType: models.FileTypeM4B, FileRole: models.FileRoleMain},
+				},
+			},
+			want: models.FileTypeM4B,
+		},
+		{
+			name: "ignores PrimaryFileID",
+			book: &models.Book{
+				PrimaryFileID: intPtr(2),
+				Files: []*models.File{
+					{ID: 1, FileType: models.FileTypeCBZ, FileRole: models.FileRoleMain},
+					{ID: 2, FileType: models.FileTypeEPUB, FileRole: models.FileRoleMain},
+				},
+			},
+			want: models.FileTypeCBZ,
+		},
+		{
+			name: "no files returns empty",
+			book: &models.Book{
+				Files: []*models.File{},
+			},
+			want: "",
+		},
+		{
+			name: "only supplement files returns empty",
+			book: &models.Book{
+				Files: []*models.File{
+					{ID: 1, FileType: models.FileTypePDF, FileRole: models.FileRoleSupplement},
+				},
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, getBookFileType(tc.book))
+		})
+	}
+}
+
+// TestDownload_ShowsAllMainFiles confirms the Download handler renders
+// a download link for each main file and excludes supplement files.
+func TestDownload_ShowsAllMainFiles(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+
+	// Create admin user
+	var roleID int
+	err := db.QueryRow("SELECT id FROM roles WHERE name = 'admin'").Scan(&roleID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO users (username, password_hash, role_id, is_active) VALUES (?, ?, ?, ?)",
+		"download_test_user", "hash", roleID, true)
+	require.NoError(t, err)
+
+	var userID int
+	err = db.QueryRow("SELECT id FROM users WHERE username = 'download_test_user'").Scan(&userID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO user_library_access (user_id, library_id) VALUES (?, NULL)", userID)
+	require.NoError(t, err)
+
+	apiKeyService := apikeys.NewService(db)
+	apiKey, err := apiKeyService.Create(ctx, userID, "Test Key")
+	require.NoError(t, err)
+
+	libraryService := libraries.NewService(db)
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	require.NoError(t, libraryService.CreateLibrary(ctx, library))
+
+	bookDir := filepath.Join(t.TempDir(), "Test Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	bookService := books.NewService(db)
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "My Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "My Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create three files: EPUB (main), M4B (main), PDF (supplement)
+	epubFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath.Join(bookDir, "my-book.epub"),
+		FilesizeBytes: 1024 * 1024, // 1 MB
+	}
+	_, err = db.NewInsert().Model(epubFile).Exec(ctx)
+	require.NoError(t, err)
+
+	m4bFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeM4B,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath.Join(bookDir, "my-book.m4b"),
+		FilesizeBytes: 50 * 1024 * 1024, // 50 MB
+	}
+	_, err = db.NewInsert().Model(m4bFile).Exec(ctx)
+	require.NoError(t, err)
+
+	supplementFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypePDF,
+		FileRole:      models.FileRoleSupplement,
+		Filepath:      filepath.Join(bookDir, "supplement.pdf"),
+		FilesizeBytes: 512 * 1024, // 512 KB
+	}
+	_, err = db.NewInsert().Model(supplementFile).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		db:             db,
+		bookService:    bookService,
+		libraryService: libraryService,
+	}
+
+	apiKeyCtx := context.WithValue(ctx, contextKeyAPIKey, apiKey)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(apiKeyCtx)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("apiKey", "bookId")
+	c.SetParamValues(apiKey.Key, strconv.Itoa(book.ID))
+
+	require.NoError(t, h.Download(c))
+
+	body := rec.Body.String()
+
+	// Should show download links for both main files
+	assert.Contains(t, body, "EPUB", "page shows EPUB type badge")
+	assert.Contains(t, body, "M4B", "page shows M4B type badge")
+
+	// Should have download links for each file
+	assert.Contains(t, body, "/file/"+strconv.Itoa(epubFile.ID), "page has EPUB download link")
+	assert.Contains(t, body, "/file/"+strconv.Itoa(m4bFile.ID), "page has M4B download link")
+
+	// Should NOT show the supplement file
+	assert.NotContains(t, body, "/file/"+strconv.Itoa(supplementFile.ID), "supplement file is excluded")
+
+	// File sizes should be shown
+	assert.Contains(t, body, "1.0 MB", "EPUB file size shown")
+	assert.Contains(t, body, "50.0 MB", "M4B file size shown")
+}
+
+// TestDownload_SingleFileStillWorks confirms that a book with a single
+// main file renders normally with its download link.
+func TestDownload_SingleFileStillWorks(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+
+	var roleID int
+	err := db.QueryRow("SELECT id FROM roles WHERE name = 'admin'").Scan(&roleID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO users (username, password_hash, role_id, is_active) VALUES (?, ?, ?, ?)",
+		"single_file_user", "hash", roleID, true)
+	require.NoError(t, err)
+
+	var userID int
+	err = db.QueryRow("SELECT id FROM users WHERE username = 'single_file_user'").Scan(&userID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO user_library_access (user_id, library_id) VALUES (?, NULL)", userID)
+	require.NoError(t, err)
+
+	apiKeyService := apikeys.NewService(db)
+	apiKey, err := apiKeyService.Create(ctx, userID, "Test Key")
+	require.NoError(t, err)
+
+	libraryService := libraries.NewService(db)
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	require.NoError(t, libraryService.CreateLibrary(ctx, library))
+
+	bookDir := filepath.Join(t.TempDir(), "Single File Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	bookService := books.NewService(db)
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Single File Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Single File Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	epubFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath.Join(bookDir, "book.epub"),
+		FilesizeBytes: 2 * 1024 * 1024,
+	}
+	_, err = db.NewInsert().Model(epubFile).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		db:             db,
+		bookService:    bookService,
+		libraryService: libraryService,
+	}
+
+	apiKeyCtx := context.WithValue(ctx, contextKeyAPIKey, apiKey)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(apiKeyCtx)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("apiKey", "bookId")
+	c.SetParamValues(apiKey.Key, strconv.Itoa(book.ID))
+
+	require.NoError(t, h.Download(c))
+
+	body := rec.Body.String()
+
+	// Should show the file's download link
+	assert.Contains(t, body, "/file/"+strconv.Itoa(epubFile.ID), "single file has download link")
+	assert.Contains(t, body, "EPUB", "shows file type")
+	assert.Contains(t, body, "2.0 MB", "shows file size")
+}
+
+// TestDownload_KoboGetsKepubLinksForEpubAndCbz confirms that Kobo
+// devices see KePub download links for EPUB and CBZ files, but regular
+// links for other file types.
+func TestDownload_KoboGetsKepubLinksForEpubAndCbz(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+
+	var roleID int
+	err := db.QueryRow("SELECT id FROM roles WHERE name = 'admin'").Scan(&roleID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO users (username, password_hash, role_id, is_active) VALUES (?, ?, ?, ?)",
+		"kobo_test_user", "hash", roleID, true)
+	require.NoError(t, err)
+
+	var userID int
+	err = db.QueryRow("SELECT id FROM users WHERE username = 'kobo_test_user'").Scan(&userID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO user_library_access (user_id, library_id) VALUES (?, NULL)", userID)
+	require.NoError(t, err)
+
+	apiKeyService := apikeys.NewService(db)
+	apiKey, err := apiKeyService.Create(ctx, userID, "Test Key")
+	require.NoError(t, err)
+
+	libraryService := libraries.NewService(db)
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	require.NoError(t, libraryService.CreateLibrary(ctx, library))
+
+	bookDir := filepath.Join(t.TempDir(), "Kobo Book")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	bookService := books.NewService(db)
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Kobo Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Kobo Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	epubFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath.Join(bookDir, "book.epub"),
+		FilesizeBytes: 1024,
+	}
+	_, err = db.NewInsert().Model(epubFile).Exec(ctx)
+	require.NoError(t, err)
+
+	m4bFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeM4B,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath.Join(bookDir, "book.m4b"),
+		FilesizeBytes: 1024,
+	}
+	_, err = db.NewInsert().Model(m4bFile).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		db:             db,
+		bookService:    bookService,
+		libraryService: libraryService,
+	}
+
+	apiKeyCtx := context.WithValue(ctx, contextKeyAPIKey, apiKey)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Linux; U; Android 2.0; Kobo Touch)")
+	req = req.WithContext(apiKeyCtx)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("apiKey", "bookId")
+	c.SetParamValues(apiKey.Key, strconv.Itoa(book.ID))
+
+	require.NoError(t, h.Download(c))
+
+	body := rec.Body.String()
+
+	// EPUB should get /kepub link on Kobo
+	assert.Contains(t, body, "/file/"+strconv.Itoa(epubFile.ID)+"/kepub", "EPUB gets KePub link on Kobo")
+	// M4B should NOT get /kepub link (not a supported kepub format)
+	assert.NotContains(t, body, "/file/"+strconv.Itoa(m4bFile.ID)+"/kepub", "M4B does not get KePub link")
+	assert.Contains(t, body, "/file/"+strconv.Itoa(m4bFile.ID), "M4B still gets a regular download link")
+}
+
+// TestDownload_ShowsFileNames confirms the Download handler shows file
+// names (falling back to book title when file has no name).
+func TestDownload_ShowsFileNames(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+	e := echo.New()
+
+	var roleID int
+	err := db.QueryRow("SELECT id FROM roles WHERE name = 'admin'").Scan(&roleID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO users (username, password_hash, role_id, is_active) VALUES (?, ?, ?, ?)",
+		"filename_test_user", "hash", roleID, true)
+	require.NoError(t, err)
+
+	var userID int
+	err = db.QueryRow("SELECT id FROM users WHERE username = 'filename_test_user'").Scan(&userID)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, "INSERT INTO user_library_access (user_id, library_id) VALUES (?, NULL)", userID)
+	require.NoError(t, err)
+
+	apiKeyService := apikeys.NewService(db)
+	apiKey, err := apiKeyService.Create(ctx, userID, "Test Key")
+	require.NoError(t, err)
+
+	libraryService := libraries.NewService(db)
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	require.NoError(t, libraryService.CreateLibrary(ctx, library))
+
+	bookDir := filepath.Join(t.TempDir(), "Named Files")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+
+	bookService := books.NewService(db)
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "The Book Title",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book Title, The",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        bookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	// File with a custom name
+	fileName := "Abridged Edition"
+	namedFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath.Join(bookDir, "abridged.epub"),
+		FilesizeBytes: 1024,
+		Name:          &fileName,
+	}
+	_, err = db.NewInsert().Model(namedFile).Exec(ctx)
+	require.NoError(t, err)
+
+	// File without a name (should fall back to book title)
+	unnamedFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeM4B,
+		FileRole:      models.FileRoleMain,
+		Filepath:      filepath.Join(bookDir, "unnamed.m4b"),
+		FilesizeBytes: 1024,
+	}
+	_, err = db.NewInsert().Model(unnamedFile).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		db:             db,
+		bookService:    bookService,
+		libraryService: libraryService,
+	}
+
+	apiKeyCtx := context.WithValue(ctx, contextKeyAPIKey, apiKey)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(apiKeyCtx)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("apiKey", "bookId")
+	c.SetParamValues(apiKey.Key, strconv.Itoa(book.ID))
+
+	require.NoError(t, h.Download(c))
+
+	body := rec.Body.String()
+
+	// The named file shows its custom name
+	assert.Contains(t, body, "Abridged Edition", "named file shows its name")
+	// The unnamed file falls back to book title
+	assert.Contains(t, body, "The Book Title", "unnamed file falls back to book title")
+}

--- a/website/docs/advanced/primary-file.md
+++ b/website/docs/advanced/primary-file.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Primary File
 
-When a book has multiple files — for example, an EPUB and a PDF, or multiple EPUB editions — Shisho designates one as the **primary file**. The primary file is the one used for downloads from the eReader browser.
+When a book has multiple files — for example, an EPUB and a PDF, or multiple EPUB editions — Shisho designates one as the **primary file**. The primary file is the one used for syncing to devices via Kobo sync.
 
 ## Why It Matters
 
@@ -34,4 +34,4 @@ The primary file is indicated with a star badge next to its name. This badge onl
 | Feature | Behavior |
 |---------|----------|
 | **Kobo sync** | All Kobo-compatible files (EPUB, CBZ) are synced — the primary file is not used |
-| **eReader browser** | The primary file is used for downloads and determining the book's file type |
+| **eReader browser** | All main files are shown on the download page; the primary file is not referenced |


### PR DESCRIPTION
Closes #294

## Summary
- Updated the eReader browser's book download page to show all main files for a book instead of a single primary file. Each file gets its own download entry with file name (or book title fallback), type badge, file size, and download link with Kobo KePub conversion when applicable.
- Updated `getBookFileType` to use the first main file's type instead of referencing `PrimaryFileID`, and removed the now-unused `formatDuration` helper.
- The old Download handler showed a single file (primary or fallback to first) with detailed metadata (page count, duration, narrators). The new handler shows all main files but with a slimmer per-file display (name, type badge, size, download link) as specified in the issue. Duration and narrator info could be a follow-up if desired.
- `getBookFileTypes` (plural, used in book list page) still shows all file types including supplements. This is intentional -- the issue only called out `getBookFileType` (singular).
- HTML uses inline styles and block-level elements only -- no flexbox, large 12px+ padding tap targets, compatible with Kobo/Kindle stock browsers.

## Test plan
- `getBookFileType` uses first main file, skips supplements, ignores PrimaryFileID (TestGetBookFileType_UsesFirstMainFile)
- Download page shows all main files and excludes supplements (TestDownload_ShowsAllMainFiles)
- Single-file books still render normally (TestDownload_SingleFileStillWorks)
- Kobo devices get KePub links only for EPUB/CBZ files (TestDownload_KoboGetsKepubLinksForEpubAndCbz)
- File names shown when set, book title used as fallback (TestDownload_ShowsFileNames)