### PR TITLE
[Backend] Take Users, Roles, Libraries response types end-to-end via tygo

### DIFF
--- a/app/components/library/LibraryListPicker.tsx
+++ b/app/components/library/LibraryListPicker.tsx
@@ -18,7 +18,7 @@ const LibraryListPicker = () => {
 
   // Load all libraries for the switcher
   const librariesQuery = useLibraries({});
-  const libraries = librariesQuery.data?.libraries || [];
+  const libraries = librariesQuery.data?.items || [];
 
   // Load lists for sidebar navigation
   const listsQuery = useListLists();

--- a/app/components/library/MobileDrawer.tsx
+++ b/app/components/library/MobileDrawer.tsx
@@ -55,7 +55,7 @@ const MobileDrawer = () => {
   const [showLibraryPicker, setShowLibraryPicker] = useState(false);
 
   const librariesQuery = useLibraries({});
-  const libraries = librariesQuery.data?.libraries || [];
+  const libraries = librariesQuery.data?.items || [];
   const currentLibrary = libraries.find((lib) => lib.id === Number(libraryId));
 
   const listsQuery = useListLists();

--- a/app/components/library/ShareListDialog.tsx
+++ b/app/components/library/ShareListDialog.tsx
@@ -78,7 +78,7 @@ export function ShareListDialog({
   const deleteShareMutation = useDeleteShare();
 
   const shares = sharesQuery.data ?? [];
-  const users = usersQuery.data?.users ?? [];
+  const users = usersQuery.data?.items ?? [];
   const listOwnerId = listQuery.data?.list.user_id;
 
   // Filter out users who already have access (shares, owner, or self)

--- a/app/components/pages/AdminLibraries.tsx
+++ b/app/components/pages/AdminLibraries.tsx
@@ -90,7 +90,7 @@ const AdminLibraries = () => {
     );
   }
 
-  const libraries = data?.libraries ?? [];
+  const libraries = data?.items ?? [];
 
   return (
     <div>

--- a/app/components/pages/AdminUsers.tsx
+++ b/app/components/pages/AdminUsers.tsx
@@ -121,8 +121,8 @@ const AdminUsers = () => {
     );
   }
 
-  const users = usersData?.users ?? [];
-  const roles = sortRoles(rolesData?.roles ?? []);
+  const users = usersData?.items ?? [];
+  const roles = sortRoles(rolesData?.items ?? []);
 
   return (
     <div className="space-y-12">

--- a/app/components/pages/CreateLibrary.tsx
+++ b/app/components/pages/CreateLibrary.tsx
@@ -21,7 +21,9 @@ import { useCreateLibrary } from "@/hooks/queries/libraries";
 import { useNavigateAfterSave } from "@/hooks/useNavigateAfterSave";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
+import type { CoverAspectRatio, DownloadFormat } from "@/types";
 import {
+  CoverAspectRatioBook,
   DownloadFormatAsk,
   DownloadFormatKepub,
   DownloadFormatOriginal,
@@ -31,8 +33,8 @@ import {
 const INITIAL_VALUES = {
   name: "",
   organizeFileStructure: true,
-  coverAspectRatio: "book",
-  downloadFormatPreference: DownloadFormatOriginal,
+  coverAspectRatio: CoverAspectRatioBook as CoverAspectRatio,
+  downloadFormatPreference: DownloadFormatOriginal as DownloadFormat,
   libraryPaths: [""],
 };
 
@@ -45,12 +47,11 @@ const CreateLibrary = () => {
   const [organizeFileStructure, setOrganizeFileStructure] = useState(
     INITIAL_VALUES.organizeFileStructure,
   );
-  const [coverAspectRatio, setCoverAspectRatio] = useState(
+  const [coverAspectRatio, setCoverAspectRatio] = useState<CoverAspectRatio>(
     INITIAL_VALUES.coverAspectRatio,
   );
-  const [downloadFormatPreference, setDownloadFormatPreference] = useState(
-    INITIAL_VALUES.downloadFormatPreference,
-  );
+  const [downloadFormatPreference, setDownloadFormatPreference] =
+    useState<DownloadFormat>(INITIAL_VALUES.downloadFormatPreference);
   const [libraryPaths, setLibraryPaths] = useState<string[]>([
     ...INITIAL_VALUES.libraryPaths,
   ]);
@@ -266,7 +267,9 @@ const CreateLibrary = () => {
               How book and series covers should be displayed in gallery views
             </p>
             <Select
-              onValueChange={setCoverAspectRatio}
+              onValueChange={(value) =>
+                setCoverAspectRatio(value as CoverAspectRatio)
+              }
               value={coverAspectRatio}
             >
               <SelectTrigger className="w-full" id="cover-aspect-ratio">
@@ -294,7 +297,9 @@ const CreateLibrary = () => {
               How EPUB and CBZ files should be downloaded for e-readers
             </p>
             <Select
-              onValueChange={setDownloadFormatPreference}
+              onValueChange={(value) =>
+                setDownloadFormatPreference(value as DownloadFormat)
+              }
               value={downloadFormatPreference}
             >
               <SelectTrigger className="w-full" id="download-format">

--- a/app/components/pages/CreateUser.tsx
+++ b/app/components/pages/CreateUser.tsx
@@ -144,8 +144,8 @@ const CreateUser = () => {
     }
   };
 
-  const roles = sortRoles(rolesData?.roles ?? []);
-  const libraries = librariesData?.libraries ?? [];
+  const roles = sortRoles(rolesData?.items ?? []);
+  const libraries = librariesData?.items ?? [];
 
   return (
     <div>

--- a/app/components/pages/LibraryRedirect.tsx
+++ b/app/components/pages/LibraryRedirect.tsx
@@ -36,7 +36,7 @@ const LibraryRedirect = () => {
     );
   }
 
-  const libraries = librariesQuery.data?.libraries || [];
+  const libraries = librariesQuery.data?.items || [];
 
   // If no libraries, redirect to settings/libraries to create one
   if (libraries.length === 0) {

--- a/app/components/pages/LibrarySettings.tsx
+++ b/app/components/pages/LibrarySettings.tsx
@@ -26,6 +26,7 @@ import { useLibrary, useUpdateLibrary } from "@/hooks/queries/libraries";
 import { useAuth } from "@/hooks/useAuth";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
+import type { CoverAspectRatio, DownloadFormat } from "@/types";
 import {
   DownloadFormatAsk,
   DownloadFormatKepub,
@@ -47,10 +48,10 @@ const LibrarySettings = () => {
 
   const [name, setName] = useState("");
   const [organizeFileStructure, setOrganizeFileStructure] = useState(true);
-  const [coverAspectRatio, setCoverAspectRatio] = useState("book");
-  const [downloadFormatPreference, setDownloadFormatPreference] = useState(
-    DownloadFormatOriginal,
-  );
+  const [coverAspectRatio, setCoverAspectRatio] =
+    useState<CoverAspectRatio>("book");
+  const [downloadFormatPreference, setDownloadFormatPreference] =
+    useState<DownloadFormat>(DownloadFormatOriginal);
   const [libraryPaths, setLibraryPaths] = useState<string[]>([""]);
   const [isInitialized, setIsInitialized] = useState(false);
   const [pluginsHaveChanges, setPluginsHaveChanges] = useState(false);
@@ -64,8 +65,8 @@ const LibrarySettings = () => {
   const [initialValues, setInitialValues] = useState<{
     name: string;
     organizeFileStructure: boolean;
-    coverAspectRatio: string;
-    downloadFormatPreference: string;
+    coverAspectRatio: CoverAspectRatio;
+    downloadFormatPreference: DownloadFormat;
     libraryPaths: string[];
   } | null>(null);
 
@@ -342,7 +343,12 @@ const LibrarySettings = () => {
           <p className="text-sm text-muted-foreground">
             How book and series covers should be displayed in gallery views
           </p>
-          <Select onValueChange={setCoverAspectRatio} value={coverAspectRatio}>
+          <Select
+            onValueChange={(value) =>
+              setCoverAspectRatio(value as CoverAspectRatio)
+            }
+            value={coverAspectRatio}
+          >
             <SelectTrigger className="w-full" id="cover-aspect-ratio">
               <SelectValue />
             </SelectTrigger>
@@ -368,7 +374,9 @@ const LibrarySettings = () => {
             How EPUB and CBZ files should be downloaded for e-readers
           </p>
           <Select
-            onValueChange={setDownloadFormatPreference}
+            onValueChange={(value) =>
+              setDownloadFormatPreference(value as DownloadFormat)
+            }
             value={downloadFormatPreference}
           >
             <SelectTrigger className="w-full" id="download-format">

--- a/app/components/pages/SecuritySettings.tsx
+++ b/app/components/pages/SecuritySettings.tsx
@@ -789,7 +789,7 @@ function KoboSetupDialog({
                   <SelectValue placeholder="Select a library..." />
                 </SelectTrigger>
                 <SelectContent>
-                  {librariesData.libraries.map((lib) => (
+                  {librariesData.items.map((lib) => (
                     <SelectItem key={lib.id} value={String(lib.id)}>
                       {lib.name}
                     </SelectItem>

--- a/app/components/pages/UserDetail.tsx
+++ b/app/components/pages/UserDetail.tsx
@@ -262,8 +262,8 @@ const UserDetail = () => {
     );
   }
 
-  const roles = sortRoles(rolesData?.roles ?? []);
-  const libraries = librariesData?.libraries ?? [];
+  const roles = sortRoles(rolesData?.items ?? []);
+  const libraries = librariesData?.items ?? [];
 
   return (
     <div>

--- a/app/hooks/queries/libraries.ts
+++ b/app/hooks/queries/libraries.ts
@@ -8,8 +8,9 @@ import {
 import { API, ShishoAPIError } from "@/libraries/api";
 import type {
   CreateLibraryPayload,
-  Library,
+  LibraryResponse,
   ListLibrariesQuery,
+  ListLibrariesResponse,
   UpdateLibraryPayload,
 } from "@/types";
 
@@ -25,11 +26,11 @@ export enum QueryKey {
 export const useLibrary = (
   id?: string,
   options: Omit<
-    UseQueryOptions<Library, ShishoAPIError>,
+    UseQueryOptions<LibraryResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<Library, ShishoAPIError>({
+  return useQuery<LibraryResponse, ShishoAPIError>({
     enabled: options.enabled !== undefined ? options.enabled : Boolean(id),
     ...options,
     queryKey: [QueryKey.RetrieveLibrary, id],
@@ -39,19 +40,14 @@ export const useLibrary = (
   });
 };
 
-interface ListLibrariesData {
-  libraries: Library[];
-  total: number;
-}
-
 export const useLibraries = (
   query: ListLibrariesQuery = {},
   options: Omit<
-    UseQueryOptions<ListLibrariesData, ShishoAPIError>,
+    UseQueryOptions<ListLibrariesResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<ListLibrariesData, ShishoAPIError>({
+  return useQuery<ListLibrariesResponse, ShishoAPIError>({
     ...options,
     queryKey: [QueryKey.ListLibraries, query],
     queryFn: ({ signal }) => {
@@ -67,11 +63,15 @@ interface CreateLibraryMutationVariables {
 export const useCreateLibrary = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<Library, ShishoAPIError, CreateLibraryMutationVariables>({
+  return useMutation<
+    LibraryResponse,
+    ShishoAPIError,
+    CreateLibraryMutationVariables
+  >({
     mutationFn: ({ payload }) => {
       return API.request("POST", "/libraries", payload, null);
     },
-    onSuccess: (data: Library) => {
+    onSuccess: (data: LibraryResponse) => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListLibraries] });
       queryClient.setQueryData(
         [QueryKey.RetrieveLibrary, String(data.id)],
@@ -89,11 +89,15 @@ interface UpdateLibraryMutationVariables {
 export const useUpdateLibrary = () => {
   const queryClient = useQueryClient();
 
-  return useMutation<Library, ShishoAPIError, UpdateLibraryMutationVariables>({
+  return useMutation<
+    LibraryResponse,
+    ShishoAPIError,
+    UpdateLibraryMutationVariables
+  >({
     mutationFn: ({ id, payload }) => {
       return API.request("POST", `/libraries/${id}`, payload, null);
     },
-    onSuccess: (data: Library) => {
+    onSuccess: (data: LibraryResponse) => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.ListLibraries] });
       queryClient.setQueryData(
         [QueryKey.RetrieveLibrary, String(data.id)],

--- a/app/hooks/queries/users.ts
+++ b/app/hooks/queries/users.ts
@@ -7,10 +7,11 @@ import {
 
 import { API, ShishoAPIError } from "@/libraries/api";
 import type {
+  CreateRolePayload,
   ListRolesResponse,
   ListUsersResponse,
-  PermissionInput,
   Role,
+  UpdateRolePayload,
   User,
 } from "@/types";
 
@@ -158,11 +159,6 @@ export const useRoles = (
   });
 };
 
-interface CreateRolePayload {
-  name: string;
-  permissions: PermissionInput[];
-}
-
 export const useCreateRole = () => {
   const queryClient = useQueryClient();
 
@@ -175,11 +171,6 @@ export const useCreateRole = () => {
     },
   });
 };
-
-interface UpdateRolePayload {
-  name?: string;
-  permissions?: PermissionInput[];
-}
 
 interface UpdateRoleVariables {
   id: number;

--- a/app/hooks/queries/users.ts
+++ b/app/hooks/queries/users.ts
@@ -6,7 +6,13 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { PermissionInput, Role, User } from "@/types";
+import type {
+  ListRolesResponse,
+  ListUsersResponse,
+  PermissionInput,
+  Role,
+  User,
+} from "@/types";
 
 export enum QueryKey {
   RetrieveUser = "RetrieveUser",
@@ -36,19 +42,14 @@ interface ListUsersQuery {
   offset?: number;
 }
 
-interface ListUsersData {
-  users: User[];
-  total: number;
-}
-
 export const useUsers = (
   query: ListUsersQuery = {},
   options: Omit<
-    UseQueryOptions<ListUsersData, ShishoAPIError>,
+    UseQueryOptions<ListUsersResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<ListUsersData, ShishoAPIError>({
+  return useQuery<ListUsersResponse, ShishoAPIError>({
     ...options,
     queryKey: [QueryKey.ListUsers, query],
     queryFn: ({ signal }) => {
@@ -142,18 +143,13 @@ export const useDeactivateUser = () => {
 
 // Roles
 
-interface ListRolesData {
-  roles: Role[];
-  total: number;
-}
-
 export const useRoles = (
   options: Omit<
-    UseQueryOptions<ListRolesData, ShishoAPIError>,
+    UseQueryOptions<ListRolesResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<ListRolesData, ShishoAPIError>({
+  return useQuery<ListRolesResponse, ShishoAPIError>({
     ...options,
     queryKey: [QueryKey.ListRoles],
     queryFn: ({ signal }) => {

--- a/pkg/libraries/handlers.go
+++ b/pkg/libraries/handlers.go
@@ -83,7 +83,7 @@ func (h *handler) create(c echo.Context) error {
 		h.onLibraryChanged()
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, library))
+	return errors.WithStack(c.JSON(http.StatusOK, LibraryResponse{Library: *library}))
 }
 
 func (h *handler) retrieve(c echo.Context) error {
@@ -100,7 +100,7 @@ func (h *handler) retrieve(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, library))
+	return errors.WithStack(c.JSON(http.StatusOK, LibraryResponse{Library: *library}))
 }
 
 func (h *handler) list(c echo.Context) error {
@@ -130,10 +130,7 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	resp := struct {
-		Libraries []*models.Library `json:"libraries"`
-		Total     int               `json:"total"`
-	}{libraries, total}
+	resp := ListLibrariesResponse{Items: libraries, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, resp))
 }
@@ -206,7 +203,7 @@ func (h *handler) update(c echo.Context) error {
 		h.onLibraryChanged()
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, library))
+	return errors.WithStack(c.JSON(http.StatusOK, LibraryResponse{Library: *library}))
 }
 
 func (h *handler) delete(c echo.Context) error {

--- a/pkg/libraries/handlers_test.go
+++ b/pkg/libraries/handlers_test.go
@@ -2,6 +2,7 @@ package libraries
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -17,6 +18,49 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"
 )
+
+// newListTestContext wires up an Echo context for the list handler with the
+// libraries service backed by a real DB.
+func newListTestContext(t *testing.T, db *bun.DB) (*handler, echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	e.HTTPErrorHandler = errcodes.NewHandler().Handle
+
+	req := httptest.NewRequest(http.MethodGet, "/libraries", nil)
+	rr := httptest.NewRecorder()
+	c := e.NewContext(req, rr)
+
+	h := &handler{libraryService: NewService(db)}
+	return h, c, rr
+}
+
+func TestListLibrariesHandler_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	_ = seedLibraryWithContent(ctx, t, db, "Alpha")
+
+	h, c, rr := newListTestContext(t, db)
+	require.NoError(t, h.list(c))
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasLibraries := raw["libraries"]
+	assert.True(t, hasItems, "list response must use 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.False(t, hasLibraries, "list response must NOT use 'libraries' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+}
 
 // newDeleteTestServer wires up the libraries DELETE route against a real DB
 // and a stubbed auth middleware that injects the provided user into the

--- a/pkg/libraries/service_test.go
+++ b/pkg/libraries/service_test.go
@@ -3,6 +3,7 @@ package libraries
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -19,7 +20,12 @@ import (
 func newTestDB(t *testing.T) *bun.DB {
 	t.Helper()
 
-	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	// Shared-cache in-memory DSN (keyed on the test name) so every pooled
+	// connection sees the same DB. A bare ":memory:" gives each connection its
+	// own empty database, which breaks handler tests that issue queries on a
+	// different connection than the one that ran migrations.
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
 	require.NoError(t, err)
 
 	db := bun.NewDB(sqldb, sqlitedialect.New())

--- a/pkg/libraries/types.go
+++ b/pkg/libraries/types.go
@@ -1,10 +1,25 @@
 package libraries
 
+import "github.com/shishobooks/shisho/pkg/models"
+
+// LibraryResponse is the single-library API response. It embeds the Library
+// model by value so tygo emits `extends Library`; the wire format is identical
+// to returning the bare model.
+type LibraryResponse struct {
+	models.Library `tstype:",extends"`
+}
+
+// ListLibrariesResponse is the list-endpoint envelope.
+type ListLibrariesResponse struct {
+	Items []*models.Library `json:"items" tstype:"Library[]"`
+	Total int               `json:"total"`
+}
+
 type CreateLibraryPayload struct {
 	Name                     string   `json:"name" validate:"required,max=100"`
 	OrganizeFileStructure    *bool    `json:"organize_file_structure,omitempty"`
-	CoverAspectRatio         string   `json:"cover_aspect_ratio" validate:"required,oneof=book audiobook book_fallback_audiobook audiobook_fallback_book"`
-	DownloadFormatPreference *string  `json:"download_format_preference,omitempty" validate:"omitempty,oneof=original kepub ask"`
+	CoverAspectRatio         string   `json:"cover_aspect_ratio" validate:"required,oneof=book audiobook book_fallback_audiobook audiobook_fallback_book" tstype:"CoverAspectRatio"`
+	DownloadFormatPreference *string  `json:"download_format_preference,omitempty" validate:"omitempty,oneof=original kepub ask" tstype:"DownloadFormat"`
 	LibraryPaths             []string `json:"library_paths" validate:"required,min=1,max=50,dive"`
 }
 
@@ -16,7 +31,7 @@ type ListLibrariesQuery struct {
 type UpdateLibraryPayload struct {
 	Name                     *string  `json:"name,omitempty" validate:"omitempty,max=100"`
 	OrganizeFileStructure    *bool    `json:"organize_file_structure,omitempty"`
-	CoverAspectRatio         *string  `json:"cover_aspect_ratio,omitempty" validate:"omitempty,oneof=book audiobook book_fallback_audiobook audiobook_fallback_book"`
-	DownloadFormatPreference *string  `json:"download_format_preference,omitempty" validate:"omitempty,oneof=original kepub ask"`
+	CoverAspectRatio         *string  `json:"cover_aspect_ratio,omitempty" validate:"omitempty,oneof=book audiobook book_fallback_audiobook audiobook_fallback_book" tstype:"CoverAspectRatio"`
+	DownloadFormatPreference *string  `json:"download_format_preference,omitempty" validate:"omitempty,oneof=original kepub ask" tstype:"DownloadFormat"`
 	LibraryPaths             []string `json:"library_paths,omitempty" validate:"omitempty,min=1,max=50,dive"`
 }

--- a/pkg/models/library.go
+++ b/pkg/models/library.go
@@ -6,8 +6,19 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// Cover aspect ratio preference constants. Determine which file's cover a
+// hybrid (e.g. EPUB + M4B) book serves.
+const (
+	//tygo:emit export type CoverAspectRatio = typeof CoverAspectRatioBook | typeof CoverAspectRatioAudiobook | typeof CoverAspectRatioBookFallbackAudiobook | typeof CoverAspectRatioAudiobookFallbackBook;
+	CoverAspectRatioBook                  = "book"
+	CoverAspectRatioAudiobook             = "audiobook"
+	CoverAspectRatioBookFallbackAudiobook = "book_fallback_audiobook"
+	CoverAspectRatioAudiobookFallbackBook = "audiobook_fallback_book"
+)
+
 // Download format preference constants.
 const (
+	//tygo:emit export type DownloadFormat = typeof DownloadFormatOriginal | typeof DownloadFormatKepub | typeof DownloadFormatAsk;
 	DownloadFormatOriginal = "original"
 	DownloadFormatKepub    = "kepub"
 	DownloadFormatAsk      = "ask"
@@ -21,7 +32,7 @@ type Library struct {
 	UpdatedAt                time.Time      `json:"updated_at"`
 	Name                     string         `bun:",nullzero" json:"name"`
 	OrganizeFileStructure    bool           `json:"organize_file_structure"`
-	CoverAspectRatio         string         `bun:",nullzero" json:"cover_aspect_ratio"`
-	DownloadFormatPreference string         `bun:",nullzero,default:'original'" json:"download_format_preference"`
+	CoverAspectRatio         string         `bun:",nullzero" json:"cover_aspect_ratio" tstype:"CoverAspectRatio"`
+	DownloadFormatPreference string         `bun:",nullzero,default:'original'" json:"download_format_preference" tstype:"DownloadFormat"`
 	LibraryPaths             []*LibraryPath `bun:"rel:has-many" json:"library_paths,omitempty" tstype:"LibraryPath[]"`
 }

--- a/pkg/roles/handlers.go
+++ b/pkg/roles/handlers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/errcodes"
-	"github.com/shishobooks/shisho/pkg/models"
 )
 
 type handler struct {
@@ -59,10 +58,7 @@ func (h *handler) list(c echo.Context) error {
 		return err
 	}
 
-	resp := struct {
-		Roles []*models.Role `json:"roles"`
-		Total int            `json:"total"`
-	}{roles, total}
+	resp := ListRolesResponse{Items: roles, Total: total}
 
 	return c.JSON(http.StatusOK, resp)
 }
@@ -106,5 +102,5 @@ func (h *handler) delete(c echo.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, map[string]string{"message": "Role deleted successfully"})
+	return c.NoContent(http.StatusNoContent)
 }

--- a/pkg/roles/handlers_test.go
+++ b/pkg/roles/handlers_test.go
@@ -1,0 +1,107 @@
+package roles
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/errcodes"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func newTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	// Shared-cache in-memory DSN so every pooled connection sees the same DB
+	// (a bare ":memory:" gives each connection its own empty database).
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
+	require.NoError(t, err)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { db.Close() })
+
+	return db
+}
+
+func newRolesEcho(t *testing.T) *echo.Echo {
+	t.Helper()
+
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	e.HTTPErrorHandler = errcodes.NewHandler().Handle
+	return e
+}
+
+func TestHandlerList_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	h := &handler{roleService: NewService(db)}
+
+	e := newRolesEcho(t)
+	req := httptest.NewRequest(http.MethodGet, "/roles", nil)
+	rr := httptest.NewRecorder()
+	c := e.NewContext(req, rr)
+
+	require.NoError(t, h.list(c))
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasRoles := raw["roles"]
+	assert.True(t, hasItems, "list response must use 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.False(t, hasRoles, "list response must NOT use 'roles' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+}
+
+func TestHandlerDelete_Returns204NoContent(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	h := &handler{roleService: NewService(db)}
+	ctx := context.Background()
+
+	role, err := h.roleService.Create(ctx, "deletable", []PermissionInput{})
+	require.NoError(t, err)
+
+	e := newRolesEcho(t)
+	req := httptest.NewRequest(http.MethodDelete, "/roles/"+strconv.Itoa(role.ID), nil)
+	rr := httptest.NewRecorder()
+	c := e.NewContext(req, rr)
+	c.SetPath("/roles/:id")
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(role.ID))
+
+	require.NoError(t, h.delete(c))
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Empty(t, rr.Body.String(), "204 response must have an empty body")
+
+	_, err = h.roleService.Retrieve(ctx, role.ID)
+	require.Error(t, err, "role should be deleted")
+}

--- a/pkg/roles/types.go
+++ b/pkg/roles/types.go
@@ -1,5 +1,13 @@
 package roles
 
+import "github.com/shishobooks/shisho/pkg/models"
+
+// ListRolesResponse is the list-endpoint envelope.
+type ListRolesResponse struct {
+	Items []*models.Role `json:"items" tstype:"Role[]"`
+	Total int            `json:"total"`
+}
+
 // PermissionInput represents a permission to grant to a role.
 type PermissionInput struct {
 	Resource  string `json:"resource" validate:"required"`

--- a/pkg/users/handlers.go
+++ b/pkg/users/handlers.go
@@ -59,10 +59,7 @@ func (h *handler) list(c echo.Context) error {
 		return err
 	}
 
-	resp := struct {
-		Users []*models.User `json:"users"`
-		Total int            `json:"total"`
-	}{users, total}
+	resp := ListUsersResponse{Items: users, Total: total}
 
 	return c.JSON(http.StatusOK, resp)
 }
@@ -189,7 +186,7 @@ func (h *handler) resetPassword(c echo.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, map[string]string{"message": "Password reset successfully"})
+	return c.NoContent(http.StatusNoContent)
 }
 
 func (h *handler) deactivate(c echo.Context) error {
@@ -211,5 +208,5 @@ func (h *handler) deactivate(c echo.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, map[string]string{"message": "User deactivated successfully"})
+	return c.NoContent(http.StatusNoContent)
 }

--- a/pkg/users/handlers_test.go
+++ b/pkg/users/handlers_test.go
@@ -2,6 +2,7 @@ package users
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -15,6 +16,112 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestHandlerList_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	h := &handler{userService: NewService(db)}
+	ctx := context.Background()
+
+	_, err := h.userService.Create(ctx, CreateUserOptions{
+		Username:         "listme",
+		Password:         "password123",
+		RoleID:           getRoleIDByName(ctx, t, db, models.RoleViewer),
+		AllLibraryAccess: true,
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	e.HTTPErrorHandler = errcodes.NewHandler().Handle
+
+	req := httptest.NewRequest(http.MethodGet, "/users", nil)
+	rr := httptest.NewRecorder()
+	c := e.NewContext(req, rr)
+
+	require.NoError(t, h.list(c))
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &raw))
+
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasUsers := raw["users"]
+	assert.True(t, hasItems, "list response must use 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.False(t, hasUsers, "list response must NOT use 'users' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+}
+
+func TestHandlerDeactivate_Returns204NoContent(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	h := &handler{userService: NewService(db)}
+	ctx := context.Background()
+
+	target, err := h.userService.Create(ctx, CreateUserOptions{
+		Username:         "deactivateme",
+		Password:         "password123",
+		RoleID:           getRoleIDByName(ctx, t, db, models.RoleViewer),
+		AllLibraryAccess: true,
+	})
+	require.NoError(t, err)
+
+	admin, err := h.userService.Create(ctx, CreateUserOptions{
+		Username:         "deactivator",
+		Password:         "password123",
+		RoleID:           getRoleIDByName(ctx, t, db, models.RoleAdmin),
+		AllLibraryAccess: true,
+	})
+	require.NoError(t, err)
+
+	c, rr := newUsersTestContext(t, "", "/users/"+strconv.Itoa(target.ID))
+	c.SetPath("/users/:id")
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(target.ID))
+	c.Set("user_id", admin.ID)
+
+	require.NoError(t, h.deactivate(c))
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Empty(t, rr.Body.String(), "204 response must have an empty body")
+
+	updated, err := h.userService.Retrieve(ctx, target.ID)
+	require.NoError(t, err)
+	assert.False(t, updated.IsActive, "user should be deactivated")
+}
+
+func TestHandlerResetPassword_Returns204NoContent(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	h := &handler{userService: NewService(db)}
+	ctx := context.Background()
+
+	user, err := h.userService.Create(ctx, CreateUserOptions{
+		Username:             "resetme204",
+		Password:             "password123",
+		RoleID:               getRoleIDByName(ctx, t, db, models.RoleViewer),
+		AllLibraryAccess:     true,
+		RequirePasswordReset: true,
+	})
+	require.NoError(t, err)
+
+	c, rr := newUsersTestContext(t, `{"new_password":"newpassword123"}`, "/users/"+strconv.Itoa(user.ID)+"/reset-password")
+	c.SetPath("/users/:id/reset-password")
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(user.ID))
+	c.Set("user_id", user.ID)
+	c.Set("user", &models.User{ID: user.ID, MustChangePassword: true})
+
+	require.NoError(t, h.resetPassword(c))
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Empty(t, rr.Body.String(), "204 response must have an empty body")
+}
 
 func newUsersTestContext(t *testing.T, payload, path string) (echo.Context, *httptest.ResponseRecorder) {
 	t.Helper()
@@ -56,7 +163,7 @@ func TestHandlerResetPassword_SelfForcedReset_DoesNotRequireCurrentPassword(t *t
 
 	err = h.resetPassword(c)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
 
 	updatedUser, err := h.userService.Retrieve(ctx, user.ID)
 	require.NoError(t, err)
@@ -141,7 +248,7 @@ func TestHandlerResetPassword_AdminResetsOtherUser_WithRequirePasswordReset(t *t
 
 	err = h.resetPassword(c)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
 
 	// Verify the flag was set on the target user
 	updatedUser, err := h.userService.Retrieve(ctx, targetUser.ID)
@@ -228,7 +335,7 @@ func TestHandlerResetPassword_SelfResetIgnoresRequirePasswordResetParam(t *testi
 
 	err = h.resetPassword(c)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
 
 	// Flag should be cleared despite the param being true
 	updatedUser, err := h.userService.Retrieve(ctx, user.ID)

--- a/pkg/users/service_test.go
+++ b/pkg/users/service_test.go
@@ -3,6 +3,7 @@ package users
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/shishobooks/shisho/pkg/migrations"
@@ -17,7 +18,12 @@ import (
 func newTestDB(t *testing.T) *bun.DB {
 	t.Helper()
 
-	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	// Shared-cache in-memory DSN (keyed on the test name) so every pooled
+	// connection sees the same DB. A bare ":memory:" gives each connection its
+	// own empty database, which breaks handler tests that issue queries on a
+	// different connection than the one that ran migrations.
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
 	require.NoError(t, err)
 
 	db := bun.NewDB(sqldb, sqlitedialect.New())

--- a/pkg/users/types.go
+++ b/pkg/users/types.go
@@ -1,5 +1,13 @@
 package users
 
+import "github.com/shishobooks/shisho/pkg/models"
+
+// ListUsersResponse is the list-endpoint envelope.
+type ListUsersResponse struct {
+	Items []*models.User `json:"items" tstype:"User[]"`
+	Total int            `json:"total"`
+}
+
 // CreateUserPayload represents the request body for creating a user.
 type CreateUserPayload struct {
 	Username             string  `json:"username" validate:"required,min=3,max=50"`

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -8,11 +8,16 @@ type_mappings:
   models.Tag: "Tag"
   models.Series: "Series"
   models.Person: "Person"
+  models.Library: "Library"
   # A model returned by name (not embedded, not field-level `tstype`-overridden)
   # also needs a mapping so tygo emits the bare interface name instead of `any`.
   # books.ts's MoveFilesResponse / MergeBooksResponse return a *models.Book.
   models.Book: "Book"
   models.Publisher: "Publisher"
+  # Models referenced by name in list envelopes (`tstype:"User[]"` etc.) need a
+  # mapping so the generated type resolves to the bare interface, not `any`.
+  models.User: "User"
+  models.Role: "Role"
 
 packages:
   - path: "github.com/shishobooks/shisho/pkg/models"
@@ -39,6 +44,8 @@ packages:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/libraries"
     output_path: "app/types/generated/libraries.ts"
+    frontmatter: |
+      import { CoverAspectRatio, DownloadFormat, Library } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/filesystem"
@@ -51,10 +58,14 @@ packages:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/users"
     output_path: "app/types/generated/users.ts"
+    frontmatter: |
+      import { User } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/roles"
     output_path: "app/types/generated/roles.ts"
+    frontmatter: |
+      import { Role } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/search"


### PR DESCRIPTION
Closes #350

## Summary
- Bring Users, Roles, and Libraries under the tygo convention, mirroring the Genres/Tags/Series/People precedent. Go is the single source of truth for every request and response shape.
- Standardize the three list endpoints on the `{ items, total }` envelope via named `ListUsersResponse` / `ListRolesResponse` / `ListLibrariesResponse` structs, replacing the resource-named keys (`users`, `roles`, `libraries`).
- Convert the three pure-acknowledgment endpoints (role delete, user password reset, user deactivate) to `204 No Content`, dropping their JSON message bodies.
- Add `//tygo:emit` union types `CoverAspectRatio` and `DownloadFormat` (with `tstype` hints on the model and request payloads plus a frontmatter import) so those fields generate as unions instead of bare `string`.
- Add a `LibraryResponse` value-embed and point the single-resource library handlers at it.
- Update frontend list consumers to read `.items` and type the hooks against the generated response types.

## Notes
- Wire format: unlike the earlier Genres/Tags/Series/People slices (which were byte-identical), this slice does change three list wire shapes (`{users}` -> `{items}`, `{roles}` -> `{items}`, `{libraries}` -> `{items}`) and drops the JSON message bodies on the three 204 endpoints. That is exactly what the issue asked for. The frontend already typed the 204 mutations as `void` and the API client already returns `undefined` for 204, so no mutation consumer needed changes beyond the list-key rename.
- `LibraryResponse` is an empty `extends Library` interface (the library response carries no extra fields). It exists for convention consistency and to give the single-resource hooks a named response type.
- The libraries, roles, and users test `newTestDB` helpers use the shared-cache in-memory DSN (the genres pattern) because the new handler tests exposed the bare `:memory:` per-connection-DB pitfall. Strictly a test-infra improvement; all existing tests in those packages still pass.
- No `website/docs/` update needed: no docs page documents these raw API response shapes or message bodies (verified by grep); `users-and-permissions.md` and `libraries.md` only describe user-facing concepts.

## Test plan
- `mise lint test` (Go lint plus the full Go test suite)
- `mise lint:js test:unit` (tygo, eslint, prettier, tsc, SDK build, and JS unit tests)
- New handler shape tests assert the list envelope keys and the 204 responses:
  - Libraries list envelope is exactly `{ items, total }`, no `libraries` key
  - Users list envelope is exactly `{ items, total }`, no `users` key
  - Roles list envelope is exactly `{ items, total }`, no `roles` key
  - User deactivate returns 204 with empty body and actually deactivates
  - User password reset returns 204 with empty body
  - Role delete returns 204 with empty body and actually deletes
- Verify generated unions: `cover_aspect_ratio` generates as `CoverAspectRatio` and `download_format_preference` as `DownloadFormat` in the generated TS, not bare `string`