### PR TITLE
[Frontend] Add in-app M4B audiobook player with basic playback

### DIFF
--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -7,6 +7,7 @@ import {
   Download,
   Edit,
   GitMerge,
+  Headphones,
   List,
   Loader2,
   MoreVertical,
@@ -78,7 +79,6 @@ import {
   DownloadFormatKepub,
   FileTypeCBZ,
   FileTypeEPUB,
-  FileTypePDF,
   type File,
 } from "@/types";
 import { getAuthorRoleLabel } from "@/utils/authorRoles";
@@ -94,6 +94,7 @@ import {
 } from "@/utils/format";
 import { hasAnyCBZFile } from "@/utils/hasAnyCBZFile";
 import { getIdentifierUrl } from "@/utils/identifiers";
+import { getReadingAction } from "@/utils/readingAction";
 import { formatSeriesNumber } from "@/utils/seriesNumber";
 
 interface DownloadError {
@@ -317,23 +318,32 @@ const FileRow = ({
               </Tooltip>
             )}
 
-            {/* Read button - CBZ, PDF, and EPUB */}
-            {(file.file_type === FileTypeCBZ ||
-              file.file_type === FileTypePDF ||
-              file.file_type === FileTypeEPUB) && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Link
-                    to={`/libraries/${libraryId}/books/${file.book_id}/files/${file.id}/read`}
-                  >
-                    <Button size="sm" variant="ghost">
-                      <BookOpen className="h-3 w-3" />
-                    </Button>
-                  </Link>
-                </TooltipTrigger>
-                <TooltipContent>Read</TooltipContent>
-              </Tooltip>
-            )}
+            {/* Read button for ebooks/comics, Listen for M4B audiobooks */}
+            {(() => {
+              const action = getReadingAction(file.file_type);
+              if (!action) return null;
+              const isListen = action === "listen";
+              return (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Link
+                      to={`/libraries/${libraryId}/books/${file.book_id}/files/${file.id}/read`}
+                    >
+                      <Button size="sm" variant="ghost">
+                        {isListen ? (
+                          <Headphones className="h-3 w-3" />
+                        ) : (
+                          <BookOpen className="h-3 w-3" />
+                        )}
+                      </Button>
+                    </Link>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {isListen ? "Listen" : "Read"}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })()}
 
             {/* Actions dropdown */}
             <DropdownMenu>
@@ -462,23 +472,30 @@ const FileRow = ({
             </Tooltip>
           )}
 
-          {/* Read button - CBZ, PDF, and EPUB */}
-          {(file.file_type === FileTypeCBZ ||
-            file.file_type === FileTypePDF ||
-            file.file_type === FileTypeEPUB) && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Link
-                  to={`/libraries/${libraryId}/books/${file.book_id}/files/${file.id}/read`}
-                >
-                  <Button size="sm" variant="ghost">
-                    <BookOpen className="h-3 w-3" />
-                  </Button>
-                </Link>
-              </TooltipTrigger>
-              <TooltipContent>Read</TooltipContent>
-            </Tooltip>
-          )}
+          {/* Read button for ebooks/comics, Listen for M4B audiobooks */}
+          {(() => {
+            const action = getReadingAction(file.file_type);
+            if (!action) return null;
+            const isListen = action === "listen";
+            return (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    to={`/libraries/${libraryId}/books/${file.book_id}/files/${file.id}/read`}
+                  >
+                    <Button size="sm" variant="ghost">
+                      {isListen ? (
+                        <Headphones className="h-3 w-3" />
+                      ) : (
+                        <BookOpen className="h-3 w-3" />
+                      )}
+                    </Button>
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent>{isListen ? "Listen" : "Read"}</TooltipContent>
+              </Tooltip>
+            );
+          })()}
 
           {/* Actions dropdown */}
           <DropdownMenu>

--- a/app/components/pages/FileDetail.test.tsx
+++ b/app/components/pages/FileDetail.test.tsx
@@ -1,0 +1,121 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { useBook, useDeleteFile } from "@/hooks/queries/books";
+import { useLibrary } from "@/hooks/queries/libraries";
+
+import FileDetail from "./FileDetail";
+
+vi.mock("@/hooks/queries/books", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/queries/books")>(
+    "@/hooks/queries/books",
+  );
+  return { ...actual, useBook: vi.fn(), useDeleteFile: vi.fn() };
+});
+vi.mock("@/hooks/queries/libraries", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/hooks/queries/libraries")
+  >("@/hooks/queries/libraries");
+  return { ...actual, useLibrary: vi.fn() };
+});
+
+// useUnsavedChanges calls react-router's useBlocker, which requires a data
+// router. We don't exercise navigation blocking here, so stub it.
+vi.mock("@/hooks/useUnsavedChanges", () => ({
+  useUnsavedChanges: () => ({
+    showBlockerDialog: false,
+    proceedNavigation: vi.fn(),
+    cancelNavigation: vi.fn(),
+  }),
+}));
+
+// LibraryLayout renders the app shell (sidebar/top nav) which needs an
+// AuthProvider. Stub it to a passthrough so we can render the page content
+// without standing up the whole shell.
+vi.mock("@/components/library/LibraryLayout", () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/components/library/LibraryBreadcrumbs", () => ({
+  default: () => <nav />,
+}));
+
+// The tabs pull their own queries; we only care about the action buttons here.
+vi.mock("@/components/files/FileDetailsTab", () => ({
+  default: () => <div>details-tab</div>,
+}));
+vi.mock("@/components/files/FileChaptersTab", () => ({
+  default: () => <div>chapters-tab</div>,
+}));
+
+const renderForFileType = (fileType: string) => {
+  vi.mocked(useBook).mockReturnValue({
+    data: {
+      id: 7,
+      title: "Book",
+      files: [
+        {
+          id: 42,
+          book_id: 7,
+          file_type: fileType,
+          filepath: "/lib/book." + fileType,
+        },
+      ],
+    },
+    isLoading: false,
+    isSuccess: true,
+  } as never);
+  vi.mocked(useLibrary).mockReturnValue({ data: { name: "Lib" } } as never);
+  vi.mocked(useDeleteFile).mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  } as never);
+
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MemoryRouter initialEntries={["/libraries/1/books/7/files/42"]}>
+        <Routes>
+          <Route
+            element={<FileDetail />}
+            path="/libraries/:libraryId/books/:bookId/files/:fileId/:tab?"
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+describe("FileDetail reading action", () => {
+  it("shows a Listen action for m4b files and not a Read action", () => {
+    renderForFileType("m4b");
+    const listen = screen.getByRole("link", { name: /listen/i });
+    expect(listen).toBeInTheDocument();
+    expect(listen).toHaveAttribute(
+      "href",
+      "/libraries/1/books/7/files/42/read",
+    );
+    expect(
+      screen.queryByRole("link", { name: /read/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a Read action for epub files and not a Listen action", () => {
+    renderForFileType("epub");
+    expect(screen.getByRole("link", { name: /read/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /listen/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows no reading action for unsupported file types", () => {
+    renderForFileType("txt");
+    expect(
+      screen.queryByRole("link", { name: /listen/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /read/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/components/pages/FileDetail.tsx
+++ b/app/components/pages/FileDetail.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Pencil, Trash2 } from "lucide-react";
+import { BookOpen, Headphones, Pencil, Trash2 } from "lucide-react";
 import { useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -20,8 +20,9 @@ import { useBook, useDeleteFile } from "@/hooks/queries/books";
 import { useLibrary } from "@/hooks/queries/libraries";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
-import { FileTypeCBZ, FileTypeEPUB, FileTypePDF, type File } from "@/types";
+import { type File } from "@/types";
 import { getFilename } from "@/utils/format";
+import { getReadingAction } from "@/utils/readingAction";
 
 const validTabs = ["details", "chapters"] as const;
 type TabValue = (typeof validTabs)[number];
@@ -190,19 +191,28 @@ const FileDetail = () => {
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-6">
         <h1 className="text-2xl font-semibold">{filename}</h1>
         <div className="flex items-center gap-2 shrink-0">
-          {/* Read button for CBZ, EPUB, and PDF files */}
-          {(file.file_type === FileTypeCBZ ||
-            file.file_type === FileTypeEPUB ||
-            file.file_type === FileTypePDF) && (
-            <Button asChild size="sm">
-              <Link
-                to={`/libraries/${libraryId}/books/${bookId}/files/${fileId}/read`}
-              >
-                <BookOpen className="h-4 w-4 sm:mr-2" />
-                <span className="hidden sm:inline">Read</span>
-              </Link>
-            </Button>
-          )}
+          {/* Read button for ebooks/comics, Listen for M4B audiobooks */}
+          {(() => {
+            const action = getReadingAction(file.file_type);
+            if (!action) return null;
+            const isListen = action === "listen";
+            return (
+              <Button asChild size="sm">
+                <Link
+                  to={`/libraries/${libraryId}/books/${bookId}/files/${fileId}/read`}
+                >
+                  {isListen ? (
+                    <Headphones className="h-4 w-4 sm:mr-2" />
+                  ) : (
+                    <BookOpen className="h-4 w-4 sm:mr-2" />
+                  )}
+                  <span className="hidden sm:inline">
+                    {isListen ? "Listen" : "Read"}
+                  </span>
+                </Link>
+              </Button>
+            );
+          })()}
 
           {activeTab === "chapters" && isEditingChapters ? (
             <>

--- a/app/components/pages/FileReader.test.tsx
+++ b/app/components/pages/FileReader.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { useBook } from "@/hooks/queries/books";
+
+import FileReader from "./FileReader";
+
+vi.mock("@/hooks/queries/books", () => ({
+  useBook: vi.fn(),
+}));
+
+// Stub the heavy readers so this test only checks dispatch by file_type.
+vi.mock("./M4BReader", () => ({
+  default: () => <div>m4b-player</div>,
+}));
+vi.mock("./CBZReader", () => ({
+  default: () => <div>cbz-reader</div>,
+}));
+vi.mock("./PDFReader", () => ({
+  default: () => <div>pdf-reader</div>,
+}));
+vi.mock("./EPUBReader", () => ({
+  default: () => <div>epub-reader</div>,
+}));
+
+const renderAt = (fileType: string) => {
+  vi.mocked(useBook).mockReturnValue({
+    data: {
+      id: 7,
+      title: "Book",
+      files: [{ id: 42, book_id: 7, file_type: fileType }],
+    },
+    isLoading: false,
+  } as never);
+
+  return render(
+    <MemoryRouter initialEntries={["/libraries/1/books/7/files/42/read"]}>
+      <Routes>
+        <Route
+          element={<FileReader />}
+          path="/libraries/:libraryId/books/:bookId/files/:fileId/read"
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+};
+
+describe("FileReader dispatch", () => {
+  it("renders the M4B player for m4b files", () => {
+    renderAt("m4b");
+    expect(screen.getByText("m4b-player")).toBeInTheDocument();
+  });
+
+  it("renders the CBZ reader for cbz files", () => {
+    renderAt("cbz");
+    expect(screen.getByText("cbz-reader")).toBeInTheDocument();
+  });
+
+  it("shows an unsupported message for unknown file types", () => {
+    renderAt("txt");
+    expect(screen.getByText(/not supported/i)).toBeInTheDocument();
+  });
+});

--- a/app/components/pages/FileReader.tsx
+++ b/app/components/pages/FileReader.tsx
@@ -3,9 +3,10 @@ import { useParams } from "react-router-dom";
 import LoadingSpinner from "@/components/library/LoadingSpinner";
 import CBZReader from "@/components/pages/CBZReader";
 import EPUBReader from "@/components/pages/EPUBReader";
+import M4BReader from "@/components/pages/M4BReader";
 import PDFReader from "@/components/pages/PDFReader";
 import { useBook } from "@/hooks/queries/books";
-import { FileTypeCBZ, FileTypeEPUB, FileTypePDF } from "@/types";
+import { FileTypeCBZ, FileTypeEPUB, FileTypeM4B, FileTypePDF } from "@/types";
 
 export default function FileReader() {
   const { libraryId, bookId, fileId } = useParams<{
@@ -36,6 +37,8 @@ export default function FileReader() {
       );
     case FileTypeEPUB:
       return <EPUBReader bookTitle={book?.title} file={file} />;
+    case FileTypeM4B:
+      return <M4BReader book={book} file={file} libraryId={libraryId!} />;
     default:
       return (
         <div className="fixed inset-0 bg-background flex items-center justify-center">

--- a/app/components/pages/M4BReader.test.tsx
+++ b/app/components/pages/M4BReader.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Book, File } from "@/types";
+
+import M4BReader from "./M4BReader";
+
+// jsdom does not implement the HTMLMediaElement playback pipeline. Stub the
+// methods so the component can call them, and let tests drive currentTime /
+// duration / paused manually plus dispatch the media events they assert on.
+let playSpy: ReturnType<typeof vi.spyOn>;
+let pauseSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  playSpy = vi
+    .spyOn(window.HTMLMediaElement.prototype, "play")
+    .mockResolvedValue(undefined);
+  pauseSpy = vi
+    .spyOn(window.HTMLMediaElement.prototype, "pause")
+    .mockImplementation(() => {});
+  vi.spyOn(window.HTMLMediaElement.prototype, "load").mockImplementation(
+    () => {},
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  document.title = "";
+});
+
+const narratorPerson = { id: 9, name: "Jane Narrator" } as never;
+const authorPerson = { id: 5, name: "Sam Author" } as never;
+
+const file = {
+  id: 42,
+  book_id: 7,
+  file_type: "m4b",
+  filepath: "/lib/book.m4b",
+  audiobook_duration_seconds: 3600,
+  narrators: [{ id: 1, file_id: 42, person_id: 9, person: narratorPerson }],
+} as unknown as File;
+
+const book = {
+  id: 7,
+  title: "The Test Audiobook",
+  cover_cache_key: "7-123",
+  authors: [{ id: 2, book_id: 7, person_id: 5, person: authorPerson }],
+  files: [file],
+} as unknown as Book;
+
+const renderReader = (props?: { book?: Book; file?: File }) =>
+  render(
+    <MemoryRouter>
+      <M4BReader
+        book={props?.book ?? book}
+        file={props?.file ?? file}
+        libraryId="1"
+      />
+    </MemoryRouter>,
+  );
+
+const getAudio = () =>
+  document.querySelector("audio") as HTMLAudioElement & {
+    currentTime: number;
+    duration: number;
+  };
+
+describe("M4BReader", () => {
+  it("renders an audio element pointed at the stream endpoint", () => {
+    renderReader();
+    const audio = getAudio();
+    expect(audio).toBeInTheDocument();
+    expect(audio.getAttribute("src")).toBe("/api/books/files/42/stream");
+  });
+
+  it("does not autoplay on mount", () => {
+    renderReader();
+    expect(playSpy).not.toHaveBeenCalled();
+    // Play button should be shown (paused state), not a pause button.
+    expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument();
+  });
+
+  it("displays the book title, author, and narrator", () => {
+    renderReader();
+    expect(
+      screen.getByRole("heading", { name: "The Test Audiobook" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Sam Author/)).toBeInTheDocument();
+    expect(screen.getByText(/Jane Narrator/)).toBeInTheDocument();
+  });
+
+  it("renders the book cover with a cache-busted URL", () => {
+    renderReader();
+    const img = screen.getByRole("img") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe("/api/books/7/cover?v=7-123");
+  });
+
+  it("sets the browser tab title to the book title", () => {
+    renderReader();
+    expect(document.title).toContain("The Test Audiobook");
+  });
+
+  it("uses the file's audiobook_duration_seconds as the total time", () => {
+    renderReader();
+    // 3600s => 1:00:00
+    expect(screen.getByText("1:00:00")).toBeInTheDocument();
+  });
+
+  it("plays when the play button is clicked and shows a pause control", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderReader();
+    await user.click(screen.getByRole("button", { name: /play/i }));
+    expect(playSpy).toHaveBeenCalled();
+
+    // Simulate the audio element firing its play event.
+    fireEvent.play(getAudio());
+    expect(screen.getByRole("button", { name: /pause/i })).toBeInTheDocument();
+  });
+
+  it("pauses when the pause button is clicked while playing", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    renderReader();
+    await user.click(screen.getByRole("button", { name: /play/i }));
+    fireEvent.play(getAudio());
+    await user.click(screen.getByRole("button", { name: /pause/i }));
+    expect(pauseSpy).toHaveBeenCalled();
+  });
+
+  it("advances the elapsed time label as the audio reports timeupdate", () => {
+    renderReader();
+    const audio = getAudio();
+    audio.currentTime = 65;
+    fireEvent.timeUpdate(audio);
+    expect(screen.getByText("1:05")).toBeInTheDocument();
+  });
+
+  it("seeks the audio when the seek bar value is committed", () => {
+    renderReader();
+    const audio = getAudio();
+    // Radix sliders expose role=slider; simulate a keyboard seek which fires
+    // value change + commit. Use the component's exposed test affordance: a
+    // direct currentTime set via the commit path is asserted through the
+    // slider's onValueCommit. We drive it via the slider thumb.
+    const slider = screen.getByRole("slider", { name: /seek/i });
+    slider.focus();
+    // ArrowRight on a Radix slider increments by step (1s) and commits.
+    fireEvent.keyDown(slider, { key: "ArrowRight" });
+    expect(audio.currentTime).toBeGreaterThan(0);
+  });
+
+  it("stays on the player and pauses at end of file", () => {
+    renderReader();
+    const audio = getAudio();
+    audio.currentTime = 3600;
+    fireEvent.play(audio);
+    fireEvent.ended(audio);
+    // After ended, the play (not pause) control is shown again.
+    expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument();
+  });
+
+  it("toggles play/pause with the space key and prevents page scroll", () => {
+    renderReader();
+    // Initially paused: space should trigger play.
+    const ev = new KeyboardEvent("keydown", {
+      key: " ",
+      bubbles: true,
+      cancelable: true,
+    });
+    const prevented = !document.dispatchEvent(ev);
+    expect(playSpy).toHaveBeenCalled();
+    expect(prevented).toBe(true);
+  });
+
+  it("falls back to the audio element duration when no metadata duration", () => {
+    const fileNoDuration = {
+      ...file,
+      audiobook_duration_seconds: undefined,
+    } as unknown as File;
+    renderReader({ file: fileNoDuration });
+    const audio = getAudio();
+    Object.defineProperty(audio, "duration", {
+      value: 125,
+      configurable: true,
+    });
+    fireEvent.loadedMetadata(audio);
+    // 125s => 2:05
+    expect(screen.getByText("2:05")).toBeInTheDocument();
+  });
+});

--- a/app/components/pages/M4BReader.tsx
+++ b/app/components/pages/M4BReader.tsx
@@ -1,0 +1,239 @@
+import { ArrowLeft, Pause, Play } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+import CoverPlaceholder from "@/components/library/CoverPlaceholder";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { usePageTitle } from "@/hooks/usePageTitle";
+import { cn } from "@/libraries/utils";
+import type { Book, File } from "@/types";
+import { formatPlayerTime } from "@/utils/format";
+
+interface M4BReaderProps {
+  file: File;
+  book?: Book;
+  libraryId: string;
+}
+
+function joinNames(
+  people: Array<{ person?: { name?: string } }> | undefined,
+): string {
+  if (!people) return "";
+  return people
+    .map((p) => p.person?.name)
+    .filter((name): name is string => Boolean(name))
+    .join(", ");
+}
+
+export default function M4BReader({ file, book, libraryId }: M4BReaderProps) {
+  const navigate = useNavigate();
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  usePageTitle(book?.title ? `Listening: ${book.title}` : "Audiobook Player");
+
+  const streamUrl = `/api/books/files/${file.id}/stream`;
+
+  // Authoritative total: prefer the duration stored on the model (available
+  // immediately, before the audio element loads its metadata), fall back to
+  // the element's own reported duration once metadata arrives.
+  const [mediaDuration, setMediaDuration] = useState(0);
+  const duration = useMemo(() => {
+    const fromFile = file.audiobook_duration_seconds;
+    if (fromFile && fromFile > 0) return fromFile;
+    return mediaDuration;
+  }, [file.audiobook_duration_seconds, mediaDuration]);
+
+  const [currentTime, setCurrentTime] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  // Keep a ref in sync so the stable togglePlay callback can read the latest
+  // playing state without resubscribing the document keydown listener.
+  const isPlayingRef = useRef(false);
+  useEffect(() => {
+    isPlayingRef.current = isPlaying;
+  }, [isPlaying]);
+
+  // While the user is dragging the seek bar we follow the pending scrub value
+  // instead of the audio's reported time, so timeupdate events don't fight the
+  // thumb. On commit we seek the element and resume following timeupdate.
+  const [isScrubbing, setIsScrubbing] = useState(false);
+  const [scrubValue, setScrubValue] = useState(0);
+
+  const [coverError, setCoverError] = useState(false);
+
+  const togglePlay = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    // Drive the decision off our own playing state (kept in sync by the
+    // play/pause events) rather than audio.paused, which is more robust and
+    // testable. play() returns a promise that can reject (e.g. if interrupted);
+    // the play/pause events remain the source of truth, so swallow.
+    if (isPlayingRef.current) {
+      audio.pause();
+    } else {
+      void audio.play().catch(() => {});
+    }
+  }, []);
+
+  // Space toggles play/pause. Handle at the document level and preventDefault
+  // so the page doesn't scroll. Ignore the key when focus is in a text input
+  // (none today, but keeps the behavior robust) and when modifier keys are
+  // held so we don't hijack browser shortcuts.
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== " " && e.key !== "Spacebar") return;
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) {
+        return;
+      }
+      e.preventDefault();
+      togglePlay();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [togglePlay]);
+
+  const handleSeekChange = useCallback(([value]: number[]) => {
+    setIsScrubbing(true);
+    setScrubValue(value);
+  }, []);
+
+  const handleSeekCommit = useCallback(([value]: number[]) => {
+    const audio = audioRef.current;
+    if (audio) {
+      audio.currentTime = value;
+    }
+    setCurrentTime(value);
+    setIsScrubbing(false);
+  }, []);
+
+  const displayTime = isScrubbing ? scrubValue : currentTime;
+
+  const authorNames = joinNames(book?.authors);
+  const narratorNames = joinNames(file.narrators);
+
+  const coverCacheKey = book?.cover_cache_key;
+  const coverUrl =
+    book?.id != null
+      ? coverCacheKey
+        ? `/api/books/${book.id}/cover?v=${coverCacheKey}`
+        : `/api/books/${book.id}/cover`
+      : null;
+
+  return (
+    <div className="fixed inset-0 bg-background flex flex-col">
+      {/* Header with a way out of the player */}
+      <header className="flex items-center gap-2 px-4 py-2 border-b">
+        <Button
+          aria-label="Back"
+          onClick={() => {
+            if (book?.id != null) {
+              navigate(`/libraries/${libraryId}/books/${book.id}`);
+            } else {
+              navigate(-1);
+            }
+          }}
+          size="icon"
+          variant="ghost"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <span className="truncate text-sm font-medium">
+          {book?.title ?? "Audiobook"}
+        </span>
+      </header>
+
+      {/* Main content: cover + metadata, stacks on small screens */}
+      <main className="flex-1 overflow-y-auto">
+        <div className="mx-auto flex h-full max-w-2xl flex-col items-center justify-center gap-6 p-4 md:p-8">
+          <div className="aspect-square w-48 sm:w-56 md:w-64 shrink-0">
+            {coverUrl && !coverError ? (
+              <img
+                alt={`${book?.title ?? "Audiobook"} cover`}
+                className="h-full w-full rounded-md border border-border object-cover shadow-sm"
+                key={coverCacheKey}
+                onError={() => setCoverError(true)}
+                src={coverUrl}
+              />
+            ) : (
+              <CoverPlaceholder
+                className="h-full w-full rounded-md border border-border"
+                variant="audiobook"
+              />
+            )}
+          </div>
+
+          <div className="w-full text-center">
+            <h1 className="text-xl font-semibold break-words md:text-2xl">
+              {book?.title ?? "Audiobook"}
+            </h1>
+            {authorNames && (
+              <p className="mt-1 text-sm text-muted-foreground break-words">
+                {authorNames}
+              </p>
+            )}
+            {narratorNames && (
+              <p className="mt-1 text-sm text-muted-foreground break-words">
+                Narrated by {narratorNames}
+              </p>
+            )}
+          </div>
+        </div>
+      </main>
+
+      {/* Player controls — always visible, no auto-hide */}
+      <footer className="border-t bg-background px-4 py-4 md:px-8">
+        <div className="mx-auto max-w-2xl space-y-3">
+          <Slider
+            max={duration > 0 ? duration : 1}
+            min={0}
+            onValueChange={handleSeekChange}
+            onValueCommit={handleSeekCommit}
+            step={1}
+            thumbLabel="Seek"
+            value={[Math.min(displayTime, duration > 0 ? duration : 1)]}
+          />
+          <div className="flex items-center justify-between text-xs tabular-nums text-muted-foreground">
+            <span>{formatPlayerTime(displayTime)}</span>
+            <span>{formatPlayerTime(duration)}</span>
+          </div>
+          <div className="flex items-center justify-center">
+            <Button
+              aria-label={isPlaying ? "Pause" : "Play"}
+              className={cn("h-14 w-14 rounded-full")}
+              onClick={togglePlay}
+              size="icon"
+            >
+              {isPlaying ? (
+                <Pause className="h-6 w-6" />
+              ) : (
+                <Play className="h-6 w-6" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </footer>
+
+      <audio
+        onEnded={() => setIsPlaying(false)}
+        onLoadedMetadata={(e) => {
+          const el = e.currentTarget;
+          if (Number.isFinite(el.duration) && el.duration > 0) {
+            setMediaDuration(el.duration);
+          }
+        }}
+        onPause={() => setIsPlaying(false)}
+        onPlay={() => setIsPlaying(true)}
+        onTimeUpdate={(e) => {
+          if (isScrubbing) return;
+          setCurrentTime(e.currentTarget.currentTime);
+        }}
+        preload="metadata"
+        ref={audioRef}
+        src={streamUrl}
+      />
+    </div>
+  );
+}

--- a/app/components/ui/slider.tsx
+++ b/app/components/ui/slider.tsx
@@ -3,10 +3,19 @@ import * as React from "react";
 
 import { cn } from "@/libraries/utils";
 
+// Radix only labels the thumb automatically for multi-thumb sliders; a single
+// thumb has no accessible name. `thumbLabel` lets callers (e.g. an audio seek
+// bar) give the thumb an aria-label without breaking existing single-arg usage.
+type SliderProps = React.ComponentPropsWithoutRef<
+  typeof SliderPrimitive.Root
+> & {
+  thumbLabel?: string;
+};
+
 const Slider = React.forwardRef<
   React.ComponentRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
+  SliderProps
+>(({ className, thumbLabel, ...props }, ref) => (
   <SliderPrimitive.Root
     ref={ref}
     className={cn(
@@ -18,7 +27,10 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
       <SliderPrimitive.Range className="absolute h-full bg-primary" />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb
+      aria-label={thumbLabel}
+      className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+    />
   </SliderPrimitive.Root>
 ));
 Slider.displayName = SliderPrimitive.Root.displayName;

--- a/app/utils/format.test.ts
+++ b/app/utils/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatDate, formatDateTime } from "./format";
+import { formatDate, formatDateTime, formatPlayerTime } from "./format";
 
 describe("formatDate", () => {
   it("preserves the UTC date regardless of local timezone", () => {
@@ -33,5 +33,33 @@ describe("formatDateTime", () => {
     expect(result).toContain("2024");
     // Should contain a time with :30 minutes regardless of timezone
     expect(result).toMatch(/:30/);
+  });
+});
+
+describe("formatPlayerTime", () => {
+  it("formats sub-minute durations as M:SS with zero minutes", () => {
+    expect(formatPlayerTime(5)).toBe("0:05");
+    expect(formatPlayerTime(45)).toBe("0:45");
+  });
+
+  it("formats minute-and-second durations as M:SS", () => {
+    expect(formatPlayerTime(65)).toBe("1:05");
+    expect(formatPlayerTime(185)).toBe("3:05");
+  });
+
+  it("formats hour-long durations as H:MM:SS", () => {
+    expect(formatPlayerTime(3661)).toBe("1:01:01");
+    expect(formatPlayerTime(3600)).toBe("1:00:00");
+  });
+
+  it("truncates fractional seconds rather than rounding up", () => {
+    expect(formatPlayerTime(59.9)).toBe("0:59");
+    expect(formatPlayerTime(0.4)).toBe("0:00");
+  });
+
+  it("clamps NaN, negative, and non-finite inputs to 0:00", () => {
+    expect(formatPlayerTime(NaN)).toBe("0:00");
+    expect(formatPlayerTime(-10)).toBe("0:00");
+    expect(formatPlayerTime(Infinity)).toBe("0:00");
   });
 });

--- a/app/utils/format.ts
+++ b/app/utils/format.ts
@@ -25,6 +25,29 @@ export const formatDuration = (seconds: number): string => {
 };
 
 /**
+ * Formats a number of seconds into a clock-style media player timestamp.
+ * Uses M:SS for durations under an hour and H:MM:SS for longer ones, with
+ * seconds truncated (not rounded). Non-finite, NaN, and negative inputs clamp
+ * to "0:00" so the player never shows garbage while metadata is loading.
+ * @example formatPlayerTime(185) // "3:05"
+ * @example formatPlayerTime(3661) // "1:01:01"
+ */
+export const formatPlayerTime = (seconds: number): string => {
+  const total =
+    Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : 0;
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const secs = total % 60;
+
+  const ss = String(secs).padStart(2, "0");
+  if (hours > 0) {
+    const mm = String(minutes).padStart(2, "0");
+    return `${hours}:${mm}:${ss}`;
+  }
+  return `${minutes}:${ss}`;
+};
+
+/**
  * Formats an ISO date string into a localized date string.
  * @example formatDate("2024-01-15T12:00:00Z") // "Jan 15, 2024" (locale-dependent)
  */

--- a/app/utils/readingAction.test.ts
+++ b/app/utils/readingAction.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { getReadingAction } from "./readingAction";
+
+describe("getReadingAction", () => {
+  it("returns a Listen action for m4b files", () => {
+    expect(getReadingAction("m4b")).toBe("listen");
+  });
+
+  it("returns a Read action for cbz, epub, and pdf files", () => {
+    expect(getReadingAction("cbz")).toBe("read");
+    expect(getReadingAction("epub")).toBe("read");
+    expect(getReadingAction("pdf")).toBe("read");
+  });
+
+  it("returns null for file types with no in-app reader", () => {
+    expect(getReadingAction("txt")).toBeNull();
+    expect(getReadingAction("")).toBeNull();
+  });
+});

--- a/app/utils/readingAction.ts
+++ b/app/utils/readingAction.ts
@@ -1,0 +1,23 @@
+import { FileTypeCBZ, FileTypeEPUB, FileTypeM4B, FileTypePDF } from "@/types";
+
+/**
+ * The in-app reading action a file type supports, surfaced as a button on the
+ * File and Book detail views. Audiobooks (M4B) get a "Listen" action that opens
+ * the audio player; ebooks/comics get a "Read" action that opens their reader.
+ * Both route through the same `/read` route. Returns null for file types with
+ * no in-app reader.
+ */
+export type ReadingAction = "read" | "listen";
+
+export function getReadingAction(fileType: string): ReadingAction | null {
+  switch (fileType) {
+    case FileTypeM4B:
+      return "listen";
+    case FileTypeCBZ:
+    case FileTypeEPUB:
+    case FileTypePDF:
+      return "read";
+    default:
+      return null;
+  }
+}

--- a/website/docs/supported-formats.md
+++ b/website/docs/supported-formats.md
@@ -18,7 +18,7 @@ fingerprints (cover pHash, text SimHash, etc.) — see
 
 ## Audiobooks
 
-- **M4B** — Full [metadata extraction](./metadata#m4b) including title, authors, narrators, series, chapters, cover art, language, and abridged status
+- **M4B** — Full [metadata extraction](./metadata#m4b) including title, authors, narrators, series, chapters, cover art, language, and abridged status. Includes an in-app player with play/pause, a draggable seek bar, and elapsed/total time, showing the cover, title, author, and narrator
 
 ## Comics
 


### PR DESCRIPTION
Closes #361

## Summary

First slice of the in-app M4B audiobook player. A new `M4BReader` component streams the whole file from the existing `/api/books/files/:id/stream` endpoint via a native `<audio>` element (cookie auth, no JS fetch), with play/pause, a click-and-drag whole-file seek bar (Radix Slider with a scrubbing state so `timeupdate` doesn't fight the drag), elapsed/total time labels, cover + title + author + narrator, a space-key toggle, no autoplay, and stop-stay-on-player at end of file.

It is wired into the existing `/read` route via a new `case FileTypeM4B` in `FileReader`, and a "Listen" action (headphones icon) is shown for M4B files in both the File detail and Book detail views via a shared, tested `getReadingAction` helper. No backend changes were needed; the streaming endpoint already existed.

This is the first slice of the M4B player series. Chapters (#362), playback speed (#363), and codec messaging (#364) are intentionally deferred and not in this PR. There is no resume/position-persistence by design for this slice (the player loads at 0 each time).

### Files changed

- `app/components/pages/M4BReader.tsx` (new) — the audiobook player surface (full-screen reader chrome, controls always visible, responsive stacked layout, back button to book detail).
- `app/components/pages/FileReader.tsx` — added `case FileTypeM4B` dispatching to `M4BReader`.
- `app/utils/readingAction.ts` (new) — `getReadingAction(fileType)` returning "listen" (m4b) / "read" (cbz/epub/pdf) / null; single source of truth for the action in both detail views.
- `app/components/pages/FileDetail.tsx` — top-bar action uses `getReadingAction` (Listen for m4b, Read for ebooks/comics).
- `app/components/pages/BookDetail.tsx` — both the desktop and mobile per-file action blocks in `FileRow` use `getReadingAction` (these are separate parallel copies; both updated). Removed the now-unused `FileTypePDF` import.
- `app/components/ui/slider.tsx` — added an optional `thumbLabel` prop so a single-thumb slider has an accessible name (Radix only auto-labels multi-thumb sliders); backward-compatible.
- `app/utils/format.ts` — added `formatPlayerTime(seconds)` returning "M:SS" / "H:MM:SS", truncating and clamping NaN/negative/Infinity to "0:00".
- `website/docs/supported-formats.md` — noted M4B now has an in-app player.

### For reviewers

Look first at:
1. `M4BReader` play/pause driven off React `isPlaying` state via a ref rather than reading `audio.paused` (the `play`/`pause` events remain the source of truth), and the scrubbing-state seek loop.
2. The `Slider` `thumbLabel` addition (shared component, backward compatible).
3. `BookDetail` touches two parallel code paths — the desktop and mobile action rows in `FileRow` are separate copies, both updated.

## Test plan

- `formatPlayerTime` formatting / truncation / clamping (`app/utils/format.test.ts`).
- `getReadingAction` listen/read/null mapping (`app/utils/readingAction.test.ts`).
- `M4BReader`: stream src; no autoplay; title/author/narrator shown; cache-busted cover URL; tab title set; uses file duration as total with fallback to audio duration; play -> pause control; pause calls pause; `timeupdate` advances elapsed; seek commit sets `currentTime`; ended pauses and stays; space toggles + `preventDefault` (`app/components/pages/M4BReader.test.tsx`, jsdom media mocked).
- `FileReader` dispatch to the M4B player / CBZ reader / unsupported (`app/components/pages/FileReader.test.tsx`).
- `FileDetail` shows Listen vs Read vs neither with the correct `/read` href (`app/components/pages/FileDetail.test.tsx`).
- Live-browser manual verification was not performed (this worktree has no running stack and no committed M4B fixture); coverage rests on the unit/component suite plus the e2e chromium pass. A real-browser smoke test of drag-seek and space-key behavior is worth doing before/after merge since jsdom can't exercise the real media pipeline or Radix pointer-drag.