### PR TITLE
[CI] Add per-attempt timeout and hang retry to e2e steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,5 +170,17 @@ jobs:
       - run: mise tygo
       - run: pnpm test:unit
       - run: mise build
-      - run: pnpm e2e:chromium
-      - run: pnpm e2e:firefox
+      - name: Run Chromium E2E
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 6
+          max_attempts: 2
+          retry_on: timeout
+          command: pnpm e2e:chromium
+      - name: Run Firefox E2E
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 6
+          max_attempts: 2
+          retry_on: timeout
+          command: pnpm e2e:firefox

--- a/.wktr.yaml
+++ b/.wktr.yaml
@@ -4,4 +4,4 @@ layout:
     - command: "claude --dangerously-skip-permissions"
     - command: "mise start"
       run: false
-    - command: ""
+    - command: "mise setup"


### PR DESCRIPTION
## Summary
- The JS Test job's `pnpm e2e:chromium` step hung for ~77 minutes on a recent run (no `timeout-minutes` anywhere, so GitHub's 6-hour default applied). The likely wedge is Playwright finishing tests but hanging on `webServer` teardown, with an orphaned `go`/`mise` child keeping the step's stdout pipe open.
- Wraps the two e2e steps in `nick-fields/retry@v3` with a 6-minute per-attempt timeout, `max_attempts: 2`, and `retry_on: timeout`. The action tree-kills the whole process tree on timeout (which a bare-shell `timeout` can't do reliably), so a hang now fails in minutes instead of running forever, and an intermittent hang gets one retry.
- Scoped deliberately to e2e only: `retry_on: timeout` means a real test failure fails fast (no full-suite rerun, since Playwright's per-test retries already cover flaky assertions). The 6-minute timeout is ~2.25x the worst healthy e2e run observed across the last 15 jobs (max 160s).
- Also includes a small unrelated tooling tweak: the wktr worktree layout now runs `mise setup` in its third pane.

## Test plan
- Confirm the JS Test job still completes normally (~7-8 min) on this PR's CI run.
- Verify the two e2e steps now run via the retry action (check the step logs show attempt tracking).
- A true hang regression would show the e2e step failing at ~6 min (then one retry) instead of running for hours.