### PR TITLE
[Frontend] Mention alias creation in merge dialogs

### DIFF
--- a/app/components/library/MetadataMergeDialog.tsx
+++ b/app/components/library/MetadataMergeDialog.tsx
@@ -140,7 +140,7 @@ export function MetadataMergeDialog({
             Select a {entityType} to merge into this one.{" "}
             {setChildConfig
               ? "Then choose to merge or set as a child."
-              : `All associated books will be transferred and the selected ${entityType} will be deleted.`}
+              : `All associated books will be transferred, the ${entityType} name will be added as an alias, and the selected ${entityType} will be deleted.`}
           </DialogDescription>
         </DialogHeader>
 
@@ -221,9 +221,10 @@ export function MetadataMergeDialog({
 
           {selectedEntity && !setChildConfig && (
             <p className="mt-4 text-sm text-muted-foreground">
-              This will move all {selectedEntity.count} book
+              Move all {selectedEntity.count} book
               {selectedEntity.count !== 1 ? "s" : ""} from "
-              {selectedEntity.name}" to "{targetName}" and delete "
+              {selectedEntity.name}" to "{targetName}", add "
+              {selectedEntity.name}" as an alias, and delete "
               {selectedEntity.name}".
             </p>
           )}


### PR DESCRIPTION
Closes #301

## Summary
- Updated two text strings in `MetadataMergeDialog.tsx` to inform users that merging creates an alias
- The dialog description (before entity selection) now mentions that the entity name will be added as an alias
- The confirmation text (after selecting an entity) follows the same wording pattern as the existing publisher merge dialog: "Move all N book(s) from 'source' to 'target', add 'source' as an alias, and delete 'source'"
- Publisher merge dialog is unchanged; it already had the correct wording

## Test plan
- Open a person/series/genre/tag detail page and click "Merge"
- Confirm the dialog description mentions alias creation
- Select an entity and confirm the detail text mentions alias creation
- Open a publisher detail page and click "Merge" — verify publisher merge wording is unchanged