### PR TITLE
[Fix] Disable pdfcpu on-disk config to stop cross-process CI race

### DIFF
--- a/pkg/pdf/CLAUDE.md
+++ b/pkg/pdf/CLAUDE.md
@@ -50,7 +50,11 @@ All PDF authors have an empty role (generic author, same as EPUB).
 
 ### Thread Safety
 
-pdfcpu's `NewDefaultConfiguration()` initializes global state (config files, font caches) that is not thread-safe. Call `pdf.EnsurePdfcpuInit()` before any concurrent use of `NewDefaultConfiguration()`. This is a shared `sync.Once` guard used by both the parser and the file generator.
+pdfcpu's `NewDefaultConfiguration()` reads/creates a shared per-user config file at `$HOME/.config/pdfcpu/config.yml` (plus a font dir and cert dir). This is **not safe across processes**: `go test` runs package binaries concurrently, and more than one package initializes pdfcpu (`pkg/pdf`, `pkg/filegen`). On a fresh machine where the file doesn't exist yet, one process can read it mid-write from another, and pdfcpu 0.12.x panics with `config problem: EOF` (it calls `fault.Fail` on any config load error rather than returning it).
+
+The package `init()` in `pdf.go` sets `model.ConfigPath = "disable"`, which makes `NewDefaultConfiguration()` return its in-memory defaults and never touch the shared file. We rely on nothing the on-disk config provides: `ValidationMode` is set explicitly at each call site, and we never fill PDF forms (the bundled Roboto font) or validate signatures (the EU certs), which are the only other things the config dir bootstraps.
+
+`pdf.EnsurePdfcpuInit()` (a shared `sync.Once` used by both the parser and the file generator) remains as belt-and-suspenders for the in-process case, but with the on-disk config disabled `NewDefaultConfiguration()` is already pure.
 
 ## Cover Extraction
 

--- a/pkg/pdf/pdf.go
+++ b/pkg/pdf/pdf.go
@@ -14,9 +14,28 @@ import (
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
+func init() {
+	// Disable pdfcpu's on-disk config so NewDefaultConfiguration() returns its
+	// in-memory defaults instead of reading/creating $HOME/.config/pdfcpu/config.yml.
+	//
+	// That shared file is the source of a cross-process race: `go test` runs
+	// package binaries concurrently, and more than one package initializes pdfcpu
+	// (pkg/pdf, pkg/filegen). On a fresh runner where the file doesn't exist yet,
+	// one process can read it mid-write from another and pdfcpu panics with
+	// "config problem: EOF" (it calls fault.Fail on any config load error in
+	// 0.12.x). A per-process sync.Once can't guard a file shared across processes.
+	//
+	// We don't use anything the on-disk config provides: ValidationMode is set
+	// explicitly at each call site, and we never fill PDF forms (Roboto font) or
+	// validate signatures (EU certs), which are the only other things the config
+	// dir bootstraps. Setting this in init() guarantees it runs before any
+	// NewDefaultConfiguration() call in the process.
+	model.ConfigPath = "disable"
+}
+
 // pdfcpuInit ensures pdfcpu's global configuration is initialized exactly once.
-// pdfcpu's NewDefaultConfiguration() writes global state (config file, font cache)
-// that is not thread-safe, so we initialize it before any concurrent access.
+// With the on-disk config disabled (see init), NewDefaultConfiguration() is pure
+// and this Once is belt-and-suspenders, but it remains cheap and harmless.
 var pdfcpuInit sync.Once
 
 // EnsurePdfcpuInit initializes pdfcpu's global state exactly once. This must be


### PR DESCRIPTION
## Problem

CI shard `Go Test (10/12)` failed in [run 26761140630](https://github.com/shishobooks/shisho/actions/runs/26761140630/job/78874683266). The `pkg/pdf` test binary panicked, which surfaced as a failure in `TestParse_NoMetadata` but actually took down the whole package:

```
panic: pdfcpu: config problem: EOF
  pdfcpu/model.NewDefaultConfiguration()  configuration.go:526
  shisho/pkg/pdf.EnsurePdfcpuInit.func1() pkg/pdf/pdf.go:26
```

## Root cause

pdfcpu's `NewDefaultConfiguration()` reads/creates a shared per-user config file at `$HOME/.config/pdfcpu/config.yml` (plus a font dir and cert dir). `go test` runs package binaries concurrently, and more than one package initializes pdfcpu (`pkg/pdf`, `pkg/filegen`). On a fresh runner where the file does not exist yet, one process can read it mid-write from another, and pdfcpu 0.12.x panics with `config problem: EOF` (it calls `fault.Fail` on any config load error instead of returning it, a behavior introduced in the 0.11 to 0.12 bump).

Our `EnsurePdfcpuInit()` `sync.Once` only serializes calls within a single process. It cannot coordinate across the separate `go test` package binaries that all share `$HOME/.config/pdfcpu/`, so this flakes intermittently depending on shard composition and timing.

## Fix

Set `model.ConfigPath = "disable"` in a `pkg/pdf` package `init()`. This makes `NewDefaultConfiguration()` return its in-memory defaults and never touch the shared file, font dir, or cert dir, removing the race at its source for every call site (parse, cover extraction, filegen bookmark writing).

We rely on nothing the on-disk config provides:
- `ValidationMode` is set explicitly at each call site.
- We never fill PDF forms (the bundled Roboto font) or validate signatures (the EU certs), which are the only other things the config dir bootstraps.

The `sync.Once` is kept as harmless belt-and-suspenders.

## Test plan

- `go test ./pkg/pdf/... ./pkg/filegen/... ./pkg/pdfpages/...` passes.
- `golangci-lint run ./pkg/pdf/...` is clean.
- Ran `TestParse_NoMetadata` with an isolated `HOME`/`XDG_CONFIG_HOME` and confirmed no `pdfcpu` config dir is created, proving the on-disk config (and the shared file the race depends on) is fully bypassed.
- Updated `pkg/pdf/CLAUDE.md` Thread Safety section to document the disable approach.
