### PR TITLE
[Backend] Take Genres response types end-to-end via tygo and establish the convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,15 @@ file.CoverImageFilename = &filename
 
 **JSON field naming is snake_case** — All JSON request/response payloads use `snake_case` (e.g., `created_at`, not `createdAt`). Go struct tags: `json:"snake_case_name"`.
 
+**API types are generated from Go via tygo (no anonymous responses, no hand-written TS).** Go is the single source of truth for every request and response shape. See ADR 0004 (`docs/adr/0004-tygo-generated-api-types.md`) for the rationale. The rules:
+- Every request and response payload is a named, exported Go struct in the package's `types.go`. No handler returns an anonymous struct, `echo.Map`, or `map[string]any`. A response that conveys nothing the client cannot already derive returns `204 No Content` instead of a body.
+- Response structs reuse the model by embedding it with `tstype:",extends"` rather than re-listing fields. Embed by VALUE (`models.Genre`), not pointer (`*models.Genre`); a pointer embed generates `extends Partial<Genre>`. This requires a `frontmatter` import of the model in the package's `tygo.yaml` entry, plus a `type_mappings` entry mapping the package-qualified selector to the bare name (e.g. `models.Genre: "Genre"`) so the generated `extends` matches the import.
+- When a response reshapes a model relation (e.g. returns `aliases` as `[]string` instead of the model's `GenreAlias[]`), exclude the model's relation field from generation with `tstype:"-"` so the response's field is the only one and `extends` does not collide. Only safe when no consumer reads that relation as objects.
+- Naming: single-resource is `{Entity}Response`; list endpoints return a `List{Entities}Response` envelope shaped `{ items, total }`; a list-item shape that genuinely differs from the single-resource shape is `{Entity}ListItem`.
+- The frontend never hand-defines a type that has a Go counterpart. If a type is missing, add or fix the Go struct and run `mise tygo`, do not write it in TypeScript.
+
+The Genres slice (`pkg/genres/`, `GenreResponse`/`ListGenresResponse`) is the reference implementation. See `pkg/CLAUDE.md` (backend mechanics) and `app/CLAUDE.md` (frontend consumption).
+
 **Self password reset route must not require users permissions** — `/users/:id/reset-password` should only require authentication. The handler enforces that self-reset is allowed and resetting another user requires `users:write`. Adding `users:read`/`users:write` middleware to the route breaks self-service password changes for roles like Viewer, including forced password reset flows.
 
 ### Frontend

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -48,6 +48,10 @@ Use semantic color tokens exclusively. Never use hardcoded Tailwind colors (`dar
 - Query hooks in `app/hooks/queries/` wrap API calls with Tanstack Query
 - TypeScript types auto-imported from `app/types/generated/`
 
+**Never hand-define a type that has a Go counterpart.** Every API request and response shape is generated from a Go struct via tygo into `app/types/generated/` (re-exported from `@/types`). The frontend imports those types; it does not restate them. If a needed type is missing or wrong, fix the Go struct in the package's `types.go` and run `mise tygo`, do not write it in TypeScript. See ADR 0004 (`docs/adr/0004-tygo-generated-api-types.md`).
+
+- **Response types are `{Entity}Response`, list responses are `ResourceListResponse<{Entity}Response>`.** Query hooks type their return as the generated response type, not the bare model. A response struct embeds the model (TS `extends Genre`) and may reshape a relation: e.g. `GenreResponse` carries `aliases: string[]`, not the model `Genre`'s relation. Consume the response field directly (`genre.aliases`), never cast it (`as unknown as string[]`) and never call `.map((a) => a.name)` expecting relation objects. Reference: `useGenresList`/`useGenre`/`useUpdateGenre` in `app/hooks/queries/genres.ts` (typed `GenreResponse`), and `GenresList.tsx`/`GenreDetail.tsx` reading `aliases` as `string[]`.
+
 **IMPORTANT - List Limits:**
 - **Default list limit is 50** - All list endpoints have a max limit of 50 items per request
 - **Always use server-side search** - Never rely on client-side filtering for searchable lists; always pass search queries to the API. This ensures users can find items beyond the initial 50 loaded.

--- a/app/components/pages/GenreDetail.tsx
+++ b/app/components/pages/GenreDetail.tsx
@@ -76,7 +76,7 @@ const GenreDetail = () => {
   );
 
   const genre = genreQuery.data;
-  const aliases = genre ? ((genre.aliases as unknown as string[]) ?? []) : [];
+  const aliases = genre?.aliases ?? [];
   const bookCount = genre?.book_count ?? 0;
 
   const handleEdit = async (data: { name: string; aliases?: string[] }) => {

--- a/app/components/pages/GenresList.tsx
+++ b/app/components/pages/GenresList.tsx
@@ -1,19 +1,19 @@
 import ResourceList from "@/components/library/ResourceList";
 import { useGenresList } from "@/hooks/queries/genres";
 import { useResourceListState } from "@/hooks/useResourceListState";
-import type { Genre } from "@/types";
+import type { GenreResponse } from "@/types";
 
 const GenresList = () => {
   const state = useResourceListState();
   const query = useGenresList(state.queryParams);
 
   return (
-    <ResourceList<Genre>
+    <ResourceList<GenreResponse>
       itemConfig={(genre) => {
         const bookCount = genre.book_count ?? 0;
         return {
           name: genre.name,
-          aliases: genre.aliases.map((a) => a.name),
+          aliases: genre.aliases,
           badges: [
             {
               label: bookCount === 1 ? "book" : "books",

--- a/app/hooks/queries/genres.ts
+++ b/app/hooks/queries/genres.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Book, Genre, ResourceListResponse } from "@/types";
+import type { Book, GenreResponse, ResourceListResponse } from "@/types";
 import type {
   ListGenresQuery,
   UpdateGenrePayload,
@@ -20,7 +20,7 @@ export enum QueryKey {
   GenreBooks = "GenreBooks",
 }
 
-export type ListGenresData = ResourceListResponse<Genre>;
+export type ListGenresData = ResourceListResponse<GenreResponse>;
 
 export const useGenresList = (
   query: ListGenresQuery = {},
@@ -41,11 +41,11 @@ export const useGenresList = (
 export const useGenre = (
   genreId?: number,
   options: Omit<
-    UseQueryOptions<Genre, ShishoAPIError>,
+    UseQueryOptions<GenreResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<Genre, ShishoAPIError>({
+  return useQuery<GenreResponse, ShishoAPIError>({
     enabled: options.enabled !== undefined ? options.enabled : Boolean(genreId),
     ...options,
     queryKey: [QueryKey.RetrieveGenre, genreId],
@@ -95,7 +95,7 @@ export const useUpdateGenre = () => {
       genreId: number;
       payload: UpdateGenrePayload;
     }) => {
-      return API.request<Genre>("PATCH", `/genres/${genreId}`, payload);
+      return API.request<GenreResponse>("PATCH", `/genres/${genreId}`, payload);
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -39,6 +39,8 @@ export * from "./generated/search";
 export * from "./generated/series";
 export * from "./generated/people";
 export {
+  type GenreResponse,
+  type ListGenresResponse,
   type ListGenresQuery,
   type UpdateGenrePayload,
   type MergeGenresPayload,

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -272,6 +272,15 @@ Request → Authenticate → RequirePermission → RequireLibraryAccess → Hand
 
 - **JSON field naming**: All JSON request and response payloads use `snake_case` for field names (e.g., `created_at`, `last_accessed_at`, not `createdAt`)
 - Go struct tags should use `json:"snake_case_name"` format
+
+- **Response shapes are named Go structs generated to TS via tygo (no anonymous responses).** Go is the single source of truth for every request and response shape; the frontend imports the generated type and never restates it. See ADR 0004 (`docs/adr/0004-tygo-generated-api-types.md`). Rules:
+  - Every request/response payload is a named, exported struct in the package's `types.go`. No handler returns an anonymous struct, `echo.Map`, or `map[string]any`. A response carrying nothing the client cannot derive returns `204 No Content`.
+  - **Reuse the model by embedding it with `tstype:",extends"`** instead of re-listing fields. Embed by **value** (`models.Genre`), not pointer: a pointer embed (`*models.Genre`) generates `extends Partial<Genre>` in TS, which is wrong for a response that always carries those fields. Shadowing fields (same `json` tag) keep the wire format byte-identical to a hand-built struct.
+  - **A value embed needs two `tygo.yaml` additions** for the package entry: a `frontmatter` import of the model (e.g. `import { Genre } from "@/types";`), and a `type_mappings` entry mapping the package-qualified selector to the bare interface name (e.g. `models.Genre: "Genre"`). Without the mapping, tygo emits `extends models.Genre` (an unresolved reference); without the frontmatter, `Genre` is undefined.
+  - **Reshaped model relations get `tstype:"-"` on the model field.** When a response returns a relation in a different shape than the model (e.g. `aliases []string` vs the model's `Aliases []*GenreAlias`), exclude the model's relation from TS generation with `tstype:"-"` (keep the `json` tag, the Go wire format is unchanged) so the generated `Entity` interface drops the relation and the response's `extends` does not collide. Only safe when no consumer reads that relation as objects.
+  - **Naming**: single-resource `{Entity}Response`; list envelope `List{Entities}Response` shaped `{ items, total }`; a list-item shape that genuinely differs from the single-resource shape `{Entity}ListItem`.
+
+  Reference implementation: `pkg/genres/types.go` (`GenreResponse`, `ListGenresResponse`), `pkg/models/genre.go` (`Aliases` field tagged `tstype:"-"`), and the genres entry in `tygo.yaml`. The wire-level regression net is `TestList_ResponseAliasesSerializeAsStringArray` in `pkg/genres/handlers_test.go`.
 - **Request binding must use structs**: The custom binder (`pkg/binder/`) uses mold (conform) and validator, which only work with structs. Never bind directly to a slice/array — wrap it in a struct:
 
 ```go

--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -49,11 +49,7 @@ func (h *handler) retrieve(c echo.Context) error {
 
 	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.GenreConfig, id)
 
-	response := struct {
-		*models.Genre
-		BookCount int      `json:"book_count"`
-		Aliases   []string `json:"aliases"`
-	}{genre, bookCount, aliasList}
+	response := GenreResponse{Genre: *genre, BookCount: bookCount, Aliases: aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -87,22 +83,14 @@ func (h *handler) list(c echo.Context) error {
 	}
 
 	// Augment with book counts and aliases
-	type GenreWithCount struct {
-		*models.Genre
-		BookCount int      `json:"book_count"`
-		Aliases   []string `json:"aliases"`
-	}
-	result := make([]GenreWithCount, len(genres))
+	result := make([]GenreResponse, len(genres))
 	for i, g := range genres {
 		bookCount, _ := h.genreService.GetBookCount(ctx, g.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.GenreConfig, g.ID)
-		result[i] = GenreWithCount{g, bookCount, aliasList}
+		result[i] = GenreResponse{Genre: *g, BookCount: bookCount, Aliases: aliasList}
 	}
 
-	response := map[string]any{
-		"items": result,
-		"total": total,
-	}
+	response := ListGenresResponse{Items: result, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -165,11 +153,7 @@ func (h *handler) update(c echo.Context) error {
 			// Return the target genre
 			bookCount, _ := h.genreService.GetBookCount(ctx, existing.ID)
 			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.GenreConfig, existing.ID)
-			response := struct {
-				*models.Genre
-				BookCount int      `json:"book_count"`
-				Aliases   []string `json:"aliases"`
-			}{existing, bookCount, aliasList}
+			response := GenreResponse{Genre: *existing, BookCount: bookCount, Aliases: aliasList}
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
@@ -204,11 +188,7 @@ func (h *handler) update(c echo.Context) error {
 
 	bookCount, _ := h.genreService.GetBookCount(ctx, id)
 	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.GenreConfig, id)
-	response := struct {
-		*models.Genre
-		BookCount int      `json:"book_count"`
-		Aliases   []string `json:"aliases"`
-	}{genre, bookCount, aliasList}
+	response := GenreResponse{Genre: *genre, BookCount: bookCount, Aliases: aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }

--- a/pkg/genres/handlers_test.go
+++ b/pkg/genres/handlers_test.go
@@ -325,6 +325,63 @@ func TestList_ResponseUsesItemsKey(t *testing.T) {
 	assert.False(t, hasGenres, "list response must NOT use 'genres' key")
 }
 
+func TestList_ResponseAliasesSerializeAsStringArray(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	ctx := context.Background()
+	e := newTestEcho(t)
+	lib := createTestLibrary(t, db)
+	genre := seedGenreWithBooks(t, db, lib, "Science Fiction", []string{"Book1"})
+	h := newTestHandler(t, db)
+
+	// Seed two aliases for the genre so we can assert they round-trip as strings.
+	_, err := db.NewRaw(
+		"INSERT INTO genre_aliases (created_at, genre_id, name, library_id) VALUES (?, ?, ?, ?), (?, ?, ?, ?)",
+		time.Now(), genre.ID, "SciFi", lib.ID,
+		time.Now(), genre.ID, "SF", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = h.list(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Top-level envelope must be { items, total } only.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	assert.True(t, hasItems, "list response must have 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+
+	// Each item's aliases must serialize as a JSON array of strings (the #324 fix
+	// at the wire level), and book_count must be present.
+	var resp struct {
+		Items []struct {
+			ID        int             `json:"id"`
+			Name      string          `json:"name"`
+			BookCount int             `json:"book_count"`
+			Aliases   json.RawMessage `json:"aliases"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, "Science Fiction", resp.Items[0].Name)
+	assert.Equal(t, 1, resp.Items[0].BookCount)
+
+	// aliases must be a JSON array whose elements are strings, not objects.
+	var aliasStrings []string
+	require.NoError(t, json.Unmarshal(resp.Items[0].Aliases, &aliasStrings),
+		"aliases must unmarshal into []string, proving it is a JSON array of strings")
+	assert.ElementsMatch(t, []string{"SciFi", "SF"}, aliasStrings)
+}
+
 func TestUpdateGenre_RenameBackToOriginalName_FrontendSendsAliases(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/genres/types.go
+++ b/pkg/genres/types.go
@@ -1,5 +1,23 @@
 package genres
 
+import "github.com/shishobooks/shisho/pkg/models"
+
+// GenreResponse is the single-genre API response. It embeds the Genre model by
+// value (so tygo emits `extends Genre`) and reshapes the aliases relation into a
+// flat []string. BookCount and Aliases shadow the embedded model's same-json-tag
+// fields, so the wire format is byte-identical to the previous anonymous struct.
+type GenreResponse struct {
+	models.Genre `tstype:",extends"`
+	BookCount    int      `json:"book_count"`
+	Aliases      []string `json:"aliases"`
+}
+
+// ListGenresResponse is the list-endpoint envelope.
+type ListGenresResponse struct {
+	Items []GenreResponse `json:"items"`
+	Total int             `json:"total"`
+}
+
 type ListGenresQuery struct {
 	Limit     int     `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
 	Offset    int     `query:"offset" json:"offset,omitempty" validate:"min=0"`

--- a/pkg/models/genre.go
+++ b/pkg/models/genre.go
@@ -14,7 +14,7 @@ type Genre struct {
 	UpdatedAt time.Time     `json:"updated_at"`
 	LibraryID int           `bun:",nullzero" json:"library_id"`
 	Name      string        `bun:",nullzero" json:"name"`
-	Aliases   []*GenreAlias `bun:"rel:has-many,join:id=genre_id" json:"aliases" tstype:"GenreAlias[]"`
+	Aliases   []*GenreAlias `bun:"rel:has-many,join:id=genre_id" json:"aliases" tstype:"-"`
 	BookCount int           `bun:",scanonly" json:"book_count"`
 }
 

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -1,5 +1,10 @@
 type_mappings:
   time.Time: "string /* RFC3339 */"
+  # When a response struct embeds a model with `tstype:",extends"`, tygo emits
+  # the package-qualified selector (e.g. `extends models.Genre`). Map it to the
+  # bare interface name so the generated `extends` matches the `import { Genre }`
+  # frontmatter. Add one entry per embedded model used in a response struct.
+  models.Genre: "Genre"
 
 packages:
   - path: "github.com/shishobooks/shisho/pkg/models"
@@ -56,6 +61,8 @@ packages:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/genres"
     output_path: "app/types/generated/genres.ts"
+    frontmatter: |
+      import { Genre } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/tags"


### PR DESCRIPTION
Closes #343

## Summary
- Pattern-setting tracer-bullet slice for PRD #341 / ADR 0004: make Go the single source of truth for API types via tygo. Also fixes the genres half of bug #324 (aliases rendering as `, ,`).
- Backend: added `GenreResponse` (value-embeds `models.Genre` with `tstype:",extends"`, plus `book_count` and `aliases []string`) and `ListGenresResponse` (`{ items, total }`) to `pkg/genres/types.go`, and replaced all four anonymous / `map[string]any` responses in the genres handlers (`retrieve`, both `update` paths, `list`) with these named structs.
- Excluded the reshaped `Genre.Aliases` relation from TS generation with `tstype:"-"` (kept the `json:"aliases"` tag so the Go wire format is unchanged) so the generated `Genre` interface drops the relation and the response's `aliases: string[]` is the only one.
- tygo: added a `frontmatter` import of `Genre` on the genres entry plus a `type_mappings` entry `models.Genre: "Genre"`, so the value embed emits `extends Genre` rather than an unresolved `extends models.Genre`.
- Frontend: converted the query hooks and pages to consume the generated response types, removing the `.map((a) => a.name)` on the list page and the `as unknown as string[]` cast on the detail page.
- Docs: documented the convention in the root, `pkg`, and `app` CLAUDE.md files, referencing ADR 0004.

## Reviewer notes
- This establishes the convention every later PRD #341 slice copies. Start with `tygo.yaml` and `pkg/genres/types.go`.
- The non-obvious bit: tygo emits the package-qualified selector for a value embed (`extends models.Genre`), which does not resolve against `import { Genre }`. The fix is a one-line `type_mappings` entry (`models.Genre: "Genre"`) per embedded model, documented in `pkg/CLAUDE.md` so later slices add their own mapping (e.g. `models.Person: "Person"`).
- Wire format is byte-identical to the previous anonymous structs (shadowing fields share their json tags), so there is no client-facing API contract change. This is a TS-type correctness fix plus convention scaffolding.
- The genres `books` sub-resource still returns `map[string]any` and is intentionally out of scope (Books slice #348).
- No `website/docs/` update is required: this change is convention/docs-facing and does not alter user-facing app behavior or config. The CLAUDE.md updates are the doc deliverable here.

## Test plan
- `go test ./pkg/genres/` passes, including the new `TestList_ResponseAliasesSerializeAsStringArray`, which asserts the LIST envelope is exactly `{ items, total }` and that each item's `aliases` serializes as a JSON array of strings with `book_count` present (the #324 fix at the wire level).
- `mise tygo` regenerates `app/types/generated/genres.ts` with `export interface GenreResponse extends Genre { book_count: number; aliases: string[] }` and `ListGenresResponse` as `{ items, total }`; the generated `Genre` interface no longer contains `aliases: GenreAlias[]` and there is no `Partial<Genre>`.
- `mise lint test` and `mise lint:js test:unit` pass (tsc enforces that `GenresList.tsx`/`GenreDetail.tsx` read `aliases` as `string[]`).
- Manual: the Genres list page renders alias names correctly with no `, ,`.