### PR TITLE
[Fix] Add PDF to supplement-to-main-file promotion paths

### DIFF
--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -51,6 +51,7 @@ import {
   FileTypeCBZ,
   FileTypeEPUB,
   FileTypeM4B,
+  FileTypePDF,
   ReviewOverrideReviewed,
   type Book,
   type File,
@@ -524,10 +525,13 @@ export function FileEditDialog({
   const isSupplement = file.file_role === FileRoleSupplement;
   const isM4b = file.file_type === FileTypeM4B;
 
-  // Check if file type can be a main file (only cbz, epub, m4b are supported)
-  const canBeMainFile = [FileTypeCBZ, FileTypeEPUB, FileTypeM4B].includes(
-    file.file_type as typeof FileTypeCBZ,
-  );
+  // Check if file type can be a main file (cbz, epub, m4b, pdf are supported)
+  const canBeMainFile = [
+    FileTypeCBZ,
+    FileTypeEPUB,
+    FileTypeM4B,
+    FileTypePDF,
+  ].includes(file.file_type as typeof FileTypeCBZ);
 
   return (
     <FormDialog hasChanges={hasChanges} onOpenChange={onOpenChange} open={open}>
@@ -596,7 +600,7 @@ export function FileEditDialog({
             {isSupplement && !canBeMainFile && (
               <p className="text-sm text-muted-foreground">
                 This file type ({file.file_type}) cannot be upgraded to a main
-                file. Only cbz, epub, and m4b files can be main files.
+                file.
               </p>
             )}
           </div>

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -817,9 +817,10 @@ func (h *handler) updateFile(c echo.Context) error {
 				models.FileTypeCBZ:  true,
 				models.FileTypeEPUB: true,
 				models.FileTypeM4B:  true,
+				models.FileTypePDF:  true,
 			}
 			if !supportedTypes[file.FileType] {
-				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("cannot upgrade to main file: file type '%s' is not supported as a main file (only cbz, epub, m4b)", file.FileType))
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("cannot upgrade to main file: file type '%s' is not supported as a main file", file.FileType))
 			}
 		}
 
@@ -2535,6 +2536,7 @@ func (h *handler) deleteFile(c echo.Context) error {
 		models.FileTypeEPUB: {},
 		models.FileTypeCBZ:  {},
 		models.FileTypeM4B:  {},
+		models.FileTypePDF:  {},
 	}
 	if h.pluginManager != nil {
 		for ext := range h.pluginManager.RegisteredFileExtensions() {

--- a/pkg/books/service_test.go
+++ b/pkg/books/service_test.go
@@ -1021,6 +1021,7 @@ func TestDeleteFileAndCleanup_PromotesSupplementWhenLastMainDeleted(t *testing.T
 		models.FileTypeEPUB: {},
 		models.FileTypeCBZ:  {},
 		models.FileTypeM4B:  {},
+		models.FileTypePDF:  {},
 	}
 
 	// Delete the main file
@@ -1318,6 +1319,7 @@ func TestDeleteFileAndCleanup_PromotesOldestSupplementFirst(t *testing.T) {
 		models.FileTypeEPUB: {},
 		models.FileTypeCBZ:  {},
 		models.FileTypeM4B:  {},
+		models.FileTypePDF:  {},
 	}
 
 	// Delete the main file

--- a/pkg/books/service_test.go
+++ b/pkg/books/service_test.go
@@ -1093,15 +1093,15 @@ func TestDeleteFileAndCleanup_DeletesBookWhenOnlyUnsupportedSupplementsRemain(t 
 	_, err = db.NewInsert().Model(mainFile).Exec(ctx)
 	require.NoError(t, err)
 
-	// Create supplement file (pdf - NOT a supported type)
-	supplementFilePath := filepath.Join(tmpDir, "supplement.pdf")
+	// Create supplement file (txt - NOT a supported type)
+	supplementFilePath := filepath.Join(tmpDir, "supplement.txt")
 	err = os.WriteFile(supplementFilePath, []byte("supplement content"), 0644)
 	require.NoError(t, err)
 
 	supplementFile := &models.File{
 		LibraryID:     library.ID,
 		BookID:        book.ID,
-		FileType:      "pdf",
+		FileType:      "txt",
 		FileRole:      models.FileRoleSupplement,
 		Filepath:      supplementFilePath,
 		FilesizeBytes: 18,
@@ -1109,11 +1109,12 @@ func TestDeleteFileAndCleanup_DeletesBookWhenOnlyUnsupportedSupplementsRemain(t 
 	_, err = db.NewInsert().Model(supplementFile).Exec(ctx)
 	require.NoError(t, err)
 
-	// Define supported types (native types only - pdf NOT included)
+	// Define supported types (native types)
 	supportedTypes := map[string]struct{}{
 		models.FileTypeEPUB: {},
 		models.FileTypeCBZ:  {},
 		models.FileTypeM4B:  {},
+		models.FileTypePDF:  {},
 	}
 
 	// Delete the main file
@@ -1137,6 +1138,100 @@ func TestDeleteFileAndCleanup_DeletesBookWhenOnlyUnsupportedSupplementsRemain(t 
 	// Verify supplement file is deleted from disk
 	_, err = os.Stat(supplementFilePath)
 	assert.True(t, os.IsNotExist(err))
+}
+
+func TestDeleteFileAndCleanup_PromotesPDFSupplementWhenLastMainFileDeleted(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+
+	// Create library
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create book
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Test Book",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Test Book",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        tmpDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create main file (epub)
+	mainFilePath := filepath.Join(tmpDir, "book.epub")
+	err = os.WriteFile(mainFilePath, []byte("main content"), 0644)
+	require.NoError(t, err)
+
+	mainFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      mainFilePath,
+		FilesizeBytes: 12,
+	}
+	_, err = db.NewInsert().Model(mainFile).Exec(ctx)
+	require.NoError(t, err)
+
+	// Create supplement file (pdf - a supported type for promotion)
+	supplementFilePath := filepath.Join(tmpDir, "supplement.pdf")
+	err = os.WriteFile(supplementFilePath, []byte("supplement content"), 0644)
+	require.NoError(t, err)
+
+	supplementFile := &models.File{
+		LibraryID:     library.ID,
+		BookID:        book.ID,
+		FileType:      models.FileTypePDF,
+		FileRole:      models.FileRoleSupplement,
+		Filepath:      supplementFilePath,
+		FilesizeBytes: 18,
+	}
+	_, err = db.NewInsert().Model(supplementFile).Exec(ctx)
+	require.NoError(t, err)
+
+	// Define supported types (native types including PDF)
+	supportedTypes := map[string]struct{}{
+		models.FileTypeEPUB: {},
+		models.FileTypeCBZ:  {},
+		models.FileTypeM4B:  {},
+		models.FileTypePDF:  {},
+	}
+
+	// Delete the main file
+	bookSvc := NewService(db)
+	result, err := bookSvc.DeleteFileAndCleanup(ctx, mainFile.ID, library, supportedTypes, nil)
+	require.NoError(t, err)
+
+	// Book should NOT be deleted (PDF supplement was promoted)
+	assert.False(t, result.BookDeleted, "book should not be deleted when PDF supplement can be promoted")
+
+	// Verify main file is deleted from DB
+	count, err := db.NewSelect().Model((*models.File)(nil)).Where("id = ?", mainFile.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+
+	// Verify book still exists
+	count, err = db.NewSelect().Model((*models.Book)(nil)).Where("id = ?", book.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	// Verify PDF supplement was promoted to main
+	var updatedSupplement models.File
+	err = db.NewSelect().Model(&updatedSupplement).Where("id = ?", supplementFile.ID).Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, models.FileRoleMain, updatedSupplement.FileRole)
 }
 
 func TestDeleteFileAndCleanup_PromotesOldestSupplementFirst(t *testing.T) {


### PR DESCRIPTION
Closes #315

## Summary
- Added `FileTypePDF` to `supportedTypes` maps in the `setFile` and `deleteFile` handlers (`pkg/books/handlers.go`), aligning them with the worker code that already supported PDF
- Added `FileTypePDF` to the `canBeMainFile` array in `FileEditDialog.tsx` so the frontend allows promoting PDF supplements to main files
- Simplified error messages in both backend and frontend to avoid listing specific formats, which can drift out of sync
- Updated existing test that incorrectly used PDF as an "unsupported" type (changed to `txt`) and added a new test verifying PDF supplement promotion succeeds when the last main file is deleted

## Test plan
- New test `TestDeleteFileAndCleanup_PromotesPDFSupplementWhenLastMainFileDeleted` verifies that deleting the last main file promotes a PDF supplement instead of deleting the book
- Updated test `TestDeleteFileAndCleanup_DeletesBookWhenOnlyUnsupportedSupplementsRemain` now uses `txt` as the unsupported type
- All four `supportedTypes` maps (two in worker code, two in handler code) are now consistent