### PR TITLE
[Backend] Remove primary-file metadata priority from OPDS entries

### DIFF
--- a/pkg/opds/service.go
+++ b/pkg/opds/service.go
@@ -736,8 +736,8 @@ func (svc *Service) bookToEntryWithKepub(baseURL string, book *models.Book, cove
 	}
 
 	// Dublin Core metadata. OPDS entries are per-book but language/publisher
-	// are file-level in our model. Use the first main file (by ID) that
-	// has a non-empty value for each field.
+	// are file-level in our model. Use the first main file (ordered by
+	// file_type via the query) that has a non-empty value for each field.
 	// Supplements don't represent the book — exclude them from the
 	// priority chain so a stray supplement-level Language or Publisher
 	// can't leak into the OPDS entry's book-level metadata.

--- a/pkg/opds/service.go
+++ b/pkg/opds/service.go
@@ -736,31 +736,15 @@ func (svc *Service) bookToEntryWithKepub(baseURL string, book *models.Book, cove
 	}
 
 	// Dublin Core metadata. OPDS entries are per-book but language/publisher
-	// are file-level in our model. Prefer the primary file (the book's
-	// canonical reading copy), falling back to the first file with a
-	// non-empty value for each field.
+	// are file-level in our model. Use the first main file (by ID) that
+	// has a non-empty value for each field.
 	// Supplements don't represent the book — exclude them from the
 	// priority chain so a stray supplement-level Language or Publisher
 	// can't leak into the OPDS entry's book-level metadata.
-	filesInPriorityOrder := make([]*models.File, 0, len(book.Files))
-	if book.PrimaryFileID != nil {
-		for _, file := range book.Files {
-			if file.ID == *book.PrimaryFileID && file.FileRole != models.FileRoleSupplement {
-				filesInPriorityOrder = append(filesInPriorityOrder, file)
-				break
-			}
-		}
-	}
 	for _, file := range book.Files {
 		if file.FileRole == models.FileRoleSupplement {
 			continue
 		}
-		if book.PrimaryFileID != nil && file.ID == *book.PrimaryFileID {
-			continue
-		}
-		filesInPriorityOrder = append(filesInPriorityOrder, file)
-	}
-	for _, file := range filesInPriorityOrder {
 		if entry.Language == "" && file.Language != nil && *file.Language != "" {
 			entry.Language = *file.Language
 		}

--- a/pkg/opds/service_test.go
+++ b/pkg/opds/service_test.go
@@ -58,7 +58,7 @@ func TestBookToEntry_LanguageAndPublisher(t *testing.T) {
 			expectedPublisher: "Audible",
 		},
 		{
-			name: "primary file is preferred over other files",
+			name: "uses first file by ID, ignoring primary file",
 			files: []*models.File{
 				{
 					ID:        1,
@@ -74,8 +74,8 @@ func TestBookToEntry_LanguageAndPublisher(t *testing.T) {
 				},
 			},
 			primaryFileID:     intPtr(2),
-			expectedLanguage:  "en-US",
-			expectedPublisher: "Audible",
+			expectedLanguage:  "fr",
+			expectedPublisher: "Gallimard",
 		},
 		{
 			name: "no files with metadata leaves fields empty",


### PR DESCRIPTION
Closes #295

## Summary
- Removed the `filesInPriorityOrder` construction in `bookToEntryWithKepub` that placed the primary file first when resolving language and publisher for OPDS entries
- Metadata resolution now uses a single loop over `book.Files`, skipping supplements and picking the first main file (by ID) with a non-empty value for each field
- Test updated to verify that `PrimaryFileID` is ignored: when set to file ID 2, the first file by ID (file 1) wins

## Test plan
- First main file by ID is used for language/publisher when primary file is set to a different file
- Single file with metadata populates both fields
- Falls back to first file with each field set across multiple files
- No metadata leaves fields empty
- No files leaves fields empty
- Supplement files excluded from metadata priority chain