### PR TITLE
[Backend] Take Lists response types end-to-end via tygo

### DIFF
--- a/app/components/library/AddToListDialog.test.tsx
+++ b/app/components/library/AddToListDialog.test.tsx
@@ -26,14 +26,14 @@ let mockBookLists: List[] = [
     created_at: "",
     updated_at: "",
     user_id: 1,
-    default_sort: "title",
+    default_sort: "title_asc",
   },
 ];
 
 // Mock the list hooks
 vi.mock("@/hooks/queries/lists", () => ({
   useListLists: () => ({
-    data: { lists: mockLists },
+    data: { items: mockLists },
     isLoading: false,
   }),
   useBookLists: () => ({
@@ -79,7 +79,7 @@ describe("AddToListDialog", () => {
         created_at: "",
         updated_at: "",
         user_id: 1,
-        default_sort: "title",
+        default_sort: "title_asc",
       },
     ];
   });
@@ -144,7 +144,7 @@ describe("AddToListDialog", () => {
           created_at: "",
           updated_at: "",
           user_id: 1,
-          default_sort: "title",
+          default_sort: "title_asc",
         },
       ];
 
@@ -337,7 +337,7 @@ describe("AddToListDialog", () => {
           created_at: "",
           updated_at: "",
           user_id: 1,
-          default_sort: "title",
+          default_sort: "title_asc",
         },
       ];
 
@@ -379,7 +379,7 @@ describe("AddToListDialog", () => {
           created_at: "",
           updated_at: "",
           user_id: 1,
-          default_sort: "title",
+          default_sort: "title_asc",
         },
         {
           id: 2,
@@ -388,7 +388,7 @@ describe("AddToListDialog", () => {
           created_at: "",
           updated_at: "",
           user_id: 1,
-          default_sort: "title",
+          default_sort: "title_asc",
         },
       ];
 

--- a/app/components/library/AddToListDialog.tsx
+++ b/app/components/library/AddToListDialog.tsx
@@ -26,10 +26,9 @@ import {
   useCreateList,
   useListLists,
   useUpdateBookLists,
-  type ListResponse,
 } from "@/hooks/queries/lists";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
-import type { CreateListPayload } from "@/types";
+import type { CreateListPayload, ListResponse } from "@/types";
 
 interface AddToListDialogProps {
   bookId: number;

--- a/app/components/library/AddToListDialog.tsx
+++ b/app/components/library/AddToListDialog.tsx
@@ -26,7 +26,7 @@ import {
   useCreateList,
   useListLists,
   useUpdateBookLists,
-  type ListWithCount,
+  type ListResponse,
 } from "@/hooks/queries/lists";
 import { useFormDialogClose } from "@/hooks/useFormDialogClose";
 import type { CreateListPayload } from "@/types";
@@ -57,8 +57,8 @@ export const AddToListDialog = ({
   const createListMutation = useCreateList();
 
   const lists = useMemo(
-    () => listsQuery.data?.lists ?? [],
-    [listsQuery.data?.lists],
+    () => listsQuery.data?.items ?? [],
+    [listsQuery.data?.items],
   );
   const isLoading = listsQuery.isLoading || bookListsQuery.isLoading;
 
@@ -107,7 +107,7 @@ export const AddToListDialog = ({
     );
   }, [lists, search]);
 
-  const handleToggle = (list: ListWithCount) => {
+  const handleToggle = (list: ListResponse) => {
     // Viewer-only lists can't be toggled
     if (list.permission === "viewer") return;
 

--- a/app/components/library/AddToListPopover.tsx
+++ b/app/components/library/AddToListPopover.tsx
@@ -17,9 +17,8 @@ import {
   useCreateList,
   useListLists,
   useRemoveBooksFromList,
-  type ListResponse,
 } from "@/hooks/queries/lists";
-import type { CreateListPayload } from "@/types";
+import type { CreateListPayload, ListResponse } from "@/types";
 
 interface AddToListPopoverProps {
   bookId: number;

--- a/app/components/library/AddToListPopover.tsx
+++ b/app/components/library/AddToListPopover.tsx
@@ -17,7 +17,7 @@ import {
   useCreateList,
   useListLists,
   useRemoveBooksFromList,
-  type ListWithCount,
+  type ListResponse,
 } from "@/hooks/queries/lists";
 import type { CreateListPayload } from "@/types";
 
@@ -51,7 +51,7 @@ const AddToListPopover = ({
   const removeMutation = useRemoveBooksFromList();
   const createListMutation = useCreateList();
 
-  const lists = listsQuery.data?.lists ?? [];
+  const lists = listsQuery.data?.items ?? [];
   const bookListIds = new Set(
     (bookListsQuery.data ?? []).map((list) => list.id),
   );
@@ -59,7 +59,7 @@ const AddToListPopover = ({
   const isLoading = listsQuery.isLoading || bookListsQuery.isLoading;
   const hasLists = lists.length > 0;
 
-  const handleToggle = async (list: ListWithCount) => {
+  const handleToggle = async (list: ListResponse) => {
     const isInList = bookListIds.has(list.id);
     setMutatingListId(list.id);
 

--- a/app/components/library/CreateListDialog.test.tsx
+++ b/app/components/library/CreateListDialog.test.tsx
@@ -37,7 +37,7 @@ describe("CreateListDialog", () => {
     created_at: "2024-01-01",
     updated_at: "2024-01-01",
     user_id: 1,
-    default_sort: "title",
+    default_sort: "title_asc",
   };
 
   describe("initialization and state preservation (edit mode)", () => {
@@ -250,7 +250,7 @@ describe("CreateListDialog", () => {
         created_at: "2024-01-01",
         updated_at: "2024-01-01",
         user_id: 1,
-        default_sort: "title",
+        default_sort: "title_asc",
       };
 
       rerender(

--- a/app/components/library/LibraryListPicker.tsx
+++ b/app/components/library/LibraryListPicker.tsx
@@ -22,7 +22,7 @@ const LibraryListPicker = () => {
 
   // Load lists for sidebar navigation
   const listsQuery = useListLists();
-  const lists = listsQuery.data?.lists || [];
+  const lists = listsQuery.data?.items || [];
   const currentLibrary = libraries.find((lib) => lib.id === Number(libraryId));
 
   // Check if we're currently viewing a list

--- a/app/components/library/MobileDrawer.tsx
+++ b/app/components/library/MobileDrawer.tsx
@@ -59,7 +59,7 @@ const MobileDrawer = () => {
   const currentLibrary = libraries.find((lib) => lib.id === Number(libraryId));
 
   const listsQuery = useListLists();
-  const lists = listsQuery.data?.lists || [];
+  const lists = listsQuery.data?.items || [];
 
   // Check if we're currently viewing a list
   const listMatch = location.pathname.match(/^\/lists\/(\d+)/);

--- a/app/components/library/SelectionToolbar.test.tsx
+++ b/app/components/library/SelectionToolbar.test.tsx
@@ -99,7 +99,7 @@ vi.mock("@/hooks/queries/jobs", () => ({
 }));
 
 vi.mock("@/hooks/queries/lists", () => ({
-  useListLists: () => ({ data: { lists: [] }, isLoading: false }),
+  useListLists: () => ({ data: { items: [] }, isLoading: false }),
   useAddBooksToList: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useCreateList: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));

--- a/app/components/library/SelectionToolbar.tsx
+++ b/app/components/library/SelectionToolbar.tsx
@@ -144,7 +144,7 @@ export const SelectionToolbar = ({ library }: SelectionToolbarProps) => {
     }
   };
 
-  const lists = listsQuery.data?.lists ?? [];
+  const lists = listsQuery.data?.items ?? [];
   const editableLists = lists.filter((list) => list.permission !== "viewer");
 
   const handleAddToList = async (listId: number, listName: string) => {

--- a/app/components/library/ShareListDialog.tsx
+++ b/app/components/library/ShareListDialog.tsx
@@ -32,6 +32,7 @@ import {
   ListPermissionEditor,
   ListPermissionManager,
   ListPermissionViewer,
+  type ListPermission,
 } from "@/types";
 
 interface ShareListDialogProps {
@@ -66,7 +67,7 @@ export function ShareListDialog({
 }: ShareListDialogProps) {
   const [selectedUserId, setSelectedUserId] = useState<string>("");
   const [selectedPermission, setSelectedPermission] =
-    useState<string>(ListPermissionViewer);
+    useState<ListPermission>(ListPermissionViewer);
 
   const { user: currentUser } = useAuth();
   const listQuery = useList(listId, { enabled: open });
@@ -79,7 +80,7 @@ export function ShareListDialog({
 
   const shares = sharesQuery.data ?? [];
   const users = usersQuery.data?.items ?? [];
-  const listOwnerId = listQuery.data?.list.user_id;
+  const listOwnerId = listQuery.data?.user_id;
 
   // Filter out users who already have access (shares, owner, or self)
   const availableUsers = users.filter(
@@ -112,7 +113,7 @@ export function ShareListDialog({
 
   const handleUpdatePermission = async (
     shareId: number,
-    permission: string,
+    permission: ListPermission,
   ) => {
     try {
       await updateShareMutation.mutateAsync({
@@ -183,7 +184,9 @@ export function ShareListDialog({
               </Select>
 
               <Select
-                onValueChange={setSelectedPermission}
+                onValueChange={(value) =>
+                  setSelectedPermission(value as ListPermission)
+                }
                 value={selectedPermission}
               >
                 <SelectTrigger className="w-28">
@@ -252,7 +255,10 @@ export function ShareListDialog({
                       <Select
                         disabled={isPending}
                         onValueChange={(value) =>
-                          handleUpdatePermission(share.id, value)
+                          handleUpdatePermission(
+                            share.id,
+                            value as ListPermission,
+                          )
                         }
                         value={share.permission}
                       >

--- a/app/components/pages/ListDetail.tsx
+++ b/app/components/pages/ListDetail.tsx
@@ -48,6 +48,7 @@ import {
   ListSortTitleDesc,
   type GallerySize,
   type ListBook,
+  type ListSort,
   type UpdateListPayload,
 } from "@/types";
 
@@ -115,14 +116,14 @@ const ListDetail = () => {
     );
   };
 
-  const [sort, setSort] = useState<string | undefined>(undefined);
+  const [sort, setSort] = useState<ListSort | undefined>(undefined);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const listQuery = useList(listId);
 
-  usePageTitle(listQuery.data?.list?.name ?? "List");
+  usePageTitle(listQuery.data?.name ?? "List");
   const listBooksQuery = useListBooks(
     listId,
     { sort, limit, offset },
@@ -202,9 +203,9 @@ const ListDetail = () => {
     );
   }
 
-  const list = listQuery.data.list;
+  const list = listQuery.data;
   const bookCount = listQuery.data.book_count;
-  const books = listBooksQuery.data?.books ?? [];
+  const books = listBooksQuery.data?.items ?? [];
 
   return (
     <div>
@@ -276,7 +277,7 @@ const ListDetail = () => {
           <div className="mb-6 flex items-center gap-2">
             <span className="text-sm text-muted-foreground">Sort by:</span>
             <Select
-              onValueChange={setSort}
+              onValueChange={(value) => setSort(value as ListSort)}
               value={sort ?? list.default_sort ?? ListSortAddedAtDesc}
             >
               <SelectTrigger className="w-48">

--- a/app/components/pages/ListsIndex.tsx
+++ b/app/components/pages/ListsIndex.tsx
@@ -12,11 +12,9 @@ import {
   useCreateListFromTemplate,
   useListLists,
   useListTemplates,
-  type ListResponse,
-  type ListTemplate,
 } from "@/hooks/queries/lists";
 import { usePageTitle } from "@/hooks/usePageTitle";
-import type { CreateListPayload } from "@/types";
+import type { CreateListPayload, ListResponse, ListTemplate } from "@/types";
 
 const ListsIndex = () => {
   usePageTitle("Lists");

--- a/app/components/pages/ListsIndex.tsx
+++ b/app/components/pages/ListsIndex.tsx
@@ -12,8 +12,8 @@ import {
   useCreateListFromTemplate,
   useListLists,
   useListTemplates,
+  type ListResponse,
   type ListTemplate,
-  type ListWithCount,
 } from "@/hooks/queries/lists";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import type { CreateListPayload } from "@/types";
@@ -28,7 +28,7 @@ const ListsIndex = () => {
   const createListMutation = useCreateList();
   const createFromTemplateMutation = useCreateListFromTemplate();
 
-  const lists = listsQuery.data?.lists ?? [];
+  const lists = listsQuery.data?.items ?? [];
   const templates = templatesQuery.data ?? [];
   const hasLists = lists.length > 0;
 
@@ -61,7 +61,7 @@ const ListsIndex = () => {
     }
   };
 
-  const renderListCard = (list: ListWithCount) => {
+  const renderListCard = (list: ListResponse) => {
     const bookCount = list.book_count ?? 0;
 
     return (

--- a/app/components/pages/SecuritySettings.tsx
+++ b/app/components/pages/SecuritySettings.tsx
@@ -803,7 +803,7 @@ function KoboSetupDialog({
                   <SelectValue placeholder="Select a list..." />
                 </SelectTrigger>
                 <SelectContent>
-                  {listsData.lists.map((list) => (
+                  {listsData.items.map((list) => (
                     <SelectItem key={list.id} value={String(list.id)}>
                       {list.name}
                     </SelectItem>

--- a/app/hooks/queries/lists.ts
+++ b/app/hooks/queries/lists.ts
@@ -15,7 +15,6 @@ import type {
   ListListBooksResponse,
   ListListsQuery,
   ListListsResponse,
-  ListResponse,
   ListShare,
   ListTemplate,
   RemoveBooksPayload,
@@ -34,12 +33,7 @@ export enum QueryKey {
   BookLists = "BookLists",
 }
 
-export type {
-  ListListsQuery,
-  ListBooksInListQuery,
-  ListResponse,
-  ListTemplate,
-};
+export type { ListListsQuery, ListBooksInListQuery };
 
 // ============================================================================
 // Query Hooks

--- a/app/hooks/queries/lists.ts
+++ b/app/hooks/queries/lists.ts
@@ -11,12 +11,16 @@ import type {
   CreateListPayload,
   CreateSharePayload,
   List,
-  ListBook,
   ListBooksInListQuery,
+  ListListBooksResponse,
   ListListsQuery,
+  ListListsResponse,
+  ListResponse,
   ListShare,
+  ListTemplate,
   RemoveBooksPayload,
   ReorderBooksPayload,
+  RetrieveListResponse,
   UpdateListPayload,
   UpdateSharePayload,
 } from "@/types";
@@ -30,36 +34,12 @@ export enum QueryKey {
   BookLists = "BookLists",
 }
 
-export interface ListWithCount extends List {
-  book_count: number;
-  permission: "owner" | "manager" | "editor" | "viewer";
-}
-
-export interface ListListsData {
-  lists: ListWithCount[];
-  total: number;
-}
-
-export interface ListBooksData {
-  books: ListBook[];
-  total: number;
-}
-
-export interface RetrieveListData {
-  list: List;
-  book_count: number;
-  permission: "owner" | "manager" | "editor" | "viewer";
-}
-
-export interface ListTemplate {
-  name: string;
-  display_name: string;
-  description: string;
-  is_ordered: boolean;
-  default_sort: string;
-}
-
-export type { ListListsQuery, ListBooksInListQuery };
+export type {
+  ListListsQuery,
+  ListBooksInListQuery,
+  ListResponse,
+  ListTemplate,
+};
 
 // ============================================================================
 // Query Hooks
@@ -68,11 +48,11 @@ export type { ListListsQuery, ListBooksInListQuery };
 export const useListLists = (
   query: ListListsQuery = {},
   options: Omit<
-    UseQueryOptions<ListListsData, ShishoAPIError>,
+    UseQueryOptions<ListListsResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<ListListsData, ShishoAPIError>({
+  return useQuery<ListListsResponse, ShishoAPIError>({
     ...options,
     queryKey: [QueryKey.ListLists, query],
     queryFn: ({ signal }) => {
@@ -84,11 +64,11 @@ export const useListLists = (
 export const useList = (
   listId?: number,
   options: Omit<
-    UseQueryOptions<RetrieveListData, ShishoAPIError>,
+    UseQueryOptions<RetrieveListResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<RetrieveListData, ShishoAPIError>({
+  return useQuery<RetrieveListResponse, ShishoAPIError>({
     enabled: options.enabled !== undefined ? options.enabled : Boolean(listId),
     ...options,
     queryKey: [QueryKey.RetrieveList, listId],
@@ -102,11 +82,11 @@ export const useListBooks = (
   listId?: number,
   query: ListBooksInListQuery = {},
   options: Omit<
-    UseQueryOptions<ListBooksData, ShishoAPIError>,
+    UseQueryOptions<ListListBooksResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<ListBooksData, ShishoAPIError>({
+  return useQuery<ListListBooksResponse, ShishoAPIError>({
     enabled: options.enabled !== undefined ? options.enabled : Boolean(listId),
     ...options,
     queryKey: [QueryKey.ListBooks, listId, query],

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -68,6 +68,13 @@ export {
   type UpdateBookListsPayload,
   type ListListsQuery,
   type ListBooksQuery as ListBooksInListQuery,
+  type ListResponse,
+  type ListResponsePermission,
+  type ListListsResponse,
+  type ListListBooksResponse,
+  type RetrieveListResponse,
+  type CheckVisibilityResponse,
+  type ListTemplate,
 } from "./generated/lists";
 
 export type { UserSettings } from "@/hooks/queries/settings";

--- a/pkg/lists/handlers.go
+++ b/pkg/lists/handlers.go
@@ -1,6 +1,7 @@
 package lists
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 
@@ -40,35 +41,37 @@ func (h *handler) list(c echo.Context) error {
 	}
 
 	// Augment with book counts
-	type ListWithCount struct {
-		*models.List
-		BookCount  int    `json:"book_count"`
-		Permission string `json:"permission"` // owner, manager, editor, viewer
-	}
-
-	result := make([]ListWithCount, len(lists))
+	result := make([]ListResponse, len(lists))
 	libraryIDs := user.GetAccessibleLibraryIDs()
 
 	for i, l := range lists {
 		count, _ := h.listsService.GetListBookCount(ctx, l.ID, libraryIDs)
-
-		// Determine permission level
-		permission := "viewer"
-		if l.UserID == user.ID {
-			permission = "owner"
-		} else if canManage, _ := h.listsService.CanManage(ctx, l.ID, user.ID); canManage {
-			permission = "manager"
-		} else if canEdit, _ := h.listsService.CanEdit(ctx, l.ID, user.ID); canEdit {
-			permission = "editor"
+		result[i] = ListResponse{
+			List:       *l,
+			BookCount:  count,
+			Permission: h.effectivePermission(ctx, l.ID, l.UserID, user.ID),
 		}
-
-		result[i] = ListWithCount{l, count, permission}
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, echo.Map{
-		"lists": result,
-		"total": total,
-	}))
+	response := ListListsResponse{Items: result, Total: total}
+
+	return errors.WithStack(c.JSON(http.StatusOK, response))
+}
+
+// effectivePermission returns the requesting user's effective permission on a
+// list: "owner" if they own it, otherwise the highest share grant (manager >
+// editor > viewer).
+func (h *handler) effectivePermission(ctx context.Context, listID, ownerID, userID int) string {
+	if ownerID == userID {
+		return PermissionOwner
+	}
+	if canManage, _ := h.listsService.CanManage(ctx, listID, userID); canManage {
+		return models.ListPermissionManager
+	}
+	if canEdit, _ := h.listsService.CanEdit(ctx, listID, userID); canEdit {
+		return models.ListPermissionEditor
+	}
+	return models.ListPermissionViewer
 }
 
 func (h *handler) retrieve(c echo.Context) error {
@@ -102,21 +105,13 @@ func (h *handler) retrieve(c echo.Context) error {
 	libraryIDs := user.GetAccessibleLibraryIDs()
 	bookCount, _ := h.listsService.GetListBookCount(ctx, id, libraryIDs)
 
-	// Determine permission
-	permission := "viewer"
-	if list.UserID == user.ID {
-		permission = "owner"
-	} else if canManage, _ := h.listsService.CanManage(ctx, id, user.ID); canManage {
-		permission = "manager"
-	} else if canEdit, _ := h.listsService.CanEdit(ctx, id, user.ID); canEdit {
-		permission = "editor"
+	response := RetrieveListResponse{
+		List:       *list,
+		BookCount:  bookCount,
+		Permission: h.effectivePermission(ctx, id, list.UserID, user.ID),
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, echo.Map{
-		"list":       list,
-		"book_count": bookCount,
-		"permission": permission,
-	}))
+	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
 
 func (h *handler) create(c echo.Context) error {
@@ -309,10 +304,9 @@ func (h *handler) listBooks(c echo.Context) error {
 		}
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, echo.Map{
-		"books": listBooks,
-		"total": total,
-	}))
+	response := ListListBooksResponse{Items: listBooks, Total: total}
+
+	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
 
 func (h *handler) addBooks(c echo.Context) error {
@@ -659,10 +653,9 @@ func (h *handler) checkVisibility(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, echo.Map{
-		"visible": visible,
-		"total":   total,
-	}))
+	response := CheckVisibilityResponse{Visible: visible, Total: total}
+
+	return errors.WithStack(c.JSON(http.StatusOK, response))
 }
 
 // Template handlers
@@ -711,20 +704,20 @@ func (h *handler) createFromTemplate(c echo.Context) error {
 }
 
 func (h *handler) templates(c echo.Context) error {
-	templates := []map[string]interface{}{
+	templates := []ListTemplate{
 		{
-			"name":         "tbr",
-			"display_name": "To Be Read",
-			"description":  "Books I want to read next",
-			"is_ordered":   true,
-			"default_sort": models.ListSortManual,
+			Name:        "tbr",
+			DisplayName: "To Be Read",
+			Description: "Books I want to read next",
+			IsOrdered:   true,
+			DefaultSort: models.ListSortManual,
 		},
 		{
-			"name":         "favorites",
-			"display_name": "Favorites",
-			"description":  "My favorite books",
-			"is_ordered":   false,
-			"default_sort": models.ListSortAddedAtDesc,
+			Name:        "favorites",
+			DisplayName: "Favorites",
+			Description: "My favorite books",
+			IsOrdered:   false,
+			DefaultSort: models.ListSortAddedAtDesc,
 		},
 	}
 

--- a/pkg/lists/handlers_test.go
+++ b/pkg/lists/handlers_test.go
@@ -1,0 +1,217 @@
+package lists
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/binder"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+)
+
+func newTestEcho(t *testing.T) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	b, err := binder.New()
+	require.NoError(t, err)
+	e.Binder = b
+	return e
+}
+
+func newTestHandler(db *bun.DB) *handler {
+	return &handler{listsService: NewService(db)}
+}
+
+// userWithUsersRead returns a User that has all-library access and users:read,
+// so it passes the sharing permission checks used by checkVisibility.
+func userWithUsersRead(t *testing.T, db *bun.DB, username string) *models.User {
+	t.Helper()
+	user := createTestUser(t, db, username)
+	user.LibraryAccess = []*models.UserLibraryAccess{{UserID: user.ID}}
+	user.Role = &models.Role{
+		Permissions: []*models.Permission{
+			{Resource: models.ResourceUsers, Operation: models.OperationRead},
+		},
+	}
+	return user
+}
+
+func TestList_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	e := newTestEcho(t)
+	user := createTestUser(t, db, "owner")
+	user.LibraryAccess = []*models.UserLibraryAccess{{UserID: user.ID}}
+	h := newTestHandler(db)
+
+	_, err := h.listsService.CreateList(t.Context(), CreateListOptions{UserID: user.ID, Name: "My List"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+
+	require.NoError(t, h.list(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasLists := raw["lists"]
+	assert.True(t, hasItems, "list response must use 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.False(t, hasLists, "list response must NOT use legacy 'lists' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+
+	var resp ListListsResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, "My List", resp.Items[0].Name)
+	assert.Equal(t, "owner", resp.Items[0].Permission)
+}
+
+func TestRetrieve_ResponseShape(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	e := newTestEcho(t)
+	user := createTestUser(t, db, "owner")
+	user.LibraryAccess = []*models.UserLibraryAccess{{UserID: user.ID}}
+	h := newTestHandler(db)
+
+	list, err := h.listsService.CreateList(t.Context(), CreateListOptions{UserID: user.ID, Name: "My List"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(list.ID))
+
+	require.NoError(t, h.retrieve(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	// Embeds the List model (so its fields are flattened in) plus book_count and
+	// permission. The legacy nested "list" key must be gone.
+	_, hasList := raw["list"]
+	assert.False(t, hasList, "retrieve response must NOT nest under a 'list' key")
+	for _, key := range []string{"id", "name", "book_count", "permission"} {
+		_, ok := raw[key]
+		assert.Truef(t, ok, "retrieve response must have %q key", key)
+	}
+
+	var resp RetrieveListResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "My List", resp.Name)
+	assert.Equal(t, 0, resp.BookCount)
+	assert.Equal(t, "owner", resp.Permission)
+}
+
+func TestListBooks_ResponseUsesItemsKey(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	e := newTestEcho(t)
+	user := createTestUser(t, db, "owner")
+	user.LibraryAccess = []*models.UserLibraryAccess{{UserID: user.ID}}
+	lib := createTestLibrary(t, db, "Lib")
+	book := createTestBook(t, db, lib.ID, "Alpha")
+	h := newTestHandler(db)
+
+	list, err := h.listsService.CreateList(t.Context(), CreateListOptions{UserID: user.ID, Name: "My List"})
+	require.NoError(t, err)
+	require.NoError(t, h.listsService.AddBooks(t.Context(), AddBooksOptions{ListID: list.ID, BookIDs: []int{book.ID}, AddedByUserID: user.ID}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(list.ID))
+
+	require.NoError(t, h.listBooks(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasBooks := raw["books"]
+	assert.True(t, hasItems, "listBooks response must use 'items' key")
+	assert.True(t, hasTotal, "listBooks response must have 'total' key")
+	assert.False(t, hasBooks, "listBooks response must NOT use legacy 'books' key")
+	assert.Len(t, raw, 2, "listBooks response must have exactly 'items' and 'total' keys")
+
+	var resp ListListBooksResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Total)
+	require.Len(t, resp.Items, 1)
+	require.NotNil(t, resp.Items[0].Book)
+	assert.Equal(t, "Alpha", resp.Items[0].Book.Title)
+}
+
+func TestCheckVisibility_ResponseShape(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	e := newTestEcho(t)
+	user := userWithUsersRead(t, db, "owner")
+	h := newTestHandler(db)
+
+	list, err := h.listsService.CreateList(t.Context(), CreateListOptions{UserID: user.ID, Name: "My List"})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/?user_id=1", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("user", user)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(list.ID))
+
+	require.NoError(t, h.checkVisibility(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasVisible := raw["visible"]
+	_, hasTotal := raw["total"]
+	assert.True(t, hasVisible, "checkVisibility response must have 'visible' key")
+	assert.True(t, hasTotal, "checkVisibility response must have 'total' key")
+	assert.Len(t, raw, 2, "checkVisibility response must have exactly 'visible' and 'total' keys")
+
+	var resp CheckVisibilityResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.Visible)
+	assert.Equal(t, 0, resp.Total)
+}
+
+func TestTemplates_ResponseShape(t *testing.T) {
+	t.Parallel()
+	e := newTestEcho(t)
+	h := &handler{}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.templates(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp []ListTemplate
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 2)
+	assert.Equal(t, "tbr", resp[0].Name)
+	assert.Equal(t, "To Be Read", resp[0].DisplayName)
+	assert.True(t, resp[0].IsOrdered)
+	assert.Equal(t, models.ListSortManual, resp[0].DefaultSort)
+	assert.Equal(t, "favorites", resp[1].Name)
+	assert.Equal(t, models.ListSortAddedAtDesc, resp[1].DefaultSort)
+}

--- a/pkg/lists/service.go
+++ b/pkg/lists/service.go
@@ -125,12 +125,16 @@ func (svc *Service) listListsWithTotal(ctx context.Context, opts ListListsOption
 		q = q.Offset(*opts.Offset)
 	}
 
+	// Count first (when requested), then Scan. We deliberately avoid bun's
+	// ScanAndCount: it runs the count and scan concurrently, and on a query
+	// with relations both goroutines mutate the shared relation-join state, a
+	// data race the -race detector flags in CI.
 	if opts.includeTotal {
-		total, err = q.ScanAndCount(ctx)
-	} else {
-		err = q.Scan(ctx)
+		if total, err = q.Count(ctx); err != nil {
+			return nil, 0, errors.WithStack(err)
+		}
 	}
-	if err != nil {
+	if err = q.Scan(ctx); err != nil {
 		return nil, 0, errors.WithStack(err)
 	}
 
@@ -362,12 +366,15 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 		q = q.Offset(*opts.Offset)
 	}
 
+	// Count first (when requested), then Scan, rather than bun's concurrent
+	// ScanAndCount, which races on shared relation-join state (see
+	// listListsWithTotal).
 	if opts.includeTotal {
-		total, err = q.ScanAndCount(ctx)
-	} else {
-		err = q.Scan(ctx)
+		if total, err = q.Count(ctx); err != nil {
+			return nil, 0, errors.WithStack(err)
+		}
 	}
-	if err != nil {
+	if err = q.Scan(ctx); err != nil {
 		return nil, 0, errors.WithStack(err)
 	}
 

--- a/pkg/lists/service_test.go
+++ b/pkg/lists/service_test.go
@@ -206,26 +206,28 @@ func TestService_Pagination(t *testing.T) {
 	assert.Equal(t, 3, total)
 	assert.Len(t, lists, 3)
 
-	// Test limit using ListLists (not ListListsWithTotal)
-	// Note: There's a known bug with bun's ScanAndCount + Limit in SQLite in-memory tests,
-	// so we use ListLists which uses Scan instead of ScanAndCount.
+	// With a limit, total still reflects all matching rows while the returned
+	// page respects the limit. ListListsWithTotal counts then scans (it no
+	// longer uses bun's concurrent ScanAndCount).
 	limit := 1
-	lists, err = svc.ListLists(ctx, ListListsOptions{
+	lists, total, err = svc.ListListsWithTotal(ctx, ListListsOptions{
 		UserID: user.ID,
 		Limit:  &limit,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, 3, total, "total should count all lists, ignoring the limit")
 	assert.Len(t, lists, 1, "should return only 1 list with limit=1")
 
-	// Test offset using ListLists
+	// Limit + offset pages correctly while total still counts all rows.
 	limit = 2
 	offset := 1
-	lists, err = svc.ListLists(ctx, ListListsOptions{
+	lists, total, err = svc.ListListsWithTotal(ctx, ListListsOptions{
 		UserID: user.ID,
 		Limit:  &limit,
 		Offset: &offset,
 	})
 	require.NoError(t, err)
+	assert.Equal(t, 3, total, "total should count all lists, ignoring limit/offset")
 	assert.Len(t, lists, 2, "should return 2 lists with limit=2 offset=1")
 }
 

--- a/pkg/lists/service_test.go
+++ b/pkg/lists/service_test.go
@@ -3,6 +3,7 @@ package lists
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/shishobooks/shisho/pkg/migrations"
@@ -17,7 +18,12 @@ import (
 func setupTestDB(t *testing.T) *bun.DB {
 	t.Helper()
 
-	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	// Use a shared-cache in-memory DSN keyed by the test name so every pooled
+	// connection sees the same database (a plain ":memory:" gives each
+	// connection its own empty DB, which breaks queries that span connections,
+	// e.g. transactions).
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
 	require.NoError(t, err)
 
 	db := bun.NewDB(sqldb, sqlitedialect.New())

--- a/pkg/lists/types.go
+++ b/pkg/lists/types.go
@@ -1,5 +1,61 @@
 package lists
 
+import "github.com/shishobooks/shisho/pkg/models"
+
+// PermissionOwner is the synthetic permission the list/retrieve handlers return
+// for a list's owner. The persisted share grants are the ListPermission values
+// (viewer/editor/manager); "owner" is computed per request, never stored.
+const (
+	//tygo:emit export type ListResponsePermission = "owner" | "manager" | "editor" | "viewer";
+	PermissionOwner = "owner"
+)
+
+// ListResponse is a single list augmented with the requesting user's effective
+// permission and the list's book count. It embeds the List model by value so
+// tygo emits `extends List` and the wire format stays byte-identical.
+type ListResponse struct {
+	models.List `tstype:",extends"`
+	BookCount   int    `json:"book_count"`
+	Permission  string `json:"permission" tstype:"ListResponsePermission"`
+}
+
+// ListListsResponse is the list-endpoint envelope.
+type ListListsResponse struct {
+	Items []ListResponse `json:"items"`
+	Total int            `json:"total"`
+}
+
+// RetrieveListResponse is the single-list API response. It mirrors ListResponse:
+// the List model fields are flattened in, plus book_count and permission.
+type RetrieveListResponse struct {
+	models.List `tstype:",extends"`
+	BookCount   int    `json:"book_count"`
+	Permission  string `json:"permission" tstype:"ListResponsePermission"`
+}
+
+// ListListBooksResponse is the books-in-list envelope. Items are ListBook rows
+// (each carrying its Book) so the frontend can read cover cache keys.
+type ListListBooksResponse struct {
+	Items []*models.ListBook `json:"items" tstype:"ListBook[]"`
+	Total int                `json:"total"`
+}
+
+// CheckVisibilityResponse reports how many of a list's books a target user can
+// see given their library access.
+type CheckVisibilityResponse struct {
+	Visible int `json:"visible"`
+	Total   int `json:"total"`
+}
+
+// ListTemplate is a built-in list template offered by the templates endpoint.
+type ListTemplate struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
+	IsOrdered   bool   `json:"is_ordered"`
+	DefaultSort string `json:"default_sort" tstype:"ListSort"`
+}
+
 // Query params for list endpoints.
 type ListListsQuery struct {
 	Limit  int `query:"limit" json:"limit,omitempty" default:"50" validate:"min=1,max=100"`
@@ -9,7 +65,7 @@ type ListListsQuery struct {
 type ListBooksQuery struct {
 	Limit  int     `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=100"`
 	Offset int     `query:"offset" json:"offset,omitempty" validate:"min=0"`
-	Sort   *string `query:"sort" json:"sort,omitempty" validate:"omitempty,oneof=manual added_at_desc added_at_asc title_asc title_desc author_asc author_desc" tstype:"string"`
+	Sort   *string `query:"sort" json:"sort,omitempty" validate:"omitempty,oneof=manual added_at_desc added_at_asc title_asc title_desc author_asc author_desc" tstype:"ListSort"`
 }
 
 // Payloads for create/update endpoints.
@@ -17,14 +73,14 @@ type CreateListPayload struct {
 	Name        string  `json:"name" validate:"required,min=1,max=200"`
 	Description *string `json:"description,omitempty" validate:"omitempty,max=2000" tstype:"string"`
 	IsOrdered   bool    `json:"is_ordered"`
-	DefaultSort *string `json:"default_sort,omitempty" validate:"omitempty,oneof=manual added_at_desc added_at_asc title_asc title_desc author_asc author_desc" tstype:"string"`
+	DefaultSort *string `json:"default_sort,omitempty" validate:"omitempty,oneof=manual added_at_desc added_at_asc title_asc title_desc author_asc author_desc" tstype:"ListSort"`
 }
 
 type UpdateListPayload struct {
 	Name        *string `json:"name,omitempty" validate:"omitempty,min=1,max=200" tstype:"string"`
 	Description *string `json:"description,omitempty" validate:"omitempty,max=2000" tstype:"string"`
 	IsOrdered   *bool   `json:"is_ordered,omitempty" tstype:"boolean"`
-	DefaultSort *string `json:"default_sort,omitempty" validate:"omitempty,oneof=manual added_at_desc added_at_asc title_asc title_desc author_asc author_desc" tstype:"string"`
+	DefaultSort *string `json:"default_sort,omitempty" validate:"omitempty,oneof=manual added_at_desc added_at_asc title_asc title_desc author_asc author_desc" tstype:"ListSort"`
 }
 
 type AddBooksPayload struct {
@@ -41,11 +97,11 @@ type ReorderBooksPayload struct {
 
 type CreateSharePayload struct {
 	UserID     int    `json:"user_id" validate:"required,min=1"`
-	Permission string `json:"permission" validate:"required,oneof=viewer editor manager"`
+	Permission string `json:"permission" validate:"required,oneof=viewer editor manager" tstype:"ListPermission"`
 }
 
 type UpdateSharePayload struct {
-	Permission string `json:"permission" validate:"required,oneof=viewer editor manager"`
+	Permission string `json:"permission" validate:"required,oneof=viewer editor manager" tstype:"ListPermission"`
 }
 
 type UpdateBookListsPayload struct {

--- a/pkg/models/list.go
+++ b/pkg/models/list.go
@@ -8,6 +8,7 @@ import (
 
 // List permission levels.
 const (
+	//tygo:emit export type ListPermission = typeof ListPermissionViewer | typeof ListPermissionEditor | typeof ListPermissionManager;
 	ListPermissionViewer  = "viewer"
 	ListPermissionEditor  = "editor"
 	ListPermissionManager = "manager"
@@ -15,6 +16,7 @@ const (
 
 // List default sort options.
 const (
+	//tygo:emit export type ListSort = typeof ListSortManual | typeof ListSortAddedAtDesc | typeof ListSortAddedAtAsc | typeof ListSortTitleAsc | typeof ListSortTitleDesc | typeof ListSortAuthorAsc | typeof ListSortAuthorDesc;
 	ListSortAddedAtDesc = "added_at_desc"
 	ListSortAddedAtAsc  = "added_at_asc"
 	ListSortTitleAsc    = "title_asc"
@@ -35,7 +37,7 @@ type List struct {
 	Name        string    `bun:",nullzero" json:"name"`
 	Description *string   `json:"description"`
 	IsOrdered   bool      `json:"is_ordered"`
-	DefaultSort string    `bun:",nullzero" json:"default_sort"`
+	DefaultSort string    `bun:",nullzero" json:"default_sort" tstype:"ListSort"`
 
 	// Relations
 	ListBooks  []*ListBook  `bun:"rel:has-many,join:id=list_id" json:"list_books,omitempty" tstype:"ListBook[]"`
@@ -64,7 +66,7 @@ type ListShare struct {
 	List           *List     `bun:"rel:belongs-to,join:list_id=id" json:"list,omitempty" tstype:"List"`
 	UserID         int       `bun:",nullzero" json:"user_id"`
 	User           *User     `bun:"rel:belongs-to,join:user_id=id" json:"user,omitempty" tstype:"User"`
-	Permission     string    `bun:",nullzero" json:"permission"`
+	Permission     string    `bun:",nullzero" json:"permission" tstype:"ListPermission"`
 	CreatedAt      time.Time `json:"created_at"`
 	SharedByUserID *int      `json:"shared_by_user_id"`
 	SharedByUser   *User     `bun:"rel:belongs-to,join:shared_by_user_id=id" json:"shared_by_user,omitempty" tstype:"User"`

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -9,6 +9,7 @@ type_mappings:
   models.Series: "Series"
   models.Person: "Person"
   models.Library: "Library"
+  models.List: "List"
   # A model returned by name (not embedded, not field-level `tstype`-overridden)
   # also needs a mapping so tygo emits the bare interface name instead of `any`.
   # books.ts's MoveFilesResponse / MergeBooksResponse return a *models.Book.
@@ -120,6 +121,8 @@ packages:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/lists"
     output_path: "app/types/generated/lists.ts"
+    frontmatter: |
+      import { List, ListBook, ListPermission, ListSort } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/settings"


### PR DESCRIPTION
Closes #349

## Summary
- Brought the Lists package under the tygo single-source-of-truth convention, mirroring the merged Genres/Series/Tags/People/Publishers/Books slices. Added named response structs in `pkg/lists/types.go` (`ListResponse`/`RetrieveListResponse` value-embedding `models.List` via `tstype:",extends"`, plus `ListListsResponse`/`ListListBooksResponse` `{items,total}` envelopes, `CheckVisibilityResponse`, and a typed `ListTemplate`), rewrote all five in-scope handlers (list, retrieve, listBooks, checkVisibility, templates) to return them instead of `echo.Map` / `[]map[string]interface{}`.
- Emitted `ListSort`/`ListPermission` unions on the model and pointed the sort/permission payload fields at them, removing the `tstype:"string"` pin on the sort fields. Added a list-local `ListResponsePermission` union (which adds the request-computed `"owner"` value) for the list/retrieve permission field.
- Updated the frontend to consume the generated types and the `{items,total}` shape, deleting the hand-written `ListWithCount`/`RetrieveListData`/`ListBooksData`/`ListTemplate` interfaces. Extracted a shared `effectivePermission` helper (owner > manager > editor > viewer) in the handlers.

## Notes
- Naming follows the merged convention over the issue's literal text: the list envelope is `ListListsResponse` (`{items,total}`) and the single-list response is `RetrieveListResponse` rather than the issue's `ListWithCount` wrapper. Both flatten the embedded `List` model (frontend reads `data.name` directly, not `data.list.name`) and add `book_count`/`permission`. The books-in-list envelope is `ListListBooksResponse`.
- The list/retrieve permission field is a distinct union from the model's `ListPermission`: it adds the request-computed `"owner"` value, so it's emitted as a separate `ListResponsePermission = "owner" | "manager" | "editor" | "viewer"`. The persisted share grant (`ListShare.Permission`, `CreateSharePayload`/`UpdateSharePayload`) uses the narrower `ListPermission`.
- No `website/docs` change: `website/docs/lists.md` documents the feature, not the JSON wire shape, and the tygo convention is already documented (ADR 0004 / #343).
- The `bookLists`/`updateBookLists` handlers (in `pkg/books`, returning `[]*models.List`) are intentionally out of scope for #349 and unchanged.
- Reviewers should look first at `pkg/lists/types.go` (the `ListResponsePermission` emit anchored to the used `PermissionOwner` const) and the `service_test.go` DSN change (a shared-cache DSN keyed by test name, required so the new handler test's `AddBooks` transaction spanning pooled connections sees the migrated schema).

## Test plan
- `mise lint` and `mise test` pass (Go lint clean, lists package tests green)
- `mise lint:js` and `mise test:unit` pass (eslint, prettier, tsc, website typecheck clean; 845 unit tests pass)
- New handler shape tests in `pkg/lists/handlers_test.go` assert envelope/field keys for all five endpoints:
  - list envelope is exactly `{items,total}` and items carry `name` plus computed `permission`
  - retrieve flattens the `List` model plus `book_count`/`permission` and drops the legacy nested `list` key
  - listBooks envelope is exactly `{items,total}` with `ListBook` items carrying their `Book`
  - checkVisibility returns exactly `{visible,total}`
  - templates returns a typed `ListTemplate[]` with the expected field names/values