### PR TITLE
[Feature] Add per-file preferred cover selection

### DIFF
--- a/app/components/files/FileChaptersTab.test.tsx
+++ b/app/components/files/FileChaptersTab.test.tsx
@@ -57,6 +57,7 @@ describe("FileChaptersTab - Play Promise handling", () => {
     filepath: "/test/book.m4b",
     filesize_bytes: 1000000,
     audiobook_duration_seconds: 3600,
+    is_preferred_cover: false,
   };
 
   const mockChapters: Chapter[] = [
@@ -178,6 +179,7 @@ describe("FileChaptersTab - M4B Playback", () => {
     filepath: "/test/book.m4b",
     filesize_bytes: 1000000,
     audiobook_duration_seconds: 3600, // 1 hour
+    is_preferred_cover: false,
   };
 
   const mockChapters: Chapter[] = [
@@ -464,6 +466,7 @@ describe("FileChaptersTab - Edit mode play after timestamp change", () => {
     filepath: "/test/book.m4b",
     filesize_bytes: 1000000,
     audiobook_duration_seconds: 3600,
+    is_preferred_cover: false,
   };
 
   const mockChapters: Chapter[] = [
@@ -636,6 +639,7 @@ describe("FileChaptersTab - PDF chapter page increment regression", () => {
     filepath: "/test/book.pdf",
     filesize_bytes: 1000000,
     page_count: 100,
+    is_preferred_cover: false,
   };
 
   const mockChapters: Chapter[] = [

--- a/app/components/library/CoverGalleryTabs.test.tsx
+++ b/app/components/library/CoverGalleryTabs.test.tsx
@@ -17,6 +17,7 @@ function makeFile(overrides: Partial<File> = {}): File {
     file_role: "main",
     filesize_bytes: 1000,
     cover_image_filename: "cover.jpg",
+    is_preferred_cover: false,
     ...overrides,
   };
 }

--- a/app/components/library/FileCoverThumbnail.test.tsx
+++ b/app/components/library/FileCoverThumbnail.test.tsx
@@ -17,6 +17,7 @@ function makeFile(overrides: Partial<File> = {}): File {
     file_role: "main",
     filesize_bytes: 1000,
     cover_image_filename: "cover.jpg",
+    is_preferred_cover: false,
     ...overrides,
   };
 }

--- a/app/components/library/FileEditDialog.test.tsx
+++ b/app/components/library/FileEditDialog.test.tsx
@@ -251,6 +251,7 @@ describe("FileEditDialog", () => {
     updated_at: "2024-01-01",
     narrators: [],
     identifiers: [],
+    is_preferred_cover: false,
   };
 
   const renderDialog = (props = {}) => {

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -145,6 +145,9 @@ export function FileEditDialog({
   const [abridged, setAbridged] = useState<string>(
     file.abridged === true ? "true" : "",
   );
+  const [isPreferredCover, setIsPreferredCover] = useState(
+    file.is_preferred_cover ?? false,
+  );
 
   const updateFileMutation = useUpdateFile();
   const uploadCoverMutation = useUploadFileCover();
@@ -222,6 +225,7 @@ export function FileEditDialog({
     coverPage: number | null;
     language: string;
     abridged: string;
+    isPreferredCover: boolean;
     /** null means "auto" — no explicit override on the file. */
     reviewOverride: ReviewOverride | null;
   } | null>(null);
@@ -266,6 +270,7 @@ export function FileEditDialog({
     // null = "auto" (no explicit override).
     const initialReviewOverride: ReviewOverride | null =
       file.review_override ?? null;
+    const initialIsPreferredCover = file.is_preferred_cover ?? false;
 
     setNarrators(initialNarrators);
     setName(initialName);
@@ -281,6 +286,7 @@ export function FileEditDialog({
     setPendingCoverFile(null);
     updatePendingCoverPreview(null);
     setDraftReviewOverride(initialReviewOverride);
+    setIsPreferredCover(initialIsPreferredCover);
 
     // Store initial values for comparison
     setInitialValues({
@@ -294,6 +300,7 @@ export function FileEditDialog({
       coverPage: file.cover_page ?? null,
       language: initialLanguage,
       abridged: initialAbridged,
+      isPreferredCover: initialIsPreferredCover,
       reviewOverride: initialReviewOverride,
     });
   }, [open, file, updatePendingCoverPreview]);
@@ -314,6 +321,7 @@ export function FileEditDialog({
       pendingCoverFile !== null ||
       (pendingCoverPage !== null &&
         pendingCoverPage !== initialValues.coverPage) ||
+      isPreferredCover !== initialValues.isPreferredCover ||
       draftReviewOverride !== initialValues.reviewOverride
     );
   }, [
@@ -328,6 +336,7 @@ export function FileEditDialog({
     abridged,
     pendingCoverFile,
     pendingCoverPage,
+    isPreferredCover,
     draftReviewOverride,
     initialValues,
   ]);
@@ -367,6 +376,7 @@ export function FileEditDialog({
       language?: string;
       abridged?: string;
       identifiers?: Array<{ type: string; value: string }>;
+      is_preferred_cover?: boolean;
     } = {};
 
     // Check if file role changed
@@ -426,6 +436,11 @@ export function FileEditDialog({
       file.identifiers?.map((id) => ({ type: id.type, value: id.value })) || [];
     if (JSON.stringify(identifiers) !== JSON.stringify(originalIdentifiers)) {
       payload.identifiers = identifiers;
+    }
+
+    // Check if preferred cover changed
+    if (isPreferredCover !== initialValues?.isPreferredCover) {
+      payload.is_preferred_cover = isPreferredCover;
     }
 
     // Only submit if something changed
@@ -512,6 +527,7 @@ export function FileEditDialog({
       coverPage: pendingCoverPage ?? initialValues?.coverPage ?? null,
       language: canonicalLanguage,
       abridged: canonicalAbridged,
+      isPreferredCover,
       reviewOverride: draftReviewOverride,
     });
     requestClose();
@@ -532,6 +548,23 @@ export function FileEditDialog({
     FileTypeM4B,
     FileTypePDF,
   ].includes(file.file_type as typeof FileTypeCBZ);
+
+  // Determine if the preferred cover checkbox should be shown:
+  // only when 2+ main (non-supplement) files of the same type category exist.
+  const isEbookCategory = (ft: string) =>
+    ft === FileTypeEPUB || ft === FileTypeCBZ || ft === FileTypePDF;
+  const isAudiobookCategory = (ft: string) => ft === FileTypeM4B;
+  const showPreferredCover = useMemo(() => {
+    if (!book?.files) return false;
+    const mainFiles = book.files.filter((f) => f.file_role === FileRoleMain);
+    const sameCategoryCount = mainFiles.filter((f) =>
+      isM4b ? isAudiobookCategory(f.file_type) : isEbookCategory(f.file_type),
+    ).length;
+    return sameCategoryCount >= 2;
+  }, [book?.files, isM4b]);
+  const preferredCoverLabel = isM4b
+    ? "Preferred audiobook cover"
+    : "Preferred ebook cover";
 
   return (
     <FormDialog hasChanges={hasChanges} onOpenChange={onOpenChange} open={open}>
@@ -758,6 +791,28 @@ export function FileEditDialog({
                   pageCount={file.page_count}
                   title="Select Cover Page"
                 />
+              )}
+
+              {/* Preferred cover checkbox — only when 2+ main files of the
+                  same type category exist on the book */}
+              {showPreferredCover && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      checked={isPreferredCover}
+                      id="preferred-cover"
+                      onCheckedChange={(checked) =>
+                        setIsPreferredCover(Boolean(checked))
+                      }
+                    />
+                    <Label
+                      className="cursor-pointer font-normal text-muted-foreground"
+                      htmlFor="preferred-cover"
+                    >
+                      {preferredCoverLabel}
+                    </Label>
+                  </div>
+                </div>
               )}
 
               {/* Narrators (only for M4B files) */}

--- a/app/components/library/ReviewPanel.test.tsx
+++ b/app/components/library/ReviewPanel.test.tsx
@@ -84,6 +84,7 @@ const baseFile: File = {
   review_override: undefined,
   review_overridden_at: undefined,
   cover_image_filename: "book.epub.cover.jpg",
+  is_preferred_cover: false,
 };
 
 describe("ReviewPanel", () => {

--- a/app/utils/coverSelection.test.ts
+++ b/app/utils/coverSelection.test.ts
@@ -57,6 +57,18 @@ const epubSupplement = file({
   file_role: "supplement",
   cover_image_filename: "supp.cover.jpg",
 });
+const preferredCBZ = file({
+  id: 9,
+  file_type: "cbz",
+  cover_image_filename: "cbz2.cover.jpg",
+  is_preferred_cover: true,
+});
+const preferredM4B = file({
+  id: 10,
+  file_type: "m4b",
+  cover_image_filename: "m4b2.cover.jpg",
+  is_preferred_cover: true,
+});
 
 describe("selectCoverFile", () => {
   it("prefers book file in default mode", () => {
@@ -124,6 +136,35 @@ describe("selectCoverFile", () => {
 
   it("unknown aspect ratio falls through to default", () => {
     expect(selectCoverFile([m4bMain, epubMain], "weird")?.id).toBe(epubMain.id);
+  });
+
+  // Preferred cover tests
+  it("preferred ebook file wins over first in bucket", () => {
+    expect(selectCoverFile([epubMain, preferredCBZ], "book")?.id).toBe(
+      preferredCBZ.id,
+    );
+  });
+
+  it("preferred audiobook file wins over first in bucket", () => {
+    expect(selectCoverFile([m4bMain, preferredM4B], "audiobook")?.id).toBe(
+      preferredM4B.id,
+    );
+  });
+
+  it("preferred ebook in non-selected bucket does not affect audiobook selection", () => {
+    expect(
+      selectCoverFile([epubMain, preferredCBZ, m4bMain], "audiobook")?.id,
+    ).toBe(m4bMain.id);
+  });
+
+  it("preferred audiobook in non-selected bucket does not affect ebook selection", () => {
+    expect(selectCoverFile([epubMain, cbzMain, preferredM4B], "book")?.id).toBe(
+      epubMain.id,
+    );
+  });
+
+  it("no preferred falls back to first file (existing behavior)", () => {
+    expect(selectCoverFile([epubMain, cbzMain], "book")?.id).toBe(epubMain.id);
   });
 });
 

--- a/app/utils/coverSelection.ts
+++ b/app/utils/coverSelection.ts
@@ -9,11 +9,16 @@ const isAudiobookFile = (f: File): boolean => f.file_type === "m4b";
 
 const hasCover = (f: File): boolean => Boolean(f.cover_image_filename);
 
+/** Pick the preferred file from a bucket, falling back to the first entry. */
+const pickFirst = (bucket: File[]): File =>
+  bucket.find((f) => f.is_preferred_cover) ?? bucket[0];
+
 /**
  * Picks which file's cover should represent a book based on the library's
  * preferred cover_aspect_ratio setting. Mirrors the backend's
  * pkg/covers.SelectFile logic. Supplements are excluded — they don't
- * represent the book.
+ * represent the book. Within each bucket (ebook / audiobook), a file with
+ * is_preferred_cover takes priority.
  */
 export const selectCoverFile = (
   files: File[] | undefined,
@@ -30,12 +35,12 @@ export const selectCoverFile = (
   switch (coverAspectRatio) {
     case "audiobook":
     case "audiobook_fallback_book":
-      if (audiobookFiles.length > 0) return audiobookFiles[0];
-      if (bookFiles.length > 0) return bookFiles[0];
+      if (audiobookFiles.length > 0) return pickFirst(audiobookFiles);
+      if (bookFiles.length > 0) return pickFirst(bookFiles);
       break;
     default:
-      if (bookFiles.length > 0) return bookFiles[0];
-      if (audiobookFiles.length > 0) return audiobookFiles[0];
+      if (bookFiles.length > 0) return pickFirst(bookFiles);
+      if (audiobookFiles.length > 0) return pickFirst(audiobookFiles);
   }
   return null;
 };

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -39,6 +39,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/sortname"
 	"github.com/shishobooks/shisho/pkg/sortspec"
 	"github.com/shishobooks/shisho/pkg/tags"
+	"github.com/uptrace/bun"
 )
 
 // ScanOptions configures a scan operation.
@@ -787,7 +788,8 @@ func (h *handler) updateFile(c echo.Context) error {
 			file.CoverMimeType = nil
 			file.CoverSource = nil
 			file.CoverPage = nil
-			opts.Columns = append(opts.Columns, "cover_image_filename", "cover_mime_type", "cover_source", "cover_page")
+			file.IsPreferredCover = false
+			opts.Columns = append(opts.Columns, "cover_image_filename", "cover_mime_type", "cover_source", "cover_page", "is_preferred_cover")
 
 			// Clear audiobook fields
 			file.AudiobookDurationSeconds = nil
@@ -1103,6 +1105,41 @@ func (h *handler) updateFile(c echo.Context) error {
 		}
 		file.IdentifierSource = strPtr(models.DataSourceManual)
 		opts.Columns = append(opts.Columns, "identifier_source")
+	}
+
+	// Handle is_preferred_cover
+	if params.IsPreferredCover != nil {
+		if *params.IsPreferredCover {
+			// Validate file has a cover
+			if file.CoverImageFilename == nil || *file.CoverImageFilename == "" {
+				return echo.NewHTTPError(http.StatusBadRequest, "cannot set preferred cover: file has no cover image")
+			}
+			// Clear is_preferred_cover on other files of the same type category
+			// in the same book. EPUB/CBZ/PDF = ebook, M4B = audiobook.
+			var sameCategory []string
+			switch file.FileType {
+			case models.FileTypeEPUB, models.FileTypeCBZ, models.FileTypePDF:
+				sameCategory = []string{models.FileTypeEPUB, models.FileTypeCBZ, models.FileTypePDF}
+			case models.FileTypeM4B:
+				sameCategory = []string{models.FileTypeM4B}
+			}
+			if len(sameCategory) > 0 {
+				_, err := h.bookService.DB().NewUpdate().
+					TableExpr("files").
+					Set("is_preferred_cover = ?", false).
+					Where("book_id = ?", file.BookID).
+					Where("id != ?", file.ID).
+					Where("file_type IN (?)", bun.List(sameCategory)).
+					Exec(ctx)
+				if err != nil {
+					return errors.WithStack(err)
+				}
+			}
+			file.IsPreferredCover = true
+		} else {
+			file.IsPreferredCover = false
+		}
+		opts.Columns = append(opts.Columns, "is_preferred_cover")
 	}
 
 	// Update the file

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -2100,6 +2100,218 @@ func TestUpdateFile_RejectsDuplicateTypesAfterTrim(t *testing.T) {
 	require.Empty(t, stored)
 }
 
+func TestUpdateFile_IsPreferredCover_SetsAndClearsSiblings(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, book := setupTestLibraryAndBook(t, db)
+	dir := t.TempDir()
+
+	// Create two EPUB files (same type category = ebook)
+	epub1Path := filepath.Join(dir, "file1.epub")
+	require.NoError(t, os.WriteFile(epub1Path, []byte("epub1"), 0o644))
+	coverName1 := "file1.epub.cover.jpg"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, coverName1), []byte("cover1"), 0o644))
+
+	epub2Path := filepath.Join(dir, "file2.epub")
+	require.NoError(t, os.WriteFile(epub2Path, []byte("epub2"), 0o644))
+	coverName2 := "file2.epub.cover.jpg"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, coverName2), []byte("cover2"), 0o644))
+
+	file1 := &models.File{
+		LibraryID:          book.LibraryID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           epub1Path,
+		FilesizeBytes:      5,
+		CoverImageFilename: &coverName1,
+	}
+	_, err := db.NewInsert().Model(file1).Exec(ctx)
+	require.NoError(t, err)
+
+	file2 := &models.File{
+		LibraryID:          book.LibraryID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           epub2Path,
+		FilesizeBytes:      5,
+		CoverImageFilename: &coverName2,
+	}
+	_, err = db.NewInsert().Model(file2).Exec(ctx)
+	require.NoError(t, err)
+
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+	e := setupTestServer(t, db)
+
+	// Set file2 as preferred
+	body := `{"is_preferred_cover": true}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file2.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	// Verify file2 is preferred
+	var f2 models.File
+	require.NoError(t, db.NewSelect().Model(&f2).Where("id = ?", file2.ID).Scan(ctx))
+	assert.True(t, f2.IsPreferredCover)
+
+	// Verify file1 is NOT preferred
+	var f1 models.File
+	require.NoError(t, db.NewSelect().Model(&f1).Where("id = ?", file1.ID).Scan(ctx))
+	assert.False(t, f1.IsPreferredCover)
+
+	// Now set file1 as preferred — file2 should be cleared
+	body = `{"is_preferred_cover": true}`
+	req = httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file1.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr = executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	require.NoError(t, db.NewSelect().Model(&f1).Where("id = ?", file1.ID).Scan(ctx))
+	assert.True(t, f1.IsPreferredCover)
+	require.NoError(t, db.NewSelect().Model(&f2).Where("id = ?", file2.ID).Scan(ctx))
+	assert.False(t, f2.IsPreferredCover, "file2 should be cleared when file1 becomes preferred")
+}
+
+func TestUpdateFile_IsPreferredCover_RejectsFileWithNoCover(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+
+	library, book := setupTestLibraryAndBook(t, db)
+	dir := t.TempDir()
+
+	epubPath := filepath.Join(dir, "file.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub"), 0o644))
+
+	file := &models.File{
+		LibraryID:     book.LibraryID,
+		BookID:        book.ID,
+		FileType:      models.FileTypeEPUB,
+		FileRole:      models.FileRoleMain,
+		Filepath:      epubPath,
+		FilesizeBytes: 4,
+		// No cover
+	}
+	_, err := db.NewInsert().Model(file).Exec(context.Background())
+	require.NoError(t, err)
+
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+	e := setupTestServer(t, db)
+
+	body := `{"is_preferred_cover": true}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	assert.Equal(t, http.StatusBadRequest, rr.Code, "response body: %s", rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "cover")
+}
+
+func TestUpdateFile_IsPreferredCover_DifferentCategoriesIndependent(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, book := setupTestLibraryAndBook(t, db)
+	dir := t.TempDir()
+
+	epubPath := filepath.Join(dir, "file.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub"), 0o644))
+	epubCover := "file.epub.cover.jpg"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, epubCover), []byte("cover"), 0o644))
+
+	m4bPath := filepath.Join(dir, "file.m4b")
+	require.NoError(t, os.WriteFile(m4bPath, []byte("m4b"), 0o644))
+	m4bCover := "file.m4b.cover.jpg"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, m4bCover), []byte("cover"), 0o644))
+
+	epubFile := &models.File{
+		LibraryID:          book.LibraryID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           epubPath,
+		FilesizeBytes:      4,
+		CoverImageFilename: &epubCover,
+		IsPreferredCover:   true, // Already preferred ebook
+	}
+	_, err := db.NewInsert().Model(epubFile).Exec(ctx)
+	require.NoError(t, err)
+
+	m4bFile := &models.File{
+		LibraryID:          book.LibraryID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeM4B,
+		FileRole:           models.FileRoleMain,
+		Filepath:           m4bPath,
+		FilesizeBytes:      3,
+		CoverImageFilename: &m4bCover,
+	}
+	_, err = db.NewInsert().Model(m4bFile).Exec(ctx)
+	require.NoError(t, err)
+
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+	e := setupTestServer(t, db)
+
+	// Set M4B as preferred — should NOT clear the EPUB preferred
+	body := `{"is_preferred_cover": true}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(m4bFile.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	var epub models.File
+	require.NoError(t, db.NewSelect().Model(&epub).Where("id = ?", epubFile.ID).Scan(ctx))
+	assert.True(t, epub.IsPreferredCover, "EPUB preferred should be preserved when M4B becomes preferred")
+
+	var m4b models.File
+	require.NoError(t, db.NewSelect().Model(&m4b).Where("id = ?", m4bFile.ID).Scan(ctx))
+	assert.True(t, m4b.IsPreferredCover)
+}
+
+func TestUpdateFile_IsPreferredCover_ClearingPreferred(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, book := setupTestLibraryAndBook(t, db)
+	dir := t.TempDir()
+
+	epubPath := filepath.Join(dir, "file.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub"), 0o644))
+	epubCover := "file.epub.cover.jpg"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, epubCover), []byte("cover"), 0o644))
+
+	file := &models.File{
+		LibraryID:          book.LibraryID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           epubPath,
+		FilesizeBytes:      4,
+		CoverImageFilename: &epubCover,
+		IsPreferredCover:   true,
+	}
+	_, err := db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+	e := setupTestServer(t, db)
+
+	// Clear preferred
+	body := `{"is_preferred_cover": false}`
+	req := httptest.NewRequest(http.MethodPost, "/books/files/"+strconv.Itoa(file.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	var f models.File
+	require.NoError(t, db.NewSelect().Model(&f).Where("id = ?", file.ID).Scan(ctx))
+	assert.False(t, f.IsPreferredCover, "preferred should be cleared")
+}
+
 func TestUpdateBook_SeriesNumberUnit_StoresChapterUnit(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/books/validators.go
+++ b/pkg/books/validators.go
@@ -49,15 +49,16 @@ type IdentifierPayload struct {
 
 // UpdateFilePayload is the payload for updating a file's metadata.
 type UpdateFilePayload struct {
-	FileRole    *string              `json:"file_role,omitempty" validate:"omitempty,oneof=main supplement"`
-	Name        *string              `json:"name,omitempty" mod:"trim" validate:"omitempty,max=500"`
-	Narrators   []string             `json:"narrators,omitempty" validate:"omitempty,dive,max=200"`
-	URL         *string              `json:"url,omitempty" validate:"omitempty,max=500,url"`
-	Publisher   *string              `json:"publisher,omitempty" validate:"omitempty,max=200"`
-	ReleaseDate *string              `json:"release_date,omitempty" validate:"omitempty"` // ISO 8601 date string
-	Language    *string              `json:"language,omitempty" validate:"omitempty,max=35"`
-	Abridged    *string              `json:"abridged,omitempty" validate:"omitempty,oneof=true false"` // "true", "false", or "" to clear
-	Identifiers *[]IdentifierPayload `json:"identifiers,omitempty" mod:"dive" validate:"omitempty,dive"`
+	FileRole         *string              `json:"file_role,omitempty" validate:"omitempty,oneof=main supplement"`
+	Name             *string              `json:"name,omitempty" mod:"trim" validate:"omitempty,max=500"`
+	Narrators        []string             `json:"narrators,omitempty" validate:"omitempty,dive,max=200"`
+	URL              *string              `json:"url,omitempty" validate:"omitempty,max=500,url"`
+	Publisher        *string              `json:"publisher,omitempty" validate:"omitempty,max=200"`
+	ReleaseDate      *string              `json:"release_date,omitempty" validate:"omitempty"` // ISO 8601 date string
+	Language         *string              `json:"language,omitempty" validate:"omitempty,max=35"`
+	Abridged         *string              `json:"abridged,omitempty" validate:"omitempty,oneof=true false"` // "true", "false", or "" to clear
+	Identifiers      *[]IdentifierPayload `json:"identifiers,omitempty" mod:"dive" validate:"omitempty,dive"`
+	IsPreferredCover *bool                `json:"is_preferred_cover,omitempty"`
 }
 
 // ResyncPayload contains the request parameters for resync operations.

--- a/pkg/covers/covers.go
+++ b/pkg/covers/covers.go
@@ -38,20 +38,30 @@ func SelectFile(files []*models.File, coverAspectRatio string) *models.File {
 		}
 	}
 
+	// Within each bucket, prefer a file with IsPreferredCover set.
+	pickFirst := func(files []*models.File) *models.File {
+		for _, f := range files {
+			if f.IsPreferredCover {
+				return f
+			}
+		}
+		return files[0]
+	}
+
 	switch coverAspectRatio {
 	case "audiobook", "audiobook_fallback_book":
 		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
+			return pickFirst(audiobookFiles)
 		}
 		if len(bookFiles) > 0 {
-			return bookFiles[0]
+			return pickFirst(bookFiles)
 		}
 	default: // "book", "book_fallback_audiobook", or any other value
 		if len(bookFiles) > 0 {
-			return bookFiles[0]
+			return pickFirst(bookFiles)
 		}
 		if len(audiobookFiles) > 0 {
-			return audiobookFiles[0]
+			return pickFirst(audiobookFiles)
 		}
 	}
 	return nil

--- a/pkg/covers/covers_test.go
+++ b/pkg/covers/covers_test.go
@@ -32,6 +32,11 @@ func TestSelectFile(t *testing.T) {
 		f.FileRole = models.FileRoleSupplement
 		return f
 	}
+	preferredWithCover := func(id int, fileType, cover string) *models.File {
+		f := withCover(id, fileType, cover)
+		f.IsPreferredCover = true
+		return f
+	}
 
 	epub := withCover(1, models.FileTypeEPUB, "epub.cover.jpg")
 	cbz := withCover(2, models.FileTypeCBZ, "cbz.cover.jpg")
@@ -41,6 +46,8 @@ func TestSelectFile(t *testing.T) {
 	audioNoCover := withCover(6, models.FileTypeM4B, "")
 	pdfSupplement := supplementWithCover(7, models.FileTypePDF, "supp.cover.jpg")
 	epubSupplement := supplementWithCover(8, models.FileTypeEPUB, "supp.cover.jpg")
+	preferredCBZ := preferredWithCover(9, models.FileTypeCBZ, "cbz2.cover.jpg")
+	preferredM4B := preferredWithCover(10, models.FileTypeM4B, "m4b2.cover.jpg")
 
 	tests := []struct {
 		name           string
@@ -143,6 +150,37 @@ func TestSelectFile(t *testing.T) {
 			files:          []*models.File{pdfSupplement, m4b},
 			aspectRatio:    "audiobook",
 			expectedFileID: m4b.ID,
+		},
+		// Preferred cover tests
+		{
+			name:           "preferred ebook file wins over first in bucket",
+			files:          []*models.File{epub, preferredCBZ},
+			aspectRatio:    "book",
+			expectedFileID: preferredCBZ.ID,
+		},
+		{
+			name:           "preferred audiobook file wins over first in bucket",
+			files:          []*models.File{m4b, preferredM4B},
+			aspectRatio:    "audiobook",
+			expectedFileID: preferredM4B.ID,
+		},
+		{
+			name:           "preferred ebook in non-selected bucket does not affect audiobook selection",
+			files:          []*models.File{epub, preferredCBZ, m4b},
+			aspectRatio:    "audiobook",
+			expectedFileID: m4b.ID,
+		},
+		{
+			name:           "preferred audiobook in non-selected bucket does not affect ebook selection",
+			files:          []*models.File{epub, cbz, preferredM4B},
+			aspectRatio:    "book",
+			expectedFileID: epub.ID,
+		},
+		{
+			name:           "no preferred falls back to first file (existing behavior)",
+			files:          []*models.File{epub, cbz},
+			aspectRatio:    "book",
+			expectedFileID: epub.ID,
 		},
 	}
 

--- a/pkg/migrations/20260529000000_add_is_preferred_cover.go
+++ b/pkg/migrations/20260529000000_add_is_preferred_cover.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE files ADD COLUMN is_preferred_cover BOOLEAN NOT NULL DEFAULT FALSE`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		// SQLite cannot drop a column before 3.35.0; rebuild if needed.
+		// Since the app targets recent SQLite, ALTER TABLE DROP COLUMN works.
+		_, err := db.Exec(`ALTER TABLE files DROP COLUMN is_preferred_cover`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/file.go
+++ b/pkg/models/file.go
@@ -70,6 +70,7 @@ type File struct {
 	ReviewOverride           *string           `json:"review_override" tstype:"ReviewOverride"`
 	ReviewOverriddenAt       *time.Time        `json:"review_overridden_at"`
 	Reviewed                 *bool             `json:"reviewed"`
+	IsPreferredCover         bool              `bun:",default:false" json:"is_preferred_cover"`
 }
 
 func (f *File) CoverExtension() string {

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -22,6 +22,19 @@ Each book contains one or more files. Files hold format-specific metadata that m
 
 **File-level fields:** name, narrators (M4B only), publisher, release date, URL, identifiers, chapters, language, abridged
 
+#### Preferred Cover
+
+When a book has multiple main files of the same type (e.g., two EPUB editions), the library's cover aspect ratio setting determines which *category* (ebook or audiobook) provides the book cover, but within that category the first file wins by default. The **Preferred cover** option lets you override which file's cover represents the book within its category.
+
+Open the file edit dialog for any main file. When 2+ main files of the same type category exist on the book, a checkbox appears near the cover section:
+
+- **Preferred ebook cover** — for EPUB, CBZ, and PDF files
+- **Preferred audiobook cover** — for M4B files
+
+Setting a file as preferred automatically clears the flag on other files of the same category in the same book. Setting preferred on an M4B does not affect EPUB/CBZ/PDF preferences, and vice versa.
+
+The file must have a cover image to be marked as preferred. This preference is not included in [sidecar files](./sidecar-files.md) — it is a per-book display preference, not intrinsic file metadata. Rescanning the library preserves preferred cover selections.
+
 ### People
 
 People represent both **authors** and **narrators**. The same person record is shared across both roles, so renaming an author automatically updates everywhere they appear.


### PR DESCRIPTION
Closes #322

## Summary
- Added `is_preferred_cover` boolean to the `files` table so users can control which file's cover represents the book within its type category (ebook or audiobook)
- Backend validates cover existence, clears siblings of the same type category when setting preferred, and clears the flag on downgrade to supplement
- Frontend shows a "Preferred ebook/audiobook cover" checkbox in the file edit dialog when 2+ main files of the same type category exist
- Cover selection logic (Go `SelectFile` and TS `selectCoverFile`) prefers files with `is_preferred_cover` within each bucket before falling back to first-file-wins

## Test plan
- Go unit tests cover set-and-clear-siblings, reject-no-cover, different-categories-independent, and clearing-preferred (handlers_test.go)
- Go unit tests cover preferred wins over first in bucket, preferred in non-selected bucket independent, no-preferred fallback (covers_test.go)
- TS unit tests mirror all Go cover selection tests (coverSelection.test.ts)
- Existing test mocks updated with `is_preferred_cover: false` to satisfy the new required field
- Documentation added to website/docs/metadata.md