### PR TITLE
[Feature] Add backend-computed cover_cache_key for immutable cover caching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,12 +86,12 @@ file.CoverImageFilename = &filename
 
 ### Frontend
 
-**Cover images require both URL cache-busting AND HTTP revalidation** — Browsers maintain an in-memory image cache independent from the HTTP cache, so `Cache-Control: no-cache` alone doesn't force a fresh fetch on `<img>` remount with the same src. Cover URLs must include `?v=${cacheKey}` where `cacheKey` reliably bumps on data refetches (e.g., `bookQuery.dataUpdatedAt`). See `app/CLAUDE.md` for details.
+**Cover images require URL-based cache busting** — API cover endpoints use `Cache-Control: immutable` so browsers cache forever. Cover URLs must include `?v=${cacheKey}` where `cacheKey` is a backend-computed `cover_cache_key` (for books/series) or `file.updated_at` (for file covers) that only changes when the actual cover changes. See `app/CLAUDE.md` for details.
 
 ```tsx
 <img
-  key={bookQuery.dataUpdatedAt}
-  src={`/api/books/${id}/cover?v=${bookQuery.dataUpdatedAt}`}
+  key={book.cover_cache_key}
+  src={`/api/books/${id}/cover?v=${book.cover_cache_key}`}
 />
 ```
 

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -314,34 +314,39 @@ Center and constrain cover images on mobile:
 </div>
 ```
 
-## Cover Image Freshness
+## Cover Image Caching
 
-Cover URLs include a `?v=${cacheKey}` query parameter that bumps whenever the underlying data is refetched. The backend emits `Cache-Control: private, no-cache` + `Last-Modified` and returns `304 Not Modified` on conditional GET, but the query-param is the primary freshness mechanism. Both layers together give reliable updates across browsers.
+API cover endpoints use `Cache-Control: private, max-age=31536000, immutable` — the browser caches the response forever. Freshness is driven by changing the URL via `?v=${cacheKey}`, where `cacheKey` is a backend-computed `cover_cache_key` field (format `"<fileId>-<updatedAt.Unix()>"`) that only changes when the actual cover changes. This is much better than the old `dataUpdatedAt` approach, which changed on every TanStack Query refetch and defeated caching.
 
-### Why URL-based busting is required
+### Cache key sources by endpoint
 
-Chromium and Firefox maintain an in-memory image cache (the HTML spec's "list of available images") that is **separate from the HTTP cache**. When an `<img>` element's `src` matches a URL previously rendered in the session, the browser serves the cached decoded bitmap without hitting HTTP — bypassing `Cache-Control: no-cache` entirely. Stable URLs + `Cache-Control` alone are insufficient.
+| Endpoint | Cache key source |
+|----------|-----------------|
+| `/api/books/:id/cover` | `book.cover_cache_key` from API response |
+| `/api/books/files/:id/cover` | `file.updated_at` from API response |
+| `/api/series/:id/cover` | `series.cover_cache_key` from API response |
 
-References:
-- [whatwg/fetch#1088](https://github.com/whatwg/fetch/issues/1088) — browsers reusing `no-cache` cached images
-- [Mozilla bug 1719583](https://bugzilla.mozilla.org/show_bug.cgi?id=1719583) — Firefox image cache persists across `fetch({cache: 'reload'})`
+### Why URL-based busting is still required
+
+Chromium and Firefox maintain an in-memory image cache (the HTML spec's "list of available images") that is **separate from the HTTP cache**. When an `<img>` element's `src` matches a URL previously rendered in the session, the browser serves the cached decoded bitmap without hitting HTTP — even with `immutable`. Changing the `?v=` param changes the URL, forcing a new network fetch.
 
 ### Rules
 
-- **Append `?v=${cacheKey}`** to cover URLs. `cacheKey` must be a value that changes when the underlying data is refetched (e.g., `bookQuery.dataUpdatedAt`), **not** `entity.updated_at` (which doesn't bump on file-cover changes).
+- **Append `?v=${cacheKey}`** to cover URLs where `cacheKey` comes from the backend (`book.cover_cache_key`, `series.cover_cache_key`, or `file.updated_at`).
 - **For pages that mutate covers** (BookDetail, FileEditDialog), also add `key={cacheKey}` to the `<img>` tag. React remounting combined with URL change gives reliable refresh.
-- **For child components that render covers**, accept a `cacheKey?: number` prop. Parents pass their query's `dataUpdatedAt` or the relevant entity's `updated_at` (for file covers, since `file.updated_at` bumps reliably on cover mutations).
-- **Source selection by endpoint:**
-  - `/api/books/:id/cover` (book cover, selected from files) — parent book query's `dataUpdatedAt` (or a cascaded `cacheKey` prop).
-  - `/api/books/files/:id/cover` (specific file's cover) — `file.updated_at` (reliable) or the parent query's `dataUpdatedAt`.
-  - `/api/series/:id/cover` (series cover, from first book) — parent series query's `dataUpdatedAt`.
+- **For child components that render covers**, accept a `cacheKey?: string` prop. Parents pass the appropriate cache key from the API response.
+
+### Exceptions (no change needed)
+
+- `GlobalSearch.tsx` — keep `searchQuery.dataUpdatedAt` (search results don't include `cover_cache_key`, small number of covers)
+- `FileEditDialog.tsx` — keep `Date.now()` for immediate preview after cover mutation
+- `IdentifyReviewForm.tsx` — keep `file.updated_at`
 
 ### Checklist for new cover components
 
-- [ ] Cover URL includes `?v=${cacheKey}` with a value that bumps when data is refetched
-- [ ] `cacheKey` source is reliable (`query.dataUpdatedAt` or `file.updated_at` — NOT `book.updated_at` for cover purposes)
+- [ ] Cover URL includes `?v=${cacheKey}` with the appropriate backend-provided cache key
 - [ ] For mutation-capable pages, `<img key={cacheKey}>` for React remount
-- [ ] Cover-mutating mutations invalidate the query whose `dataUpdatedAt` drives the key
+- [ ] Cover-mutating mutations invalidate the query whose data drives the key
 
 ### Breadcrumbs
 

--- a/app/components/library/BookGallerySection.test.tsx
+++ b/app/components/library/BookGallerySection.test.tsx
@@ -66,13 +66,11 @@ function makeQueryResult(
   data: ResourceListResponse<Book>;
   isLoading: boolean;
   isSuccess: boolean;
-  dataUpdatedAt: number;
 } {
   return {
     data: { items: books, total },
     isLoading: false,
     isSuccess: true,
-    dataUpdatedAt: Date.now(),
   };
 }
 

--- a/app/components/library/BookGallerySection.test.tsx
+++ b/app/components/library/BookGallerySection.test.tsx
@@ -172,7 +172,6 @@ describe("BookGallerySection", () => {
             data: { items: [], total: 0 },
             isLoading: true,
             isSuccess: false,
-            dataUpdatedAt: 0,
           }}
           title="Books"
         />,

--- a/app/components/library/BookGallerySection.tsx
+++ b/app/components/library/BookGallerySection.tsx
@@ -19,7 +19,6 @@ interface BookGalleryQuery {
   data: ResourceListResponse<Book> | undefined;
   isLoading: boolean;
   isSuccess: boolean;
-  dataUpdatedAt: number;
 }
 
 interface BookGallerySectionProps {
@@ -149,7 +148,7 @@ export function BookGallerySection({
         {query.data?.items.map((book) => (
           <BookItem
             book={book}
-            cacheKey={query.dataUpdatedAt}
+            cacheKey={book.cover_cache_key}
             gallerySize={effectiveSize}
             key={book.id}
             libraryId={libraryId}

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -62,7 +62,7 @@ interface BookItemProps {
   isSelected?: boolean;
   onSelect?: () => void;
   onShiftSelect?: () => void;
-  cacheKey?: number;
+  cacheKey?: string;
   gallerySize?: GallerySize;
 }
 

--- a/app/components/library/CoverGalleryTabs.test.tsx
+++ b/app/components/library/CoverGalleryTabs.test.tsx
@@ -23,7 +23,7 @@ function makeFile(overrides: Partial<File> = {}): File {
 }
 
 describe("CoverGalleryTabs", () => {
-  it("renders cover image with stable URL when no cacheKey is provided", () => {
+  it("renders cover image with cache key from file updated_at", () => {
     const files = [
       makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
       makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
@@ -33,60 +33,83 @@ describe("CoverGalleryTabs", () => {
 
     const img = container.querySelector("img");
     expect(img).not.toBeNull();
-    expect(img?.getAttribute("src")).toBe("/api/books/files/1/cover");
+    expect(img?.getAttribute("src")).toBe(
+      "/api/books/files/1/cover?v=2024-01-01T00:00:00Z",
+    );
   });
 
-  it("re-mounts cover image when cacheKey changes", () => {
+  it("re-mounts cover image when file updated_at changes", () => {
     const files = [
-      makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
+      makeFile({
+        id: 1,
+        file_type: "epub",
+        filepath: "/library/a.epub",
+        updated_at: "2024-01-01T00:00:00Z",
+      }),
       makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
     ];
 
-    const { container, rerender } = render(
-      <CoverGalleryTabs cacheKey={111} files={files} />,
-    );
+    const { container, rerender } = render(<CoverGalleryTabs files={files} />);
     const firstImg = container.querySelector("img");
     expect(firstImg).not.toBeNull();
     expect(firstImg?.getAttribute("src")).toBe(
-      "/api/books/files/1/cover?v=111",
+      "/api/books/files/1/cover?v=2024-01-01T00:00:00Z",
     );
 
-    // Simulate an error first so the img is unmounted, then a cacheKey bump
-    // should cause it to re-mount (simulating a "retry" after the cover was
-    // fixed on disk — equivalent to the old cacheBuster-driven retry flow).
     fireEvent.error(firstImg!);
     expect(container.querySelector("img")).toBeNull();
 
-    rerender(<CoverGalleryTabs cacheKey={222} files={files} />);
+    const updatedFiles = [
+      makeFile({
+        id: 1,
+        file_type: "epub",
+        filepath: "/library/a.epub",
+        updated_at: "2024-06-01T00:00:00Z",
+      }),
+      makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
+    ];
+    rerender(<CoverGalleryTabs files={updatedFiles} />);
     const secondImg = container.querySelector("img");
     expect(secondImg).not.toBeNull();
     expect(secondImg?.getAttribute("src")).toBe(
-      "/api/books/files/1/cover?v=222",
+      "/api/books/files/1/cover?v=2024-06-01T00:00:00Z",
     );
   });
 
-  it("mounts a fresh <img> element when cacheKey changes (even without error)", () => {
+  it("mounts a fresh <img> element when file updated_at changes (even without error)", () => {
     const files = [
-      makeFile({ id: 1, file_type: "epub", filepath: "/library/a.epub" }),
+      makeFile({
+        id: 1,
+        file_type: "epub",
+        filepath: "/library/a.epub",
+        updated_at: "2024-01-01T00:00:00Z",
+      }),
       makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
     ];
 
-    const { container, rerender } = render(
-      <CoverGalleryTabs cacheKey={111} files={files} />,
-    );
+    const { container, rerender } = render(<CoverGalleryTabs files={files} />);
     const firstImg = container.querySelector("img");
     expect(firstImg).not.toBeNull();
     expect(firstImg?.getAttribute("src")).toBe(
-      "/api/books/files/1/cover?v=111",
+      "/api/books/files/1/cover?v=2024-01-01T00:00:00Z",
     );
 
-    rerender(<CoverGalleryTabs cacheKey={222} files={files} />);
+    const updatedFiles = [
+      makeFile({
+        id: 1,
+        file_type: "epub",
+        filepath: "/library/a.epub",
+        updated_at: "2024-06-01T00:00:00Z",
+      }),
+      makeFile({ id: 2, file_type: "m4b", filepath: "/library/b.m4b" }),
+    ];
+    rerender(<CoverGalleryTabs files={updatedFiles} />);
     const secondImg = container.querySelector("img");
 
     expect(secondImg).not.toBeNull();
-    expect(secondImg).not.toBe(firstImg); // Different DOM node — React remounted
+    expect(secondImg).not.toBe(firstImg);
     expect(secondImg?.getAttribute("src")).toBe(
-      "/api/books/files/1/cover?v=222",
+      "/api/books/files/1/cover?v=2024-06-01T00:00:00Z",
     );
   });
 });

--- a/app/components/library/CoverGalleryTabs.tsx
+++ b/app/components/library/CoverGalleryTabs.tsx
@@ -14,12 +14,6 @@ import { getFilename } from "@/utils/format";
 interface CoverGalleryTabsProps {
   files: File[];
   className?: string;
-  /**
-   * Forces the <img> to remount (and thus re-request) when this value changes.
-   * Typically set to a React Query `dataUpdatedAt` so cover updates triggered
-   * by mutations on this page flow through HTTP revalidation.
-   */
-  cacheKey?: number;
 }
 
 interface FileWithLabel extends File {
@@ -61,11 +55,7 @@ function getFilesWithLabels(files: File[]): FileWithLabel[] {
  * Allows switching between different file covers when a book has multiple files.
  * Only renders when there are 2+ files.
  */
-function CoverGalleryTabs({
-  files,
-  className,
-  cacheKey,
-}: CoverGalleryTabsProps) {
+function CoverGalleryTabs({ files, className }: CoverGalleryTabsProps) {
   const [selectedFileId, setSelectedFileId] = useState<number | null>(null);
   const [coverLoaded, setCoverLoaded] = useState(false);
   const [coverError, setCoverError] = useState(false);
@@ -85,9 +75,10 @@ function CoverGalleryTabs({
   const placeholderVariant = isAudiobook ? "audiobook" : "book";
 
   const hasCover = selectedFile?.cover_image_filename && !coverError;
+  const fileCacheKey = selectedFile?.updated_at;
   const coverUrl = selectedFile
-    ? cacheKey
-      ? `/api/books/files/${selectedFile.id}/cover?v=${cacheKey}`
+    ? fileCacheKey
+      ? `/api/books/files/${selectedFile.id}/cover?v=${fileCacheKey}`
       : `/api/books/files/${selectedFile.id}/cover`
     : null;
 
@@ -104,13 +95,9 @@ function CoverGalleryTabs({
     setCoverLoaded(false);
   }, [selectedFileId]);
 
-  // Reset the error flag whenever the URL changes (tab switch) or when the
-  // cacheKey bumps (cover mutation). If we only reset on tab change, a
-  // previously-failed cover stays unmounted even after the underlying file
-  // gets a valid cover.
   useEffect(() => {
     setCoverError(false);
-  }, [coverUrl, cacheKey]);
+  }, [coverUrl]);
 
   const handleCoverLoad = () => {
     if (coverUrl) {
@@ -155,7 +142,7 @@ function CoverGalleryTabs({
               "absolute inset-0 w-full h-full object-cover",
               !coverLoaded && "opacity-0",
             )}
-            key={`${selectedFile?.id}-${cacheKey ?? 0}`}
+            key={`${selectedFile?.id}-${fileCacheKey ?? ""}`}
             onError={() => setCoverError(true)}
             onLoad={handleCoverLoad}
             src={coverUrl}

--- a/app/components/library/DraggableBookList.tsx
+++ b/app/components/library/DraggableBookList.tsx
@@ -36,7 +36,6 @@ interface DraggableBookItemProps {
   addedByUsername?: string;
   isDragOverlay?: boolean;
   insertPosition?: InsertPosition;
-  cacheKey?: number;
   gallerySize?: GallerySize;
 }
 
@@ -45,7 +44,6 @@ const DraggableBookItem = ({
   addedByUsername,
   isDragOverlay = false,
   insertPosition = null,
-  cacheKey,
   gallerySize = DEFAULT_GALLERY_SIZE,
 }: DraggableBookItemProps) => {
   const {
@@ -76,7 +74,7 @@ const DraggableBookItem = ({
         <BookItem
           addedByUsername={addedByUsername}
           book={listBook.book}
-          cacheKey={cacheKey}
+          cacheKey={listBook.book.cover_cache_key}
           libraryId={listBook.book.library_id.toString()}
         />
       </div>
@@ -104,7 +102,7 @@ const DraggableBookItem = ({
       <BookItem
         addedByUsername={addedByUsername}
         book={listBook.book}
-        cacheKey={cacheKey}
+        cacheKey={listBook.book.cover_cache_key}
         libraryId={listBook.book.library_id.toString()}
       />
     </div>
@@ -115,7 +113,6 @@ interface DraggableBookListProps {
   books: ListBook[];
   isOwner: boolean;
   onReorder: (bookIds: number[]) => void;
-  cacheKey?: number;
   gallerySize?: GallerySize;
 }
 
@@ -123,7 +120,6 @@ export const DraggableBookList = ({
   books,
   isOwner,
   onReorder,
-  cacheKey,
   gallerySize = DEFAULT_GALLERY_SIZE,
 }: DraggableBookListProps) => {
   const [items, setItems] = useState(books);
@@ -239,7 +235,6 @@ export const DraggableBookList = ({
               addedByUsername={
                 !isOwner ? listBook.added_by_user?.username : undefined
               }
-              cacheKey={cacheKey}
               gallerySize={gallerySize}
               insertPosition={getInsertPosition(listBook.book_id)}
               key={listBook.id}
@@ -254,7 +249,6 @@ export const DraggableBookList = ({
             addedByUsername={
               !isOwner ? activeItem.added_by_user?.username : undefined
             }
-            cacheKey={cacheKey}
             gallerySize={gallerySize}
             isDragOverlay
             listBook={activeItem}

--- a/app/components/library/FileCoverThumbnail.test.tsx
+++ b/app/components/library/FileCoverThumbnail.test.tsx
@@ -42,7 +42,7 @@ describe("FileCoverThumbnail", () => {
   it("re-mounts the img when cacheKey bumps after an error", () => {
     const file = makeFile();
     const { container, rerender } = render(
-      <FileCoverThumbnail cacheKey={111} file={file} />,
+      <FileCoverThumbnail cacheKey="111" file={file} />,
     );
     const firstImg = container.querySelector("img");
     expect(firstImg).not.toBeNull();
@@ -53,7 +53,7 @@ describe("FileCoverThumbnail", () => {
     fireEvent.error(firstImg!);
     expect(container.querySelector("img")).toBeNull();
 
-    rerender(<FileCoverThumbnail cacheKey={222} file={file} />);
+    rerender(<FileCoverThumbnail cacheKey="222" file={file} />);
     const secondImg = container.querySelector("img");
     expect(secondImg).not.toBeNull();
     expect(secondImg?.getAttribute("src")).toBe(

--- a/app/components/library/FileCoverThumbnail.tsx
+++ b/app/components/library/FileCoverThumbnail.tsx
@@ -8,11 +8,7 @@ interface FileCoverThumbnailProps {
   file: File;
   className?: string;
   onClick?: () => void;
-  /**
-   * Forces the <img> to remount (and thus re-request) when this value changes.
-   * Typically a React Query `dataUpdatedAt` from a mutation-aware query.
-   */
-  cacheKey?: number;
+  cacheKey?: string;
   /**
    * Whether to apply interactive styles (cursor-pointer, hover:scale, hover:shadow).
    * Defaults to true. Pass false for non-interactive contexts like file list rows.
@@ -81,7 +77,7 @@ function FileCoverThumbnail({
             "absolute inset-0 w-full h-full object-cover",
             !imageLoaded && "opacity-0",
           )}
-          key={`${file.id}-${cacheKey ?? 0}`}
+          key={`${file.id}-${cacheKey ?? ""}`}
           onError={() => setImageError(true)}
           onLoad={() => setImageLoaded(true)}
           src={coverUrl}

--- a/app/components/library/FileEditDialog.test.tsx
+++ b/app/components/library/FileEditDialog.test.tsx
@@ -579,6 +579,7 @@ describe("FileEditDialog", () => {
       sort_title: "Test Book",
       sort_title_source: DataSourceManual,
       author_source: DataSourceManual,
+      cover_cache_key: "",
       files: [],
     };
 

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -98,8 +98,7 @@ export function FileEditDialog({
   const isPageBased = isPageBasedFileType(file.file_type);
   // Dialog-local cover cache key — bumped synchronously after cover mutations
   // (upload / set-cover-page) so the preview `<img>` refreshes immediately on
-  // save, without waiting for the parent query to refetch. Elsewhere in the
-  // codebase we use `query.dataUpdatedAt` for this; intentional divergence.
+  // save, without waiting for the parent query to refetch.
   const [coverCacheKey, setCoverCacheKey] = useState(() => Date.now());
   const [coverPagePickerOpen, setCoverPagePickerOpen] = useState(false);
   const [pendingCoverPage, setPendingCoverPage] = useState<number | null>(null);

--- a/app/components/library/FileListSection.test.tsx
+++ b/app/components/library/FileListSection.test.tsx
@@ -68,13 +68,11 @@ function makeQueryResult(
   data: ResourceListResponse<File>;
   isLoading: boolean;
   isSuccess: boolean;
-  dataUpdatedAt: number;
 } {
   return {
     data: { items: files, total },
     isLoading: false,
     isSuccess: true,
-    dataUpdatedAt: Date.now(),
   };
 }
 
@@ -250,7 +248,6 @@ describe("FileListSection", () => {
             data: { items: [], total: 0 },
             isLoading: true,
             isSuccess: false,
-            dataUpdatedAt: 0,
           }}
           title="Files"
         />,

--- a/app/components/library/FileListSection.tsx
+++ b/app/components/library/FileListSection.tsx
@@ -13,7 +13,6 @@ interface FileListQuery {
   data: ResourceListResponse<File> | undefined;
   isLoading: boolean;
   isSuccess: boolean;
-  dataUpdatedAt: number;
 }
 
 interface FileListSectionProps {

--- a/app/components/library/FileListSection.tsx
+++ b/app/components/library/FileListSection.tsx
@@ -125,7 +125,7 @@ export function FileListSection({
           >
             <div className="w-12 shrink-0">
               <FileCoverThumbnail
-                cacheKey={query.dataUpdatedAt}
+                cacheKey={file.updated_at}
                 className="w-full"
                 file={file}
                 interactive={false}

--- a/app/components/library/ReviewPanel.test.tsx
+++ b/app/components/library/ReviewPanel.test.tsx
@@ -61,6 +61,7 @@ const baseBook: Book = {
   sort_title: "Test Book",
   sort_title_source: "manual",
   author_source: "manual",
+  cover_cache_key: "",
   files: [],
   authors: [
     { id: 1, book_id: 1, person_id: 1, sort_order: 0, role: undefined },

--- a/app/components/library/SelectableBookItem.tsx
+++ b/app/components/library/SelectableBookItem.tsx
@@ -10,7 +10,7 @@ interface SelectableBookItemProps {
   coverAspectRatio?: string;
   addedByUsername?: string;
   pageBookIds: number[];
-  cacheKey?: number;
+  cacheKey?: string;
   gallerySize?: GallerySize;
 }
 

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -127,7 +127,7 @@ interface FileRowProps {
   isFileSelected?: boolean;
   onToggleSelect?: () => void;
   onMoveFile?: () => void;
-  cacheKey?: number;
+  cacheKey?: string;
   onDeleteFile: () => void;
   isDeletingFile: boolean;
 }
@@ -740,10 +740,7 @@ const BookDetail = () => {
     );
   };
 
-  // Key source for cover images — used as <img key> so React remounts the
-  // element (triggering revalidation) when data is refreshed. Also included
-  // in the URL as ?v= to bypass the browser's in-memory image cache.
-  const coverCacheKey = bookQuery.dataUpdatedAt;
+  const coverCacheKey = bookQuery.data?.cover_cache_key;
   const coverUrl = bookQuery.data?.id
     ? coverCacheKey
       ? `/api/books/${bookQuery.data.id}/cover?v=${coverCacheKey}`
@@ -993,7 +990,7 @@ const BookDetail = () => {
         <div className="lg:col-span-1 space-y-4 md:space-y-6">
           {mainFiles.length > 1 ? (
             /* Multiple files - show cover gallery with tabs */
-            <CoverGalleryTabs cacheKey={coverCacheKey} files={mainFiles} />
+            <CoverGalleryTabs files={mainFiles} />
           ) : (
             /* Single file - show book cover directly */
             <div
@@ -1309,7 +1306,7 @@ const BookDetail = () => {
               <div className="space-y-2">
                 {mainFiles.map((file) => (
                   <FileRow
-                    cacheKey={coverCacheKey}
+                    cacheKey={file.updated_at}
                     file={file}
                     hasExpandableMetadata={hasExpandableMetadata(file)}
                     isDeletingFile={deletingFileId === file.id}
@@ -1352,7 +1349,7 @@ const BookDetail = () => {
                   <div className="space-y-2">
                     {supplements.map((file) => (
                       <FileRow
-                        cacheKey={coverCacheKey}
+                        cacheKey={file.updated_at}
                         file={file}
                         hasExpandableMetadata={hasExpandableMetadata(file)}
                         isDeletingFile={deletingFileId === file.id}

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -525,7 +525,7 @@ const HomeContent = () => {
   const renderBookItem = (book: Book) => (
     <SelectableBookItem
       book={book}
-      cacheKey={booksQuery.dataUpdatedAt}
+      cacheKey={book.cover_cache_key}
       coverAspectRatio={coverAspectRatio}
       gallerySize={effectiveSize}
       key={book.id}

--- a/app/components/pages/ListDetail.tsx
+++ b/app/components/pages/ListDetail.tsx
@@ -341,7 +341,6 @@ const ListDetail = () => {
               ) : listBooksQuery.isSuccess ? (
                 <DraggableBookList
                   books={books}
-                  cacheKey={listBooksQuery.dataUpdatedAt}
                   gallerySize={effectiveSize}
                   isOwner={isOwner}
                   onReorder={handleReorder}
@@ -363,7 +362,7 @@ const ListDetail = () => {
                         !isOwner ? listBook.added_by_user?.username : undefined
                       }
                       book={listBook.book}
-                      cacheKey={listBooksQuery.dataUpdatedAt}
+                      cacheKey={listBook.book.cover_cache_key}
                       gallerySize={effectiveSize}
                       key={listBook.id}
                       libraryId={listBook.book.library_id.toString()}

--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -258,7 +258,7 @@ const SeriesDetail = () => {
               {seriesBooksQuery.data.map((book) => (
                 <BookItem
                   book={book}
-                  cacheKey={seriesBooksQuery.dataUpdatedAt}
+                  cacheKey={book.cover_cache_key}
                   gallerySize={effectiveSize}
                   key={book.id}
                   libraryId={libraryId!}

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -50,7 +50,7 @@ interface SeriesCardProps {
   libraryId: string;
   aspectClass: string;
   isAudiobook: boolean;
-  cacheKey?: number;
+  cacheKey?: string;
   gallerySize?: GallerySize;
 }
 
@@ -238,7 +238,7 @@ const SeriesList = () => {
     return (
       <SeriesCard
         aspectClass={aspectClass}
-        cacheKey={seriesQuery.dataUpdatedAt}
+        cacheKey={seriesItem.cover_cache_key}
         gallerySize={effectiveSize}
         isAudiobook={isAudiobook}
         key={seriesItem.id}

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -105,11 +105,12 @@ All file-serving endpoints must include a `Cache-Control` header to prevent reve
 
 | Endpoint Category | Header | Reason |
 |---|---|---|
-| **Cover endpoints** (`/cover`) | `Cache-Control: private, no-cache` | Allows conditional revalidation via `Last-Modified`/`ETag` |
+| **API cover endpoints** (`/api/*/cover`) | `Cache-Control: private, max-age=31536000, immutable` | Browser caches forever; URL changes via `?v=cover_cache_key` when cover changes |
+| **External cover endpoints** (OPDS, eReader, Kobo) | `Cache-Control: private, no-cache` | External clients don't use `?v=` cache-busting; revalidation via `Last-Modified`/`ETag` |
 | **Download/stream endpoints** (`/download`, `/stream`) | `Cache-Control: private, no-store` | No proxy caching at all — generated files can change without the URL changing |
 | **Page endpoint** (`getPage`) | `Cache-Control: public, max-age=31536000, immutable` | Rendered pages are immutable per fileID+pageNum |
 
-When adding a new endpoint that serves files via `c.File()` or `c.Stream()`, set the appropriate `Cache-Control` header before the call:
+When adding a new endpoint that serves files via `c.File()` or `c.Stream()`, set the appropriate `Cache-Control` header before the call. Cover endpoints should use the constants in `pkg/covers/covers.go` (`covers.CacheControlImmutable` for API endpoints, `covers.CacheControlNoCache` for external):
 
 ```go
 c.Response().Header().Set("Cache-Control", "private, no-store")

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -708,6 +708,12 @@ func (h *handler) update(c echo.Context) error {
 	// any *_source column, so UpdateBook short-circuits its own recompute).
 	h.bookService.RecomputeReviewedForBook(ctx, book.ID)
 
+	aspectRatio := ""
+	if book.Library != nil {
+		aspectRatio = book.Library.CoverAspectRatio
+	}
+	book.CoverCacheKey = covers.CacheKey(book.Files, aspectRatio)
+
 	return errors.WithStack(c.JSON(http.StatusOK, book))
 }
 

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -111,6 +111,12 @@ func (h *handler) retrieve(c echo.Context) error {
 		}
 	}
 
+	aspectRatio := ""
+	if book.Library != nil {
+		aspectRatio = book.Library.CoverAspectRatio
+	}
+	book.CoverCacheKey = covers.CacheKey(book.Files, aspectRatio)
+
 	return errors.WithStack(c.JSON(http.StatusOK, book))
 }
 
@@ -188,6 +194,14 @@ func (h *handler) list(c echo.Context) error {
 	books, total, err := h.bookService.ListBooksWithTotal(ctx, opts)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	for _, b := range books {
+		aspectRatio := ""
+		if b.Library != nil {
+			aspectRatio = b.Library.CoverAspectRatio
+		}
+		b.CoverCacheKey = covers.CacheKey(b.Files, aspectRatio)
 	}
 
 	resp := struct {
@@ -1453,7 +1467,7 @@ func (h *handler) fileCover(c echo.Context) error {
 	// root-level files. The cover always lives alongside the file.
 	coverPath := filepath.Join(filepath.Dir(file.Filepath), coverFilename)
 
-	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	c.Response().Header().Set("Cache-Control", covers.CacheControlImmutable)
 	return errors.WithStack(c.File(coverPath))
 }
 
@@ -1645,7 +1659,7 @@ func (h *handler) bookCover(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio)
+	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio, covers.CacheControlImmutable)
 }
 
 // downloadFile handles downloading a file with generated metadata embedded.

--- a/pkg/books/handlers_book_cover_cache_test.go
+++ b/pkg/books/handlers_book_cover_cache_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/libraries"
 )
 
-func TestBookCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+func TestBookCover_SetsCacheControlImmutable(t *testing.T) {
 	t.Parallel()
 
 	db := setupTestDB(t)

--- a/pkg/books/handlers_book_cover_cache_test.go
+++ b/pkg/books/handlers_book_cover_cache_test.go
@@ -39,7 +39,7 @@ func TestBookCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	require.NoError(t, h.bookCover(c))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "private, max-age=31536000, immutable", rec.Header().Get("Cache-Control"))
 	assert.NotEmpty(t, rec.Header().Get("ETag"))
 	// Last-Modified is intentionally NOT emitted: the served file's identity
 	// can change (hybrid book + aspect-ratio change, file removed) without any
@@ -85,5 +85,5 @@ func TestBookCover_Returns304WhenIfNoneMatchMatches(t *testing.T) {
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
 	assert.Empty(t, rec2.Body.Bytes())
 	assert.Equal(t, etag, rec2.Header().Get("ETag"))
-	assert.Equal(t, "private, no-cache", rec2.Header().Get("Cache-Control"))
+	assert.Equal(t, "private, max-age=31536000, immutable", rec2.Header().Get("Cache-Control"))
 }

--- a/pkg/books/handlers_file_cover_cache_test.go
+++ b/pkg/books/handlers_file_cover_cache_test.go
@@ -93,7 +93,7 @@ func TestFileCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	require.NoError(t, h.fileCover(c))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "private, max-age=31536000, immutable", rec.Header().Get("Cache-Control"))
 	assert.NotEmpty(t, rec.Header().Get("Last-Modified"))
 	assert.NotEmpty(t, rec.Body.Bytes())
 }
@@ -129,5 +129,5 @@ func TestFileCover_Returns304WhenIfModifiedSinceMatches(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
 	assert.Empty(t, rec2.Body.Bytes())
-	assert.Equal(t, "private, no-cache", rec2.Header().Get("Cache-Control"))
+	assert.Equal(t, "private, max-age=31536000, immutable", rec2.Header().Get("Cache-Control"))
 }

--- a/pkg/books/handlers_file_cover_cache_test.go
+++ b/pkg/books/handlers_file_cover_cache_test.go
@@ -74,7 +74,7 @@ func seedBookWithFileCover(ctx context.Context, t *testing.T, db *bun.DB) int {
 	return file.ID
 }
 
-func TestFileCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+func TestFileCover_SetsCacheControlImmutable(t *testing.T) {
 	t.Parallel()
 
 	db := setupTestDB(t)

--- a/pkg/books/handlers_list_test.go
+++ b/pkg/books/handlers_list_test.go
@@ -3,6 +3,7 @@ package books
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -209,4 +210,94 @@ func TestListHandler_NoLibraryIDSkipsStoredLookup(t *testing.T) {
 	// → Cheese (newer) before Apple (older).
 	assert.Equal(t, cheese.ID, resp.Items[0].ID)
 	assert.Equal(t, apple.ID, resp.Items[1].ID)
+}
+
+func seedFile(t *testing.T, db *bun.DB, book *models.Book, fileType string, hasCover bool) *models.File {
+	t.Helper()
+	f := &models.File{
+		LibraryID:     book.LibraryID,
+		BookID:        book.ID,
+		FileType:      fileType,
+		FileRole:      models.FileRoleMain,
+		Filepath:      book.Filepath,
+		FilesizeBytes: 1000,
+	}
+	if hasCover {
+		cover := "test.cover.jpg"
+		mime := "image/jpeg"
+		f.CoverImageFilename = &cover
+		f.CoverMimeType = &mime
+	}
+	_, err := db.NewInsert().Model(f).Exec(context.Background())
+	require.NoError(t, err)
+	return f
+}
+
+func TestListHandler_IncludesCoverCacheKey(t *testing.T) {
+	t.Parallel()
+
+	db := setupBooksTestDB(t)
+	lib := seedLibrary(t, db, "CoverLib")
+	user := seedUserWithLibAccess(t, db, "eve", lib)
+
+	now := time.Now()
+	book := seedBook(t, db, lib, "WithCover", "WithCover", now)
+	file := seedFile(t, db, book, models.FileTypeEPUB, true)
+
+	h := &handler{bookService: NewService(db), settingsService: settings.NewService(db)}
+	e := newTestEchoBooks(t)
+	req := httptest.NewRequest(http.MethodGet, "/books?library_id="+strconv.Itoa(lib.ID), nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	require.NoError(t, h.list(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Items []struct {
+			ID            int    `json:"id"`
+			CoverCacheKey string `json:"cover_cache_key"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 1)
+
+	// Reload the file to get its DB-assigned UpdatedAt.
+	reloaded := &models.File{}
+	err := db.NewSelect().Model(reloaded).Where("f.id = ?", file.ID).Scan(context.Background())
+	require.NoError(t, err)
+
+	expected := fmt.Sprintf("%d-%d", file.ID, reloaded.UpdatedAt.Unix())
+	assert.Equal(t, expected, resp.Items[0].CoverCacheKey)
+}
+
+func TestListHandler_CoverCacheKeyEmptyWhenNoCover(t *testing.T) {
+	t.Parallel()
+
+	db := setupBooksTestDB(t)
+	lib := seedLibrary(t, db, "NoCoverLib")
+	user := seedUserWithLibAccess(t, db, "frank", lib)
+
+	now := time.Now()
+	book := seedBook(t, db, lib, "NoCover", "NoCover", now)
+	seedFile(t, db, book, models.FileTypeEPUB, false)
+
+	h := &handler{bookService: NewService(db), settingsService: settings.NewService(db)}
+	e := newTestEchoBooks(t)
+	req := httptest.NewRequest(http.MethodGet, "/books?library_id="+strconv.Itoa(lib.ID), nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	require.NoError(t, h.list(c))
+
+	var resp struct {
+		Items []struct {
+			CoverCacheKey string `json:"cover_cache_key"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 1)
+	assert.Empty(t, resp.Items[0].CoverCacheKey)
 }

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -817,10 +817,10 @@ func (svc *Service) GetFirstBooksFilesForSeries(ctx context.Context, seriesIDs [
 	}
 
 	bookIDs := make([]int, len(rows))
-	bookToSeries := make(map[int]int, len(rows))
+	bookToSeries := make(map[int][]int, len(rows))
 	for i, r := range rows {
 		bookIDs[i] = r.BookID
-		bookToSeries[r.BookID] = r.SeriesID
+		bookToSeries[r.BookID] = append(bookToSeries[r.BookID], r.SeriesID)
 	}
 
 	var files []*models.File
@@ -834,7 +834,7 @@ func (svc *Service) GetFirstBooksFilesForSeries(ctx context.Context, seriesIDs [
 
 	result := make(map[int][]*models.File, len(rows))
 	for _, f := range files {
-		if sid, ok := bookToSeries[f.BookID]; ok {
+		for _, sid := range bookToSeries[f.BookID] {
 			result[sid] = append(result[sid], f)
 		}
 	}

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -776,6 +776,71 @@ func (svc *Service) GetFirstBookInSeriesByID(ctx context.Context, seriesID int) 
 	return &book, nil
 }
 
+// GetFirstBooksFilesForSeries returns the files of each series' first book,
+// keyed by series ID. Uses two queries regardless of input size: one window-
+// function query to find the first book per series, then one query to load
+// files for those books. The first-book ordering matches GetFirstBookInSeriesByID
+// (whole numbers before fractions, then series_number, then title).
+func (svc *Service) GetFirstBooksFilesForSeries(ctx context.Context, seriesIDs []int) (map[int][]*models.File, error) {
+	if len(seriesIDs) == 0 {
+		return nil, nil
+	}
+
+	type row struct {
+		SeriesID int `bun:"series_id"`
+		BookID   int `bun:"book_id"`
+	}
+	var rows []row
+	err := svc.db.NewRaw(`
+		SELECT series_id, book_id FROM (
+			SELECT
+				bs.series_id,
+				bs.book_id,
+				ROW_NUMBER() OVER (
+					PARTITION BY bs.series_id
+					ORDER BY
+						CASE WHEN bs.series_number = CAST(bs.series_number AS INTEGER) THEN 0 ELSE 1 END ASC,
+						bs.series_number ASC,
+						b.title ASC
+				) AS rn
+			FROM book_series bs
+			INNER JOIN books b ON b.id = bs.book_id
+			WHERE bs.series_id IN (?)
+		) WHERE rn = 1
+	`, bun.List(seriesIDs)).Scan(ctx, &rows)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	bookIDs := make([]int, len(rows))
+	bookToSeries := make(map[int]int, len(rows))
+	for i, r := range rows {
+		bookIDs[i] = r.BookID
+		bookToSeries[r.BookID] = r.SeriesID
+	}
+
+	var files []*models.File
+	err = svc.db.NewSelect().
+		Model(&files).
+		Where("f.book_id IN (?)", bun.List(bookIDs)).
+		Scan(ctx)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	result := make(map[int][]*models.File, len(rows))
+	for _, f := range files {
+		if sid, ok := bookToSeries[f.BookID]; ok {
+			result[sid] = append(result[sid], f)
+		}
+	}
+	return result, nil
+}
+
 // OrganizeBookFiles is the public entry point for triggering file organization.
 // It checks the library's OrganizeFileStructure setting internally and returns
 // early if disabled.

--- a/pkg/covers/covers.go
+++ b/pkg/covers/covers.go
@@ -16,6 +16,11 @@ import (
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
+const (
+	CacheControlImmutable = "private, max-age=31536000, immutable"
+	CacheControlNoCache   = "private, no-cache"
+)
+
 // SelectFile picks the file whose cover should represent a book based on the
 // library's preferred cover aspect ratio. It always falls back across types
 // when the preferred kind has no covers — a book-only library still gets a
@@ -67,6 +72,18 @@ func SelectFile(files []*models.File, coverAspectRatio string) *models.File {
 	return nil
 }
 
+// CacheKey returns a stable cache key for the cover that would be served for
+// the given files and aspect ratio. The key only changes when the selected
+// cover file changes (different file selected, or the file's UpdatedAt bumps
+// after a cover upload/regeneration). Returns "" when no cover exists.
+func CacheKey(files []*models.File, coverAspectRatio string) string {
+	f := SelectFile(files, coverAspectRatio)
+	if f == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d-%d", f.ID, f.UpdatedAt.Unix())
+}
+
 // ServeBookCover selects the cover file from `files` using the library's
 // preferred aspect ratio and serves it. Callers must perform any auth and
 // library-access checks before calling. Returns errcodes.NotFound when no
@@ -76,6 +93,10 @@ func SelectFile(files []*models.File, coverAspectRatio string) *models.File {
 // filepath because book.Filepath can be a synthetic organized-folder path that
 // never exists on disk for root-level books.
 //
+// cacheControl sets the Cache-Control header. API callers should pass
+// CacheControlImmutable (the frontend uses ?v=cover_cache_key to bust cache);
+// external callers (OPDS, eReader, Kobo) should pass CacheControlNoCache.
+//
 // Conditional GET uses an ETag of `"<file_id>-<mtime_unix>"` and intentionally
 // omits Last-Modified. SelectFile's choice depends on the library's
 // CoverAspectRatio and which files belong to the book, so the served file's
@@ -84,7 +105,7 @@ func SelectFile(files []*models.File, coverAspectRatio string) *models.File {
 // served, and the new cover may have an older mtime than the previously-served
 // one. Mtime-only revalidation would return stale 304s in that case; baking
 // the file ID into the validator ensures it bumps whenever selection changes.
-func ServeBookCover(c echo.Context, files []*models.File, coverAspectRatio string) error {
+func ServeBookCover(c echo.Context, files []*models.File, coverAspectRatio string, cacheControl string) error {
 	coverFile := SelectFile(files, coverAspectRatio)
 	if coverFile == nil || coverFile.CoverImageFilename == nil || *coverFile.CoverImageFilename == "" {
 		return errcodes.NotFound("Cover")
@@ -105,7 +126,7 @@ func ServeBookCover(c echo.Context, files []*models.File, coverAspectRatio strin
 
 	etag := fmt.Sprintf(`"%d-%d"`, coverFile.ID, modTime.Unix())
 
-	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	c.Response().Header().Set("Cache-Control", cacheControl)
 	c.Response().Header().Set("ETag", etag)
 
 	if inm := c.Request().Header.Get("If-None-Match"); inm != "" && inm == etag {

--- a/pkg/covers/covers_test.go
+++ b/pkg/covers/covers_test.go
@@ -211,7 +211,7 @@ func TestServeBookCover_NotFoundWhenNoCover(t *testing.T) {
 		{ID: 1, FileType: models.FileTypeEPUB, CoverImageFilename: nil},
 	}
 
-	err := ServeBookCover(c, files, "book")
+	err := ServeBookCover(c, files, "book", CacheControlNoCache)
 	require.Error(t, err)
 	var ecErr *errcodes.Error
 	require.ErrorAs(t, err, &ecErr)
@@ -237,7 +237,7 @@ func TestServeBookCover_ServesCoverFile(t *testing.T) {
 		{ID: 1, FileType: models.FileTypeEPUB, Filepath: bookPath, CoverImageFilename: &coverName},
 	}
 
-	require.NoError(t, ServeBookCover(c, files, "book"))
+	require.NoError(t, ServeBookCover(c, files, "book", CacheControlNoCache))
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
 	assert.NotEmpty(t, rec.Header().Get("ETag"))
@@ -272,7 +272,7 @@ func TestServeBookCover_ETagIncludesFileIDAndMtime(t *testing.T) {
 		{ID: 42, FileType: models.FileTypeEPUB, Filepath: bookPath, CoverImageFilename: &coverName},
 	}
 
-	require.NoError(t, ServeBookCover(c, files, "book"))
+	require.NoError(t, ServeBookCover(c, files, "book", CacheControlNoCache))
 	assert.Equal(t, fmt.Sprintf(`"%d-%d"`, 42, pinned.Unix()), rec.Header().Get("ETag"))
 }
 
@@ -295,7 +295,7 @@ func TestServeBookCover_Returns304WhenIfNoneMatchMatches(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	c1 := e.NewContext(req1, rec1)
-	require.NoError(t, ServeBookCover(c1, files, "book"))
+	require.NoError(t, ServeBookCover(c1, files, "book", CacheControlNoCache))
 	etag := rec1.Header().Get("ETag")
 	require.NotEmpty(t, etag)
 
@@ -305,7 +305,7 @@ func TestServeBookCover_Returns304WhenIfNoneMatchMatches(t *testing.T) {
 	rec2 := httptest.NewRecorder()
 	c2 := e.NewContext(req2, rec2)
 
-	require.NoError(t, ServeBookCover(c2, files, "book"))
+	require.NoError(t, ServeBookCover(c2, files, "book", CacheControlNoCache))
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
 	assert.Empty(t, rec2.Body.Bytes())
 	assert.Equal(t, etag, rec2.Header().Get("ETag"))
@@ -353,7 +353,7 @@ func TestServeBookCover_AspectRatioChangeInvalidatesEtagEvenWhenNewCoverMtimeIsO
 	req1 := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec1 := httptest.NewRecorder()
 	c1 := e.NewContext(req1, rec1)
-	require.NoError(t, ServeBookCover(c1, files, "book"))
+	require.NoError(t, ServeBookCover(c1, files, "book", CacheControlNoCache))
 	require.Equal(t, http.StatusOK, rec1.Code)
 	assert.Equal(t, []byte("epub-cover"), rec1.Body.Bytes())
 	etagEPUB := rec1.Header().Get("ETag")
@@ -368,7 +368,7 @@ func TestServeBookCover_AspectRatioChangeInvalidatesEtagEvenWhenNewCoverMtimeIsO
 	req2.Header.Set("If-None-Match", etagEPUB)
 	rec2 := httptest.NewRecorder()
 	c2 := e.NewContext(req2, rec2)
-	require.NoError(t, ServeBookCover(c2, files, "audiobook"))
+	require.NoError(t, ServeBookCover(c2, files, "audiobook", CacheControlNoCache))
 	assert.Equal(t, http.StatusOK, rec2.Code,
 		"expected 200 after aspect-ratio change (ETag must change with file identity, not just mtime)")
 	etagM4B := rec2.Header().Get("ETag")
@@ -377,6 +377,76 @@ func TestServeBookCover_AspectRatioChangeInvalidatesEtagEvenWhenNewCoverMtimeIsO
 	assert.True(t, strings.HasPrefix(etagM4B, `"22-`),
 		"ETag should encode the M4B file ID (22) in <id-mtime> format, got %q", etagM4B)
 	assert.Equal(t, []byte("m4b-cover"), rec2.Body.Bytes())
+}
+
+func TestCacheKey_ReturnsFileIDAndUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	updatedAt := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC)
+	cover := "book.epub.cover.jpg"
+	files := []*models.File{
+		{ID: 42, FileType: models.FileTypeEPUB, CoverImageFilename: &cover, UpdatedAt: updatedAt},
+	}
+
+	got := CacheKey(files, "book")
+	assert.Equal(t, fmt.Sprintf("%d-%d", 42, updatedAt.Unix()), got)
+}
+
+func TestCacheKey_ReturnsEmptyWhenNoCover(t *testing.T) {
+	t.Parallel()
+
+	files := []*models.File{
+		{ID: 1, FileType: models.FileTypeEPUB, CoverImageFilename: nil},
+	}
+
+	assert.Empty(t, CacheKey(files, "book"))
+}
+
+func TestCacheKey_ReturnsEmptyForNilFiles(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, CacheKey(nil, "book"))
+}
+
+func TestCacheKey_RespectsAspectRatio(t *testing.T) {
+	t.Parallel()
+
+	epubCover := "epub.cover.jpg"
+	m4bCover := "m4b.cover.jpg"
+	epubTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	m4bTime := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	files := []*models.File{
+		{ID: 10, FileType: models.FileTypeEPUB, CoverImageFilename: &epubCover, UpdatedAt: epubTime},
+		{ID: 20, FileType: models.FileTypeM4B, CoverImageFilename: &m4bCover, UpdatedAt: m4bTime},
+	}
+
+	bookKey := CacheKey(files, "book")
+	audioKey := CacheKey(files, "audiobook")
+
+	assert.Equal(t, fmt.Sprintf("%d-%d", 10, epubTime.Unix()), bookKey)
+	assert.Equal(t, fmt.Sprintf("%d-%d", 20, m4bTime.Unix()), audioKey)
+	assert.NotEqual(t, bookKey, audioKey)
+}
+
+func TestServeBookCover_UsesCacheControlParam(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	bookPath := filepath.Join(dir, "book.epub")
+	require.NoError(t, os.WriteFile(bookPath, []byte("epub"), 0o644))
+	coverName := "book.epub.cover.jpg"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, coverName), []byte("jpeg"), 0o644))
+
+	files := []*models.File{
+		{ID: 1, FileType: models.FileTypeEPUB, Filepath: bookPath, CoverImageFilename: &coverName},
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, ServeBookCover(c, files, "book", "private, max-age=31536000, immutable"))
+	assert.Equal(t, "private, max-age=31536000, immutable", rec.Header().Get("Cache-Control"))
 }
 
 func TestServeBookCover_NotFoundWhenCoverFileMissingOnDisk(t *testing.T) {
@@ -398,7 +468,7 @@ func TestServeBookCover_NotFoundWhenCoverFileMissingOnDisk(t *testing.T) {
 		{ID: 1, FileType: models.FileTypeEPUB, Filepath: bookPath, CoverImageFilename: &coverName},
 	}
 
-	err := ServeBookCover(c, files, "book")
+	err := ServeBookCover(c, files, "book", CacheControlNoCache)
 	require.Error(t, err)
 	var ecErr *errcodes.Error
 	require.ErrorAs(t, err, &ecErr)

--- a/pkg/ereader/handlers.go
+++ b/pkg/ereader/handlers.go
@@ -674,7 +674,7 @@ func (h *handler) Cover(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio)
+	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio, covers.CacheControlNoCache)
 }
 
 // DownloadFile handles file downloads with API key authentication.

--- a/pkg/lists/handlers.go
+++ b/pkg/lists/handlers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
+	"github.com/shishobooks/shisho/pkg/covers"
 	"github.com/shishobooks/shisho/pkg/errcodes"
 	"github.com/shishobooks/shisho/pkg/models"
 )
@@ -296,6 +297,16 @@ func (h *handler) listBooks(c echo.Context) error {
 	listBooks, total, err := h.listsService.ListBooksWithTotal(ctx, opts)
 	if err != nil {
 		return errors.WithStack(err)
+	}
+
+	for _, lb := range listBooks {
+		if lb.Book != nil {
+			aspectRatio := ""
+			if lb.Book.Library != nil {
+				aspectRatio = lb.Book.Library.CoverAspectRatio
+			}
+			lb.Book.CoverCacheKey = covers.CacheKey(lb.Book.Files, aspectRatio)
+		}
 	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, echo.Map{

--- a/pkg/lists/service.go
+++ b/pkg/lists/service.go
@@ -327,6 +327,7 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 		Relation("Book.BookSeries").
 		Relation("Book.BookSeries.Series").
 		Relation("Book.Files").
+		Relation("Book.Library").
 		Relation("AddedByUser").
 		Where("lb.list_id = ?", opts.ListID)
 

--- a/pkg/models/book.go
+++ b/pkg/models/book.go
@@ -31,4 +31,5 @@ type Book struct {
 	BookTags          []*BookTag    `bun:"rel:has-many,join:id=book_id" json:"book_tags,omitempty" tstype:"BookTag[]"`
 	TagSource         *string       `json:"tag_source" tstype:"DataSource"`
 	Files             []*File       `bun:"rel:has-many" json:"files" tstype:"File[]"`
+	CoverCacheKey     string        `bun:"-" json:"cover_cache_key"`
 }

--- a/pkg/models/series.go
+++ b/pkg/models/series.go
@@ -29,6 +29,7 @@ type Series struct {
 	Aliases            []*SeriesAlias `bun:"rel:has-many,join:id=series_id" json:"aliases" tstype:"SeriesAlias[]"`
 	BookSeries         []*BookSeries  `bun:"rel:has-many" json:"book_series,omitempty" tstype:"BookSeries[]"`
 	BookCount          int            `bun:",scanonly" json:"book_count"`
+	CoverCacheKey      string         `bun:"-" json:"cover_cache_key"`
 }
 
 type BookSeries struct {

--- a/pkg/opds/handlers.go
+++ b/pkg/opds/handlers.go
@@ -860,7 +860,7 @@ func (h *handler) bookCover(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio)
+	return covers.ServeBookCover(c, book.Files, library.CoverAspectRatio, covers.CacheControlNoCache)
 }
 
 // isKOReader returns true when the request comes from KOReader's OPDS client.

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -58,6 +58,13 @@ func (h *handler) retrieve(c echo.Context) error {
 
 	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.SeriesConfig, id)
 
+	seriesFiles, _ := h.bookService.GetFirstBooksFilesForSeries(ctx, []int{id})
+	aspectRatio := ""
+	if series.Library != nil {
+		aspectRatio = series.Library.CoverAspectRatio
+	}
+	series.CoverCacheKey = covers.CacheKey(seriesFiles[id], aspectRatio)
+
 	response := struct {
 		*models.Series
 		BookCount int      `json:"book_count"`
@@ -95,7 +102,14 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Augment with book counts and aliases
+	// Batch-load cover cache keys for all series.
+	seriesIDs := make([]int, len(seriesList))
+	for i, s := range seriesList {
+		seriesIDs[i] = s.ID
+	}
+	seriesFiles, _ := h.bookService.GetFirstBooksFilesForSeries(ctx, seriesIDs)
+
+	// Augment with book counts, aliases, and cover cache keys.
 	type SeriesWithCount struct {
 		*models.Series
 		BookCount int      `json:"book_count"`
@@ -105,6 +119,11 @@ func (h *handler) list(c echo.Context) error {
 	for i, s := range seriesList {
 		count, _ := h.seriesService.GetSeriesBookCount(ctx, s.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.SeriesConfig, s.ID)
+		aspectRatio := ""
+		if s.Library != nil {
+			aspectRatio = s.Library.CoverAspectRatio
+		}
+		s.CoverCacheKey = covers.CacheKey(seriesFiles[s.ID], aspectRatio)
 		result[i] = SeriesWithCount{s, count, aliasList}
 	}
 
@@ -321,7 +340,7 @@ func (h *handler) seriesCover(c echo.Context) error {
 	// cover happens to have an older mtime than the previous first book's cover.
 	etag := fmt.Sprintf(`"%d-%d"`, coverFile.ID, modTime.Unix())
 
-	c.Response().Header().Set("Cache-Control", "private, no-cache")
+	c.Response().Header().Set("Cache-Control", covers.CacheControlImmutable)
 	c.Response().Header().Set("ETag", etag)
 
 	// Conditional GET uses ETag only. If-Modified-Since is intentionally not

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -280,6 +280,14 @@ func (h *handler) seriesBooks(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
+	for _, b := range booksList {
+		aspectRatio := ""
+		if b.Library != nil {
+			aspectRatio = b.Library.CoverAspectRatio
+		}
+		b.CoverCacheKey = covers.CacheKey(b.Files, aspectRatio)
+	}
+
 	return errors.WithStack(c.JSON(http.StatusOK, booksList))
 }
 

--- a/pkg/series/handlers_cover_cache_test.go
+++ b/pkg/series/handlers_cover_cache_test.go
@@ -3,6 +3,7 @@ package series
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"image"
 	"image/jpeg"
@@ -15,6 +16,8 @@ import (
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/aliases"
+	"github.com/shishobooks/shisho/pkg/binder"
 	"github.com/shishobooks/shisho/pkg/books"
 	"github.com/shishobooks/shisho/pkg/libraries"
 	"github.com/shishobooks/shisho/pkg/migrations"
@@ -26,11 +29,21 @@ import (
 	"github.com/uptrace/bun/driver/sqliteshim"
 )
 
+func newTestEchoSeries(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	return e
+}
+
 func setupSeriesTestDB(t *testing.T) *bun.DB {
 	t.Helper()
 
 	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
 	require.NoError(t, err)
+	sqldb.SetMaxOpenConns(1)
 
 	db := bun.NewDB(sqldb, sqlitedialect.New())
 
@@ -122,6 +135,181 @@ func seedSeriesWithCover(ctx context.Context, t *testing.T, db *bun.DB) int {
 	return seriesRecord.ID
 }
 
+func TestSeriesList_IncludesCoverCacheKey(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "CoverKeyLib",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	series1 := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Series A",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "Series A",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err = db.NewInsert().Model(series1).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Book 1",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book 1",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	sn := 1.0
+	_, err = db.NewInsert().Model(&models.BookSeries{
+		BookID: book.ID, SeriesID: series1.ID, SeriesNumber: &sn, SortOrder: 1,
+	}).Exec(ctx)
+	require.NoError(t, err)
+
+	coverFilename := "test.cover.jpg"
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filepath.Join(book.Filepath, "test.epub"),
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		seriesService:  NewService(db),
+		bookService:    books.NewService(db),
+		libraryService: libraries.NewService(db),
+		aliasService:   aliases.NewService(db),
+	}
+
+	e := newTestEchoSeries(t)
+	req := httptest.NewRequest(http.MethodGet, "/series?limit=10&offset=0", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.list(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Items []struct {
+			ID            int    `json:"id"`
+			CoverCacheKey string `json:"cover_cache_key"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 1)
+
+	reloaded := &models.File{}
+	require.NoError(t, db.NewSelect().Model(reloaded).Where("f.id = ?", file.ID).Scan(ctx))
+
+	expected := fmt.Sprintf("%d-%d", file.ID, reloaded.UpdatedAt.Unix())
+	assert.Equal(t, expected, resp.Items[0].CoverCacheKey)
+}
+
+func TestSeriesRetrieve_IncludesCoverCacheKey(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+
+	library := &models.Library{
+		Name:                     "RetrieveCoverLib",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	series1 := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "My Series",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "My Series",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err = db.NewInsert().Model(series1).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Book A",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "Book A",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	sn := 1.0
+	_, err = db.NewInsert().Model(&models.BookSeries{
+		BookID: book.ID, SeriesID: series1.ID, SeriesNumber: &sn, SortOrder: 1,
+	}).Exec(ctx)
+	require.NoError(t, err)
+
+	coverFilename := "test.cover.jpg"
+	mimeType := "image/jpeg"
+	file := &models.File{
+		LibraryID:          library.ID,
+		BookID:             book.ID,
+		FileType:           models.FileTypeEPUB,
+		FileRole:           models.FileRoleMain,
+		Filepath:           filepath.Join(book.Filepath, "test.epub"),
+		FilesizeBytes:      1000,
+		CoverImageFilename: &coverFilename,
+		CoverMimeType:      &mimeType,
+	}
+	_, err = db.NewInsert().Model(file).Exec(ctx)
+	require.NoError(t, err)
+
+	h := &handler{
+		seriesService:  NewService(db),
+		bookService:    books.NewService(db),
+		libraryService: libraries.NewService(db),
+		aliasService:   aliases.NewService(db),
+	}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(series1.ID))
+
+	require.NoError(t, h.retrieve(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		ID            int    `json:"id"`
+		CoverCacheKey string `json:"cover_cache_key"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+
+	reloaded := &models.File{}
+	require.NoError(t, db.NewSelect().Model(reloaded).Where("f.id = ?", file.ID).Scan(ctx))
+
+	expected := fmt.Sprintf("%d-%d", file.ID, reloaded.UpdatedAt.Unix())
+	assert.Equal(t, expected, resp.CoverCacheKey)
+}
+
 func TestSeriesCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	t.Parallel()
 
@@ -145,7 +333,7 @@ func TestSeriesCover_SetsCacheControlPrivateNoCache(t *testing.T) {
 	require.NoError(t, h.seriesCover(c))
 
 	assert.Equal(t, http.StatusOK, rec.Code)
-	assert.Equal(t, "private, no-cache", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "private, max-age=31536000, immutable", rec.Header().Get("Cache-Control"))
 	assert.NotEmpty(t, rec.Header().Get("ETag"))
 	// Last-Modified is intentionally NOT emitted: it would re-enable IMS-based
 	// revalidation inside http.ServeContent, which can return stale 304s when
@@ -190,7 +378,7 @@ func TestSeriesCover_Returns304WhenIfNoneMatchMatches(t *testing.T) {
 	assert.Equal(t, http.StatusNotModified, rec2.Code)
 	assert.Empty(t, rec2.Body.Bytes())
 	assert.Equal(t, etag, rec2.Header().Get("ETag"))
-	assert.Equal(t, "private, no-cache", rec2.Header().Get("Cache-Control"))
+	assert.Equal(t, "private, max-age=31536000, immutable", rec2.Header().Get("Cache-Control"))
 }
 
 func TestSeriesCover_Returns200WhenIfNoneMatchMismatches(t *testing.T) {

--- a/pkg/series/handlers_cover_cache_test.go
+++ b/pkg/series/handlers_cover_cache_test.go
@@ -310,7 +310,7 @@ func TestSeriesRetrieve_IncludesCoverCacheKey(t *testing.T) {
 	assert.Equal(t, expected, resp.CoverCacheKey)
 }
 
-func TestSeriesCover_SetsCacheControlPrivateNoCache(t *testing.T) {
+func TestSeriesCover_SetsCacheControlImmutable(t *testing.T) {
 	t.Parallel()
 
 	db := setupSeriesTestDB(t)


### PR DESCRIPTION
## Summary
- Cover URLs previously used `?v=${dataUpdatedAt}` (a TanStack Query timestamp that changes on every refetch), combined with `Cache-Control: private, no-cache`, resulting in zero caching — every page load re-fetched all cover images
- Backend now computes a `cover_cache_key` (`<fileId>-<updatedAt.Unix()>`) on book and series responses that only changes when the actual cover file changes, enabling browsers to cache covers indefinitely via `Cache-Control: private, max-age=31536000, immutable`
- OPDS/eReader/Kobo endpoints retain `no-cache` since they don't use `?v=` params; frontend components use `cover_cache_key` from API responses instead of `dataUpdatedAt`

## Test plan
- Verify book list page loads covers with `?v=<cover_cache_key>` in the URL and `Cache-Control: immutable` in the response
- Verify series list page uses series-level `cover_cache_key` for cover URLs
- Verify book detail page uses `cover_cache_key` for the main cover and `file.updated_at` for per-file cover thumbnails
- Verify uploading a new cover updates the cache key and the new cover appears immediately
- Verify OPDS feed cover responses still use `Cache-Control: no-cache`
- Verify books/series with no cover image have empty `cover_cache_key` and no `?v=` param