### PR TITLE
[Backend] Take Tags response types end-to-end via tygo

### DIFF
--- a/app/components/pages/TagDetail.tsx
+++ b/app/components/pages/TagDetail.tsx
@@ -76,7 +76,7 @@ const TagDetail = () => {
   );
 
   const tag = tagQuery.data;
-  const aliases = tag ? ((tag.aliases as unknown as string[]) ?? []) : [];
+  const aliases = tag?.aliases ?? [];
   const bookCount = tag?.book_count ?? 0;
 
   const handleEdit = async (data: { name: string; aliases?: string[] }) => {

--- a/app/components/pages/TagsList.tsx
+++ b/app/components/pages/TagsList.tsx
@@ -1,19 +1,19 @@
 import ResourceList from "@/components/library/ResourceList";
 import { useTagsList } from "@/hooks/queries/tags";
 import { useResourceListState } from "@/hooks/useResourceListState";
-import type { Tag } from "@/types";
+import type { TagResponse } from "@/types";
 
 const TagsList = () => {
   const state = useResourceListState();
   const query = useTagsList(state.queryParams);
 
   return (
-    <ResourceList<Tag>
+    <ResourceList<TagResponse>
       itemConfig={(tag) => {
         const bookCount = tag.book_count ?? 0;
         return {
           name: tag.name,
-          aliases: tag.aliases.map((a) => a.name),
+          aliases: tag.aliases,
           badges: [
             {
               label: bookCount === 1 ? "book" : "books",

--- a/app/hooks/queries/tags.ts
+++ b/app/hooks/queries/tags.ts
@@ -6,7 +6,11 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Book, ResourceListResponse, Tag } from "@/types";
+import type {
+  ListTagBooksResponse,
+  ResourceListResponse,
+  TagResponse,
+} from "@/types";
 import type { ListTagsQuery, UpdateTagPayload } from "@/types/generated/tags";
 
 import { QueryKey as BooksQueryKey } from "./books";
@@ -17,7 +21,7 @@ export enum QueryKey {
   TagBooks = "TagBooks",
 }
 
-export type ListTagsData = ResourceListResponse<Tag>;
+export type ListTagsData = ResourceListResponse<TagResponse>;
 
 export const useTagsList = (
   query: ListTagsQuery = {},
@@ -38,11 +42,11 @@ export const useTagsList = (
 export const useTag = (
   tagId?: number,
   options: Omit<
-    UseQueryOptions<Tag, ShishoAPIError>,
+    UseQueryOptions<TagResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<Tag, ShishoAPIError>({
+  return useQuery<TagResponse, ShishoAPIError>({
     enabled: options.enabled !== undefined ? options.enabled : Boolean(tagId),
     ...options,
     queryKey: [QueryKey.RetrieveTag, tagId],
@@ -61,11 +65,11 @@ export const useTagBooks = (
   tagId?: number,
   query: TagBooksQuery = {},
   options: Omit<
-    UseQueryOptions<ResourceListResponse<Book>, ShishoAPIError>,
+    UseQueryOptions<ListTagBooksResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<ResourceListResponse<Book>, ShishoAPIError>({
+  return useQuery<ListTagBooksResponse, ShishoAPIError>({
     enabled: options.enabled !== undefined ? options.enabled : Boolean(tagId),
     ...options,
     queryKey: [QueryKey.TagBooks, tagId, query],
@@ -86,7 +90,7 @@ export const useUpdateTag = () => {
       tagId: number;
       payload: UpdateTagPayload;
     }) => {
-      return API.request<Tag>("PATCH", `/tags/${tagId}`, payload);
+      return API.request<TagResponse>("PATCH", `/tags/${tagId}`, payload);
     },
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -46,6 +46,9 @@ export {
   type MergeGenresPayload,
 } from "./generated/genres";
 export {
+  type TagResponse,
+  type ListTagsResponse,
+  type ListTagBooksResponse,
   type ListTagsQuery,
   type UpdateTagPayload,
   type MergeTagsPayload,

--- a/pkg/models/tag.go
+++ b/pkg/models/tag.go
@@ -14,7 +14,7 @@ type Tag struct {
 	UpdatedAt time.Time   `json:"updated_at"`
 	LibraryID int         `bun:",nullzero" json:"library_id"`
 	Name      string      `bun:",nullzero" json:"name"`
-	Aliases   []*TagAlias `bun:"rel:has-many,join:id=tag_id" json:"aliases" tstype:"TagAlias[]"`
+	Aliases   []*TagAlias `bun:"rel:has-many,join:id=tag_id" json:"aliases" tstype:"-"`
 	BookCount int         `bun:",scanonly" json:"book_count"`
 }
 

--- a/pkg/tags/handlers.go
+++ b/pkg/tags/handlers.go
@@ -48,11 +48,7 @@ func (h *handler) retrieve(c echo.Context) error {
 
 	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, id)
 
-	response := struct {
-		*models.Tag
-		BookCount int      `json:"book_count"`
-		Aliases   []string `json:"aliases"`
-	}{tag, bookCount, aliasList}
+	response := TagResponse{Tag: *tag, BookCount: bookCount, Aliases: aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -84,22 +80,14 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	type TagWithCount struct {
-		*models.Tag
-		BookCount int      `json:"book_count"`
-		Aliases   []string `json:"aliases"`
-	}
-	result := make([]TagWithCount, len(tags))
+	result := make([]TagResponse, len(tags))
 	for i, t := range tags {
 		bookCount, _ := h.tagService.GetBookCount(ctx, t.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, t.ID)
-		result[i] = TagWithCount{t, bookCount, aliasList}
+		result[i] = TagResponse{Tag: *t, BookCount: bookCount, Aliases: aliasList}
 	}
 
-	response := map[string]any{
-		"items": result,
-		"total": total,
-	}
+	response := ListTagsResponse{Items: result, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -156,11 +144,7 @@ func (h *handler) update(c echo.Context) error {
 
 			bookCount, _ := h.tagService.GetBookCount(ctx, existing.ID)
 			aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, existing.ID)
-			response := struct {
-				*models.Tag
-				BookCount int      `json:"book_count"`
-				Aliases   []string `json:"aliases"`
-			}{existing, bookCount, aliasList}
+			response := TagResponse{Tag: *existing, BookCount: bookCount, Aliases: aliasList}
 			return errors.WithStack(c.JSON(http.StatusOK, response))
 		}
 
@@ -193,11 +177,7 @@ func (h *handler) update(c echo.Context) error {
 
 	bookCount, _ := h.tagService.GetBookCount(ctx, id)
 	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.TagConfig, id)
-	response := struct {
-		*models.Tag
-		BookCount int      `json:"book_count"`
-		Aliases   []string `json:"aliases"`
-	}{tag, bookCount, aliasList}
+	response := TagResponse{Tag: *tag, BookCount: bookCount, Aliases: aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -232,10 +212,7 @@ func (h *handler) books(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	response := map[string]any{
-		"items": books,
-		"total": total,
-	}
+	response := ListTagBooksResponse{Items: books, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }

--- a/pkg/tags/handlers_test.go
+++ b/pkg/tags/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/aliases"
@@ -224,4 +225,61 @@ func TestList_ResponseUsesItemsKey(t *testing.T) {
 	err = json.Unmarshal(resp["items"], &items)
 	require.NoError(t, err)
 	assert.Len(t, items, 2)
+}
+
+func TestList_ResponseAliasesSerializeAsStringArray(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	ctx := context.Background()
+	e := newTestEcho(t)
+	lib := createTestLibrary(t, db)
+	tag := seedTagWithBooks(t, db, lib, "Science Fiction", []string{"Book1"})
+	h := newTestHandler(db)
+
+	// Seed two aliases for the tag so we can assert they round-trip as strings.
+	_, err := db.NewRaw(
+		"INSERT INTO tag_aliases (created_at, tag_id, name, library_id) VALUES (?, ?, ?, ?), (?, ?, ?, ?)",
+		time.Now(), tag.ID, "SciFi", lib.ID,
+		time.Now(), tag.ID, "SF", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = h.list(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Top-level envelope must be { items, total } only.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	assert.True(t, hasItems, "list response must have 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+
+	// Each item's aliases must serialize as a JSON array of strings (the #324 fix
+	// at the wire level), and book_count must be present.
+	var resp struct {
+		Items []struct {
+			ID        int             `json:"id"`
+			Name      string          `json:"name"`
+			BookCount int             `json:"book_count"`
+			Aliases   json.RawMessage `json:"aliases"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, "Science Fiction", resp.Items[0].Name)
+	assert.Equal(t, 1, resp.Items[0].BookCount)
+
+	// aliases must be a JSON array whose elements are strings, not objects.
+	var aliasStrings []string
+	require.NoError(t, json.Unmarshal(resp.Items[0].Aliases, &aliasStrings),
+		"aliases must unmarshal into []string, proving it is a JSON array of strings")
+	assert.ElementsMatch(t, []string{"SciFi", "SF"}, aliasStrings)
 }

--- a/pkg/tags/types.go
+++ b/pkg/tags/types.go
@@ -1,5 +1,29 @@
 package tags
 
+import "github.com/shishobooks/shisho/pkg/models"
+
+// TagResponse is the single-tag API response. It embeds the Tag model by value
+// (so tygo emits `extends Tag`) and reshapes the aliases relation into a flat
+// []string. BookCount and Aliases shadow the embedded model's same-json-tag
+// fields, so the wire format is byte-identical to the previous anonymous struct.
+type TagResponse struct {
+	models.Tag `tstype:",extends"`
+	BookCount  int      `json:"book_count"`
+	Aliases    []string `json:"aliases"`
+}
+
+// ListTagsResponse is the list-endpoint envelope.
+type ListTagsResponse struct {
+	Items []TagResponse `json:"items"`
+	Total int           `json:"total"`
+}
+
+// ListTagBooksResponse is the envelope for the tag books sub-resource.
+type ListTagBooksResponse struct {
+	Items []*models.Book `json:"items" tstype:"Book[]"`
+	Total int            `json:"total"`
+}
+
 type ListTagsQuery struct {
 	Limit     int     `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
 	Offset    int     `query:"offset" json:"offset,omitempty" validate:"min=0"`

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -5,6 +5,7 @@ type_mappings:
   # bare interface name so the generated `extends` matches the `import { Genre }`
   # frontmatter. Add one entry per embedded model used in a response struct.
   models.Genre: "Genre"
+  models.Tag: "Tag"
 
 packages:
   - path: "github.com/shishobooks/shisho/pkg/models"
@@ -67,6 +68,8 @@ packages:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/tags"
     output_path: "app/types/generated/tags.ts"
+    frontmatter: |
+      import { Book, Tag } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/publishers"


### PR DESCRIPTION
Closes #344

## Summary
- Mirror the Genres reference (PR #365): add named `TagResponse` (value-embeds `models.Tag` with `tstype:",extends"`, plus `book_count` and `aliases []string`) and `ListTagsResponse` (`{ items, total }`) to `pkg/tags/types.go`, and replace all four anonymous/`map[string]any` responses in the tags handlers with the named structs. The model's `TagAlias` relation is excluded from TS generation with `tstype:"-"`, and the tygo entry gains a `frontmatter` import plus a `models.Tag: "Tag"` mapping so the generated `extends Tag` resolves.
- Per the issue, also convert the tag books sub-resource to a named `ListTagBooksResponse` envelope (`{ items: Book[]; total }`) instead of `map[string]any`. This is the one place this slice goes further than the genres slice, where the books sub-resource conversion was deferred to #348.
- The frontend now consumes the generated `TagResponse`, `ListTagsResponse`, and `ListTagBooksResponse`, dropping the hand-written `Tag` usage, the `.map((a) => a.name)` workaround on the list page, and the `as unknown as string[]` cast on the detail page. This fixes the tags half of the aliases rendering bug (#324).

## Notes
- Wire format is byte-identical to the previous anonymous/`map[string]any` responses (the shadowing fields share their json tags). This is a TypeScript type-correctness fix plus the #324 aliases fix, not an API contract change. `useTagBooks` is now typed `ListTagBooksResponse`, which is structurally identical to the `ResourceListResponse<Book>` that `BookGallerySection` consumes, so it slots in without changes there.
- No `website/docs/` update was required: no docs page references the tag/genre API response shapes, and the CLAUDE.md tygo convention docs added by the genres slice already cover this generically.

## Test plan
- `mise tygo` regenerates `app/types/generated/tags.ts` with `TagResponse extends Tag` carrying `aliases: string[]` and `book_count`, and `models.ts`'s `Tag` no longer carrying `aliases: TagAlias[]`
- `go test ./pkg/tags/...` passes, including the new `TestList_ResponseAliasesSerializeAsStringArray` (asserts the list envelope is exactly `{ items, total }` and each item's `aliases` serializes as a JSON string array with `book_count` present)
- The existing tag books sub-resource envelope tests (`TestBooks_ResponseShape`, `TestBooks_DefaultPagination`, `TestBooks_ExplicitLimitOffset`) still hold after the conversion to the named struct
- `pnpm lint:types`, `pnpm lint:eslint`, and `pnpm lint:prettier` all pass