### PR TITLE
[Backend] Take Series response types end-to-end via tygo

### DIFF
--- a/app/components/pages/SeriesDetail.tsx
+++ b/app/components/pages/SeriesDetail.tsx
@@ -169,7 +169,7 @@ const SeriesDetail = () => {
   }
 
   const series = seriesQuery.data;
-  const aliases = (series.aliases as unknown as string[]) ?? [];
+  const aliases = series.aliases ?? [];
   const canDelete = series.book_count === 0;
 
   return (

--- a/app/components/pages/SeriesList.tsx
+++ b/app/components/pages/SeriesList.tsx
@@ -27,7 +27,7 @@ import { useIsTruncated } from "@/hooks/useIsTruncated";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { pageForSizeChange, parseGallerySize } from "@/libraries/gallerySize";
 import { cn } from "@/libraries/utils";
-import type { GallerySize, Series } from "@/types";
+import type { GallerySize, SeriesResponse } from "@/types";
 import { isCoverLoaded, markCoverLoaded } from "@/utils/coverCache";
 
 // For series, we don't have access to the underlying files, so we use the
@@ -46,7 +46,7 @@ const getSeriesAspectRatioClass = (coverAspectRatio: string): string => {
 };
 
 interface SeriesCardProps {
-  seriesItem: Series;
+  seriesItem: SeriesResponse;
   libraryId: string;
   aspectClass: string;
   isAudiobook: boolean;
@@ -231,7 +231,7 @@ const SeriesList = () => {
   const isStaleData =
     confirmedSearch !== null && debouncedSearch !== confirmedSearch;
 
-  const renderSeriesItem = (seriesItem: Series) => {
+  const renderSeriesItem = (seriesItem: SeriesResponse) => {
     const aspectClass = getSeriesAspectRatioClass(coverAspectRatio);
     const isAudiobook = coverAspectRatio.startsWith("audiobook");
 

--- a/app/hooks/queries/series.ts
+++ b/app/hooks/queries/series.ts
@@ -6,7 +6,7 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Book, ResourceListResponse, Series } from "@/types";
+import type { Book, ResourceListResponse, SeriesResponse } from "@/types";
 import type {
   ListSeriesQuery,
   UpdateSeriesPayload,
@@ -21,13 +21,9 @@ export enum QueryKey {
   SeriesBooks = "SeriesBooks",
 }
 
-export interface SeriesWithCount extends Series {
-  book_count: number;
-}
-
 export type { ListSeriesQuery };
 
-export type ListSeriesData = ResourceListResponse<Series>;
+export type ListSeriesData = ResourceListResponse<SeriesResponse>;
 
 export const useSeriesList = (
   query: ListSeriesQuery = {},
@@ -48,11 +44,11 @@ export const useSeriesList = (
 export const useSeries = (
   seriesId?: number,
   options: Omit<
-    UseQueryOptions<SeriesWithCount, ShishoAPIError>,
+    UseQueryOptions<SeriesResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<SeriesWithCount, ShishoAPIError>({
+  return useQuery<SeriesResponse, ShishoAPIError>({
     enabled:
       options.enabled !== undefined ? options.enabled : Boolean(seriesId),
     ...options,
@@ -98,7 +94,7 @@ export const useUpdateSeries = () => {
       seriesId: number;
       payload: UpdateSeriesPayload;
     }) => {
-      return API.request<SeriesWithCount>(
+      return API.request<SeriesResponse>(
         "PATCH",
         `/series/${seriesId}`,
         payload,

--- a/pkg/models/series.go
+++ b/pkg/models/series.go
@@ -26,7 +26,7 @@ type Series struct {
 	SortNameSource     string         `bun:",notnull" json:"sort_name_source" tstype:"DataSource"`
 	Description        *string        `json:"description,omitempty"`
 	CoverImageFilename *string        `json:"cover_image_filename,omitempty"`
-	Aliases            []*SeriesAlias `bun:"rel:has-many,join:id=series_id" json:"aliases" tstype:"SeriesAlias[]"`
+	Aliases            []*SeriesAlias `bun:"rel:has-many,join:id=series_id" json:"aliases" tstype:"-"`
 	BookSeries         []*BookSeries  `bun:"rel:has-many" json:"book_series,omitempty" tstype:"BookSeries[]"`
 	BookCount          int            `bun:",scanonly" json:"book_count"`
 	CoverCacheKey      string         `bun:"-" json:"cover_cache_key"`

--- a/pkg/series/handlers.go
+++ b/pkg/series/handlers.go
@@ -65,11 +65,7 @@ func (h *handler) retrieve(c echo.Context) error {
 	}
 	series.CoverCacheKey = covers.CacheKey(seriesFiles[id], aspectRatio)
 
-	response := struct {
-		*models.Series
-		BookCount int      `json:"book_count"`
-		Aliases   []string `json:"aliases"`
-	}{series, bookCount, aliasList}
+	response := SeriesResponse{Series: *series, BookCount: bookCount, Aliases: aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -110,12 +106,7 @@ func (h *handler) list(c echo.Context) error {
 	seriesFiles, _ := h.bookService.GetFirstBooksFilesForSeries(ctx, seriesIDs)
 
 	// Augment with book counts, aliases, and cover cache keys.
-	type SeriesWithCount struct {
-		*models.Series
-		BookCount int      `json:"book_count"`
-		Aliases   []string `json:"aliases"`
-	}
-	result := make([]SeriesWithCount, len(seriesList))
+	result := make([]SeriesResponse, len(seriesList))
 	for i, s := range seriesList {
 		count, _ := h.seriesService.GetSeriesBookCount(ctx, s.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.SeriesConfig, s.ID)
@@ -124,13 +115,10 @@ func (h *handler) list(c echo.Context) error {
 			aspectRatio = s.Library.CoverAspectRatio
 		}
 		s.CoverCacheKey = covers.CacheKey(seriesFiles[s.ID], aspectRatio)
-		result[i] = SeriesWithCount{s, count, aliasList}
+		result[i] = SeriesResponse{Series: *s, BookCount: count, Aliases: aliasList}
 	}
 
-	response := map[string]any{
-		"items": result,
-		"total": total,
-	}
+	response := ListSeriesResponse{Items: result, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -242,11 +230,7 @@ func (h *handler) update(c echo.Context) error {
 	bookCount, _ := h.seriesService.GetSeriesBookCount(ctx, id)
 	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.SeriesConfig, id)
 
-	response := struct {
-		*models.Series
-		BookCount int      `json:"book_count"`
-		Aliases   []string `json:"aliases"`
-	}{series, bookCount, aliasList}
+	response := SeriesResponse{Series: *series, BookCount: bookCount, Aliases: aliasList}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }

--- a/pkg/series/handlers_test.go
+++ b/pkg/series/handlers_test.go
@@ -1,0 +1,164 @@
+package series
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/pkg/aliases"
+	"github.com/shishobooks/shisho/pkg/books"
+	"github.com/shishobooks/shisho/pkg/libraries"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+// newSeriesHandler builds a handler wired with the services the list/retrieve
+// endpoints exercise (series, books, libraries, aliases).
+func newSeriesHandler(db *bun.DB) *handler {
+	return &handler{
+		seriesService:  NewService(db),
+		bookService:    books.NewService(db),
+		libraryService: libraries.NewService(db),
+		aliasService:   aliases.NewService(db),
+	}
+}
+
+// seedSeriesWithAliases creates a library, a series with a book, and two
+// aliases for that series. Returns the series ID.
+func seedSeriesWithAliases(ctx context.Context, t *testing.T, db *bun.DB) int {
+	t.Helper()
+
+	library := &models.Library{
+		Name:                     "Alias Library",
+		CoverAspectRatio:         "book",
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+
+	seriesRecord := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Mistborn",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "Mistborn",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err = db.NewInsert().Model(seriesRecord).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "The Final Empire",
+		TitleSource:     models.DataSourceFilepath,
+		SortTitle:       "The Final Empire",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        t.TempDir(),
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	sn := 1.0
+	_, err = db.NewInsert().Model(&models.BookSeries{
+		BookID: book.ID, SeriesID: seriesRecord.ID, SeriesNumber: &sn, SortOrder: 1,
+	}).Exec(ctx)
+	require.NoError(t, err)
+
+	_, err = db.NewRaw(
+		"INSERT INTO series_aliases (created_at, series_id, name, library_id) VALUES (?, ?, ?, ?), (?, ?, ?, ?)",
+		time.Now(), seriesRecord.ID, "Final Empire", library.ID,
+		time.Now(), seriesRecord.ID, "Era 1", library.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	return seriesRecord.ID
+}
+
+func TestSeriesList_ResponseEnvelopeAndAliasesSerializeAsStringArray(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	seedSeriesWithAliases(ctx, t, db)
+
+	h := newSeriesHandler(db)
+	e := newTestEchoSeries(t)
+	req := httptest.NewRequest(http.MethodGet, "/series?limit=10&offset=0", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.list(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Top-level envelope must be { items, total } only.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasSeries := raw["series"]
+	assert.True(t, hasItems, "list response must have 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.False(t, hasSeries, "list response must NOT use 'series' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+
+	// Each item must carry book_count and serialize aliases as a JSON array of
+	// strings (the #324 fix at the wire level), not relation objects.
+	var resp struct {
+		Items []struct {
+			ID        int             `json:"id"`
+			Name      string          `json:"name"`
+			BookCount int             `json:"book_count"`
+			Aliases   json.RawMessage `json:"aliases"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, "Mistborn", resp.Items[0].Name)
+	assert.Equal(t, 1, resp.Items[0].BookCount)
+
+	var aliasStrings []string
+	require.NoError(t, json.Unmarshal(resp.Items[0].Aliases, &aliasStrings),
+		"aliases must unmarshal into []string, proving it is a JSON array of strings")
+	assert.ElementsMatch(t, []string{"Final Empire", "Era 1"}, aliasStrings)
+}
+
+func TestSeriesRetrieve_ResponseAliasesSerializeAsStringArray(t *testing.T) {
+	t.Parallel()
+
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	seriesID := seedSeriesWithAliases(ctx, t, db)
+
+	h := newSeriesHandler(db)
+	e := newTestEchoSeries(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(seriesID))
+
+	require.NoError(t, h.retrieve(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		ID        int             `json:"id"`
+		Name      string          `json:"name"`
+		BookCount int             `json:"book_count"`
+		Aliases   json.RawMessage `json:"aliases"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "Mistborn", resp.Name)
+	assert.Equal(t, 1, resp.BookCount)
+
+	var aliasStrings []string
+	require.NoError(t, json.Unmarshal(resp.Aliases, &aliasStrings),
+		"aliases must unmarshal into []string, proving it is a JSON array of strings")
+	assert.ElementsMatch(t, []string{"Final Empire", "Era 1"}, aliasStrings)
+}

--- a/pkg/series/types.go
+++ b/pkg/series/types.go
@@ -1,5 +1,30 @@
 package series
 
+import "github.com/shishobooks/shisho/pkg/models"
+
+// SeriesResponse is the single-series API response. It embeds the Series model
+// by value (so tygo emits `extends Series`) and reshapes the aliases relation
+// into a flat []string. BookCount and Aliases shadow the embedded model's
+// same-json-tag fields, so the wire format is byte-identical to the previous
+// anonymous struct. The name follows the project-wide {Entity}Response
+// convention (ADR 0004); the revive "stutter" warning is a false positive
+// because the entity is itself named "Series".
+//
+//nolint:revive // SeriesResponse name is mandated by the {Entity}Response convention (ADR 0004)
+type SeriesResponse struct {
+	models.Series `tstype:",extends"`
+	BookCount     int      `json:"book_count"`
+	Aliases       []string `json:"aliases"`
+}
+
+// ListSeriesResponse is the list-endpoint envelope.
+//
+//nolint:revive // ListSeriesResponse name is mandated by the List{Entities}Response convention (ADR 0004)
+type ListSeriesResponse struct {
+	Items []SeriesResponse `json:"items"`
+	Total int              `json:"total"`
+}
+
 type ListSeriesQuery struct {
 	Limit     int     `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
 	Offset    int     `query:"offset" json:"offset,omitempty" validate:"min=0"`

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -6,6 +6,7 @@ type_mappings:
   # frontmatter. Add one entry per embedded model used in a response struct.
   models.Genre: "Genre"
   models.Tag: "Tag"
+  models.Series: "Series"
 
 packages:
   - path: "github.com/shishobooks/shisho/pkg/models"
@@ -54,6 +55,8 @@ packages:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/series"
     output_path: "app/types/generated/series.ts"
+    frontmatter: |
+      import { Series } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/people"


### PR DESCRIPTION
Closes #345

## Summary
- Replicates the Genres tygo convention (ADR 0004) for Series end-to-end. Adds named `SeriesResponse` (value-embeds `models.Series` via `tstype:",extends"`, adds `book_count` and `aliases []string`) and `ListSeriesResponse` (`{ items, total }` envelope) to `pkg/series/types.go`, and replaces all three anonymous / `map[string]any` handler responses (`retrieve`, `list`, `update`) with these named structs.
- Excludes the reshaped `Series.Aliases` relation from TS generation with `tstype:"-"` so the generated `Series` interface drops the relation and the response's `aliases: string[]` is the only one (no `extends` collision). Wires the tygo `frontmatter` import and `type_mappings` entry (`models.Series: "Series"`).
- Frontend now consumes the generated response types: deletes the hand-written `SeriesWithCount`, types `useSeriesList` / `useSeries` / `useUpdateSeries` as `SeriesResponse` / `ResourceListResponse<SeriesResponse>`, and reads `series.aliases` directly with no `as unknown as string[]` cast.
- Wire format is byte-identical to before (shadowing fields share json tags), so there is no API contract change.

This mirrors the Genres reference (#365, commit 967e66c) and the Tags slice (#368) exactly. Reviewers should start at `tygo.yaml` and `pkg/series/types.go`.

## Notes
- The one delta from the Genres slice: `series.SeriesResponse` triggers revive's "stutter" warning (the entity is literally named "Series"), which `GenreResponse` did not. Resolved with a targeted `//nolint:revive` on both type declarations citing the ADR 0004 naming convention, matching the existing `//nolint:revive` style in the codebase.
- No `app/types/index.ts` change needed: series already re-exports via `export * from "./generated/series"`.
- No `website/docs/` change: like the Genres and Tags slices, this is an internal API-type correctness fix with byte-identical wire format and no user-facing behavior change.
- The series `books` sub-resource handler (`seriesBooks`) returns a plain `[]Book` and was intentionally left out of scope (matches the Genres slice).
- Remaining `as unknown as string[]` casts in TagDetail / PublisherDetail / PersonDetail are out of scope (their own PRD #341 slices).

## Test plan
- `go test ./pkg/series/` passes, including the two new wire-format regression tests:
  - `TestSeriesList_ResponseEnvelopeAndAliasesSerializeAsStringArray` asserts the list endpoint returns exactly `{ items, total }` with each item carrying `book_count` and `aliases` serialized as a JSON string array.
  - `TestSeriesRetrieve_ResponseAliasesSerializeAsStringArray` asserts the retrieve endpoint returns `book_count` and `aliases` as a JSON string array.
- Existing cover-cache / ETag tests for list / retrieve / cover still pass under the new response types.
- `mise tygo` regenerates `app/types/generated/series.ts` with `SeriesResponse extends Series`, `aliases: string[]`, and the `{ items, total }` `ListSeriesResponse` envelope; the generated `Series` interface no longer carries an `aliases` field.
- `mise check:quiet` passes (Go lint + tests, JS lint + unit tests).