### PR TITLE
[Backend] Take People response types end-to-end via tygo

### DIFF
--- a/app/components/pages/PersonDetail.tsx
+++ b/app/components/pages/PersonDetail.tsx
@@ -92,7 +92,7 @@ const PersonDetail = () => {
   );
 
   const person = personQuery.data;
-  const aliases = person ? ((person.aliases as unknown as string[]) ?? []) : [];
+  const aliases = person?.aliases ?? [];
   const bookCount = person?.authored_book_count ?? 0;
   const narratedFileCount = person?.narrated_file_count ?? 0;
 

--- a/app/components/pages/PersonList.tsx
+++ b/app/components/pages/PersonList.tsx
@@ -1,13 +1,14 @@
 import ResourceList from "@/components/library/ResourceList";
-import { usePeopleList, type PersonWithCounts } from "@/hooks/queries/people";
+import { usePeopleList } from "@/hooks/queries/people";
 import { useResourceListState } from "@/hooks/useResourceListState";
+import type { PersonResponse } from "@/types";
 
 const PersonList = () => {
   const state = useResourceListState();
   const query = usePeopleList(state.queryParams);
 
   return (
-    <ResourceList<PersonWithCounts>
+    <ResourceList<PersonResponse>
       itemConfig={(person) => {
         const badges = [];
         if (person.authored_book_count > 0) {
@@ -41,7 +42,7 @@ const PersonList = () => {
           name: person.name,
           secondaryText:
             person.sort_name !== person.name ? person.sort_name : undefined,
-          aliases: person.aliases.map((a) => a.name),
+          aliases: person.aliases,
           badges,
         };
       }}

--- a/app/hooks/queries/entity-search.ts
+++ b/app/hooks/queries/entity-search.ts
@@ -2,14 +2,14 @@ import { useQueries } from "@tanstack/react-query";
 import { useMemo } from "react";
 
 import { API } from "@/libraries/api";
-import type { AuthorInput } from "@/types";
+import type { AuthorInput, PersonResponse } from "@/types";
 
 import {
   QueryKey as GenresQueryKey,
   useGenresList,
   type ListGenresData,
 } from "./genres";
-import { usePeopleList, type PersonWithCounts } from "./people";
+import { usePeopleList } from "./people";
 import { usePublishersList } from "./publishers";
 import { useSeriesList } from "./series";
 import {
@@ -51,7 +51,7 @@ export function usePeopleSearch(
     },
     { enabled: enabled && !!libraryId },
   );
-  const adapted = data?.items.map((p: PersonWithCounts) => ({
+  const adapted = data?.items.map((p: PersonResponse) => ({
     name: p.name,
     id: p.id,
     authored_book_count: p.authored_book_count,

--- a/app/hooks/queries/people.ts
+++ b/app/hooks/queries/people.ts
@@ -6,8 +6,11 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Book, File, Person, ResourceListResponse } from "@/types";
-import type { UpdatePersonPayload } from "@/types/generated/people";
+import type { Book, File, PersonResponse, ResourceListResponse } from "@/types";
+import type {
+  ListPeopleQuery,
+  UpdatePersonPayload,
+} from "@/types/generated/people";
 
 import { QueryKey as BooksQueryKey } from "./books";
 import { QueryKey as SearchQueryKey } from "./search";
@@ -19,19 +22,7 @@ export enum QueryKey {
   PersonNarratedFiles = "PersonNarratedFiles",
 }
 
-export interface ListPeopleQuery {
-  limit?: number;
-  offset?: number;
-  library_id?: number;
-  search?: string;
-}
-
-export interface PersonWithCounts extends Person {
-  authored_book_count: number;
-  narrated_file_count: number;
-}
-
-export type ListPeopleData = ResourceListResponse<PersonWithCounts>;
+export type ListPeopleData = ResourceListResponse<PersonResponse>;
 
 export const usePeopleList = (
   query: ListPeopleQuery = {},
@@ -52,11 +43,11 @@ export const usePeopleList = (
 export const usePerson = (
   personId?: number,
   options: Omit<
-    UseQueryOptions<PersonWithCounts, ShishoAPIError>,
+    UseQueryOptions<PersonResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<PersonWithCounts, ShishoAPIError>({
+  return useQuery<PersonResponse, ShishoAPIError>({
     enabled:
       options.enabled !== undefined ? options.enabled : Boolean(personId),
     ...options,
@@ -133,7 +124,7 @@ export const useUpdatePerson = () => {
       personId: number;
       payload: UpdatePersonPayload;
     }) => {
-      return API.request<PersonWithCounts>(
+      return API.request<PersonResponse>(
         "PATCH",
         `/people/${personId}`,
         payload,

--- a/pkg/models/person.go
+++ b/pkg/models/person.go
@@ -16,7 +16,7 @@ type Person struct {
 	Name           string         `bun:",nullzero" json:"name"`
 	SortName       string         `bun:",notnull" json:"sort_name"`
 	SortNameSource string         `bun:",notnull" json:"sort_name_source" tstype:"DataSource"`
-	Aliases        []*PersonAlias `bun:"rel:has-many,join:id=person_id" json:"aliases" tstype:"PersonAlias[]"`
+	Aliases        []*PersonAlias `bun:"rel:has-many,join:id=person_id" json:"aliases" tstype:"-"`
 }
 
 // Author role constants for CBZ ComicInfo.xml creator types.

--- a/pkg/people/handlers.go
+++ b/pkg/people/handlers.go
@@ -72,12 +72,12 @@ func (h *handler) retrieve(c echo.Context) error {
 
 	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PersonConfig, id)
 
-	response := struct {
-		*models.Person
-		AuthoredBookCount int      `json:"authored_book_count"`
-		NarratedFileCount int      `json:"narrated_file_count"`
-		Aliases           []string `json:"aliases"`
-	}{person, authoredCount, narratedCount, aliasList}
+	response := PersonResponse{
+		Person:            *person,
+		AuthoredBookCount: authoredCount,
+		NarratedFileCount: narratedCount,
+		Aliases:           aliasList,
+	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -111,24 +111,20 @@ func (h *handler) list(c echo.Context) error {
 	}
 
 	// Augment with counts and aliases
-	type PersonWithCounts struct {
-		*models.Person
-		AuthoredBookCount int      `json:"authored_book_count"`
-		NarratedFileCount int      `json:"narrated_file_count"`
-		Aliases           []string `json:"aliases"`
-	}
-	result := make([]PersonWithCounts, len(people))
+	result := make([]PersonResponse, len(people))
 	for i, p := range people {
 		authoredCount, _ := h.personService.GetAuthoredBookCount(ctx, p.ID)
 		narratedCount, _ := h.personService.GetNarratedFileCount(ctx, p.ID)
 		aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PersonConfig, p.ID)
-		result[i] = PersonWithCounts{p, authoredCount, narratedCount, aliasList}
+		result[i] = PersonResponse{
+			Person:            *p,
+			AuthoredBookCount: authoredCount,
+			NarratedFileCount: narratedCount,
+			Aliases:           aliasList,
+		}
 	}
 
-	response := map[string]any{
-		"items": result,
-		"total": total,
-	}
+	response := ListPeopleResponse{Items: result, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -302,12 +298,12 @@ func (h *handler) update(c echo.Context) error {
 	narratedCount, _ := h.personService.GetNarratedFileCount(ctx, id)
 	aliasList, _ := h.aliasService.ListAliases(ctx, aliases.PersonConfig, id)
 
-	response := struct {
-		*models.Person
-		AuthoredBookCount int      `json:"authored_book_count"`
-		NarratedFileCount int      `json:"narrated_file_count"`
-		Aliases           []string `json:"aliases"`
-	}{person, authoredCount, narratedCount, aliasList}
+	response := PersonResponse{
+		Person:            *person,
+		AuthoredBookCount: authoredCount,
+		NarratedFileCount: narratedCount,
+		Aliases:           aliasList,
+	}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -344,10 +340,7 @@ func (h *handler) authoredBooks(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	response := map[string]any{
-		"items": books,
-		"total": total,
-	}
+	response := ListAuthoredBooksResponse{Items: books, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
@@ -384,10 +377,7 @@ func (h *handler) narratedFiles(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	response := map[string]any{
-		"items": files,
-		"total": total,
-	}
+	response := ListNarratedFilesResponse{Items: files, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }

--- a/pkg/people/handlers_test.go
+++ b/pkg/people/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/shishobooks/shisho/pkg/aliases"
@@ -394,4 +395,63 @@ func TestList_ResponseUsesItemsKey(t *testing.T) {
 	err = json.Unmarshal(resp["items"], &items)
 	require.NoError(t, err)
 	assert.Len(t, items, 2)
+}
+
+func TestList_ResponseAliasesSerializeAsStringArray(t *testing.T) {
+	t.Parallel()
+	db := setupHandlerTestDB(t)
+	ctx := context.Background()
+	lib := createTestLibrary(t, db)
+	h := newTestHandler(db)
+
+	person := seedPersonWithAuthoredBooks(t, db, lib, "Brandon Sanderson", []string{"Book1"})
+
+	// Seed two aliases so we can assert they round-trip as JSON strings.
+	_, err := db.NewRaw(
+		"INSERT INTO person_aliases (created_at, person_id, name, library_id) VALUES (?, ?, ?, ?), (?, ?, ?, ?)",
+		time.Now(), person.ID, "B. Sanderson", lib.ID,
+		time.Now(), person.ID, "Brandon S.", lib.ID,
+	).Exec(ctx)
+	require.NoError(t, err)
+
+	e := newTestEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = h.list(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Top-level envelope must be { items, total } only.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	assert.True(t, hasItems, "list response must have 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+
+	// Each item's aliases must serialize as a JSON array of strings (the #324 fix
+	// at the wire level), and the counts must be present.
+	var resp struct {
+		Items []struct {
+			ID                int             `json:"id"`
+			Name              string          `json:"name"`
+			AuthoredBookCount int             `json:"authored_book_count"`
+			NarratedFileCount int             `json:"narrated_file_count"`
+			Aliases           json.RawMessage `json:"aliases"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, "Brandon Sanderson", resp.Items[0].Name)
+	assert.Equal(t, 1, resp.Items[0].AuthoredBookCount)
+
+	// aliases must be a JSON array whose elements are strings, not objects.
+	var aliasStrings []string
+	require.NoError(t, json.Unmarshal(resp.Items[0].Aliases, &aliasStrings),
+		"aliases must unmarshal into []string, proving it is a JSON array of strings")
+	assert.ElementsMatch(t, []string{"B. Sanderson", "Brandon S."}, aliasStrings)
 }

--- a/pkg/people/types.go
+++ b/pkg/people/types.go
@@ -22,13 +22,13 @@ type ListPeopleResponse struct {
 
 // ListAuthoredBooksResponse is the authored-books sub-resource envelope.
 type ListAuthoredBooksResponse struct {
-	Items []*models.Book `json:"items"`
+	Items []*models.Book `json:"items" tstype:"Book[]"`
 	Total int            `json:"total"`
 }
 
 // ListNarratedFilesResponse is the narrated-files sub-resource envelope.
 type ListNarratedFilesResponse struct {
-	Items []*models.File `json:"items"`
+	Items []*models.File `json:"items" tstype:"File[]"`
 	Total int            `json:"total"`
 }
 

--- a/pkg/people/types.go
+++ b/pkg/people/types.go
@@ -1,5 +1,37 @@
 package people
 
+import "github.com/shishobooks/shisho/pkg/models"
+
+// PersonResponse is the single-person API response. It embeds the Person model
+// by value (so tygo emits `extends Person`) and reshapes the aliases relation
+// into a flat []string. AuthoredBookCount and NarratedFileCount are derived
+// counts; Aliases shadows the embedded model's same-json-tag field, so the wire
+// format is byte-identical to the previous anonymous struct.
+type PersonResponse struct {
+	models.Person     `tstype:",extends"`
+	AuthoredBookCount int      `json:"authored_book_count"`
+	NarratedFileCount int      `json:"narrated_file_count"`
+	Aliases           []string `json:"aliases"`
+}
+
+// ListPeopleResponse is the list-endpoint envelope.
+type ListPeopleResponse struct {
+	Items []PersonResponse `json:"items"`
+	Total int              `json:"total"`
+}
+
+// ListAuthoredBooksResponse is the authored-books sub-resource envelope.
+type ListAuthoredBooksResponse struct {
+	Items []*models.Book `json:"items"`
+	Total int            `json:"total"`
+}
+
+// ListNarratedFilesResponse is the narrated-files sub-resource envelope.
+type ListNarratedFilesResponse struct {
+	Items []*models.File `json:"items"`
+	Total int            `json:"total"`
+}
+
 type ListPeopleQuery struct {
 	Limit     int     `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
 	Offset    int     `query:"offset" json:"offset,omitempty" validate:"min=0"`

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -8,11 +8,10 @@ type_mappings:
   models.Tag: "Tag"
   models.Series: "Series"
   models.Person: "Person"
-  # Models referenced by name (not embedded) in a package's response structs also
-  # need a mapping so tygo emits the bare interface name instead of `any`. The
-  # people sub-resource envelopes return []*models.Book / []*models.File.
+  # A model returned by name (not embedded, not field-level `tstype`-overridden)
+  # also needs a mapping so tygo emits the bare interface name instead of `any`.
+  # books.ts's MoveFilesResponse / MergeBooksResponse return a *models.Book.
   models.Book: "Book"
-  models.File: "File"
 
 packages:
   - path: "github.com/shishobooks/shisho/pkg/models"

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -7,12 +7,20 @@ type_mappings:
   models.Genre: "Genre"
   models.Tag: "Tag"
   models.Series: "Series"
+  models.Person: "Person"
+  # Models referenced by name (not embedded) in a package's response structs also
+  # need a mapping so tygo emits the bare interface name instead of `any`. The
+  # people sub-resource envelopes return []*models.Book / []*models.File.
+  models.Book: "Book"
+  models.File: "File"
 
 packages:
   - path: "github.com/shishobooks/shisho/pkg/models"
     output_path: "app/types/generated/models.ts"
   - path: "github.com/shishobooks/shisho/pkg/books"
     output_path: "app/types/generated/books.ts"
+    frontmatter: |
+      import { Book } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/config"
@@ -61,6 +69,8 @@ packages:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/people"
     output_path: "app/types/generated/people.ts"
+    frontmatter: |
+      import { Book, File, Person } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/genres"


### PR DESCRIPTION
Closes #346

## Summary

- Took the People API slice end-to-end through tygo-generated types, mirroring the Genres reference (#343). Added named response structs in `pkg/people/types.go` (`PersonResponse` value-embedding `models.Person` via `tstype:",extends"`, plus `ListPeopleResponse`, `ListAuthoredBooksResponse`, and `ListNarratedFilesResponse` envelopes), rewrote the handlers to return them instead of anonymous structs and `map[string]any`, and changed `models.Person.Aliases` to `tstype:"-"` so the generated `Person` drops the relation and `PersonResponse` carries `aliases: string[]`.
- Updated the frontend to consume the generated `PersonResponse`: deleted the hand-written `PersonWithCounts`, fixed the `, ,` alias-rendering bug (`person.aliases.map((a) => a.name)` over already-string aliases), and removed the `as unknown as string[]` cast. Fixes #324 for people.

## Details

- `pkg/people/types.go` - added `PersonResponse`, `ListPeopleResponse`, `ListAuthoredBooksResponse`, `ListNarratedFilesResponse`; imports `models`.
- `pkg/people/handlers.go` - `retrieve`/`update` return `PersonResponse`; `list` returns `ListPeopleResponse`; `authoredBooks`/`narratedFiles` return the named sub-resource envelopes (removed all anonymous structs and `map[string]any`).
- `pkg/models/person.go` - `Person.Aliases` tag changed from `tstype:"PersonAlias[]"` to `tstype:"-"`.
- `tygo.yaml` - added `models.Person`/`models.Book`/`models.File` type_mappings, a `frontmatter` import for the people entry, and a `Book` import for the books entry.
- `app/hooks/queries/people.ts`, `app/hooks/queries/entity-search.ts`, `app/components/pages/PersonList.tsx`, `app/components/pages/PersonDetail.tsx` - consume generated `PersonResponse`, drop the cast and the `, ,` bug.

## Notes

- The `{items,total}` envelope was already the wire shape for all three People endpoints (list, authored-books, narrated-files) via `map[string]any`; this change makes them named, tygo-generated structs without altering the JSON. No user-facing API shape change, so no `website/docs/` update is needed.
- The `tygo.yaml` change adds global `models.Book`/`models.File` mappings (needed so the People sub-resource envelopes generate typed `Book`/`File` instead of `any`), which also upgraded the pre-existing `any /* models.Book */` in `books.ts` to a typed `Book`. That required adding a `Book` frontmatter import to the books entry. Strict improvement, removes an `any`, and tsc is clean.
- Rebased onto the Tags slice (#368) that landed on master; the only conflict was the `type_mappings` block in `tygo.yaml`, resolved by keeping all entries.

## Test plan

- `pkg/people/handlers_test.go:TestList_ResponseAliasesSerializeAsStringArray` asserts the list envelope is exactly `{items,total}` and per-item `aliases` serialize as a JSON string array, with counts present.
- Existing envelope/shape tests still assert `{items,total}` for list, authored-books, and narrated-files (`TestList_ResponseUsesItemsKey`, `TestAuthoredBooks_ResponseShape`, `TestNarratedFiles_ResponseShape`, plus pagination tests).
- Ran `mise lint`, `go test ./pkg/people/...`, `pnpm lint:types`, `pnpm lint:eslint`, `pnpm lint:prettier`, and `pnpm test:unit` (845 passing) locally; all green.