### PR TITLE
[Backend] Take Jobs and logs response types end-to-end via tygo

### DIFF
--- a/app/components/library/ResyncButton.tsx
+++ b/app/components/library/ResyncButton.tsx
@@ -20,7 +20,7 @@ export function ResyncButton({ libraryId }: ResyncButtonProps) {
   const { data, isLoading } = useLatestScanJob(libraryId);
   const createJob = useCreateJob();
 
-  const latestJob = data?.jobs[0];
+  const latestJob = data?.items[0];
   const isActive =
     latestJob?.status === "pending" || latestJob?.status === "in_progress";
   const isFailed = latestJob?.status === "failed";

--- a/app/components/pages/AdminJobs.tsx
+++ b/app/components/pages/AdminJobs.tsx
@@ -129,7 +129,7 @@ const AdminJobs = () => {
     );
   }
 
-  const jobs = data?.jobs ?? [];
+  const jobs = data?.items ?? [];
 
   return (
     <div>

--- a/app/components/pages/AdminLogs.tsx
+++ b/app/components/pages/AdminLogs.tsx
@@ -36,7 +36,7 @@ const AdminLogs = () => {
 
   const entries: LogViewerEntry[] = useMemo(
     () =>
-      (data?.entries ?? []).map((e) => ({
+      (data?.items ?? []).map((e) => ({
         id: e.id,
         level: e.level,
         timestamp: e.timestamp,

--- a/app/components/pages/JobDetail.tsx
+++ b/app/components/pages/JobDetail.tsx
@@ -14,25 +14,25 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useJobLogs } from "@/hooks/queries/jobs";
+import { useJob, useJobLogs } from "@/hooks/queries/jobs";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import {
-  JobLogLevelError,
-  JobLogLevelFatal,
-  JobLogLevelInfo,
-  JobLogLevelWarn,
   JobStatusInProgress,
+  LogLevelError,
+  LogLevelFatal,
+  LogLevelInfo,
+  LogLevelWarn,
 } from "@/types";
 
 const getLevelColor = (level: string) => {
   switch (level) {
-    case JobLogLevelInfo:
+    case LogLevelInfo:
       return "bg-blue-500/20 text-blue-400";
-    case JobLogLevelWarn:
+    case LogLevelWarn:
       return "bg-yellow-500/20 text-yellow-400";
-    case JobLogLevelError:
+    case LogLevelError:
       return "bg-red-500/20 text-red-400";
-    case JobLogLevelFatal:
+    case LogLevelFatal:
       return "bg-red-700/30 text-red-300";
     default:
       return "bg-muted text-muted-foreground";
@@ -80,13 +80,20 @@ const JobDetail = () => {
   const [levelFilter, setLevelFilter] = useState<string[]>([]);
   const [pluginFilter, setPluginFilter] = useState<string>("");
 
-  const { data, isLoading, error } = useJobLogs(id, {
+  const { data: job, isLoading: isJobLoading, error: jobError } = useJob(id);
+
+  const {
+    data: logsData,
+    isLoading: isLogsLoading,
+    error: logsError,
+  } = useJobLogs(id, {
     level: levelFilter.length > 0 ? levelFilter : undefined,
     plugin: pluginFilter || undefined,
   });
 
-  const job = data?.job;
-  const logs = useMemo(() => data?.logs ?? [], [data?.logs]);
+  const isLoading = isJobLoading || isLogsLoading;
+  const error = jobError ?? logsError;
+  const logs = useMemo(() => logsData?.items ?? [], [logsData?.items]);
 
   // Extract unique plugin names from log data
   const pluginNames = useMemo(() => {
@@ -206,24 +213,21 @@ const JobDetail = () => {
           value={searchTerm}
         />
         <div className="flex items-center gap-2">
-          {[
-            JobLogLevelInfo,
-            JobLogLevelWarn,
-            JobLogLevelError,
-            JobLogLevelFatal,
-          ].map((level) => (
-            <Button
-              className={
-                levelFilter.includes(level) ? getLevelColor(level) : ""
-              }
-              key={level}
-              onClick={() => toggleLevelFilter(level)}
-              size="sm"
-              variant={levelFilter.includes(level) ? "secondary" : "outline"}
-            >
-              {level}
-            </Button>
-          ))}
+          {[LogLevelInfo, LogLevelWarn, LogLevelError, LogLevelFatal].map(
+            (level) => (
+              <Button
+                className={
+                  levelFilter.includes(level) ? getLevelColor(level) : ""
+                }
+                key={level}
+                onClick={() => toggleLevelFilter(level)}
+                size="sm"
+                variant={levelFilter.includes(level) ? "secondary" : "outline"}
+              >
+                {level}
+              </Button>
+            ),
+          )}
         </div>
         {pluginNames.length > 0 && (
           <Select

--- a/app/hooks/queries/jobs.ts
+++ b/app/hooks/queries/jobs.ts
@@ -6,7 +6,13 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { CreateJobPayload, Job, JobLog, ListJobsQuery } from "@/types";
+import type {
+  CreateJobPayload,
+  Job,
+  ListJobLogsResponse,
+  ListJobsQuery,
+  ListJobsResponse,
+} from "@/types";
 
 export enum QueryKey {
   RetrieveJob = "RetrieveJob",
@@ -15,10 +21,24 @@ export enum QueryKey {
   LatestScanJob = "LatestScanJob",
 }
 
-interface ListJobsData {
-  jobs: Job[];
-  total: number;
-}
+type ListJobsData = ListJobsResponse;
+
+export const useJob = (
+  jobId?: string,
+  options: Omit<
+    UseQueryOptions<Job, ShishoAPIError>,
+    "queryKey" | "queryFn"
+  > = {},
+) => {
+  return useQuery<Job, ShishoAPIError>({
+    enabled: options.enabled !== undefined ? options.enabled : Boolean(jobId),
+    ...options,
+    queryKey: [QueryKey.RetrieveJob, jobId],
+    queryFn: ({ signal }) => {
+      return API.request("GET", `/jobs/${jobId}`, null, null, signal);
+    },
+  });
+};
 
 export const useJobs = (
   query: ListJobsQuery = {},
@@ -56,10 +76,7 @@ export const useLatestScanJob = (libraryId: number | undefined) => {
   });
 };
 
-interface ListJobLogsData {
-  logs: JobLog[];
-  job: Job;
-}
+type ListJobLogsData = ListJobLogsResponse;
 
 interface UseJobLogsOptions {
   afterId?: number;

--- a/app/hooks/queries/logs.ts
+++ b/app/hooks/queries/logs.ts
@@ -1,23 +1,13 @@
 import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
+import type { ListLogsResponse } from "@/types";
 
 export enum QueryKey {
   ListLogs = "ListLogs",
 }
 
-export interface LogEntry {
-  id: number;
-  level: string;
-  timestamp: string;
-  message: string;
-  data?: Record<string, unknown>;
-  error?: string;
-}
-
-interface ListLogsData {
-  entries: LogEntry[];
-}
+type ListLogsData = ListLogsResponse;
 
 interface UseLogsOptions {
   level?: string;

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -22,6 +22,7 @@ export {
 export * from "./generated/filesystem";
 export * from "./generated/jobs";
 export * from "./generated/joblogs";
+export * from "./generated/logs";
 export * from "./generated/libraries";
 export * from "./generated/auth";
 export * from "./generated/users";

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -316,6 +316,10 @@ q.Where("b.id = ?", id)
 
 Check existing queries in `pkg/books/service.go` for reference. Common aliases: `b` (books), `f` (files), `a` (authors), `p` (persons), `s` (series), `bs` (book_series), `ch` (chapters), `n` (narrators).
 
+- **Unified `LogLevel` enum (`pkg/models/log_level.go`)**: A single `LogLevel` (`debug`, `info`, `warn`, `error`, `fatal`) is the canonical log-severity enum, shared by `models.JobLog.Level` (job logs) and `logs.LogEntry.Level` (app/server logs). There is no separate `JobLogLevel` — use `models.LogLevel*` consts everywhere, and `tstype:"LogLevel"` on level fields / `tstype:"LogLevel[]"` on level query filters. Both level query validators (`joblogs.ListJobLogsQuery.Level`, `logs.ListLogsQuery.Level`) carry the full `oneof=debug info warn error fatal`. The frontend imports `LogLevel*` from `@/types` (generated into `models.ts`).
+
+- **Jobs / job logs / app logs follow the `{ items, total }` envelope** like every other list endpoint: `jobs.ListJobsResponse` (`items: Job[]`), `joblogs.ListJobLogsResponse` (`items: JobLog[]`), and `logs.ListLogsResponse` (`items: LogEntry[]`). The foreign-model slices use a field-level `tstype:"Job[]"` / `tstype:"JobLog[]"` override plus a frontmatter import (the publishers `ListPublisherFilesResponse` pattern) so tygo emits a clean `Job[]` rather than `(any | undefined)[]`. **The joblogs list response no longer bundles the `job`** — the handler only does an existence check (404 on unknown job); the client fetches the job separately via `GET /jobs/:id` (the `useJob` hook). `POST /auth/logout` returns `204 No Content` (pure acknowledgment), not a JSON message body.
+
 ### Config
 
 - Self-hosted app with config file-based configuration

--- a/pkg/auth/handlers.go
+++ b/pkg/auth/handlers.go
@@ -92,7 +92,7 @@ func (h *handler) logout(c echo.Context) error {
 	}
 	c.SetCookie(cookie)
 
-	return c.JSON(http.StatusOK, map[string]string{"message": "Logged out successfully"})
+	return c.NoContent(http.StatusNoContent)
 }
 
 // me returns the current authenticated user's info.

--- a/pkg/auth/handlers_test.go
+++ b/pkg/auth/handlers_test.go
@@ -129,6 +129,32 @@ func TestHandler_Setup_RejectsWhenUsersExist(t *testing.T) {
 	assert.Contains(t, errResp.Message, "Setup has already been completed")
 }
 
+func TestHandler_Logout_Returns204NoContent(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	svc := NewService(db, "test-jwt-secret", 30*24*time.Hour)
+	h := &handler{authService: svc}
+
+	c, rr := newTestContext(t, "", http.MethodPost, "/auth/logout")
+
+	err := h.logout(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Empty(t, rr.Body.String(), "logout response body must be empty")
+
+	// The session cookie must still be cleared (MaxAge < 0).
+	require.NotEmpty(t, rr.Result().Cookies())
+	var sessionCookie *http.Cookie
+	for _, ck := range rr.Result().Cookies() {
+		if ck.Name == CookieName {
+			sessionCookie = ck
+		}
+	}
+	require.NotNil(t, sessionCookie, "logout must set the session cookie")
+	assert.Negative(t, sessionCookie.MaxAge, "logout must expire the session cookie")
+}
+
 func TestHandler_Login_ReturnsMustChangePassword(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/joblogs/handlers.go
+++ b/pkg/joblogs/handlers.go
@@ -23,11 +23,11 @@ func (h *handler) listLogs(c echo.Context) error {
 		return errcodes.NotFound("Job")
 	}
 
-	// Verify job exists
-	job, err := h.jobService.RetrieveJob(ctx, jobs.RetrieveJobOptions{
+	// Verify job exists. The job itself is fetched separately by the client via
+	// GET /jobs/:id; this is purely an existence check so unknown jobs 404.
+	if _, err := h.jobService.RetrieveJob(ctx, jobs.RetrieveJobOptions{
 		ID: &jobID,
-	})
-	if err != nil {
+	}); err != nil {
 		return errors.WithStack(err)
 	}
 
@@ -48,10 +48,7 @@ func (h *handler) listLogs(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	resp := struct {
-		Logs interface{} `json:"logs"`
-		Job  interface{} `json:"job"`
-	}{logs, job}
+	resp := ListJobLogsResponse{Items: logs, Total: len(logs)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, resp))
 }

--- a/pkg/joblogs/handlers_test.go
+++ b/pkg/joblogs/handlers_test.go
@@ -1,0 +1,104 @@
+package joblogs
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/jobs"
+	"github.com/shishobooks/shisho/pkg/migrations"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func newTestDB(t *testing.T) *bun.DB {
+	t.Helper()
+
+	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
+	require.NoError(t, err)
+	// Pin to a single connection so writes are visible to subsequent reads (a
+	// bare :memory: DSN gives each pooled connection its own empty database).
+	sqldb.SetMaxOpenConns(1)
+
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+
+	_, err = migrations.BringUpToDate(context.Background(), db)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	return db
+}
+
+// TestListLogs_ResponseUsesItemsTotalEnvelopeWithoutJob asserts the joblogs list
+// response returns the standard { items, total } envelope and no longer bundles
+// the job. The job is now fetched separately by the client via GET /jobs/:id.
+func TestListLogs_ResponseUsesItemsTotalEnvelopeWithoutJob(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Seed a job and two logs for it.
+	job := &models.Job{
+		Type:       models.JobTypeScan,
+		Status:     models.JobStatusPending,
+		DataParsed: &models.JobScanData{},
+	}
+	require.NoError(t, jobs.NewService(db).CreateJob(ctx, job))
+
+	svc := NewService(db)
+	require.NoError(t, svc.CreateJobLog(ctx, &models.JobLog{JobID: job.ID, Level: models.LogLevelInfo, Message: "first"}))
+	require.NoError(t, svc.CreateJobLog(ctx, &models.JobLog{JobID: job.ID, Level: models.LogLevelWarn, Message: "second"}))
+
+	h := &handler{jobLogService: svc, jobService: jobs.NewService(db)}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/jobs/"+strconv.Itoa(job.ID)+"/logs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues(strconv.Itoa(job.ID))
+
+	require.NoError(t, h.listLogs(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Top-level envelope must be { items, total } only — no "job", no "logs".
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasJob := raw["job"]
+	_, hasLogs := raw["logs"]
+	assert.True(t, hasItems, "response must have 'items' key")
+	assert.True(t, hasTotal, "response must have 'total' key")
+	assert.False(t, hasJob, "response must NOT bundle the 'job' anymore")
+	assert.False(t, hasLogs, "response must NOT use legacy 'logs' key")
+	assert.Len(t, raw, 2, "response must have exactly 'items' and 'total' keys")
+
+	var resp struct {
+		Items []struct {
+			ID      int    `json:"id"`
+			Message string `json:"message"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 2)
+	assert.Equal(t, 2, resp.Total)
+	assert.Equal(t, "first", resp.Items[0].Message)
+}

--- a/pkg/joblogs/logger.go
+++ b/pkg/joblogs/logger.go
@@ -32,20 +32,20 @@ func (svc *Service) NewJobLogger(ctx context.Context, jobID int, log logger.Logg
 // Info logs an info-level message.
 func (l *JobLogger) Info(msg string, data logger.Data) {
 	l.log.Info(msg, data)
-	l.persist(models.JobLogLevelInfo, msg, data, nil)
+	l.persist(models.LogLevelInfo, msg, data, nil)
 }
 
 // Warn logs a warning-level message.
 func (l *JobLogger) Warn(msg string, data logger.Data) {
 	l.log.Warn(msg, data)
-	l.persist(models.JobLogLevelWarn, msg, data, nil)
+	l.persist(models.LogLevelWarn, msg, data, nil)
 }
 
 // Error logs an error-level message with automatic stack trace.
 func (l *JobLogger) Error(msg string, err error, data logger.Data) {
 	l.log.Err(err).Error(msg, data)
 	stack := string(debug.Stack())
-	l.persist(models.JobLogLevelError, msg, data, &stack)
+	l.persist(models.LogLevelError, msg, data, &stack)
 }
 
 // Fatal logs a fatal-level message with automatic stack trace (for panics).
@@ -58,7 +58,7 @@ func (l *JobLogger) Fatal(msg string, err error, data logger.Data) {
 	}
 	l.log.Error(msg, data)
 	stack := string(debug.Stack())
-	l.persist(models.JobLogLevelFatal, msg, data, &stack)
+	l.persist(models.LogLevelFatal, msg, data, &stack)
 }
 
 func (l *JobLogger) persist(level, msg string, data logger.Data, stackTrace *string) {

--- a/pkg/joblogs/types.go
+++ b/pkg/joblogs/types.go
@@ -1,8 +1,17 @@
 package joblogs
 
+import "github.com/shishobooks/shisho/pkg/models"
+
 type ListJobLogsQuery struct {
 	AfterID *int     `query:"after_id" json:"after_id,omitempty"`
-	Level   []string `query:"level" json:"level,omitempty" validate:"dive,oneof=info warn error fatal"`
+	Level   []string `query:"level" json:"level,omitempty" validate:"dive,oneof=debug info warn error fatal" tstype:"LogLevel[]"`
 	Search  *string  `query:"search" json:"search,omitempty"`
 	Plugin  *string  `query:"plugin" json:"plugin,omitempty"`
+}
+
+// ListJobLogsResponse is the GET /jobs/:id/logs list-endpoint envelope. The job
+// itself is no longer bundled here; clients fetch it separately via GET /jobs/:id.
+type ListJobLogsResponse struct {
+	Items []*models.JobLog `json:"items" tstype:"JobLog[]"`
+	Total int              `json:"total"`
 }

--- a/pkg/jobs/handlers.go
+++ b/pkg/jobs/handlers.go
@@ -131,10 +131,7 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	resp := struct {
-		Jobs  []*models.Job `json:"jobs"`
-		Total int           `json:"total"`
-	}{jobs, total}
+	resp := ListJobsResponse{Items: jobs, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, resp))
 }

--- a/pkg/jobs/handlers_test.go
+++ b/pkg/jobs/handlers_test.go
@@ -1,0 +1,66 @@
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestList_ResponseUsesItemsTotalEnvelope asserts that GET /jobs returns the
+// standard { items, total } envelope (not the legacy { jobs, total } shape).
+func TestList_ResponseUsesItemsTotalEnvelope(t *testing.T) {
+	t.Parallel()
+
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Seed two jobs.
+	for i := 0; i < 2; i++ {
+		job := &models.Job{
+			Type:       models.JobTypeScan,
+			Status:     models.JobStatusPending,
+			DataParsed: &models.JobScanData{},
+		}
+		require.NoError(t, NewService(db).CreateJob(ctx, job))
+	}
+
+	h := &handler{jobService: NewService(db), db: db}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/jobs?limit=10&offset=0", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.list(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Top-level envelope must be { items, total } only.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasJobs := raw["jobs"]
+	assert.True(t, hasItems, "list response must have 'items' key")
+	assert.True(t, hasTotal, "list response must have 'total' key")
+	assert.False(t, hasJobs, "list response must NOT use legacy 'jobs' key")
+	assert.Len(t, raw, 2, "list response must have exactly 'items' and 'total' keys")
+
+	var resp struct {
+		Items []struct {
+			ID int `json:"id"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// At least the two jobs we seeded are present (other migration-seeded jobs
+	// may also exist), and total counts them.
+	assert.GreaterOrEqual(t, len(resp.Items), 2)
+	assert.GreaterOrEqual(t, resp.Total, 2)
+}

--- a/pkg/jobs/service_test.go
+++ b/pkg/jobs/service_test.go
@@ -27,6 +27,11 @@ func newTestDB(t *testing.T) *bun.DB {
 
 	sqldb, err := sql.Open(sqliteshim.ShimName, ":memory:")
 	require.NoError(t, err)
+	// A bare :memory: DSN gives each pooled connection its own empty database, so
+	// data written on one connection is invisible to the next. Pin the pool to a
+	// single connection (matching pkg/database for :memory:) so multi-step tests
+	// that write then read see a consistent database.
+	sqldb.SetMaxOpenConns(1)
 
 	db := bun.NewDB(sqldb, sqlitedialect.New())
 

--- a/pkg/jobs/types.go
+++ b/pkg/jobs/types.go
@@ -1,7 +1,9 @@
 package jobs
 
+import "github.com/shishobooks/shisho/pkg/models"
+
 type CreateJobPayload struct {
-	Type      string      `json:"type" validate:"required,oneof=export scan bulk_download recompute_review"`
+	Type      string      `json:"type" validate:"required,oneof=export scan bulk_download recompute_review" tstype:"JobType"`
 	Data      interface{} `json:"data" validate:"required" tstype:"JobExportData | JobScanData | JobBulkDownloadData | JobRecomputeReviewData"`
 	LibraryID *int        `json:"library_id,omitempty"`
 }
@@ -9,7 +11,13 @@ type CreateJobPayload struct {
 type ListJobsQuery struct {
 	Limit             int      `query:"limit" json:"limit,omitempty" default:"10" validate:"min=1,max=100"`
 	Offset            int      `query:"offset" json:"offset,omitempty" validate:"min=0"`
-	Status            []string `query:"status" json:"status,omitempty" validate:"dive,oneof=pending in_progress completed failed"`
-	Type              *string  `query:"type" json:"type,omitempty" validate:"omitempty,oneof=export scan bulk_download recompute_review"`
+	Status            []string `query:"status" json:"status,omitempty" validate:"dive,oneof=pending in_progress completed failed" tstype:"JobStatus[]"`
+	Type              *string  `query:"type" json:"type,omitempty" validate:"omitempty,oneof=export scan bulk_download recompute_review" tstype:"JobType"`
 	LibraryIDOrGlobal *int     `query:"library_id_or_global" json:"library_id_or_global,omitempty"`
+}
+
+// ListJobsResponse is the GET /jobs list-endpoint envelope.
+type ListJobsResponse struct {
+	Items []*models.Job `json:"items" tstype:"Job[]"`
+	Total int           `json:"total"`
 }

--- a/pkg/logs/handlers.go
+++ b/pkg/logs/handlers.go
@@ -36,9 +36,7 @@ func (h *handler) listLogs(c echo.Context) error {
 
 	entries := h.buffer.Query(level, search, limit, afterID)
 
-	resp := struct {
-		Entries []LogEntry `json:"entries"`
-	}{Entries: entries}
+	resp := ListLogsResponse{Items: entries, Total: len(entries)}
 
 	return errors.WithStack(c.JSON(http.StatusOK, resp))
 }

--- a/pkg/logs/handlers_test.go
+++ b/pkg/logs/handlers_test.go
@@ -1,0 +1,57 @@
+package logs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListLogs_ResponseUsesItemsTotalEnvelope asserts GET /logs returns the
+// standard { items, total } envelope (not the legacy { entries } shape).
+func TestListLogs_ResponseUsesItemsTotalEnvelope(t *testing.T) {
+	t.Parallel()
+
+	buf := NewRingBuffer(10, nil)
+	// Feed two zerolog-style JSON lines into the buffer.
+	_, err := buf.Write([]byte(`{"level":"info","message":"hello","timestamp":"2026-06-08T00:00:00Z"}` + "\n" +
+		`{"level":"warn","message":"careful","timestamp":"2026-06-08T00:00:01Z"}` + "\n"))
+	require.NoError(t, err)
+
+	h := &handler{buffer: buf}
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/logs", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, h.listLogs(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// Top-level envelope must be { items, total } only.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+	_, hasItems := raw["items"]
+	_, hasTotal := raw["total"]
+	_, hasEntries := raw["entries"]
+	assert.True(t, hasItems, "response must have 'items' key")
+	assert.True(t, hasTotal, "response must have 'total' key")
+	assert.False(t, hasEntries, "response must NOT use legacy 'entries' key")
+	assert.Len(t, raw, 2, "response must have exactly 'items' and 'total' keys")
+
+	var resp struct {
+		Items []struct {
+			Level   string `json:"level"`
+			Message string `json:"message"`
+		} `json:"items"`
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 2)
+	assert.Equal(t, 2, resp.Total)
+	assert.Equal(t, "hello", resp.Items[0].Message)
+}

--- a/pkg/logs/ring_buffer.go
+++ b/pkg/logs/ring_buffer.go
@@ -13,16 +13,6 @@ import (
 	"github.com/shishobooks/shisho/pkg/events"
 )
 
-// LogEntry represents a parsed log entry stored in the ring buffer.
-type LogEntry struct {
-	ID        uint64         `json:"id"`
-	Level     string         `json:"level"`
-	Timestamp time.Time      `json:"timestamp"`
-	Message   string         `json:"message"`
-	Data      map[string]any `json:"data,omitempty"`
-	Error     *string        `json:"error,omitempty"`
-}
-
 // levelSeverity maps level strings to numeric severity for filtering.
 var levelSeverity = map[string]int{
 	"debug": 0,

--- a/pkg/logs/types.go
+++ b/pkg/logs/types.go
@@ -1,9 +1,27 @@
 package logs
 
+import "time"
+
+// LogEntry represents a parsed log entry stored in the ring buffer.
+type LogEntry struct {
+	ID        uint64         `json:"id"`
+	Level     string         `json:"level" tstype:"LogLevel"`
+	Timestamp time.Time      `json:"timestamp"`
+	Message   string         `json:"message"`
+	Data      map[string]any `json:"data,omitempty"`
+	Error     *string        `json:"error,omitempty"`
+}
+
 // ListLogsQuery defines query parameters for GET /logs.
 type ListLogsQuery struct {
-	Level   *string `query:"level" json:"level,omitempty" validate:"omitempty,oneof=debug info warn error"`
+	Level   *string `query:"level" json:"level,omitempty" validate:"omitempty,oneof=debug info warn error fatal"`
 	Search  *string `query:"search" json:"search,omitempty"`
 	Limit   *int    `query:"limit" json:"limit,omitempty" validate:"omitempty,min=1,max=1000"`
 	AfterID *uint64 `query:"after_id" json:"after_id,omitempty"`
+}
+
+// ListLogsResponse is the GET /logs list-endpoint envelope.
+type ListLogsResponse struct {
+	Items []LogEntry `json:"items"`
+	Total int        `json:"total"`
 }

--- a/pkg/logs/types.go
+++ b/pkg/logs/types.go
@@ -14,7 +14,7 @@ type LogEntry struct {
 
 // ListLogsQuery defines query parameters for GET /logs.
 type ListLogsQuery struct {
-	Level   *string `query:"level" json:"level,omitempty" validate:"omitempty,oneof=debug info warn error fatal"`
+	Level   *string `query:"level" json:"level,omitempty" validate:"omitempty,oneof=debug info warn error fatal" tstype:"LogLevel"`
 	Search  *string `query:"search" json:"search,omitempty"`
 	Limit   *int    `query:"limit" json:"limit,omitempty" validate:"omitempty,min=1,max=1000"`
 	AfterID *uint64 `query:"after_id" json:"after_id,omitempty"`

--- a/pkg/models/job_log.go
+++ b/pkg/models/job_log.go
@@ -6,21 +6,13 @@ import (
 	"github.com/uptrace/bun"
 )
 
-const (
-	//tygo:emit export type JobLogLevel = typeof JobLogLevelInfo | typeof JobLogLevelWarn | typeof JobLogLevelError | typeof JobLogLevelFatal;
-	JobLogLevelInfo  = "info"
-	JobLogLevelWarn  = "warn"
-	JobLogLevelError = "error"
-	JobLogLevelFatal = "fatal"
-)
-
 type JobLog struct {
 	bun.BaseModel `bun:"table:job_logs,alias:jl" tstype:"-"`
 
 	ID         int       `bun:",pk,nullzero" json:"id"`
 	CreatedAt  time.Time `json:"created_at"`
 	JobID      int       `bun:",nullzero" json:"job_id"`
-	Level      string    `bun:",nullzero" json:"level" tstype:"JobLogLevel"`
+	Level      string    `bun:",nullzero" json:"level" tstype:"LogLevel"`
 	Message    string    `bun:",nullzero" json:"message"`
 	Plugin     *string   `json:"plugin,omitempty"`
 	Data       *string   `json:"data,omitempty"`

--- a/pkg/models/log_level.go
+++ b/pkg/models/log_level.go
@@ -1,0 +1,10 @@
+package models
+
+const (
+	//tygo:emit export type LogLevel = typeof LogLevelDebug | typeof LogLevelInfo | typeof LogLevelWarn | typeof LogLevelError | typeof LogLevelFatal;
+	LogLevelDebug = "debug"
+	LogLevelInfo  = "info"
+	LogLevelWarn  = "warn"
+	LogLevelError = "error"
+	LogLevelFatal = "fatal"
+)

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -30,11 +30,19 @@ packages:
   - path: "github.com/shishobooks/shisho/pkg/jobs"
     output_path: "app/types/generated/jobs.ts"
     frontmatter: |
-      import { JobBulkDownloadData, JobExportData, JobRecomputeReviewData, JobScanData } from "@/types";
+      import { Job, JobBulkDownloadData, JobExportData, JobRecomputeReviewData, JobScanData, JobStatus, JobType } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/joblogs"
     output_path: "app/types/generated/joblogs.ts"
+    frontmatter: |
+      import { JobLog, LogLevel } from "@/types";
+    include_files:
+      - types.go
+  - path: "github.com/shishobooks/shisho/pkg/logs"
+    output_path: "app/types/generated/logs.ts"
+    frontmatter: |
+      import { LogLevel } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/libraries"


### PR DESCRIPTION
Closes #351

## Summary
- Brings Jobs, job logs, app logs, and the log level under the tygo "Go is the single source of truth" convention, mirroring the merged Genres / Series / People / Publishers / Books slices. Reviewers should start at `tygo.yaml` plus `pkg/jobs/types.go`, `pkg/joblogs/types.go`, and `pkg/logs/types.go`.
- Adds `ListJobsResponse`, `ListJobLogsResponse`, and `ListLogsResponse` `{ items, total }` envelopes. The wire shape changed key names: `GET /jobs` is now `{ items, total }` (was `{ jobs, total }`) and `GET /logs` is `{ items, total }` (was `{ entries }`). All frontend consumers were updated in the same PR; there is no other consumer in the repo.
- Splits the joblogs response to drop the bundled `job`. `GET /jobs/:id/logs` no longer returns the job: the handler only does an existence check (404 on unknown job), and the job-detail page now issues two queries (`useJob` against the existing `GET /jobs/:id`, plus `useJobLogs`).
- Moves `LogEntry` into the `logs` package's `types.go` and adds it to tygo. Unifies `JobLogLevel` into a single 5-value `models.LogLevel` (debug, info, warn, error, fatal) used by both the job-log model and the app-log entry; both level validators now accept all five values. `LogLevel` gained a `debug` value relative to the old `JobLogLevel`; this is harmless since the `JobLogger` only ever writes info/warn/error/fatal.
- Makes `POST /auth/logout` return `204 No Content`. The frontend consumes the generated types, deletes the hand-written `LogEntry`, and renames `JobLogLevel*` references to `LogLevel*`.
- Foreign-model list items use a field-level `tstype:"Job[]"` / `tstype:"JobLog[]"` override (the publishers `ListPublisherFilesResponse` pattern) so tygo emits clean `Job[]` / `JobLog[]`. Also pins the jobs package's shared in-memory test DB to a single connection (`SetMaxOpenConns(1)`), fixing a latent multi-connection `:memory:` isolation bug surfaced by the new handler test.
- No `website/docs/` change: internal API-type plumbing with no user-facing doc surface, consistent with the sibling slices. The doc deliverable is the `pkg/CLAUDE.md` update. Behavior-changing items were written test-first (red confirmed before green).

## Test plan
- `go test ./pkg/jobs/... ./pkg/joblogs/... ./pkg/logs/... ./pkg/auth/... ./pkg/models/...` passes.
- `GET /jobs` returns `{ items, total }` with no legacy `jobs` key (`pkg/jobs/handlers_test.go:TestList_ResponseUsesItemsTotalEnvelope`).
- `GET /jobs/:id/logs` returns `{ items, total }` and no longer bundles `job` / `logs` (`pkg/joblogs/handlers_test.go:TestListLogs_ResponseUsesItemsTotalEnvelopeWithoutJob`).
- `GET /logs` returns `{ items, total }` with no legacy `entries` key (`pkg/logs/handlers_test.go:TestListLogs_ResponseUsesItemsTotalEnvelope`).
- `POST /auth/logout` returns 204 with an empty body and still clears the session cookie (`pkg/auth/handlers_test.go:TestHandler_Logout_Returns204NoContent`).
- `mise tygo` regenerates `jobs.ts` / `joblogs.ts` / `logs.ts` with the unified `LogLevel` and `{ items, total }` envelopes; `pnpm lint:types` and `eslint` on the changed frontend files pass.
- Verify the job-detail page still renders job metadata and logs, and that level filter buttons work, now that the job is fetched via the separate `useJob` query.