### PR TITLE
[Feature] Add file-type selection to batch download

### DIFF
--- a/app/components/library/SelectionToolbar.test.tsx
+++ b/app/components/library/SelectionToolbar.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SelectionToolbar } from "./SelectionToolbar";
 
@@ -24,17 +24,78 @@ vi.mock("@/hooks/useBulkSelection", () => ({
   }),
 }));
 
+const mockStartDownload = vi.fn();
+
 vi.mock("@/hooks/useBulkDownload", () => ({
-  useBulkDownload: () => ({ startDownload: vi.fn() }),
+  useBulkDownload: () => ({ startDownload: mockStartDownload }),
 }));
 
+const mockBooks = [
+  {
+    id: 1,
+    title: "Book One",
+    files: [
+      {
+        id: 101,
+        file_type: "epub",
+        file_role: "main",
+        filesize_bytes: 1000,
+      },
+    ],
+  },
+  {
+    id: 2,
+    title: "Book Two",
+    files: [
+      {
+        id: 201,
+        file_type: "epub",
+        file_role: "main",
+        filesize_bytes: 2000,
+      },
+      {
+        id: 202,
+        file_type: "m4b",
+        file_role: "main",
+        filesize_bytes: 5000,
+      },
+    ],
+  },
+  {
+    id: 3,
+    title: "Book Three",
+    files: [
+      {
+        id: 301,
+        file_type: "cbz",
+        file_role: "main",
+        filesize_bytes: 3000,
+      },
+      {
+        id: 302,
+        file_type: "pdf",
+        file_role: "supplement",
+        filesize_bytes: 500,
+      },
+    ],
+  },
+];
+
 vi.mock("@/hooks/queries/books", () => ({
-  useBooks: () => ({ data: { books: [] }, isLoading: false }),
+  useBooks: () => ({
+    data: { items: mockBooks, total: 3 },
+    isLoading: false,
+  }),
   useDeleteBooks: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
+const mockCreateJobMutateAsync = vi.fn();
+
 vi.mock("@/hooks/queries/jobs", () => ({
-  useCreateJob: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateJob: () => ({
+    mutateAsync: mockCreateJobMutateAsync,
+    isPending: false,
+  }),
 }));
 
 vi.mock("@/hooks/queries/lists", () => ({
@@ -120,5 +181,120 @@ describe("SelectionToolbar — More popover bulk review actions", () => {
       override: "unreviewed",
     });
     expect(mockExitSelectionMode).toHaveBeenCalled();
+  });
+});
+
+describe("SelectionToolbar — Download file-type selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows file-type checkboxes in the download popover", async () => {
+    const user = createUser();
+    render(wrap(<SelectionToolbar />));
+
+    // The desktop Download button should be present with size info
+    const downloadBtn = screen.getByRole("button", { name: /download/i });
+    await user.click(downloadBtn);
+
+    // All four file-type labels should appear in the popover
+    expect(screen.getByText("EPUB")).toBeInTheDocument();
+    expect(screen.getByText("M4B")).toBeInTheDocument();
+    expect(screen.getByText("CBZ")).toBeInTheDocument();
+    expect(screen.getByText("PDF")).toBeInTheDocument();
+  });
+
+  it("checks available file types by default and disables unavailable ones", async () => {
+    const user = createUser();
+    render(wrap(<SelectionToolbar />));
+
+    await user.click(screen.getByRole("button", { name: /download/i }));
+
+    const checkboxes = screen.getAllByRole("checkbox");
+
+    // EPUB (index 0), M4B (index 1), CBZ (index 2) are available main file types
+    expect(checkboxes[0]).toHaveAttribute("data-state", "checked");
+    expect(checkboxes[1]).toHaveAttribute("data-state", "checked");
+    expect(checkboxes[2]).toHaveAttribute("data-state", "checked");
+    // PDF only exists as supplement, so it should be disabled
+    expect(checkboxes[3]).toBeDisabled();
+  });
+
+  it("updates file count when toggling file types", async () => {
+    const user = createUser();
+    render(wrap(<SelectionToolbar />));
+
+    await user.click(screen.getByRole("button", { name: /download/i }));
+
+    // Initially: 4 files (101 epub, 201 epub, 202 m4b, 301 cbz)
+    expect(screen.getByText(/4 files/)).toBeInTheDocument();
+
+    // Uncheck M4B
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]); // M4B
+
+    // Now: 3 files
+    expect(screen.getByText(/3 files/)).toBeInTheDocument();
+  });
+
+  it("submits only selected file types for download", async () => {
+    const user = createUser();
+    mockCreateJobMutateAsync.mockResolvedValueOnce({ id: 42 });
+    render(wrap(<SelectionToolbar />));
+
+    await user.click(screen.getByRole("button", { name: /download/i }));
+
+    const checkboxes = screen.getAllByRole("checkbox");
+
+    // Uncheck M4B and CBZ, keep only EPUB
+    await user.click(checkboxes[1]); // M4B
+    await user.click(checkboxes[2]); // CBZ
+
+    // Click the Download button inside the popover (second one, first is the trigger)
+    const downloadButtons = screen.getAllByRole("button", {
+      name: /download/i,
+    });
+    // The last "Download" button is the submit button inside the popover
+    await user.click(downloadButtons[downloadButtons.length - 1]);
+
+    expect(mockCreateJobMutateAsync).toHaveBeenCalledWith({
+      payload: {
+        type: "bulk_download",
+        data: {
+          file_ids: [101, 201],
+          estimated_size_bytes: 3000,
+        },
+      },
+    });
+  });
+
+  it("excludes supplement files even when their type matches", async () => {
+    const user = createUser();
+    mockCreateJobMutateAsync.mockResolvedValueOnce({ id: 42 });
+    render(wrap(<SelectionToolbar />));
+
+    await user.click(screen.getByRole("button", { name: /download/i }));
+
+    const checkboxes = screen.getAllByRole("checkbox");
+
+    // Uncheck EPUB, M4B — keep only CBZ
+    await user.click(checkboxes[0]); // EPUB
+    await user.click(checkboxes[1]); // M4B
+
+    const downloadButtons = screen.getAllByRole("button", {
+      name: /download/i,
+    });
+    await user.click(downloadButtons[downloadButtons.length - 1]);
+
+    // Only the main CBZ file (301), not the supplement PDF (302)
+    expect(mockCreateJobMutateAsync).toHaveBeenCalledWith({
+      payload: {
+        type: "bulk_download",
+        data: {
+          file_ids: [301],
+          estimated_size_bytes: 3000,
+        },
+      },
+    });
   });
 });

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -11,18 +11,20 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { CreateListDialog } from "@/components/library/CreateListDialog";
 import { DeleteConfirmationDialog } from "@/components/library/DeleteConfirmationDialog";
 import { MergeBooksDialog } from "@/components/library/MergeBooksDialog";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { FILE_TYPE_OPTIONS } from "@/constants/fileTypes";
 import { useBooks, useDeleteBooks } from "@/hooks/queries/books";
 import { useCreateJob } from "@/hooks/queries/jobs";
 import {
@@ -34,6 +36,10 @@ import { useBulkSetReview } from "@/hooks/queries/review";
 import { useBulkDownload } from "@/hooks/useBulkDownload";
 import { useBulkSelection } from "@/hooks/useBulkSelection";
 import type { CreateListPayload, Library, ReviewOverride } from "@/types";
+import {
+  collectDownloadFiles,
+  getAvailableFileTypes,
+} from "@/utils/downloadFiles";
 import { formatFileSize } from "@/utils/format";
 
 interface SelectionToolbarProps {
@@ -60,30 +66,52 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
   const deleteBooksMutation = useDeleteBooks();
   const bulkSetReviewMutation = useBulkSetReview();
 
+  const [downloadPopoverOpen, setDownloadPopoverOpen] = useState(false);
+  const [selectedDownloadTypes, setSelectedDownloadTypes] = useState<string[]>(
+    [],
+  );
+
   // Fetch all selected books (not just current page) for download info and delete dialog
   const allSelectedBooksQuery = useBooks(
     { ids: selectedBookIds },
     { enabled: selectedBookIds.length > 0 },
   );
 
+  const allBooks = useMemo(
+    () => allSelectedBooksQuery.data?.items ?? [],
+    [allSelectedBooksQuery.data?.items],
+  );
+
+  // Distinct file types available across main files of selected books.
+  // Sorted and joined into a stable key so the effect below doesn't loop
+  // when upstream hooks return fresh array references with identical contents.
+  const availableFileTypes = useMemo(
+    () => getAvailableFileTypes(allBooks, selectedBookIds).sort(),
+    [allBooks, selectedBookIds],
+  );
+  const availableFileTypesKey = availableFileTypes.join(",");
+
+  // Auto-select all available types when the set of available types changes
+  useEffect(() => {
+    setSelectedDownloadTypes(availableFileTypesKey.split(",").filter(Boolean));
+  }, [availableFileTypesKey]);
+
   const downloadInfo = useMemo(() => {
-    const allBooks = allSelectedBooksQuery.data?.items;
-    if (!allBooks || selectedBookIds.length === 0) return null;
+    if (allBooks.length === 0 || selectedBookIds.length === 0) return null;
+    return collectDownloadFiles(
+      allBooks,
+      selectedBookIds,
+      selectedDownloadTypes,
+    );
+  }, [allBooks, selectedBookIds, selectedDownloadTypes]);
 
-    const fileIds: number[] = [];
-    let totalSize = 0;
-
-    for (const bookId of selectedBookIds) {
-      const book = allBooks.find((b) => b.id === bookId);
-      const firstMain = book?.files?.find((f) => f.file_role === "main");
-      if (firstMain) {
-        fileIds.push(firstMain.id);
-        totalSize += firstMain.filesize_bytes ?? 0;
-      }
-    }
-
-    return { fileIds, totalSize };
-  }, [allSelectedBooksQuery.data?.items, selectedBookIds]);
+  const toggleDownloadType = (fileType: string) => {
+    setSelectedDownloadTypes((prev) =>
+      prev.includes(fileType)
+        ? prev.filter((t) => t !== fileType)
+        : [...prev, fileType],
+    );
+  };
 
   const handleDownload = async () => {
     if (!downloadInfo || downloadInfo.fileIds.length === 0) return;
@@ -210,6 +238,66 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
   const bookLabel =
     selectedBookIds.length === 1 ? `1 book` : `${selectedBookIds.length} books`;
 
+  const downloadContent = (onDownloadClick: () => void) => (
+    <div className="p-3 space-y-3">
+      <p className="text-xs font-medium text-muted-foreground">
+        File types to include
+      </p>
+      <div className="space-y-2">
+        {FILE_TYPE_OPTIONS.map((option) => {
+          const isAvailable = availableFileTypes.includes(
+            option.value as never,
+          );
+          const isChecked =
+            isAvailable && selectedDownloadTypes.includes(option.value);
+          return (
+            <label
+              className="flex items-center gap-2 text-sm cursor-pointer"
+              key={option.value}
+            >
+              <Checkbox
+                checked={isChecked}
+                disabled={!isAvailable}
+                onCheckedChange={() => toggleDownloadType(option.value)}
+              />
+              <span
+                className={
+                  isAvailable ? "" : "text-muted-foreground opacity-50"
+                }
+              >
+                {option.label}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+      {downloadInfo && downloadInfo.totalSize > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {downloadInfo.fileIds.length}{" "}
+          {downloadInfo.fileIds.length === 1 ? "file" : "files"} &middot;{" "}
+          {formatFileSize(downloadInfo.totalSize)}
+        </p>
+      )}
+      <Button
+        className="w-full"
+        disabled={
+          !downloadInfo ||
+          downloadInfo.fileIds.length === 0 ||
+          createJobMutation.isPending
+        }
+        onClick={onDownloadClick}
+        size="sm"
+      >
+        {createJobMutation.isPending ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Download className="h-4 w-4" />
+        )}
+        Download
+      </Button>
+    </div>
+  );
+
   const addToListContent = (
     <>
       <p className="text-xs font-medium text-muted-foreground px-3 py-2">
@@ -312,36 +400,14 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
             </Button>
           </div>
 
-          <div className="border-t p-1">
-            <Button
-              className="w-full justify-start gap-2 font-normal"
-              disabled={
-                !downloadInfo ||
-                downloadInfo.fileIds.length === 0 ||
-                createJobMutation.isPending
-              }
-              onClick={() => {
-                setActionsPopoverOpen(false);
-                handleDownload();
-              }}
-              size="sm"
-              variant="ghost"
-            >
-              {createJobMutation.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin shrink-0" />
-              ) : (
-                <Download className="h-4 w-4 shrink-0 text-muted-foreground" />
-              )}
-              <span className="truncate">
-                Download
-                {downloadInfo && downloadInfo.totalSize > 0 && (
-                  <span className="text-xs opacity-75 ml-1">
-                    ({formatFileSize(downloadInfo.totalSize)})
-                  </span>
-                )}
-              </span>
-            </Button>
+          <div className="border-t">
+            {downloadContent(() => {
+              setActionsPopoverOpen(false);
+              handleDownload();
+            })}
+          </div>
 
+          <div className="border-t p-1">
             {selectedBookIds.length >= 2 && library && (
               <Button
                 className="w-full justify-start gap-2 font-normal"
@@ -387,28 +453,28 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
           </PopoverContent>
         </Popover>
 
-        <Button
-          disabled={
-            !downloadInfo ||
-            downloadInfo.fileIds.length === 0 ||
-            createJobMutation.isPending
-          }
-          onClick={handleDownload}
-          size="sm"
-          variant="default"
+        <Popover
+          onOpenChange={setDownloadPopoverOpen}
+          open={downloadPopoverOpen}
         >
-          {createJobMutation.isPending ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Download className="h-4 w-4" />
-          )}
-          Download
-          {downloadInfo && downloadInfo.totalSize > 0 && (
-            <span className="text-xs opacity-75">
-              ({formatFileSize(downloadInfo.totalSize)})
-            </span>
-          )}
-        </Button>
+          <PopoverTrigger asChild>
+            <Button size="sm" variant="default">
+              <Download className="h-4 w-4" />
+              Download
+              {downloadInfo && downloadInfo.totalSize > 0 && (
+                <span className="text-xs opacity-75">
+                  ({formatFileSize(downloadInfo.totalSize)})
+                </span>
+              )}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="center" className="w-56 p-0" side="top">
+            {downloadContent(() => {
+              setDownloadPopoverOpen(false);
+              handleDownload();
+            })}
+          </PopoverContent>
+        </Popover>
 
         {selectedBookIds.length >= 2 && library && (
           <Button

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -35,7 +35,12 @@ import {
 import { useBulkSetReview } from "@/hooks/queries/review";
 import { useBulkDownload } from "@/hooks/useBulkDownload";
 import { useBulkSelection } from "@/hooks/useBulkSelection";
-import type { CreateListPayload, Library, ReviewOverride } from "@/types";
+import type {
+  CreateListPayload,
+  FileType,
+  Library,
+  ReviewOverride,
+} from "@/types";
 import {
   collectDownloadFiles,
   getAvailableFileTypes,
@@ -246,7 +251,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
       <div className="space-y-2">
         {FILE_TYPE_OPTIONS.map((option) => {
           const isAvailable = availableFileTypes.includes(
-            option.value as never,
+            option.value as FileType,
           );
           const isChecked =
             isAvailable && selectedDownloadTypes.includes(option.value);

--- a/app/utils/downloadFiles.test.ts
+++ b/app/utils/downloadFiles.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import type { Book, File } from "@/types";
+
+import { collectDownloadFiles, getAvailableFileTypes } from "./downloadFiles";
+
+const makeFile = (overrides: Partial<File>): File =>
+  ({
+    id: 1,
+    file_type: "epub",
+    file_role: "main",
+    filesize_bytes: 1000,
+    ...overrides,
+  }) as File;
+
+const makeBook = (id: number, files: Partial<File>[]): Book =>
+  ({
+    id,
+    files: files.map((f, i) => makeFile({ id: id * 100 + i, ...f })),
+  }) as Book;
+
+describe("getAvailableFileTypes", () => {
+  it("returns distinct file types from main files across selected books", () => {
+    const books = [
+      makeBook(1, [{ file_type: "epub" }, { file_type: "m4b" }]),
+      makeBook(2, [{ file_type: "cbz" }]),
+    ];
+    const result = getAvailableFileTypes(books, [1, 2]);
+    expect(result.sort()).toEqual(["cbz", "epub", "m4b"]);
+  });
+
+  it("excludes supplement files", () => {
+    const books = [
+      makeBook(1, [
+        { file_type: "epub", file_role: "main" },
+        { file_type: "pdf", file_role: "supplement" },
+      ]),
+    ];
+    const result = getAvailableFileTypes(books, [1]);
+    expect(result).toEqual(["epub"]);
+  });
+
+  it("only considers selected book IDs", () => {
+    const books = [
+      makeBook(1, [{ file_type: "epub" }]),
+      makeBook(2, [{ file_type: "cbz" }]),
+    ];
+    const result = getAvailableFileTypes(books, [1]);
+    expect(result).toEqual(["epub"]);
+  });
+
+  it("returns empty array when no books match", () => {
+    const result = getAvailableFileTypes([], [1]);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("collectDownloadFiles", () => {
+  it("returns all main files matching selected types", () => {
+    const books = [
+      makeBook(1, [
+        { file_type: "epub", filesize_bytes: 500 },
+        { file_type: "m4b", filesize_bytes: 2000 },
+      ]),
+      makeBook(2, [{ file_type: "epub", filesize_bytes: 300 }]),
+    ];
+    const result = collectDownloadFiles(books, [1, 2], ["epub"]);
+    expect(result.fileIds).toEqual([100, 200]);
+    expect(result.totalSize).toBe(800);
+  });
+
+  it("includes multiple files of the same type from one book", () => {
+    const books = [
+      makeBook(1, [
+        { file_type: "epub", filesize_bytes: 500 },
+        { file_type: "epub", filesize_bytes: 700 },
+      ]),
+    ];
+    const result = collectDownloadFiles(books, [1], ["epub"]);
+    expect(result.fileIds).toEqual([100, 101]);
+    expect(result.totalSize).toBe(1200);
+  });
+
+  it("excludes supplement files even if type matches", () => {
+    const books = [
+      makeBook(1, [
+        { file_type: "pdf", file_role: "main", filesize_bytes: 100 },
+        { file_type: "pdf", file_role: "supplement", filesize_bytes: 200 },
+      ]),
+    ];
+    const result = collectDownloadFiles(books, [1], ["pdf"]);
+    expect(result.fileIds).toEqual([100]);
+    expect(result.totalSize).toBe(100);
+  });
+
+  it("returns empty results when no types are selected", () => {
+    const books = [makeBook(1, [{ file_type: "epub", filesize_bytes: 500 }])];
+    const result = collectDownloadFiles(books, [1], []);
+    expect(result.fileIds).toEqual([]);
+    expect(result.totalSize).toBe(0);
+  });
+
+  it("handles multiple selected types", () => {
+    const books = [
+      makeBook(1, [
+        { file_type: "epub", filesize_bytes: 500 },
+        { file_type: "m4b", filesize_bytes: 2000 },
+        { file_type: "cbz", filesize_bytes: 300 },
+      ]),
+    ];
+    const result = collectDownloadFiles(books, [1], ["epub", "cbz"]);
+    expect(result.fileIds).toEqual([100, 102]);
+    expect(result.totalSize).toBe(800);
+  });
+
+  it("only considers selected book IDs", () => {
+    const books = [
+      makeBook(1, [{ file_type: "epub", filesize_bytes: 500 }]),
+      makeBook(2, [{ file_type: "epub", filesize_bytes: 300 }]),
+    ];
+    const result = collectDownloadFiles(books, [1], ["epub"]);
+    expect(result.fileIds).toEqual([100]);
+    expect(result.totalSize).toBe(500);
+  });
+
+  it("handles null filesize_bytes gracefully", () => {
+    const books = [
+      makeBook(1, [
+        { file_type: "epub", filesize_bytes: undefined as unknown as number },
+      ]),
+    ];
+    const result = collectDownloadFiles(books, [1], ["epub"]);
+    expect(result.fileIds).toEqual([100]);
+    expect(result.totalSize).toBe(0);
+  });
+});

--- a/app/utils/downloadFiles.ts
+++ b/app/utils/downloadFiles.ts
@@ -1,0 +1,56 @@
+import { FileRoleMain, type Book, type FileType } from "@/types";
+
+/**
+ * Returns the distinct file types present across main files in the selected books.
+ * Supplements are excluded.
+ */
+export const getAvailableFileTypes = (
+  books: Book[],
+  selectedBookIds: number[],
+): FileType[] => {
+  const selectedIds = new Set(selectedBookIds);
+  const types = new Set<FileType>();
+
+  for (const book of books) {
+    if (!selectedIds.has(book.id)) continue;
+    for (const file of book.files ?? []) {
+      if (file.file_role === FileRoleMain) {
+        types.add(file.file_type);
+      }
+    }
+  }
+
+  return Array.from(types);
+};
+
+interface DownloadFileInfo {
+  fileIds: number[];
+  totalSize: number;
+}
+
+/**
+ * Collects all main files matching the selected file types across the selected books.
+ * Returns their IDs and the total size in bytes. Supplements are excluded.
+ */
+export const collectDownloadFiles = (
+  books: Book[],
+  selectedBookIds: number[],
+  selectedFileTypes: string[],
+): DownloadFileInfo => {
+  const selectedIds = new Set(selectedBookIds);
+  const typeSet = new Set(selectedFileTypes);
+  const fileIds: number[] = [];
+  let totalSize = 0;
+
+  for (const book of books) {
+    if (!selectedIds.has(book.id)) continue;
+    for (const file of book.files ?? []) {
+      if (file.file_role === FileRoleMain && typeSet.has(file.file_type)) {
+        fileIds.push(file.id);
+        totalSize += file.filesize_bytes ?? 0;
+      }
+    }
+  }
+
+  return { fileIds, totalSize };
+};

--- a/website/docs/advanced/bulk-download.md
+++ b/website/docs/advanced/bulk-download.md
@@ -10,14 +10,24 @@ Shisho supports downloading multiple books at once as a zip file. This is useful
 
 1. **Enter select mode** in the library gallery by long-pressing a book or using the selection toggle.
 2. **Select the books** you want to download — you can select across pages and use Shift+click for range selection.
-3. **Click the Download button** in the selection toolbar at the bottom of the screen. The button shows the estimated total file size.
-4. Shisho creates a background job to prepare your download. You'll see a progress toast showing how many files have been processed.
-5. **Navigate freely** while the download is being prepared — the progress toast persists across pages and will notify you when the download is ready.
-6. Once complete, click **Download Zip** to save the file.
+3. **Click the Download button** in the selection toolbar at the bottom of the screen.
+4. **Choose which file types to include** (e.g., EPUB, M4B, CBZ, PDF). All available types are selected by default. The file count and total size update as you toggle types.
+5. **Click Download** to start. Shisho creates a background job to prepare your zip. You'll see a progress toast showing how many files have been processed.
+6. **Navigate freely** while the download is being prepared — the progress toast persists across pages and will notify you when the download is ready.
+7. Once complete, click **Download Zip** to save the file.
+
+## File Type Selection
+
+When you click the Download button, a popover shows checkboxes for each file type (EPUB, M4B, CBZ, PDF). Types that don't exist among the selected books' main files are disabled.
+
+- **All available types are selected by default** — uncheck any types you don't need.
+- **Multiple files of the same type** from a single book are all included (e.g., if a book has two EPUBs, both are downloaded).
+- **Supplement files are excluded** — only main files are included in the download, regardless of type selection.
+- The total file count and size shown in the popover reflect your current type selection.
 
 ## What's Included
 
-- Each selected book contributes its **primary file** (the file designated for downloads and device sync).
+- Each selected book contributes all **main files** matching your selected file types. Supplement files are always excluded.
 - Files include **embedded metadata** — the same enriched version you get from individual downloads, with title, authors, cover art, and other metadata written into the file.
 - The zip uses **store mode** (no compression) since ebook formats like EPUB and CBZ are already compressed internally. This makes the download faster and the file size estimate accurate.
 


### PR DESCRIPTION
Closes #296

## Summary

- Replaced the batch download's single-file-per-book logic with a file-type selection mechanism in the SelectionToolbar
- The download popover (desktop) / inline section (mobile Actions menu) shows checkboxes for each file type (EPUB, M4B, CBZ, PDF) with all available types checked by default and unavailable types disabled
- Downloads include all main files matching selected types across selected books, excluding supplements; total file count and size update reactively as types are toggled
- Extracted `getAvailableFileTypes` and `collectDownloadFiles` utility functions into `app/utils/downloadFiles.ts` with 11 unit tests
- Updated bulk download documentation to describe the new file-type selection flow

## Test plan

- 11 unit tests for `downloadFiles.ts` covering type detection, supplement exclusion, multi-file per book, empty states, null filesize handling
- 5 component tests for SelectionToolbar covering popover display, default checked state, file count updates on toggle, submit with filtered types, supplement exclusion
- `availableFileTypes` derivation uses a string key (`availableFileTypesKey`) to prevent infinite re-render loops when upstream hooks return fresh array references with identical contents
- Download content is rendered inline in the mobile Actions popover (not as a nested popover) since nested popovers on mobile are unreliable
- No Go backend changes needed; the existing `bulk_download` job API accepts arbitrary file IDs