### PR TITLE
[Backend] Take Books response types end-to-end via tygo

### DIFF
--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -46,6 +46,7 @@ import {
   FileTypeCBZ,
   ReviewOverrideReviewed,
   type AuthorInput,
+  type AuthorRole,
   type Book,
   type ReviewOverride,
   type SeriesInput,
@@ -236,7 +237,10 @@ export function BookEditDialog({
     setAuthors(authors.filter((_, i) => i !== index));
   };
 
-  const handleAuthorRoleChange = (index: number, role: string | undefined) => {
+  const handleAuthorRoleChange = (
+    index: number,
+    role: AuthorRole | undefined,
+  ) => {
     const updated = [...authors];
     updated[index].role = role;
     setAuthors(updated);
@@ -504,7 +508,9 @@ export function BookEditDialog({
                           onValueChange={(value) =>
                             handleAuthorRoleChange(
                               idx,
-                              value === "none" ? undefined : value,
+                              value === "none"
+                                ? undefined
+                                : (value as AuthorRole),
                             )
                           }
                           value={author.role || "none"}

--- a/app/components/library/FileEditDialog.tsx
+++ b/app/components/library/FileEditDialog.tsx
@@ -366,7 +366,7 @@ export function FileEditDialog({
 
   const handleSubmit = async () => {
     const payload: {
-      file_role?: string;
+      file_role?: FileRole;
       name?: string;
       narrators?: string[];
       url?: string;

--- a/app/components/pages/Home.tsx
+++ b/app/components/pages/Home.tsx
@@ -44,7 +44,7 @@ import {
   sortSpecsEqual,
   type SortLevel,
 } from "@/libraries/sortSpec";
-import type { Book, GallerySize, Genre, Tag } from "@/types";
+import type { Book, GallerySize, Genre, ReviewedFilter, Tag } from "@/types";
 
 const HomeContent = () => {
   const { libraryId } = useParams();
@@ -450,7 +450,7 @@ const HomeContent = () => {
 
   // Add reviewed filter if present
   if (reviewedFilterParam && reviewedFilterParam !== "all") {
-    booksQueryParams.reviewed_filter = reviewedFilterParam;
+    booksQueryParams.reviewed_filter = reviewedFilterParam as ReviewedFilter;
   }
 
   // Sort: serialize only the effective (possibly resolved-from-default) sort.

--- a/app/hooks/queries/resync.ts
+++ b/app/hooks/queries/resync.ts
@@ -1,7 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { API } from "@/libraries/api";
-import { Book, File } from "@/types";
+import {
+  Book,
+  File,
+  type ResyncBookResponse,
+  type ResyncFileResponse,
+} from "@/types";
 
 import { QueryKey } from "./books";
 import { QueryKey as ChaptersQueryKey } from "./chapters";
@@ -10,15 +15,6 @@ export type RescanMode = "scan" | "refresh" | "reset";
 
 export interface ResyncPayload {
   mode: RescanMode;
-}
-
-export interface ResyncFileResult {
-  file_deleted?: boolean;
-  book_deleted?: boolean;
-}
-
-export interface ResyncBookResult {
-  book_deleted?: boolean;
 }
 
 export const useResyncFile = () => {
@@ -31,8 +27,8 @@ export const useResyncFile = () => {
     }: {
       fileId: number;
       payload: ResyncPayload;
-    }): Promise<File | ResyncFileResult> => {
-      return API.request<File | ResyncFileResult>(
+    }): Promise<File | ResyncFileResponse> => {
+      return API.request<File | ResyncFileResponse>(
         "POST",
         `/books/files/${fileId}/resync`,
         payload,
@@ -64,8 +60,8 @@ export const useResyncBook = () => {
     }: {
       bookId: number;
       payload: ResyncPayload;
-    }): Promise<Book | ResyncBookResult> => {
-      return API.request<Book | ResyncBookResult>(
+    }): Promise<Book | ResyncBookResponse> => {
+      return API.request<Book | ResyncBookResponse>(
         "POST",
         `/books/${bookId}/resync`,
         payload,

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,33 +1,24 @@
 export * from "./generated/models";
 export {
   type AuthorInput,
+  type DeleteBookResponse,
+  type DeleteBooksPayload,
+  type DeleteBooksResponse,
+  type DeleteFileResponse,
   type IdentifierPayload,
+  type ListBooksQuery,
+  type ListBooksResponse,
   type MergeBooksPayload,
   type MergeBooksResponse,
   type MoveFilesPayload,
   type MoveFilesResponse,
+  type ResyncBookResponse,
+  type ResyncFileResponse,
   type ResyncPayload,
   type SeriesInput,
   type UpdateBookPayload,
   type UpdateFilePayload,
-  type ListBooksQuery as GeneratedListBooksQuery,
 } from "./generated/books";
-
-// Extended ListBooksQuery with ids filter for bulk operations
-export interface ListBooksQuery {
-  limit?: number;
-  offset?: number;
-  library_id?: number;
-  series_id?: number;
-  search?: string;
-  file_types?: string[];
-  genre_ids?: number[];
-  tag_ids?: number[];
-  language?: string;
-  ids?: number[];
-  sort?: string;
-  reviewed_filter?: string; // "" or "all" = all books, "needs_review", "reviewed"
-}
 export * from "./generated/filesystem";
 export * from "./generated/jobs";
 export * from "./generated/joblogs";
@@ -83,23 +74,4 @@ export type { UserSettings } from "@/hooks/queries/settings";
 export interface ResourceListResponse<T> {
   items: T[];
   total: number;
-}
-
-// Delete operation types
-// TODO: Move these to types.go and regenerate via tygo
-export interface DeleteBookResponse {
-  files_deleted: number;
-}
-
-export interface DeleteFileResponse {
-  book_deleted: boolean;
-}
-
-export interface DeleteBooksPayload {
-  book_ids: number[];
-}
-
-export interface DeleteBooksResponse {
-  books_deleted: number;
-  files_deleted: number;
 }

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -204,10 +204,7 @@ func (h *handler) list(c echo.Context) error {
 		b.CoverCacheKey = covers.CacheKey(b.Files, aspectRatio)
 	}
 
-	resp := struct {
-		Items []*models.Book `json:"items"`
-		Total int            `json:"total"`
-	}{books, total}
+	resp := ListBooksResponse{Items: books, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, resp))
 }
@@ -1896,9 +1893,9 @@ func (h *handler) resyncFile(c echo.Context) error {
 
 	// Handle deletion case
 	if result.FileDeleted {
-		return c.JSON(http.StatusOK, map[string]interface{}{
-			"file_deleted": true,
-			"book_deleted": result.BookDeleted,
+		return c.JSON(http.StatusOK, ResyncFileResponse{
+			FileDeleted: true,
+			BookDeleted: result.BookDeleted,
 		})
 	}
 
@@ -1950,8 +1947,8 @@ func (h *handler) resyncBook(c echo.Context) error {
 
 	// Handle deletion case
 	if result.BookDeleted {
-		return c.JSON(http.StatusOK, map[string]interface{}{
-			"book_deleted": true,
+		return c.JSON(http.StatusOK, ResyncBookResponse{
+			BookDeleted: true,
 		})
 	}
 
@@ -2387,27 +2384,6 @@ func (h *handler) mergeBooks(c echo.Context) error {
 	})
 }
 
-// DeleteBooksRequest is the request body for bulk book deletion.
-type DeleteBooksRequest struct {
-	BookIDs []int `json:"book_ids"`
-}
-
-// DeleteBooksResponse is the response for bulk book deletion.
-type DeleteBooksResponse struct {
-	BooksDeleted int `json:"books_deleted"`
-	FilesDeleted int `json:"files_deleted"`
-}
-
-// DeleteBookResponse is the response for deleting a book.
-type DeleteBookResponse struct {
-	FilesDeleted int `json:"files_deleted"`
-}
-
-// DeleteFileResponse is the response for deleting a file.
-type DeleteFileResponse struct {
-	BookDeleted bool `json:"book_deleted"`
-}
-
 // deleteBook handles DELETE /books/:id.
 func (h *handler) deleteBook(c echo.Context) error {
 	ctx := c.Request().Context()
@@ -2618,7 +2594,7 @@ func (h *handler) deleteBooks(c echo.Context) error {
 	ctx := c.Request().Context()
 	log := logger.FromContext(ctx)
 
-	var req DeleteBooksRequest
+	var req DeleteBooksPayload
 	if err := c.Bind(&req); err != nil {
 		return errcodes.ValidationError("Invalid request body")
 	}

--- a/pkg/books/handlers_list_test.go
+++ b/pkg/books/handlers_list_test.go
@@ -212,6 +212,50 @@ func TestListHandler_NoLibraryIDSkipsStoredLookup(t *testing.T) {
 	assert.Equal(t, apple.ID, resp.Items[1].ID)
 }
 
+// TestListHandler_ResponseEnvelope asserts the list endpoint returns exactly
+// the { items, total } envelope (the ListBooksResponse shape, ADR 0004), with
+// no extra top-level keys.
+func TestListHandler_ResponseEnvelope(t *testing.T) {
+	t.Parallel()
+
+	db := setupBooksTestDB(t)
+	lib := seedLibrary(t, db, "EnvelopeLib")
+	user := seedUserWithLibAccess(t, db, "grace", lib)
+
+	now := time.Now()
+	apple := seedBook(t, db, lib, "Apple", "Apple", now)
+
+	h := &handler{bookService: NewService(db), settingsService: settings.NewService(db)}
+	e := newTestEchoBooks(t)
+	req := httptest.NewRequest(http.MethodGet, "/books?library_id="+strconv.Itoa(lib.ID), nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	require.NoError(t, h.list(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// Top-level envelope must be { items, total } only.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	assert.True(t, hasItems, "list response must have 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+
+	var resp struct {
+		Items []struct {
+			ID int `json:"id"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, apple.ID, resp.Items[0].ID)
+	assert.Equal(t, 1, resp.Total)
+}
+
 func seedFile(t *testing.T, db *bun.DB, book *models.Book, fileType string, hasCover bool) *models.File {
 	t.Helper()
 	f := &models.File{

--- a/pkg/books/types.go
+++ b/pkg/books/types.go
@@ -14,7 +14,13 @@ type ListBooksQuery struct {
 	Language       *string  `query:"language" json:"language,omitempty" validate:"omitempty,max=35" tstype:"string"` // Filter by language tag
 	IDs            []int    `query:"ids" json:"ids,omitempty"`                                                       // Filter by specific book IDs
 	Sort           string   `query:"sort" json:"sort,omitempty" validate:"omitempty,max=200"`
-	ReviewedFilter string   `query:"reviewed_filter" json:"reviewed_filter,omitempty" validate:"omitempty,oneof=all needs_review reviewed"` // "" or "all" = all books, "needs_review", "reviewed"
+	ReviewedFilter string   `query:"reviewed_filter" json:"reviewed_filter,omitempty" validate:"omitempty,oneof=all needs_review reviewed" tstype:"ReviewedFilter"` // "" or "all" = all books, "needs_review", "reviewed"
+}
+
+// ListBooksResponse is the list-endpoint envelope for books.
+type ListBooksResponse struct {
+	Items []*models.Book `json:"items" tstype:"Book[]"`
+	Total int            `json:"total"`
 }
 
 type UpdateBookPayload struct {
@@ -31,14 +37,14 @@ type UpdateBookPayload struct {
 // AuthorInput represents an author with an optional role (for CBZ files).
 type AuthorInput struct {
 	Name string  `json:"name" validate:"required,max=200"`
-	Role *string `json:"role,omitempty" validate:"omitempty,oneof=writer penciller inker colorist letterer cover_artist editor translator"`
+	Role *string `json:"role,omitempty" validate:"omitempty,oneof=writer penciller inker colorist letterer cover_artist editor translator" tstype:"AuthorRole"`
 }
 
 // SeriesInput represents a series association with optional number.
 type SeriesInput struct {
 	Name             string   `json:"name" validate:"required,max=200"`
 	Number           *float64 `json:"number,omitempty"`
-	SeriesNumberUnit *string  `json:"series_number_unit,omitempty" validate:"omitempty,oneof=volume chapter"`
+	SeriesNumberUnit *string  `json:"series_number_unit,omitempty" validate:"omitempty,oneof=volume chapter" tstype:"SeriesNumberUnit"`
 }
 
 // IdentifierPayload represents an identifier in update requests.
@@ -49,7 +55,7 @@ type IdentifierPayload struct {
 
 // UpdateFilePayload is the payload for updating a file's metadata.
 type UpdateFilePayload struct {
-	FileRole         *string              `json:"file_role,omitempty" validate:"omitempty,oneof=main supplement"`
+	FileRole         *string              `json:"file_role,omitempty" validate:"omitempty,oneof=main supplement" tstype:"FileRole"`
 	Name             *string              `json:"name,omitempty" mod:"trim" validate:"omitempty,max=500"`
 	Narrators        []string             `json:"narrators,omitempty" validate:"omitempty,dive,max=200"`
 	URL              *string              `json:"url,omitempty" validate:"omitempty,max=500,url"`
@@ -92,7 +98,7 @@ type MoveFilesPayload struct {
 
 // MoveFilesResponse is the response from a move files operation.
 type MoveFilesResponse struct {
-	TargetBook        *models.Book `json:"target_book"`
+	TargetBook        *models.Book `json:"target_book" tstype:"Book"`
 	FilesMoved        int          `json:"files_moved"`
 	SourceBookDeleted bool         `json:"source_book_deleted"`
 }
@@ -105,7 +111,48 @@ type MergeBooksPayload struct {
 
 // MergeBooksResponse is the response from a merge books operation.
 type MergeBooksResponse struct {
-	TargetBook   *models.Book `json:"target_book"`
+	TargetBook   *models.Book `json:"target_book" tstype:"Book"`
 	FilesMoved   int          `json:"files_moved"`
 	BooksDeleted int          `json:"books_deleted"`
+}
+
+// DeleteBooksPayload is the request body for bulk book deletion.
+type DeleteBooksPayload struct {
+	BookIDs []int `json:"book_ids"`
+}
+
+// DeleteBooksResponse is the response for bulk book deletion. It reports the
+// cascade consequences (counts of deleted books and files).
+type DeleteBooksResponse struct {
+	BooksDeleted int `json:"books_deleted"`
+	FilesDeleted int `json:"files_deleted"`
+}
+
+// DeleteBookResponse is the response for deleting a single book. It reports the
+// number of files that cascaded with the book.
+type DeleteBookResponse struct {
+	FilesDeleted int `json:"files_deleted"`
+}
+
+// DeleteFileResponse is the response for deleting a single file. It reports
+// whether deleting the file's last file also deleted the parent book.
+type DeleteFileResponse struct {
+	BookDeleted bool `json:"book_deleted"`
+}
+
+// ResyncFileResponse is returned by the file resync endpoint when the resync
+// determined the file no longer exists on disk. It reports the cascade
+// consequences (the file was deleted, and possibly its parent book). When the
+// file still exists, the endpoint returns the refreshed File model instead.
+type ResyncFileResponse struct {
+	FileDeleted bool `json:"file_deleted"`
+	BookDeleted bool `json:"book_deleted"`
+}
+
+// ResyncBookResponse is returned by the book resync endpoint when the resync
+// determined the book no longer exists on disk. It reports the cascade
+// consequence (the book was deleted). When the book still exists, the endpoint
+// returns the refreshed Book model instead.
+type ResyncBookResponse struct {
+	BookDeleted bool `json:"book_deleted"`
 }

--- a/pkg/models/file.go
+++ b/pkg/models/file.go
@@ -26,6 +26,16 @@ const (
 	ReviewOverrideUnreviewed = "unreviewed"
 )
 
+// ReviewedFilter values for the book list endpoint's reviewed_filter query
+// param. "" and "all" both mean "all books"; the other two scope to
+// needs-review or reviewed books respectively.
+const (
+	//tygo:emit export type ReviewedFilter = typeof ReviewedFilterAll | typeof ReviewedFilterNeedsReview | typeof ReviewedFilterReviewed;
+	ReviewedFilterAll         = "all"
+	ReviewedFilterNeedsReview = "needs_review"
+	ReviewedFilterReviewed    = "reviewed"
+)
+
 type File struct {
 	bun.BaseModel `bun:"table:files,alias:f" tstype:"-"`
 

--- a/pkg/models/person.go
+++ b/pkg/models/person.go
@@ -21,6 +21,7 @@ type Person struct {
 
 // Author role constants for CBZ ComicInfo.xml creator types.
 const (
+	//tygo:emit export type AuthorRole = typeof AuthorRoleWriter | typeof AuthorRolePenciller | typeof AuthorRoleInker | typeof AuthorRoleColorist | typeof AuthorRoleLetterer | typeof AuthorRoleCoverArtist | typeof AuthorRoleEditor | typeof AuthorRoleTranslator;
 	AuthorRoleWriter      = "writer"
 	AuthorRolePenciller   = "penciller"
 	AuthorRoleInker       = "inker"
@@ -39,7 +40,7 @@ type Author struct {
 	PersonID  int     `bun:",nullzero" json:"person_id"`
 	Person    *Person `bun:"rel:belongs-to,join:person_id=id" json:"person,omitempty" tstype:"Person"`
 	SortOrder int     `bun:",nullzero" json:"sort_order"`
-	Role      *string `json:"role"` // CBZ creator role: writer, penciller, inker, etc. NULL for generic author
+	Role      *string `json:"role" tstype:"AuthorRole"` // CBZ creator role: writer, penciller, inker, etc. NULL for generic author
 }
 
 type Narrator struct {

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -20,7 +20,7 @@ packages:
   - path: "github.com/shishobooks/shisho/pkg/books"
     output_path: "app/types/generated/books.ts"
     frontmatter: |
-      import { Book } from "@/types";
+      import { AuthorRole, Book, FileRole, ReviewedFilter, SeriesNumberUnit } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/config"


### PR DESCRIPTION
Closes #348

## Summary
- Bring the Books API responses and request enums under the tygo single-source-of-truth convention (ADR 0004), mirroring the merged Tags (#368) and Series (#369) slices.
- Add a named `ListBooksResponse` (`{ items, total }`) envelope replacing the anonymous list struct, and move the delete/resync response types into `pkg/books/types.go` as named structs (`DeleteBookResponse`, `DeleteFileResponse`, `DeleteBooksResponse`, `ResyncFileResponse`, `ResyncBookResponse`), keeping their typed cascade-consequence bodies.
- Add `//tygo:emit` unions for `AuthorRole` and `ReviewedFilter` in `pkg/models` plus `tstype` hints so the books payload/query enum fields generate as unions instead of bare `string` (also applying the existing `FileRole` and `SeriesNumberUnit` hints).
- Delete the duplicate frontend `ListBooksQuery` and hand-written `Delete*` types from the barrel and wire all consumers to the generated types.

## Notes
- The wire format is byte-identical to before (shadowing json tags unchanged); this is a TypeScript type-correctness change, not an API contract change. The one genuinely behavior-bearing assertion (the `{ items, total }` envelope) is covered by the new shape test.
- Reviewers should start at `tygo.yaml` and `pkg/books/types.go`, then the generated `app/types/generated/books.ts`.
- Scope decisions worth a glance: (1) `DeleteBooksRequest` was renamed to `DeleteBooksPayload` to match the project's request-naming convention and the existing frontend name. (2) The new `AuthorRole`/`ReviewedFilter` unions are emitted in `pkg/models` (alongside `FileRole`/`SeriesNumberUnit`) so they're importable via `@/types`; `Author.Role` on the model also got the `AuthorRole` hint for consistency, which surfaced and fixed loose-`string` usages in BookEditDialog/FileEditDialog/Home. (3) `MoveFilesResponse`/`MergeBooksResponse` `target_book` now generate as `Book` instead of `any` (enabled by the newly-required `Book` frontmatter import), a small strict-typing win in the same spirit as the enum hints.
- `RescanMode` and the local `ResyncPayload` in resync.ts were intentionally left as-is (frontend-only request concern, out of scope for this response-types slice).
- No `website/docs/` change required: no docs page documents the `GET /books` response shape or the delete/resync endpoints, matching the Tags/Series slices' conclusion.

## Test plan
- `mise lint` and `mise test` pass (Go lint clean, all packages green, including the new `TestListHandler_ResponseEnvelope`).
- `mise lint:js` and `mise test:unit` pass (eslint, prettier, tsc, website typecheck clean; 845/845 unit tests).
- `GET /books` returns exactly the `{ items, total }` envelope with no extra top-level keys, asserted by `pkg/books/handlers_list_test.go:TestListHandler_ResponseEnvelope`.
- Existing delete-file response shape and list sort/cover-cache behaviors remain green under the named structs.