### PR TITLE
[Fix] Identify search cancels superseded requests so newest query wins

### DIFF
--- a/app/components/library/IdentifyBookDialog.test.tsx
+++ b/app/components/library/IdentifyBookDialog.test.tsx
@@ -1,0 +1,265 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { PluginSearchResponse } from "@/hooks/queries/plugins";
+import {
+  DataSourceManual,
+  FileRoleMain,
+  FileTypeEPUB,
+  type Book,
+  type File,
+} from "@/types";
+
+import { IdentifyBookDialog } from "./IdentifyBookDialog";
+
+beforeAll(() => {
+  // @ts-expect-error - global defined by Vite
+  globalThis.__APP_VERSION__ = "test";
+});
+
+// Silence the act() warnings that async query resolution triggers in jsdom.
+const originalConsoleError = console.error;
+beforeAll(() => {
+  console.error = (...args: unknown[]) => {
+    if (
+      typeof args[0] === "string" &&
+      args[0].includes("was not wrapped in act")
+    ) {
+      return;
+    }
+    originalConsoleError(...args);
+  };
+});
+afterAll(() => {
+  console.error = originalConsoleError;
+});
+
+// Mock the ancillary plugin hooks so they don't hit the network, but leave
+// usePluginSearch (the hook under test) using its real implementation against
+// the mocked API.request below.
+vi.mock("@/hooks/queries/plugins", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/queries/plugins")
+  >("@/hooks/queries/plugins");
+  return {
+    ...actual,
+    usePluginIdentifierTypes: () => ({ data: [] }),
+    usePluginOrder: () => ({ data: [{ scope: "shisho", id: "test" }] }),
+  };
+});
+
+// Deferred-promise harness keyed by the query string in the search payload.
+// Lets a test resolve searches out of submission order.
+type Deferred = {
+  resolve: (value: PluginSearchResponse) => void;
+  promise: Promise<PluginSearchResponse>;
+};
+const deferredsByQuery = new Map<string, Deferred>();
+function deferredFor(query: string): Deferred {
+  let d = deferredsByQuery.get(query);
+  if (!d) {
+    let resolve!: (value: PluginSearchResponse) => void;
+    const promise = new Promise<PluginSearchResponse>((res) => {
+      resolve = res;
+    });
+    d = { resolve, promise };
+    deferredsByQuery.set(query, d);
+  }
+  return d;
+}
+
+const requestMock = vi.fn();
+vi.mock("@/libraries/api", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/libraries/api")>("@/libraries/api");
+  return {
+    ...actual,
+    API: {
+      request: (...args: unknown[]) => requestMock(...args),
+    },
+  };
+});
+
+const createUser = () =>
+  userEvent.setup({
+    advanceTimers: vi.advanceTimersByTime,
+    delay: null,
+  });
+
+function makeFile(overrides: Partial<File> = {}): File {
+  return {
+    id: 1,
+    book_id: 1,
+    library_id: 1,
+    filepath: "/test/book.epub",
+    file_type: FileTypeEPUB,
+    file_role: FileRoleMain,
+    filesize_bytes: 1000,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    narrators: [],
+    identifiers: [],
+    ...overrides,
+  } as File;
+}
+
+function makeBook(overrides: Partial<Book> = {}): Book {
+  return {
+    id: 1,
+    library_id: 1,
+    filepath: "/test/book.epub",
+    title: "Query A",
+    title_source: DataSourceManual,
+    sort_title: "",
+    sort_title_source: DataSourceManual,
+    author_source: DataSourceManual,
+    authors: [],
+    files: [makeFile()],
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  } as Book;
+}
+
+function response(title: string): PluginSearchResponse {
+  return {
+    results: [
+      {
+        title,
+        plugin_scope: "shisho",
+        plugin_id: "test",
+      },
+    ],
+    total_plugins: 1,
+  };
+}
+
+function renderDialog(book: Book) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+  const onOpenChange = vi.fn();
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <IdentifyBookDialog book={book} onOpenChange={onOpenChange} open />
+    </QueryClientProvider>,
+  );
+  return { ...view, onOpenChange };
+}
+
+describe("IdentifyBookDialog search sequencing", () => {
+  beforeEach(() => {
+    deferredsByQuery.clear();
+    requestMock.mockReset();
+    // Each /plugins/search call returns the deferred keyed by its query, so
+    // the test controls resolution order. The query's AbortSignal is the last
+    // arg; record it so we can assert supersession cancels the older request.
+    requestMock.mockImplementation(
+      (
+        _method: string,
+        path: string,
+        payload: { query: string } | null,
+        _query: unknown,
+        signal?: AbortSignal,
+      ) => {
+        if (path === "/plugins/search" && payload) {
+          const d = deferredFor(payload.query);
+          // Reject (abort) when the query's signal fires so a superseded
+          // request settles as cancelled instead of resolving stale data.
+          return new Promise<PluginSearchResponse>((resolve, reject) => {
+            d.promise.then(resolve);
+            signal?.addEventListener("abort", () =>
+              reject(new DOMException("aborted", "AbortError")),
+            );
+          });
+        }
+        return Promise.resolve(null);
+      },
+    );
+  });
+
+  it("renders the most-recently-submitted query's results even when an earlier search resolves last", async () => {
+    const user = createUser();
+    // Opening the dialog auto-searches "Query A".
+    renderDialog(makeBook({ title: "Query A" }));
+
+    // Wait for the auto-search request to fire.
+    await waitFor(() =>
+      expect(requestMock).toHaveBeenCalledWith(
+        "POST",
+        "/plugins/search",
+        expect.objectContaining({ query: "Query A" }),
+        null,
+        expect.anything(),
+      ),
+    );
+
+    // Submit a new query "Query B" while "Query A" is still in flight.
+    const input = screen.getByPlaceholderText(/Search by title/i);
+    await user.clear(input);
+    await user.type(input, "Query B");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() =>
+      expect(requestMock).toHaveBeenCalledWith(
+        "POST",
+        "/plugins/search",
+        expect.objectContaining({ query: "Query B" }),
+        null,
+        expect.anything(),
+      ),
+    );
+
+    // Resolve B first, then resolve the superseded A LAST.
+    deferredFor("Query B").resolve(response("Result B"));
+    await waitFor(() =>
+      expect(screen.getByText("Result B")).toBeInTheDocument(),
+    );
+
+    deferredFor("Query A").resolve(response("Result A"));
+
+    // The stale A result must never replace B's results.
+    await waitFor(() => {
+      expect(screen.getByText("Result B")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Result A")).not.toBeInTheDocument();
+  });
+
+  it("aborts the superseded request when a newer search is submitted", async () => {
+    const user = createUser();
+    renderDialog(makeBook({ title: "Query A" }));
+
+    let abortedA = false;
+    await waitFor(() => expect(requestMock).toHaveBeenCalled());
+    // Find the AbortSignal handed to the first (auto-search) request and watch
+    // it for abort.
+    const firstCall = requestMock.mock.calls.find(
+      (c) => (c[2] as { query?: string })?.query === "Query A",
+    );
+    const signalA = firstCall?.[4] as AbortSignal | undefined;
+    expect(signalA).toBeInstanceOf(AbortSignal);
+    signalA?.addEventListener("abort", () => {
+      abortedA = true;
+    });
+
+    const input = screen.getByPlaceholderText(/Search by title/i);
+    await user.clear(input);
+    await user.type(input, "Query B");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => expect(abortedA).toBe(true));
+  });
+});

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -1,3 +1,4 @@
+import equal from "fast-deep-equal";
 import { AlertTriangle, ExternalLink, Loader2, Search, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -19,6 +20,7 @@ import {
   usePluginIdentifierTypes,
   usePluginOrder,
   usePluginSearch,
+  type PluginSearchParams,
   type PluginSearchResult,
 } from "@/hooks/queries/plugins";
 import { cn } from "@/libraries/utils";
@@ -60,12 +62,17 @@ export function IdentifyBookDialog({
     undefined,
   );
   const [reviewHasChanges, setReviewHasChanges] = useState(false);
-  const searchMutation = usePluginSearch();
+  // The submitted-search snapshot, distinct from the live input fields above.
+  // Every trigger point (auto-search on open, Enter/click, file selector) sets
+  // this rather than imperatively firing a request; the query is keyed on it so
+  // a new submission supersedes (and aborts) any in-flight search.
+  const [submittedParams, setSubmittedParams] =
+    useState<PluginSearchParams | null>(null);
+  const searchQuery = usePluginSearch(submittedParams);
   const { data: pluginIdentifierTypes } = usePluginIdentifierTypes();
   const { data: enricherPlugins } = usePluginOrder(PluginHookMetadataEnricher);
   const hasEnricherPlugins = (enricherPlugins?.length ?? 0) > 0;
   const inputRef = useRef<HTMLInputElement>(null);
-  const hasSearchedRef = useRef(false);
   const queryUserTouched = useRef(false);
 
   const mainFiles = useMemo(
@@ -79,12 +86,25 @@ export function IdentifyBookDialog({
     : pickInitialFile(book);
   const isAudiobook = selectedFile?.file_type === "m4b";
 
+  // Submit a search. Setting a new (distinct) snapshot supersedes any in-flight
+  // query and aborts it. For an identical re-submit (same snapshot) the query
+  // key is unchanged, so explicitly refetch — pressing Search/Enter must always
+  // produce visible loading feedback rather than being a silent no-op, while
+  // distinct keys (and dialog re-opens) still benefit from caching.
+  const submitSearch = (params: PluginSearchParams) => {
+    setSelectedResult(null);
+    if (equal(params, submittedParams)) {
+      searchQuery.refetch();
+    } else {
+      setSubmittedParams(params);
+    }
+  };
+
   // Pre-fill form and auto-search when dialog opens
   useEffect(() => {
     if (open) {
       setStep("search");
       setSelectedResult(null);
-      hasSearchedRef.current = false;
       queryUserTouched.current = false;
 
       const initialFile = pickInitialFile(book);
@@ -104,24 +124,27 @@ export function IdentifyBookDialog({
       setIdentifiers(initialIds);
       setSelectedFileId(initialFileId);
 
-      if (initialQuery) {
-        hasSearchedRef.current = true;
-        searchMutation.mutate({
-          query: initialQuery,
-          bookId: book.id,
-          fileId: initialFileId,
-          author: initialAuthor || undefined,
-          identifiers: initialIds.length > 0 ? initialIds : undefined,
-        });
-      }
+      // Setting the snapshot drives the query; a structurally-equal snapshot
+      // from a previous open hits the cache (same query key) instead of
+      // refetching.
+      setSubmittedParams(
+        initialQuery
+          ? {
+              query: initialQuery,
+              bookId: book.id,
+              fileId: initialFileId,
+              author: initialAuthor || undefined,
+              identifiers: initialIds.length > 0 ? initialIds : undefined,
+            }
+          : null,
+      );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, book.title, book.authors, book.files, mainFiles]);
 
   const handleSearch = () => {
     if (!query.trim()) return;
-    setSelectedResult(null);
-    searchMutation.mutate({
+    submitSearch({
       query: query.trim(),
       bookId: book.id,
       fileId: selectedFileId,
@@ -131,20 +154,25 @@ export function IdentifyBookDialog({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !searchMutation.isPending) {
+    if (e.key === "Enter") {
       handleSearch();
     }
   };
 
-  const results = searchMutation.data?.results ?? [];
-  const pluginErrors = searchMutation.data?.errors ?? [];
-  const skippedPlugins = searchMutation.data?.skipped_plugins ?? [];
-  const totalPlugins = searchMutation.data?.total_plugins ?? 0;
+  // isFetching is true across new-key loads, identical-resubmit refetches, and
+  // stale-key background refetches — the full set of "a search is running"
+  // states. It drives the loading indicator and the dimming/disabling of any
+  // results kept on screen via keepPreviousData.
+  const isSearching = searchQuery.isFetching;
+  const results = searchQuery.data?.results ?? [];
+  const pluginErrors = searchQuery.data?.errors ?? [];
+  const skippedPlugins = searchQuery.data?.skipped_plugins ?? [];
+  const totalPlugins = searchQuery.data?.total_plugins ?? 0;
   const selectedFileType = selectedFile?.file_type;
 
   // Detect plugin IDs that appear under multiple scopes
   const ambiguousIds = useMemo(() => {
-    const items = searchMutation.data?.results ?? [];
+    const items = searchQuery.data?.results ?? [];
     const scopesByPluginId = new Map<string, Set<string>>();
     for (const r of items) {
       const scopes = scopesByPluginId.get(r.plugin_id) ?? new Set();
@@ -156,7 +184,7 @@ export function IdentifyBookDialog({
       if (scopes.size > 1) ids.add(id);
     }
     return ids;
-  }, [searchMutation.data?.results]);
+  }, [searchQuery.data?.results]);
 
   const pluginLabel = (result: PluginSearchResult) =>
     ambiguousIds.has(result.plugin_id)
@@ -233,9 +261,7 @@ export function IdentifyBookDialog({
                           const fileTitle =
                             file.name || getFilename(file.filepath);
                           setQuery(fileTitle);
-                          setSelectedResult(null);
-                          searchMutation.reset();
-                          searchMutation.mutate({
+                          submitSearch({
                             query: fileTitle,
                             bookId: book.id,
                             fileId: file.id,
@@ -295,11 +321,11 @@ export function IdentifyBookDialog({
                 value={query}
               />
               <Button
-                disabled={searchMutation.isPending || !query.trim()}
+                disabled={!query.trim()}
                 onClick={handleSearch}
                 variant="outline"
               >
-                {searchMutation.isPending ? (
+                {isSearching ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
                   <Search className="h-4 w-4" />
@@ -356,218 +382,253 @@ export function IdentifyBookDialog({
               )}
             </div>
 
-            {/* Results */}
-            <div className="min-h-[200px] max-h-[60vh] overflow-y-auto">
-              {searchMutation.isPending && (
+            {/* Results. While a search is in flight, any prior results stay
+                mounted (keepPreviousData) but are dimmed and made
+                non-interactive, with a loading indicator pinned to a stable
+                spot, so a stale result can't be selected mid-search. The very
+                first search has no prior data, so it shows the centered spinner
+                alone. */}
+            <div className="relative min-h-[200px] max-h-[60vh] overflow-y-auto">
+              {isSearching && !searchQuery.data && (
                 <div className="flex items-center justify-center py-12">
                   <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                 </div>
               )}
 
-              {searchMutation.isSuccess && pluginErrors.length > 0 && (
-                <div className="mb-3 space-y-2">
-                  {pluginErrors.map((err) => (
-                    <div
-                      className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2.5 text-xs"
-                      key={`${err.plugin_scope}-${err.plugin_id}`}
-                    >
-                      <AlertTriangle className="h-4 w-4 shrink-0 text-destructive mt-0.5" />
-                      <div className="min-w-0 flex-1">
-                        <p className="font-medium text-destructive">
-                          {err.plugin_name || err.plugin_id} failed
-                        </p>
-                        <p
-                          className="text-muted-foreground break-words"
-                          title={err.message}
-                        >
-                          {err.message}
-                        </p>
-                      </div>
-                    </div>
-                  ))}
+              {isSearching && searchQuery.data && (
+                <div className="pointer-events-none sticky top-0 z-10 flex items-center justify-center py-2">
+                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                 </div>
               )}
 
-              {searchMutation.isSuccess &&
-                results.length === 0 &&
-                pluginErrors.length === 0 &&
-                (() => {
-                  const message = computeIdentifyEmptyState({
-                    hasEnricherPlugins,
-                    totalPlugins,
-                    skippedPlugins,
-                    fileType: selectedFileType,
-                  });
-                  return (
-                    <div className="text-center py-12 text-muted-foreground space-y-2">
-                      <p>No results found.</p>
-                      <p className="text-xs">{message.primary}</p>
-                      {message.secondary && (
-                        <p className="text-xs">{message.secondary}</p>
-                      )}
-                    </div>
-                  );
-                })()}
+              <div
+                className={cn(
+                  isSearching &&
+                    searchQuery.data &&
+                    "pointer-events-none opacity-50",
+                )}
+              >
+                {searchQuery.isSuccess && pluginErrors.length > 0 && (
+                  <div className="mb-3 space-y-2">
+                    {pluginErrors.map((err) => (
+                      <div
+                        className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-2.5 text-xs"
+                        key={`${err.plugin_scope}-${err.plugin_id}`}
+                      >
+                        <AlertTriangle className="h-4 w-4 shrink-0 text-destructive mt-0.5" />
+                        <div className="min-w-0 flex-1">
+                          <p className="font-medium text-destructive">
+                            {err.plugin_name || err.plugin_id} failed
+                          </p>
+                          <p
+                            className="text-muted-foreground break-words"
+                            title={err.message}
+                          >
+                            {err.message}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
 
-              {searchMutation.isSuccess && results.length > 0 && (
-                <div className="space-y-2">
-                  {results.map((result, index) => (
-                    <button
-                      className={cn(
-                        "w-full text-left rounded-lg border-2 p-3 cursor-pointer transition-colors",
-                        "hover:bg-muted/50",
-                        selectedResult === result
-                          ? "border-primary bg-primary/5"
-                          : "border-border",
-                      )}
-                      key={`${result.plugin_scope}-${result.plugin_id}-${index}`}
-                      onClick={() => handleSelectResult(result)}
-                      type="button"
-                    >
-                      <div className="flex gap-3">
-                        {/* Cover thumbnail */}
-                        <ResultCoverThumbnail
-                          coverPage={result.cover_page}
-                          coverUrl={result.cover_url}
-                          isAudiobook={isAudiobook}
-                          previewFileId={selectedFileId ?? selectedFile?.id}
-                          previewFileType={selectedFileType}
-                          previewPageCount={selectedFile?.page_count}
-                        />
+                {searchQuery.isSuccess &&
+                  results.length === 0 &&
+                  pluginErrors.length === 0 &&
+                  (() => {
+                    const message = computeIdentifyEmptyState({
+                      hasEnricherPlugins,
+                      totalPlugins,
+                      skippedPlugins,
+                      fileType: selectedFileType,
+                    });
+                    return (
+                      <div className="text-center py-12 text-muted-foreground space-y-2">
+                        <p>No results found.</p>
+                        <p className="text-xs">{message.primary}</p>
+                        {message.secondary && (
+                          <p className="text-xs">{message.secondary}</p>
+                        )}
+                      </div>
+                    );
+                  })()}
 
-                        {/* Details */}
-                        <div className="flex-1 min-w-0">
-                          {/* Zone 1: Identity */}
-                          <div>
-                            {/* Title + subtitle + badges */}
-                            <div className="flex items-start justify-between gap-4">
-                              <div className="min-w-0 flex-1">
-                                <p className="font-medium leading-tight">
-                                  {result.title}
-                                </p>
-                                {result.subtitle && (
-                                  <p className="text-sm text-muted-foreground/80 leading-tight mt-0.5">
-                                    {result.subtitle}
+                {searchQuery.isSuccess && results.length > 0 && (
+                  <div className="space-y-2">
+                    {results.map((result, index) => (
+                      <button
+                        className={cn(
+                          "w-full text-left rounded-lg border-2 p-3 cursor-pointer transition-colors",
+                          "hover:bg-muted/50",
+                          selectedResult === result
+                            ? "border-primary bg-primary/5"
+                            : "border-border",
+                        )}
+                        key={`${result.plugin_scope}-${result.plugin_id}-${index}`}
+                        onClick={() => handleSelectResult(result)}
+                        type="button"
+                      >
+                        <div className="flex gap-3">
+                          {/* Cover thumbnail */}
+                          <ResultCoverThumbnail
+                            coverPage={result.cover_page}
+                            coverUrl={result.cover_url}
+                            isAudiobook={isAudiobook}
+                            previewFileId={selectedFileId ?? selectedFile?.id}
+                            previewFileType={selectedFileType}
+                            previewPageCount={selectedFile?.page_count}
+                          />
+
+                          {/* Details */}
+                          <div className="flex-1 min-w-0">
+                            {/* Zone 1: Identity */}
+                            <div>
+                              {/* Title + subtitle + badges */}
+                              <div className="flex items-start justify-between gap-4">
+                                <div className="min-w-0 flex-1">
+                                  <p className="font-medium leading-tight">
+                                    {result.title}
                                   </p>
-                                )}
-                                {result.series && (
-                                  <p className="text-xs text-muted-foreground font-medium mt-0.5">
-                                    {result.series}
-                                    {result.series_number != null &&
-                                      ` ${formatSeriesNumber(result.series_number, result.series_number_unit, selectedFileType)}`}
-                                  </p>
-                                )}
-                              </div>
-                              <div className="flex items-center gap-1 shrink-0">
-                                {result.confidence != null && (
-                                  <Badge
-                                    className={cn(
-                                      "text-xs",
-                                      result.confidence >= 0.9
-                                        ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
-                                        : result.confidence >= 0.7
-                                          ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
-                                          : "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-                                    )}
-                                    variant="secondary"
-                                  >
-                                    {Math.round(result.confidence * 100)}%
+                                  {result.subtitle && (
+                                    <p className="text-sm text-muted-foreground/80 leading-tight mt-0.5">
+                                      {result.subtitle}
+                                    </p>
+                                  )}
+                                  {result.series && (
+                                    <p className="text-xs text-muted-foreground font-medium mt-0.5">
+                                      {result.series}
+                                      {result.series_number != null &&
+                                        ` ${formatSeriesNumber(result.series_number, result.series_number_unit, selectedFileType)}`}
+                                    </p>
+                                  )}
+                                </div>
+                                <div className="flex items-center gap-1 shrink-0">
+                                  {result.confidence != null && (
+                                    <Badge
+                                      className={cn(
+                                        "text-xs",
+                                        result.confidence >= 0.9
+                                          ? "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400"
+                                          : result.confidence >= 0.7
+                                            ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400"
+                                            : "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+                                      )}
+                                      variant="secondary"
+                                    >
+                                      {Math.round(result.confidence * 100)}%
+                                    </Badge>
+                                  )}
+                                  <Badge className="text-xs" variant="outline">
+                                    {pluginLabel(result)}
                                   </Badge>
-                                )}
-                                <Badge className="text-xs" variant="outline">
-                                  {pluginLabel(result)}
-                                </Badge>
+                                </div>
                               </div>
+
+                              {/* People */}
+                              {(() => {
+                                const authors = resolveAuthors(result);
+                                const narrators = result.narrators;
+                                const hasAuthors =
+                                  authors && authors.length > 0;
+                                const hasNarrators =
+                                  narrators && narrators.length > 0;
+                                return hasAuthors || hasNarrators ? (
+                                  <div className="mt-2 space-y-0.5">
+                                    {hasAuthors && (
+                                      <p className="text-sm text-muted-foreground">
+                                        {authors}
+                                      </p>
+                                    )}
+                                    {hasNarrators && (
+                                      <p className="text-xs text-muted-foreground">
+                                        Narrated by {narrators.join(", ")}
+                                      </p>
+                                    )}
+                                  </div>
+                                ) : null;
+                              })()}
+
+                              {/* Date + publisher + language + abridged */}
+                              {(() => {
+                                const metaItems: string[] = [];
+                                if (result.release_date) {
+                                  metaItems.push(
+                                    formatDate(result.release_date),
+                                  );
+                                }
+                                if (result.publisher) {
+                                  metaItems.push(result.publisher);
+                                }
+                                if (result.language) {
+                                  metaItems.push(
+                                    getLanguageName(result.language) ||
+                                      result.language,
+                                  );
+                                }
+                                if (result.abridged != null) {
+                                  metaItems.push(
+                                    result.abridged ? "Abridged" : "Unabridged",
+                                  );
+                                }
+                                return metaItems.length > 0 ? (
+                                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground/80 mt-2">
+                                    {metaItems.map((item, i) => (
+                                      <span
+                                        className="flex items-center gap-x-2"
+                                        key={`${i}-${item}`}
+                                      >
+                                        {i > 0 && (
+                                          <span className="text-muted-foreground/50">
+                                            ·
+                                          </span>
+                                        )}
+                                        <span>{item}</span>
+                                      </span>
+                                    ))}
+                                  </div>
+                                ) : null;
+                              })()}
                             </div>
 
-                            {/* People */}
-                            {(() => {
-                              const authors = resolveAuthors(result);
-                              const narrators = result.narrators;
-                              const hasAuthors = authors && authors.length > 0;
-                              const hasNarrators =
-                                narrators && narrators.length > 0;
-                              return hasAuthors || hasNarrators ? (
-                                <div className="mt-2 space-y-0.5">
-                                  {hasAuthors && (
-                                    <p className="text-sm text-muted-foreground">
-                                      {authors}
-                                    </p>
-                                  )}
-                                  {hasNarrators && (
-                                    <p className="text-xs text-muted-foreground">
-                                      Narrated by {narrators.join(", ")}
-                                    </p>
-                                  )}
-                                </div>
-                              ) : null;
-                            })()}
-
-                            {/* Date + publisher + language + abridged */}
-                            {(() => {
-                              const metaItems: string[] = [];
-                              if (result.release_date) {
-                                metaItems.push(formatDate(result.release_date));
-                              }
-                              if (result.publisher) {
-                                metaItems.push(result.publisher);
-                              }
-                              if (result.language) {
-                                metaItems.push(
-                                  getLanguageName(result.language) ||
-                                    result.language,
-                                );
-                              }
-                              if (result.abridged != null) {
-                                metaItems.push(
-                                  result.abridged ? "Abridged" : "Unabridged",
-                                );
-                              }
-                              return metaItems.length > 0 ? (
-                                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground/80 mt-2">
-                                  {metaItems.map((item, i) => (
-                                    <span
-                                      className="flex items-center gap-x-2"
-                                      key={`${i}-${item}`}
-                                    >
-                                      {i > 0 && (
-                                        <span className="text-muted-foreground/50">
-                                          ·
-                                        </span>
-                                      )}
-                                      <span>{item}</span>
-                                    </span>
-                                  ))}
-                                </div>
-                              ) : null;
-                            })()}
-                          </div>
-
-                          {/* Zone 2: Identifiers */}
-                          {result.identifiers &&
-                            result.identifiers.filter(
-                              (id) => id.type && id.value,
-                            ).length > 0 && (
-                              <div className="flex flex-wrap gap-1 mt-2.5">
-                                {result.identifiers
-                                  .filter((id) => id.type && id.value)
-                                  .map((id) => {
-                                    const url = getIdentifierUrl(
-                                      id.type,
-                                      id.value,
-                                      pluginIdentifierTypes,
-                                    );
-                                    return url ? (
-                                      <a
-                                        className="inline-flex"
-                                        href={url}
-                                        key={`${id.type}-${id.value}`}
-                                        onClick={(e) => e.stopPropagation()}
-                                        rel="noopener noreferrer"
-                                        target="_blank"
-                                      >
+                            {/* Zone 2: Identifiers */}
+                            {result.identifiers &&
+                              result.identifiers.filter(
+                                (id) => id.type && id.value,
+                              ).length > 0 && (
+                                <div className="flex flex-wrap gap-1 mt-2.5">
+                                  {result.identifiers
+                                    .filter((id) => id.type && id.value)
+                                    .map((id) => {
+                                      const url = getIdentifierUrl(
+                                        id.type,
+                                        id.value,
+                                        pluginIdentifierTypes,
+                                      );
+                                      return url ? (
+                                        <a
+                                          className="inline-flex"
+                                          href={url}
+                                          key={`${id.type}-${id.value}`}
+                                          onClick={(e) => e.stopPropagation()}
+                                          rel="noopener noreferrer"
+                                          target="_blank"
+                                        >
+                                          <Badge
+                                            className="text-xs hover:bg-primary/20 transition-colors"
+                                            variant="secondary"
+                                          >
+                                            {formatIdentifierType(
+                                              id.type,
+                                              pluginIdentifierTypes,
+                                            )}
+                                            : {id.value}
+                                            <ExternalLink className="h-3 w-3 ml-1 shrink-0" />
+                                          </Badge>
+                                        </a>
+                                      ) : (
                                         <Badge
-                                          className="text-xs hover:bg-primary/20 transition-colors"
+                                          className="text-xs"
+                                          key={`${id.type}-${id.value}`}
                                           variant="secondary"
                                         >
                                           {formatIdentifierType(
@@ -575,86 +636,73 @@ export function IdentifyBookDialog({
                                             pluginIdentifierTypes,
                                           )}
                                           : {id.value}
-                                          <ExternalLink className="h-3 w-3 ml-1 shrink-0" />
                                         </Badge>
-                                      </a>
-                                    ) : (
-                                      <Badge
-                                        className="text-xs"
-                                        key={`${id.type}-${id.value}`}
-                                        variant="secondary"
-                                      >
-                                        {formatIdentifierType(
-                                          id.type,
-                                          pluginIdentifierTypes,
-                                        )}
-                                        : {id.value}
-                                      </Badge>
-                                    );
-                                  })}
-                              </div>
+                                      );
+                                    })}
+                                </div>
+                              )}
+
+                            {/* Zone 3: Taxonomy */}
+                            {(() => {
+                              const genres = result.genres ?? [];
+                              const tags = result.tags ?? [];
+                              return genres.length > 0 || tags.length > 0 ? (
+                                <div className="mt-2.5 space-y-1">
+                                  {genres.length > 0 && (
+                                    <div className="flex flex-wrap items-center gap-1">
+                                      <span className="text-[0.65rem] uppercase tracking-wide font-medium text-muted-foreground/50 mr-1">
+                                        Genres
+                                      </span>
+                                      {genres.map((g) => (
+                                        <Badge
+                                          className="text-xs"
+                                          key={`genre-${g}`}
+                                          variant="outline"
+                                        >
+                                          {g}
+                                        </Badge>
+                                      ))}
+                                    </div>
+                                  )}
+                                  {tags.length > 0 && (
+                                    <div className="flex flex-wrap items-center gap-1">
+                                      <span className="text-[0.65rem] uppercase tracking-wide font-medium text-muted-foreground/50 mr-1">
+                                        Tags
+                                      </span>
+                                      {tags.map((tag) => (
+                                        <Badge
+                                          className="text-xs"
+                                          key={`tag-${tag}`}
+                                          variant="outline"
+                                        >
+                                          {tag}
+                                        </Badge>
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
+                              ) : null;
+                            })()}
+
+                            {/* Zone 4: Description */}
+                            {result.description && (
+                              <p className="text-xs text-muted-foreground line-clamp-3 whitespace-pre-line mt-2.5">
+                                {result.description}
+                              </p>
                             )}
-
-                          {/* Zone 3: Taxonomy */}
-                          {(() => {
-                            const genres = result.genres ?? [];
-                            const tags = result.tags ?? [];
-                            return genres.length > 0 || tags.length > 0 ? (
-                              <div className="mt-2.5 space-y-1">
-                                {genres.length > 0 && (
-                                  <div className="flex flex-wrap items-center gap-1">
-                                    <span className="text-[0.65rem] uppercase tracking-wide font-medium text-muted-foreground/50 mr-1">
-                                      Genres
-                                    </span>
-                                    {genres.map((g) => (
-                                      <Badge
-                                        className="text-xs"
-                                        key={`genre-${g}`}
-                                        variant="outline"
-                                      >
-                                        {g}
-                                      </Badge>
-                                    ))}
-                                  </div>
-                                )}
-                                {tags.length > 0 && (
-                                  <div className="flex flex-wrap items-center gap-1">
-                                    <span className="text-[0.65rem] uppercase tracking-wide font-medium text-muted-foreground/50 mr-1">
-                                      Tags
-                                    </span>
-                                    {tags.map((tag) => (
-                                      <Badge
-                                        className="text-xs"
-                                        key={`tag-${tag}`}
-                                        variant="outline"
-                                      >
-                                        {tag}
-                                      </Badge>
-                                    ))}
-                                  </div>
-                                )}
-                              </div>
-                            ) : null;
-                          })()}
-
-                          {/* Zone 4: Description */}
-                          {result.description && (
-                            <p className="text-xs text-muted-foreground line-clamp-3 whitespace-pre-line mt-2.5">
-                              {result.description}
-                            </p>
-                          )}
+                          </div>
                         </div>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              )}
+                      </button>
+                    ))}
+                  </div>
+                )}
 
-              {searchMutation.isError && (
-                <div className="text-center py-12 text-destructive">
-                  Search failed. Please try again.
-                </div>
-              )}
+                {searchQuery.isError && (
+                  <div className="text-center py-12 text-destructive">
+                    Search failed. Please try again.
+                  </div>
+                )}
+              </div>
             </div>
           </DialogBody>
         )}

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -88,7 +88,7 @@ export function IdentifyBookDialog({
 
   // Submit a search. Setting a new (distinct) snapshot supersedes any in-flight
   // query and aborts it. For an identical re-submit (same snapshot) the query
-  // key is unchanged, so explicitly refetch — pressing Search/Enter must always
+  // key is unchanged, so explicitly refetch. Pressing Search/Enter must always
   // produce visible loading feedback rather than being a silent no-op, while
   // distinct keys (and dialog re-opens) still benefit from caching.
   const submitSearch = (params: PluginSearchParams) => {
@@ -160,7 +160,7 @@ export function IdentifyBookDialog({
   };
 
   // isFetching is true across new-key loads, identical-resubmit refetches, and
-  // stale-key background refetches — the full set of "a search is running"
+  // stale-key background refetches: the full set of "a search is running"
   // states. It drives the loading indicator and the dimming/disabling of any
   // results kept on screen via keepPreviousData.
   const isSearching = searchQuery.isFetching;

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -1,4 +1,5 @@
 import {
+  keepPreviousData,
   useMutation,
   useQueries,
   useQuery,
@@ -106,6 +107,7 @@ export enum QueryKey {
   PluginOrder = "PluginOrder",
   PluginRepositories = "PluginRepositories",
   PluginIdentifierTypes = "PluginIdentifierTypes",
+  PluginSearch = "PluginSearch",
 }
 
 // --- Queries ---
@@ -691,27 +693,54 @@ export interface PluginSearchResponse {
   total_plugins?: number;
 }
 
-export const usePluginSearch = () => {
-  return useMutation<
-    PluginSearchResponse,
-    ShishoAPIError,
-    {
-      query: string;
-      bookId: number;
-      fileId?: number;
-      author?: string;
-      identifiers?: Array<{ type: string; value: string }>;
-    }
-  >({
-    mutationFn: ({ query, bookId, fileId, author, identifiers }) => {
-      return API.request<PluginSearchResponse>("POST", "/plugins/search", {
-        query,
-        book_id: bookId,
-        file_id: fileId,
-        author: author || undefined,
-        identifiers: identifiers?.length ? identifiers : undefined,
-      });
+// PluginSearchParams is the immutable snapshot of a submitted Identify search.
+// The dialog holds one of these (distinct from the live input fields) and the
+// query is keyed on it, so submitting a new search supersedes any in-flight
+// one: TanStack Query aborts the previous query's request (via its signal) and
+// the displayed results are always those of the most recently submitted key.
+export interface PluginSearchParams {
+  query: string;
+  bookId: number;
+  fileId?: number;
+  author?: string;
+  identifiers?: Array<{ type: string; value: string }>;
+}
+
+// usePluginSearch models the Identify search as a query (not a mutation): the
+// backend POST /plugins/search performs no writes to Shisho state — it only
+// fans out to plugins — so it's semantically a read. As a query it gets request
+// sequencing and an AbortSignal for free (a mutation's mutationFn gets neither
+// in TanStack Query v5). The POST method and request payload shape are
+// unchanged. `params` is null until a search has been submitted; the query is
+// disabled until there's a non-empty query string.
+//
+// `placeholderData: keepPreviousData` keeps the previous key's results mounted
+// while a new search loads, avoiding a dialog resize. Loading/dimming is driven
+// off `isFetching` by the caller, not `isPlaceholderData` — `isFetching` is
+// true across new-key loads, identical-resubmit refetches, and stale-key
+// background refetches, whereas `isPlaceholderData` misses the latter two.
+export const usePluginSearch = (params: PluginSearchParams | null) => {
+  return useQuery<PluginSearchResponse, ShishoAPIError>({
+    enabled: Boolean(params && params.query),
+    queryKey: [QueryKey.PluginSearch, params],
+    queryFn: ({ signal }) => {
+      // params is non-null here because the query is disabled otherwise.
+      const p = params as PluginSearchParams;
+      return API.request<PluginSearchResponse>(
+        "POST",
+        "/plugins/search",
+        {
+          query: p.query,
+          book_id: p.bookId,
+          file_id: p.fileId,
+          author: p.author || undefined,
+          identifiers: p.identifiers?.length ? p.identifiers : undefined,
+        },
+        null,
+        signal,
+      );
     },
+    placeholderData: keepPreviousData,
   });
 };
 

--- a/app/hooks/queries/plugins.ts
+++ b/app/hooks/queries/plugins.ts
@@ -707,8 +707,8 @@ export interface PluginSearchParams {
 }
 
 // usePluginSearch models the Identify search as a query (not a mutation): the
-// backend POST /plugins/search performs no writes to Shisho state — it only
-// fans out to plugins — so it's semantically a read. As a query it gets request
+// backend POST /plugins/search performs no writes to Shisho state (it only
+// fans out to plugins), so it's semantically a read. As a query it gets request
 // sequencing and an AbortSignal for free (a mutation's mutationFn gets neither
 // in TanStack Query v5). The POST method and request payload shape are
 // unchanged. `params` is null until a search has been submitted; the query is
@@ -716,7 +716,7 @@ export interface PluginSearchParams {
 //
 // `placeholderData: keepPreviousData` keeps the previous key's results mounted
 // while a new search loads, avoiding a dialog resize. Loading/dimming is driven
-// off `isFetching` by the caller, not `isPlaceholderData` — `isFetching` is
+// off `isFetching` by the caller, not `isPlaceholderData`. `isFetching` is
 // true across new-key loads, identical-resubmit refetches, and stale-key
 // background refetches, whereas `isPlaceholderData` misses the latter two.
 export const usePluginSearch = (params: PluginSearchParams | null) => {

--- a/pkg/plugins/handler_enrich.go
+++ b/pkg/plugins/handler_enrich.go
@@ -210,12 +210,12 @@ type enricherRuntime interface {
 // aggregates the results, per-plugin errors, and file-type skips.
 //
 // It checks the request context for cancellation before invoking each plugin
-// and stops early when the client has gone away — there is no point fanning
-// out to the remaining plugins (and their outbound API calls) for a search the
-// client has already superseded. A per-plugin failure that is itself caused by
-// client cancellation (context.Canceled) is dropped rather than reported as a
-// plugin failure or logged as a warning; a genuine per-plugin timeout
-// (context.DeadlineExceeded) is still reported.
+// and stops early when the client has gone away, since there is no point
+// fanning out to the remaining plugins (and their outbound API calls) for a
+// search the client has already superseded. A per-plugin failure that is
+// itself caused by client cancellation (context.Canceled) is dropped rather
+// than reported as a plugin failure or logged as a warning; a genuine
+// per-plugin timeout (context.DeadlineExceeded) is still reported.
 func aggregateEnricherSearches[T enricherRuntime](
 	ctx context.Context,
 	runtimes []T,
@@ -259,7 +259,7 @@ func aggregateEnricherSearches[T enricherRuntime](
 		resp, sErr := runSearch(ctx, rt)
 		if sErr != nil {
 			// Don't report a per-plugin failure that's just the client
-			// cancelling the request — it's not a plugin malfunction, and
+			// cancelling the request, since it's not a plugin malfunction, and
 			// logging it would be noise. A genuine deadline timeout is a real
 			// failure and is still reported.
 			if errors.Is(sErr, context.Canceled) {

--- a/pkg/plugins/handler_enrich.go
+++ b/pkg/plugins/handler_enrich.go
@@ -165,12 +165,75 @@ func (h *handler) searchMetadata(c echo.Context) error {
 	}
 
 	log := logger.FromContext(ctx)
-	allResults := make([]EnrichSearchResult, 0)
-	var pluginErrors []PluginSearchError
-	var skippedPlugins []PluginSearchSkipped
-	for _, rt := range runtimes {
+	runSearch := func(ctx context.Context, rt *Runtime) (*SearchResponse, error) {
+		return h.manager.RunMetadataSearch(ctx, rt, searchCtx, targetFilePath)
+	}
+	disabledFields := func(ctx context.Context, rt *Runtime) []string {
 		manifest := rt.Manifest()
-		// Skip plugins that don't handle this file type
+		if manifest.Capabilities.MetadataEnricher == nil {
+			return nil
+		}
+		declaredFields := manifest.Capabilities.MetadataEnricher.Fields
+		effectiveSettings, fErr := h.service.GetEffectiveFieldSettings(ctx, book.LibraryID, rt.Scope(), rt.PluginID(), declaredFields)
+		if fErr != nil {
+			return nil
+		}
+		var out []string
+		for field, enabled := range effectiveSettings {
+			if !enabled {
+				out = append(out, field)
+			}
+		}
+		return out
+	}
+
+	allResults, pluginErrors, skippedPlugins := aggregateEnricherSearches(ctx, runtimes, fileType, runSearch, disabledFields, log)
+
+	return c.JSON(http.StatusOK, PluginSearchResponse{
+		Results:        allResults,
+		Errors:         pluginErrors,
+		SkippedPlugins: skippedPlugins,
+		TotalPlugins:   len(runtimes),
+	})
+}
+
+// enricherRuntime is the subset of *Runtime that aggregateEnricherSearches
+// needs. It exists so the aggregation loop can be unit-tested with a fake
+// runtime instead of a full Goja VM.
+type enricherRuntime interface {
+	Scope() string
+	PluginID() string
+	Manifest() *Manifest
+}
+
+// aggregateEnricherSearches runs each enricher's search() hook in order and
+// aggregates the results, per-plugin errors, and file-type skips.
+//
+// It checks the request context for cancellation before invoking each plugin
+// and stops early when the client has gone away — there is no point fanning
+// out to the remaining plugins (and their outbound API calls) for a search the
+// client has already superseded. A per-plugin failure that is itself caused by
+// client cancellation (context.Canceled) is dropped rather than reported as a
+// plugin failure or logged as a warning; a genuine per-plugin timeout
+// (context.DeadlineExceeded) is still reported.
+func aggregateEnricherSearches[T enricherRuntime](
+	ctx context.Context,
+	runtimes []T,
+	fileType string,
+	runSearch func(context.Context, T) (*SearchResponse, error),
+	disabledFields func(context.Context, T) []string,
+	log logger.Logger,
+) (results []EnrichSearchResult, pluginErrors []PluginSearchError, skippedPlugins []PluginSearchSkipped) {
+	results = make([]EnrichSearchResult, 0)
+	for _, rt := range runtimes {
+		// Stop early if the client has cancelled the request. Continuing would
+		// fan out to plugins (and their external APIs) for a superseded search.
+		if ctx.Err() != nil {
+			break
+		}
+
+		manifest := rt.Manifest()
+		// Skip plugins that don't handle this file type.
 		if fileType != "" {
 			enricherCap := manifest.Capabilities.MetadataEnricher
 			if enricherCap == nil {
@@ -193,8 +256,15 @@ func (h *handler) searchMetadata(c echo.Context) error {
 			}
 		}
 
-		resp, sErr := h.manager.RunMetadataSearch(ctx, rt, searchCtx, targetFilePath)
+		resp, sErr := runSearch(ctx, rt)
 		if sErr != nil {
+			// Don't report a per-plugin failure that's just the client
+			// cancelling the request — it's not a plugin malfunction, and
+			// logging it would be noise. A genuine deadline timeout is a real
+			// failure and is still reported.
+			if errors.Is(sErr, context.Canceled) {
+				continue
+			}
 			log.Warn("enricher search failed", logger.Data{
 				"scope":  rt.Scope(),
 				"plugin": rt.PluginID(),
@@ -212,36 +282,17 @@ func (h *handler) searchMetadata(c echo.Context) error {
 			continue
 		}
 
-		// Compute disabled fields for this plugin
-		var disabledFields []string
-		if manifest.Capabilities.MetadataEnricher != nil {
-			declaredFields := manifest.Capabilities.MetadataEnricher.Fields
-			effectiveSettings, fErr := h.service.GetEffectiveFieldSettings(ctx, book.LibraryID, rt.Scope(), rt.PluginID(), declaredFields)
-			if fErr == nil {
-				for field, enabled := range effectiveSettings {
-					if !enabled {
-						disabledFields = append(disabledFields, field)
-					}
-				}
-			}
-		}
-
+		df := disabledFields(ctx, rt)
 		for _, md := range resp.Results {
-			allResults = append(allResults, EnrichSearchResult{
+			results = append(results, EnrichSearchResult{
 				ParsedMetadata: md,
 				PluginScope:    md.PluginScope,
 				PluginID:       md.PluginID,
-				DisabledFields: disabledFields,
+				DisabledFields: df,
 			})
 		}
 	}
-
-	return c.JSON(http.StatusOK, PluginSearchResponse{
-		Results:        allResults,
-		Errors:         pluginErrors,
-		SkippedPlugins: skippedPlugins,
-		TotalPlugins:   len(runtimes),
-	})
+	return results, pluginErrors, skippedPlugins
 }
 
 // DownloadCoverFromURL fetches a cover image from a URL and populates md.CoverData and md.CoverMimeType.

--- a/pkg/plugins/handler_enrich_test.go
+++ b/pkg/plugins/handler_enrich_test.go
@@ -10,7 +10,125 @@ import (
 	"github.com/robinjoseph08/golib/logger"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// fakeEnricherRuntime is a minimal enricherRuntime for testing the search
+// aggregation loop without a real Goja VM.
+type fakeEnricherRuntime struct {
+	scope    string
+	id       string
+	manifest *Manifest
+}
+
+func (f *fakeEnricherRuntime) Scope() string       { return f.scope }
+func (f *fakeEnricherRuntime) PluginID() string    { return f.id }
+func (f *fakeEnricherRuntime) Manifest() *Manifest { return f.manifest }
+
+func newFakeEnricher(id string, fileTypes []string) *fakeEnricherRuntime {
+	return &fakeEnricherRuntime{
+		scope: "shisho",
+		id:    id,
+		manifest: &Manifest{
+			Name: id,
+			Capabilities: Capabilities{
+				MetadataEnricher: &MetadataEnricherCap{FileTypes: fileTypes},
+			},
+		},
+	}
+}
+
+func TestAggregateEnricherSearches_StopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runtimes := []*fakeEnricherRuntime{
+		newFakeEnricher("first", []string{"epub"}),
+		newFakeEnricher("second", []string{"epub"}),
+		newFakeEnricher("third", []string{"epub"}),
+	}
+
+	var invoked []string
+	runSearch := func(_ context.Context, rt *fakeEnricherRuntime) (*SearchResponse, error) {
+		invoked = append(invoked, rt.PluginID())
+		// The client disconnects after the first plugin runs. The aggregator
+		// must notice the cancellation and stop before invoking the rest.
+		if rt.PluginID() == "first" {
+			cancel()
+		}
+		return &SearchResponse{Results: []mediafile.ParsedMetadata{{Title: rt.PluginID()}}}, nil
+	}
+	disabled := func(_ context.Context, _ *fakeEnricherRuntime) []string { return nil }
+
+	results, pluginErrors, _ := aggregateEnricherSearches(ctx, runtimes, "epub", runSearch, disabled, testLogger())
+
+	assert.Equal(t, []string{"first"}, invoked, "should stop invoking plugins once the context is cancelled")
+	require.Len(t, results, 1)
+	assert.Equal(t, "first", results[0].Title)
+	assert.Empty(t, pluginErrors, "client cancellation must not be reported as a plugin error")
+}
+
+func TestAggregateEnricherSearches_CancellationNotReportedAsError(t *testing.T) {
+	t.Parallel()
+
+	runtimes := []*fakeEnricherRuntime{
+		newFakeEnricher("cancelled", []string{"epub"}),
+	}
+	runSearch := func(_ context.Context, _ *fakeEnricherRuntime) (*SearchResponse, error) {
+		// A per-plugin search that fails specifically due to client
+		// cancellation must not be surfaced as a plugin failure.
+		return nil, context.Canceled
+	}
+	disabled := func(_ context.Context, _ *fakeEnricherRuntime) []string { return nil }
+
+	results, pluginErrors, _ := aggregateEnricherSearches(context.Background(), runtimes, "epub", runSearch, disabled, testLogger())
+
+	assert.Empty(t, results)
+	assert.Empty(t, pluginErrors, "context.Canceled must not be added to plugin errors")
+}
+
+func TestAggregateEnricherSearches_TimeoutStillReported(t *testing.T) {
+	t.Parallel()
+
+	runtimes := []*fakeEnricherRuntime{
+		newFakeEnricher("timed-out", []string{"epub"}),
+	}
+	runSearch := func(_ context.Context, _ *fakeEnricherRuntime) (*SearchResponse, error) {
+		// A genuine per-plugin timeout (deadline exceeded) is a real failure
+		// and must still be reported to the user.
+		return nil, context.DeadlineExceeded
+	}
+	disabled := func(_ context.Context, _ *fakeEnricherRuntime) []string { return nil }
+
+	results, pluginErrors, _ := aggregateEnricherSearches(context.Background(), runtimes, "epub", runSearch, disabled, testLogger())
+
+	assert.Empty(t, results)
+	require.Len(t, pluginErrors, 1, "per-plugin timeout must still be reported")
+	assert.Equal(t, "timed-out", pluginErrors[0].PluginID)
+}
+
+func TestAggregateEnricherSearches_SkipsUnsupportedFileType(t *testing.T) {
+	t.Parallel()
+
+	runtimes := []*fakeEnricherRuntime{
+		newFakeEnricher("epub-only", []string{"epub"}),
+		newFakeEnricher("cbz-only", []string{"cbz"}),
+	}
+	var invoked []string
+	runSearch := func(_ context.Context, rt *fakeEnricherRuntime) (*SearchResponse, error) {
+		invoked = append(invoked, rt.PluginID())
+		return &SearchResponse{Results: []mediafile.ParsedMetadata{{Title: rt.PluginID()}}}, nil
+	}
+	disabled := func(_ context.Context, _ *fakeEnricherRuntime) []string { return nil }
+
+	results, _, skipped := aggregateEnricherSearches(context.Background(), runtimes, "epub", runSearch, disabled, testLogger())
+
+	assert.Equal(t, []string{"epub-only"}, invoked)
+	require.Len(t, results, 1)
+	assert.Equal(t, "epub-only", results[0].Title)
+	require.Len(t, skipped, 1)
+	assert.Equal(t, "cbz-only", skipped[0].PluginID)
+}
 
 func testLogger() logger.Logger {
 	return logger.New()

--- a/pkg/plugins/hooks_test.go
+++ b/pkg/plugins/hooks_test.go
@@ -842,10 +842,96 @@ func installCancelTestPlugin(t *testing.T, pluginID, parseBody string) (*Manager
 	return manager, rt
 }
 
-// runWithDeadline runs fn and enforces that it returns within budget; otherwise
-// it fails the test instead of deadlocking the whole suite.
-func runWithDeadline(t *testing.T, budget time.Duration, fn func() error) error {
+// installCancelTestEnricher installs an enricher plugin whose search() hook
+// runs the given JS body, so cancellation/interrupt behaviour can be tested
+// against a real Goja runtime.
+func installCancelTestEnricher(t *testing.T, pluginID, searchBody string) (*Manager, *Runtime) {
 	t.Helper()
+
+	db := setupTestDB(t)
+	service := NewService(db)
+	pluginDir := t.TempDir()
+
+	destDir := filepath.Join(pluginDir, "test", pluginID)
+	require.NoError(t, os.MkdirAll(destDir, 0755))
+
+	manifest := `{
+  "manifestVersion": 1,
+  "id": "` + pluginID + `",
+  "name": "Cancel Enricher",
+  "version": "1.0.0",
+  "capabilities": {
+    "metadataEnricher": {
+      "description": "Cancel test enricher",
+      "fileTypes": ["epub"],
+      "fields": ["title"]
+    }
+  }
+}`
+	mainJS := `var plugin = (function() {
+  return {
+    metadataEnricher: {
+      search: function(context) { ` + searchBody + ` }
+    }
+  };
+})();`
+
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "manifest.json"), []byte(manifest), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(destDir, "main.js"), []byte(mainJS), 0644))
+
+	manager := NewManager(service, pluginDir, "")
+	plugin := &models.Plugin{
+		Scope:       "test",
+		ID:          pluginID,
+		Name:        "Cancel Enricher",
+		Version:     "1.0.0",
+		Status:      models.PluginStatusActive,
+		InstalledAt: time.Now(),
+	}
+	require.NoError(t, service.InstallPlugin(context.Background(), plugin))
+	require.NoError(t, manager.LoadPlugin(context.Background(), "test", pluginID))
+
+	rt := manager.GetRuntime("test", pluginID)
+	require.NotNil(t, rt)
+	return manager, rt
+}
+
+// TestRunMetadataSearch_ParentCancelUnwrapsToContextCanceled proves that when
+// the *parent* request context is cancelled mid-search, the error returned by
+// RunMetadataSearch unwraps to context.Canceled. The search aggregation loop
+// (aggregateEnricherSearches) relies on errors.Is(err, context.Canceled) to
+// distinguish a client-cancelled search (drop it, no log noise) from a genuine
+// per-plugin timeout (context.DeadlineExceeded, still reported).
+func TestRunMetadataSearch_ParentCancelUnwrapsToContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	mgr, rt := installCancelTestEnricher(t, "sleep-enricher", "shisho.sleep(3000); return { results: [{ title: \"done\" }] };")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the search starts sleeping.
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		cancel()
+	}()
+
+	searchCtx := map[string]interface{}{"query": "anything"}
+	err := runWithDeadline(t, func() error {
+		_, e := mgr.RunMetadataSearch(ctx, rt, searchCtx, "")
+		return e
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled),
+		"parent cancellation must unwrap to context.Canceled, got %T: %v", err, err)
+	assert.False(t, errors.Is(err, context.DeadlineExceeded),
+		"a parent cancel is not a deadline timeout")
+}
+
+// runWithDeadline runs fn and enforces that it returns within a fixed budget;
+// otherwise it fails the test instead of deadlocking the whole suite.
+func runWithDeadline(t *testing.T, fn func() error) error {
+	t.Helper()
+	const budget = 5 * time.Second
 	ch := make(chan error, 1)
 	go func() { ch <- fn() }()
 	select {
@@ -871,7 +957,7 @@ func TestRunFileParser_InterruptsInfiniteLoop(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := runWithDeadline(t, 5*time.Second, func() error {
+	err := runWithDeadline(t, func() error {
 		_, e := mgr.RunFileParser(ctx, rt, "/some/file.bin", "bin")
 		return e
 	})
@@ -888,7 +974,7 @@ func TestRunFileParser_InterruptsInfiniteLoop(t *testing.T) {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel2()
 	start2 := time.Now()
-	err2 := runWithDeadline(t, 5*time.Second, func() error {
+	err2 := runWithDeadline(t, func() error {
 		_, e := mgr.RunFileParser(ctx2, rt, "/some/file.bin", "bin")
 		return e
 	})
@@ -911,7 +997,7 @@ func TestRunFileParser_InterruptsLongSleep(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	err := runWithDeadline(t, 5*time.Second, func() error {
+	err := runWithDeadline(t, func() error {
 		_, e := mgr.RunFileParser(ctx, rt, "/some/file.bin", "bin")
 		return e
 	})


### PR DESCRIPTION
Closes #366

## Summary
- Fixes the Identify search race where a slow superseded request could overwrite a newer query's results. On the frontend, `usePluginSearch` is converted from a `useMutation` to a cancellable `useQuery` keyed on an immutable "submitted search params" snapshot (mirroring the global-search query pattern), so submitting a new search supersedes and aborts the in-flight one via the query's `AbortSignal`, and the rendered results are always those of the most recent key.
- On the backend, the enricher fan-out loop is extracted into `aggregateEnricherSearches`, which checks request-context cancellation before each plugin (stopping early when the client disconnects) and drops `context.Canceled` per-plugin failures from logs and response errors while still reporting genuine `context.DeadlineExceeded` timeouts.
- The HTTP method (POST) and the request/response payload shapes are unchanged.

## Why a query, not a mutation
- The backend handler is a read: it makes no writes to Shisho state, only outbound plugin API calls. TanStack Query v5 mutations don't receive an `AbortSignal` (only queries do), so converting to a query is what enables cancellation and sequencing.
- Loading is driven off `isFetching` (not `isPlaceholderData`) intentionally, so it covers new-key loads, identical-resubmit refetches, and stale-key background refetches. `keepPreviousData` is used only to avoid layout shift by keeping prior results mounted.
- The backend distinguishes client cancellation (`context.Canceled`, suppressed) from a genuine per-plugin timeout (`context.DeadlineExceeded`, still reported). The suppression relies on `errors.Is(err, context.Canceled)` traversing the `errors.Wrap` -> `*goja.InterruptedError` -> `context.Canceled` chain, which the real-runtime unwrap test exercises end-to-end.

## Files changed
- `app/hooks/queries/plugins.ts` — `usePluginSearch` is now a query taking a `PluginSearchParams | null` snapshot, threading the query `AbortSignal` into `API.request`, using `placeholderData: keepPreviousData`, and disabled until a non-empty query is submitted. Added the `PluginSearch` query key and exported `PluginSearchParams`.
- `app/components/library/IdentifyBookDialog.tsx` — Holds a single `submittedParams` snapshot distinct from the live inputs. All trigger points (auto-search on open, Enter/click, file selector) set it via a `submitSearch` helper that `refetch()`es on an identical re-submit and otherwise sets new params. Loading and dimming are driven off `isFetching`; prior results stay mounted but dimmed and non-interactive with a stable sticky spinner, while the first search shows a centered spinner with no prior data.
- `pkg/plugins/handler_enrich.go` — Extracted the per-enricher loop into the generic `aggregateEnricherSearches` (over a new `enricherRuntime` interface) with the context-cancellation early-break and `context.Canceled` suppression; `searchMetadata` now delegates to it.
- `pkg/plugins/handler_enrich_test.go` — Unit tests for the aggregation loop (stop-on-cancel, cancellation-not-reported, timeout-still-reported, file-type skip).
- `pkg/plugins/hooks_test.go` — Added `installCancelTestEnricher` and a parent-cancel-unwraps-to-`context.Canceled` end-to-end test; dropped now-unused params from test helpers to satisfy lint.

## Test plan
- Run `mise lint:js test:unit` to verify the frontend conversion, then `mise lint test` for the backend changes.
- Frontend component tests (written red-first, confirmed failing against the mutation, then green):
  - Renders the most-recently-submitted query's results even when an earlier search resolves last.
  - Aborts the superseded request when a newer search is submitted.
- Backend unit tests:
  - `TestAggregateEnricherSearches_StopsOnContextCancel` — server stops fanning out after client cancellation.
  - `TestAggregateEnricherSearches_CancellationNotReportedAsError` — client cancellation is not reported as a plugin error.
  - `TestAggregateEnricherSearches_TimeoutStillReported` — a per-plugin timeout is still reported.
  - `TestAggregateEnricherSearches_SkipsUnsupportedFileType` — unsupported file types are still skipped.
  - `TestRunMetadataSearch_ParentCancelUnwrapsToContextCanceled` — parent-cancel error unwraps to `context.Canceled` through the real Goja runtime.
- Manual: open the Identify dialog with slow plugins, submit a query, then quickly submit a different query before the first resolves; confirm the dialog shows the second query's results, prior results dim and become non-interactive during the re-search, and re-submitting an identical query still shows loading feedback.

## Docs
No website docs changes: this restores expected behavior rather than changing a documented feature.