### PR TITLE
[Frontend] Add chapter navigation to the M4B player

### DIFF
--- a/app/components/pages/M4BReader.test.tsx
+++ b/app/components/pages/M4BReader.test.tsx
@@ -42,6 +42,27 @@ const file = {
   narrators: [{ id: 1, file_id: 42, person_id: 9, person: narratorPerson }],
 } as unknown as File;
 
+// A file with three chapters spanning a 3600s book: 0–1200, 1200–2400, 2400–end.
+// Chapter starts are in MILLISECONDS on the model.
+const fileWithChapters = {
+  ...file,
+  chapters: [
+    { id: 1, title: "Chapter One", start_timestamp_ms: 0, sort_order: 0 },
+    {
+      id: 2,
+      title: "Chapter Two",
+      start_timestamp_ms: 1200000,
+      sort_order: 1,
+    },
+    {
+      id: 3,
+      title: "Chapter Three",
+      start_timestamp_ms: 2400000,
+      sort_order: 2,
+    },
+  ],
+} as unknown as File;
+
 const book = {
   id: 7,
   title: "The Test Audiobook",
@@ -187,5 +208,176 @@ describe("M4BReader", () => {
     fireEvent.loadedMetadata(audio);
     // 125s => 2:05
     expect(screen.getByText("2:05")).toBeInTheDocument();
+  });
+
+  describe("chapter navigation", () => {
+    it("renders a chapter dropdown that jumps to the selected chapter's start", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderReader({ file: fileWithChapters });
+      const audio = getAudio();
+
+      await user.click(screen.getByRole("combobox", { name: /chapter/i }));
+      await user.click(
+        await screen.findByRole("option", { name: /chapter three/i }),
+      );
+      // Chapter Three starts at 2400000ms => 2400s.
+      expect(audio.currentTime).toBe(2400);
+    });
+
+    it("shows the current chapter title and updates it as playback crosses a boundary", () => {
+      renderReader({ file: fileWithChapters });
+      const audio = getAudio();
+      const combobox = screen.getByRole("combobox", { name: /chapter/i });
+
+      // Start of the file: first chapter is the displayed/selected chapter.
+      expect(combobox).toHaveTextContent("Chapter One");
+
+      // Advance past the second chapter boundary (1200s).
+      audio.currentTime = 1300;
+      fireEvent.timeUpdate(audio);
+      expect(combobox).toHaveTextContent("Chapter Two");
+      expect(combobox).not.toHaveTextContent("Chapter One");
+    });
+
+    it("renders chapter markers along the seek bar at the correct positions", () => {
+      const { container } = renderReader({ file: fileWithChapters });
+      // The first chapter starts at 0 (no marker); the two later chapters get
+      // markers positioned by start/duration.
+      const markers = container.querySelectorAll(
+        '[aria-hidden="true"][style*="left"]',
+      );
+      const lefts = Array.from(markers).map(
+        (m) => (m as HTMLElement).style.left,
+      );
+      // 1200/3600 => 33.33%, 2400/3600 => 66.66%
+      expect(lefts).toHaveLength(2);
+      expect(lefts[0]).toMatch(/^33\.33/);
+      expect(lefts[1]).toMatch(/^66\.66/);
+    });
+
+    it("advances to the next chapter with the next button", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderReader({ file: fileWithChapters });
+      const audio = getAudio();
+
+      await user.click(screen.getByRole("button", { name: /next chapter/i }));
+      // From 0 (chapter one), next chapter starts at 1200s.
+      expect(audio.currentTime).toBe(1200);
+    });
+
+    it("restarts the current chapter with previous when more than ~5s in", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderReader({ file: fileWithChapters });
+      const audio = getAudio();
+
+      // Move to 1300s (well into chapter two, which starts at 1200s).
+      audio.currentTime = 1300;
+      fireEvent.timeUpdate(audio);
+      await user.click(
+        screen.getByRole("button", { name: /previous chapter/i }),
+      );
+      // More than 5s in => restart current chapter (1200s).
+      expect(audio.currentTime).toBe(1200);
+    });
+
+    it("goes to the prior chapter with previous when within ~5s of the start", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderReader({ file: fileWithChapters });
+      const audio = getAudio();
+
+      // Move to 1203s (just 3s into chapter two).
+      audio.currentTime = 1203;
+      fireEvent.timeUpdate(audio);
+      await user.click(
+        screen.getByRole("button", { name: /previous chapter/i }),
+      );
+      // Within 5s => go to prior chapter (chapter one, start 0).
+      expect(audio.currentTime).toBe(0);
+    });
+
+    it("skips forward and back by 30 seconds with the skip buttons", async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderReader({ file: fileWithChapters });
+      const audio = getAudio();
+
+      audio.currentTime = 100;
+      fireEvent.timeUpdate(audio);
+
+      await user.click(
+        screen.getByRole("button", { name: /skip forward 30 seconds/i }),
+      );
+      expect(audio.currentTime).toBe(130);
+
+      await user.click(
+        screen.getByRole("button", { name: /skip back 30 seconds/i }),
+      );
+      expect(audio.currentTime).toBe(100);
+    });
+
+    it("skips with the left and right arrow keys", () => {
+      renderReader({ file: fileWithChapters });
+      const audio = getAudio();
+      audio.currentTime = 100;
+      fireEvent.timeUpdate(audio);
+
+      const right = new KeyboardEvent("keydown", {
+        key: "ArrowRight",
+        bubbles: true,
+        cancelable: true,
+      });
+      const rightPrevented = !document.dispatchEvent(right);
+      expect(audio.currentTime).toBe(130);
+      expect(rightPrevented).toBe(true);
+
+      const left = new KeyboardEvent("keydown", {
+        key: "ArrowLeft",
+        bubbles: true,
+        cancelable: true,
+      });
+      const leftPrevented = !document.dispatchEvent(left);
+      expect(audio.currentTime).toBe(100);
+      expect(leftPrevented).toBe(true);
+    });
+
+    it("clamps arrow-key skips to the start and end of the file", () => {
+      renderReader({ file: fileWithChapters });
+      const audio = getAudio();
+
+      // Near the start: skip back clamps to 0.
+      audio.currentTime = 10;
+      fireEvent.timeUpdate(audio);
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+      expect(audio.currentTime).toBe(0);
+
+      // Near the end: skip forward clamps to the duration (3600s).
+      audio.currentTime = 3590;
+      fireEvent.timeUpdate(audio);
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+      expect(audio.currentTime).toBe(3600);
+    });
+
+    it("renders the player with chapter navigation absent for a file with no chapters", () => {
+      renderReader({ file });
+      // No chapter controls when there are no chapters.
+      expect(
+        screen.queryByRole("combobox", { name: /chapter/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /next chapter/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /previous chapter/i }),
+      ).not.toBeInTheDocument();
+      // The player itself still works.
+      expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument();
+      // Plain skip controls remain available even without chapters.
+      expect(
+        screen.getByRole("button", { name: /skip forward 30 seconds/i }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/app/components/pages/M4BReader.tsx
+++ b/app/components/pages/M4BReader.tsx
@@ -1,13 +1,33 @@
-import { ArrowLeft, Pause, Play } from "lucide-react";
+import {
+  ArrowLeft,
+  Pause,
+  Play,
+  RotateCcw,
+  RotateCw,
+  SkipBack,
+  SkipForward,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import CoverPlaceholder from "@/components/library/CoverPlaceholder";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { cn } from "@/libraries/utils";
 import type { Book, File } from "@/types";
+import {
+  resolveChapters,
+  resolvePlayback,
+  SKIP_SECONDS,
+} from "@/utils/chapters";
 import { formatPlayerTime } from "@/utils/format";
 
 interface M4BReaderProps {
@@ -53,6 +73,16 @@ export default function M4BReader({ file, book, libraryId }: M4BReaderProps) {
     isPlayingRef.current = isPlaying;
   }, [isPlaying]);
 
+  // Keep the live time and duration in refs so the stable keydown handler can
+  // compute skip targets from the latest values without resubscribing on every
+  // timeupdate — and, crucially, without lagging a render behind, so successive
+  // synchronous arrow presses each build on the prior one's seek.
+  const currentTimeRef = useRef(0);
+  const durationRef = useRef(duration);
+  useEffect(() => {
+    durationRef.current = duration;
+  }, [duration]);
+
   // While the user is dragging the seek bar we follow the pending scrub value
   // instead of the audio's reported time, so timeupdate events don't fight the
   // thumb. On commit we seek the element and resume following timeupdate.
@@ -60,6 +90,40 @@ export default function M4BReader({ file, book, libraryId }: M4BReaderProps) {
   const [scrubValue, setScrubValue] = useState(0);
 
   const [coverError, setCoverError] = useState(false);
+
+  // Resolve the file's chapters into absolute second boundaries once. The pure
+  // module handles unit conversion (ms -> s), sorting, and dropping chapters
+  // without a start. A file with no usable chapters yields an empty list and
+  // chapter navigation is simply absent.
+  const chapters = useMemo(
+    () => resolveChapters(file.chapters, duration),
+    [file.chapters, duration],
+  );
+  const hasChapters = chapters.length > 0;
+
+  // The displayed/effective time follows the scrub value while dragging so the
+  // chapter readout and dropdown track the thumb, otherwise the audio's time.
+  const displayTime = isScrubbing ? scrubValue : currentTime;
+
+  // Derive all playback-relative targets (current chapter, prev/next, skips)
+  // from the pure module. Recomputed as time/chapters/duration change.
+  const playback = useMemo(
+    () => resolvePlayback(chapters, displayTime, duration),
+    [chapters, displayTime, duration],
+  );
+
+  // Seek the audio element and keep our currentTime in sync. Centralized so the
+  // buttons, dropdown, and keyboard shortcuts all go through one path. Writes
+  // the time ref eagerly (before the state update flushes) so the keydown
+  // handler always reads the freshest position.
+  const seekTo = useCallback((seconds: number) => {
+    const audio = audioRef.current;
+    if (audio) {
+      audio.currentTime = seconds;
+    }
+    currentTimeRef.current = seconds;
+    setCurrentTime(seconds);
+  }, []);
 
   const togglePlay = useCallback(() => {
     const audio = audioRef.current;
@@ -75,41 +139,59 @@ export default function M4BReader({ file, book, libraryId }: M4BReaderProps) {
     }
   }, []);
 
-  // Space toggles play/pause. Handle at the document level and preventDefault
-  // so the page doesn't scroll. Ignore the key when focus is in a text input
-  // (none today, but keeps the behavior robust) and when modifier keys are
-  // held so we don't hijack browser shortcuts.
+  // Space toggles play/pause; Left/Right arrows skip back/forward by 30s. Handle
+  // at the document level and preventDefault so the page doesn't scroll. Ignore
+  // the keys when focus is in a text input or when modifier keys are held so we
+  // don't hijack browser shortcuts. The chapter dropdown (a Radix Select), while
+  // open, handles its own arrow-key navigation and stops propagation, so its
+  // keys never reach this document-level listener.
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== " " && e.key !== "Spacebar") return;
       if (e.ctrlKey || e.metaKey || e.altKey) return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) {
         return;
       }
-      e.preventDefault();
-      togglePlay();
+
+      if (e.key === " " || e.key === "Spacebar") {
+        e.preventDefault();
+        togglePlay();
+        return;
+      }
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        const target = Math.max(currentTimeRef.current - SKIP_SECONDS, 0);
+        seekTo(target);
+        return;
+      }
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        const max = durationRef.current;
+        const target = Math.min(
+          currentTimeRef.current + SKIP_SECONDS,
+          max > 0 ? max : currentTimeRef.current + SKIP_SECONDS,
+        );
+        seekTo(target);
+        return;
+      }
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [togglePlay]);
+  }, [togglePlay, seekTo]);
 
   const handleSeekChange = useCallback(([value]: number[]) => {
     setIsScrubbing(true);
     setScrubValue(value);
   }, []);
 
-  const handleSeekCommit = useCallback(([value]: number[]) => {
-    const audio = audioRef.current;
-    if (audio) {
-      audio.currentTime = value;
-    }
-    setCurrentTime(value);
-    setIsScrubbing(false);
-  }, []);
-
-  const displayTime = isScrubbing ? scrubValue : currentTime;
+  const handleSeekCommit = useCallback(
+    ([value]: number[]) => {
+      seekTo(value);
+      setIsScrubbing(false);
+    },
+    [seekTo],
+  );
 
   const authorNames = joinNames(book?.authors);
   const narratorNames = joinNames(file.narrators);
@@ -121,6 +203,8 @@ export default function M4BReader({ file, book, libraryId }: M4BReaderProps) {
         ? `/api/books/${book.id}/cover?v=${coverCacheKey}`
         : `/api/books/${book.id}/cover`
       : null;
+
+  const sliderMax = duration > 0 ? duration : 1;
 
   return (
     <div className="fixed inset-0 bg-background flex flex-col">
@@ -186,20 +270,92 @@ export default function M4BReader({ file, book, libraryId }: M4BReaderProps) {
       {/* Player controls — always visible, no auto-hide */}
       <footer className="border-t bg-background px-4 py-4 md:px-8">
         <div className="mx-auto max-w-2xl space-y-3">
-          <Slider
-            max={duration > 0 ? duration : 1}
-            min={0}
-            onValueChange={handleSeekChange}
-            onValueCommit={handleSeekCommit}
-            step={1}
-            thumbLabel="Seek"
-            value={[Math.min(displayTime, duration > 0 ? duration : 1)]}
-          />
+          {/* Chapter dropdown (only with chapters). Its trigger doubles as the
+              current chapter title, kept in sync with playback via `value`. */}
+          {hasChapters && (
+            <Select
+              onValueChange={(value) => {
+                const chapter = chapters[Number(value)];
+                if (chapter) seekTo(chapter.startSeconds);
+              }}
+              value={
+                playback.currentChapterIndex != null
+                  ? String(playback.currentChapterIndex)
+                  : undefined
+              }
+            >
+              <SelectTrigger aria-label="Chapter" className="w-full min-w-0">
+                <SelectValue placeholder="Select chapter" />
+              </SelectTrigger>
+              <SelectContent>
+                {chapters.map((chapter) => (
+                  <SelectItem key={chapter.index} value={String(chapter.index)}>
+                    <span className="truncate" title={chapter.title}>
+                      {chapter.title}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+
+          <div className="relative">
+            <Slider
+              max={sliderMax}
+              min={0}
+              onValueChange={handleSeekChange}
+              onValueCommit={handleSeekCommit}
+              step={1}
+              thumbLabel="Seek"
+              value={[Math.min(displayTime, sliderMax)]}
+            />
+            {/* Chapter markers along the seek bar, positioned by start/duration.
+                Skip the first marker at 0 (it sits under the thumb origin). */}
+            {hasChapters &&
+              duration > 0 &&
+              chapters.map((chapter) =>
+                chapter.startSeconds <= 0 ? null : (
+                  <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute top-1/2 h-2 w-px -translate-x-1/2 -translate-y-1/2 bg-primary/40"
+                    key={chapter.index}
+                    style={{
+                      left: `${(chapter.startSeconds / duration) * 100}%`,
+                    }}
+                  />
+                ),
+              )}
+          </div>
+
           <div className="flex items-center justify-between text-xs tabular-nums text-muted-foreground">
             <span>{formatPlayerTime(displayTime)}</span>
             <span>{formatPlayerTime(duration)}</span>
           </div>
-          <div className="flex items-center justify-center">
+
+          <div className="flex items-center justify-center gap-2 sm:gap-4">
+            {hasChapters && (
+              <Button
+                aria-label="Previous chapter"
+                disabled={playback.previousChapterTarget == null}
+                onClick={() => {
+                  if (playback.previousChapterTarget != null) {
+                    seekTo(playback.previousChapterTarget);
+                  }
+                }}
+                size="icon"
+                variant="ghost"
+              >
+                <SkipBack className="h-5 w-5" />
+              </Button>
+            )}
+            <Button
+              aria-label="Skip back 30 seconds"
+              onClick={() => seekTo(playback.skipBackTarget)}
+              size="icon"
+              variant="ghost"
+            >
+              <RotateCcw className="h-5 w-5" />
+            </Button>
             <Button
               aria-label={isPlaying ? "Pause" : "Play"}
               className={cn("h-14 w-14 rounded-full")}
@@ -212,6 +368,29 @@ export default function M4BReader({ file, book, libraryId }: M4BReaderProps) {
                 <Play className="h-6 w-6" />
               )}
             </Button>
+            <Button
+              aria-label="Skip forward 30 seconds"
+              onClick={() => seekTo(playback.skipForwardTarget)}
+              size="icon"
+              variant="ghost"
+            >
+              <RotateCw className="h-5 w-5" />
+            </Button>
+            {hasChapters && (
+              <Button
+                aria-label="Next chapter"
+                disabled={playback.nextChapterTarget == null}
+                onClick={() => {
+                  if (playback.nextChapterTarget != null) {
+                    seekTo(playback.nextChapterTarget);
+                  }
+                }}
+                size="icon"
+                variant="ghost"
+              >
+                <SkipForward className="h-5 w-5" />
+              </Button>
+            )}
           </div>
         </div>
       </footer>
@@ -228,7 +407,9 @@ export default function M4BReader({ file, book, libraryId }: M4BReaderProps) {
         onPlay={() => setIsPlaying(true)}
         onTimeUpdate={(e) => {
           if (isScrubbing) return;
-          setCurrentTime(e.currentTarget.currentTime);
+          const time = e.currentTarget.currentTime;
+          currentTimeRef.current = time;
+          setCurrentTime(time);
         }}
         preload="metadata"
         ref={audioRef}

--- a/app/components/pages/M4BReader.tsx
+++ b/app/components/pages/M4BReader.tsx
@@ -26,6 +26,7 @@ import type { Book, File } from "@/types";
 import {
   resolveChapters,
   resolvePlayback,
+  resolveSkipTarget,
   SKIP_SECONDS,
 } from "@/utils/chapters";
 import { formatPlayerTime } from "@/utils/format";
@@ -161,18 +162,24 @@ export default function M4BReader({ file, book, libraryId }: M4BReaderProps) {
       }
       if (e.key === "ArrowLeft") {
         e.preventDefault();
-        const target = Math.max(currentTimeRef.current - SKIP_SECONDS, 0);
-        seekTo(target);
+        seekTo(
+          resolveSkipTarget(
+            currentTimeRef.current,
+            -SKIP_SECONDS,
+            durationRef.current,
+          ),
+        );
         return;
       }
       if (e.key === "ArrowRight") {
         e.preventDefault();
-        const max = durationRef.current;
-        const target = Math.min(
-          currentTimeRef.current + SKIP_SECONDS,
-          max > 0 ? max : currentTimeRef.current + SKIP_SECONDS,
+        seekTo(
+          resolveSkipTarget(
+            currentTimeRef.current,
+            SKIP_SECONDS,
+            durationRef.current,
+          ),
         );
-        seekTo(target);
         return;
       }
     };

--- a/app/utils/chapters.test.ts
+++ b/app/utils/chapters.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import type { Chapter } from "@/types";
+
+import {
+  PREVIOUS_CHAPTER_RESTART_THRESHOLD_SECONDS,
+  resolveChapters,
+  resolvePlayback,
+  SKIP_SECONDS,
+} from "./chapters";
+
+// Build a minimal Chapter with only the fields the resolver reads. The rest of
+// the model (timestamps, file_id, etc.) is irrelevant to the pure module.
+const chapter = (
+  title: string,
+  startMs: number | undefined,
+  sortOrder: number,
+): Chapter =>
+  ({
+    title,
+    start_timestamp_ms: startMs,
+    sort_order: sortOrder,
+  }) as Chapter;
+
+describe("resolveChapters", () => {
+  it("returns no chapters for an empty list", () => {
+    const result = resolveChapters([], 3600);
+    expect(result).toEqual([]);
+  });
+
+  it("returns no chapters for an undefined list", () => {
+    const result = resolveChapters(undefined, 3600);
+    expect(result).toEqual([]);
+  });
+
+  it("derives a single chapter spanning the whole file", () => {
+    const result = resolveChapters([chapter("Only", 0, 0)], 3600);
+    expect(result).toEqual([
+      { index: 0, title: "Only", startSeconds: 0, endSeconds: 3600 },
+    ]);
+  });
+
+  it("converts millisecond starts to seconds and ends each chapter where the next begins", () => {
+    const result = resolveChapters(
+      [
+        chapter("One", 0, 0),
+        chapter("Two", 60000, 1),
+        chapter("Three", 120000, 2),
+      ],
+      300,
+    );
+    expect(result).toEqual([
+      { index: 0, title: "One", startSeconds: 0, endSeconds: 60 },
+      { index: 1, title: "Two", startSeconds: 60, endSeconds: 120 },
+      { index: 2, title: "Three", startSeconds: 120, endSeconds: 300 },
+    ]);
+  });
+
+  it("sorts chapters by start time when they arrive out of order", () => {
+    const result = resolveChapters(
+      [chapter("Two", 60000, 1), chapter("One", 0, 0)],
+      120,
+    );
+    expect(result.map((c) => c.title)).toEqual(["One", "Two"]);
+    expect(result[0].startSeconds).toBe(0);
+    expect(result[1].startSeconds).toBe(60);
+  });
+
+  it("treats chapters with missing start timestamps as no chapters", () => {
+    const result = resolveChapters(
+      [chapter("One", undefined, 0), chapter("Two", undefined, 1)],
+      120,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("drops only the chapters missing a start timestamp, keeping the rest", () => {
+    const result = resolveChapters(
+      [
+        chapter("One", 0, 0),
+        chapter("Bad", undefined, 1),
+        chapter("Two", 60000, 2),
+      ],
+      120,
+    );
+    expect(result.map((c) => c.title)).toEqual(["One", "Two"]);
+    expect(result[1].endSeconds).toBe(120);
+  });
+});
+
+describe("resolvePlayback", () => {
+  const chapters = resolveChapters(
+    [
+      chapter("One", 0, 0),
+      chapter("Two", 60000, 1),
+      chapter("Three", 120000, 2),
+    ],
+    180,
+  );
+
+  it("reports no current chapter when there are no chapters", () => {
+    const result = resolvePlayback([], 50, 180);
+    expect(result.currentChapterIndex).toBeNull();
+    expect(result.currentChapter).toBeNull();
+  });
+
+  it("clamps the current chapter to the first one when time is before the first start", () => {
+    // start is 0 so this can only happen with a defensive negative time, but
+    // the last-chapter-at-or-before rule still yields the first chapter.
+    const result = resolvePlayback(chapters, -5, 180);
+    expect(result.currentChapterIndex).toBe(0);
+    expect(result.currentChapter?.title).toBe("One");
+  });
+
+  it("selects the last chapter whose start is at or before the current time", () => {
+    const result = resolvePlayback(chapters, 90, 180);
+    expect(result.currentChapterIndex).toBe(1);
+    expect(result.currentChapter?.title).toBe("Two");
+  });
+
+  it("treats an exact boundary as the start of the next chapter", () => {
+    const result = resolvePlayback(chapters, 120, 180);
+    expect(result.currentChapterIndex).toBe(2);
+    expect(result.currentChapter?.title).toBe("Three");
+  });
+
+  it("keeps the last chapter selected past the end of the file", () => {
+    const result = resolvePlayback(chapters, 999, 180);
+    expect(result.currentChapterIndex).toBe(2);
+    expect(result.currentChapter?.title).toBe("Three");
+  });
+
+  describe("next chapter target", () => {
+    it("jumps to the start of the following chapter", () => {
+      const result = resolvePlayback(chapters, 30, 180);
+      expect(result.nextChapterTarget).toBe(60);
+    });
+
+    it("is null on the last chapter (nothing to advance to)", () => {
+      const result = resolvePlayback(chapters, 150, 180);
+      expect(result.nextChapterTarget).toBeNull();
+    });
+
+    it("is null when there are no chapters", () => {
+      const result = resolvePlayback([], 30, 180);
+      expect(result.nextChapterTarget).toBeNull();
+    });
+  });
+
+  describe("previous chapter target (smart restart rule)", () => {
+    it("restarts the current chapter when more than the threshold into it", () => {
+      // 60 + threshold + a hair => restart current chapter (start 60).
+      const time = 60 + PREVIOUS_CHAPTER_RESTART_THRESHOLD_SECONDS + 0.5;
+      const result = resolvePlayback(chapters, time, 180);
+      expect(result.previousChapterTarget).toBe(60);
+    });
+
+    it("goes to the prior chapter when within the threshold of the current start", () => {
+      // 60 + threshold - a hair => prior chapter (start 0).
+      const time = 60 + PREVIOUS_CHAPTER_RESTART_THRESHOLD_SECONDS - 0.5;
+      const result = resolvePlayback(chapters, time, 180);
+      expect(result.previousChapterTarget).toBe(0);
+    });
+
+    it("restarts the first chapter (target 0) rather than going negative", () => {
+      // Within the first chapter, before the threshold: there is no prior
+      // chapter, so the target restarts at 0.
+      const result = resolvePlayback(chapters, 2, 180);
+      expect(result.previousChapterTarget).toBe(0);
+    });
+
+    it("restarts the first chapter when well into it", () => {
+      const result = resolvePlayback(chapters, 40, 180);
+      expect(result.previousChapterTarget).toBe(0);
+    });
+
+    it("is null when there are no chapters", () => {
+      const result = resolvePlayback([], 30, 180);
+      expect(result.previousChapterTarget).toBeNull();
+    });
+  });
+
+  describe("skip targets", () => {
+    it("skips forward by the skip interval", () => {
+      const result = resolvePlayback(chapters, 30, 180);
+      expect(result.skipForwardTarget).toBe(30 + SKIP_SECONDS);
+    });
+
+    it("skips backward by the skip interval", () => {
+      const result = resolvePlayback(chapters, 100, 180);
+      expect(result.skipBackTarget).toBe(100 - SKIP_SECONDS);
+    });
+
+    it("clamps skip back to 0 at the start of the file", () => {
+      const result = resolvePlayback(chapters, 10, 180);
+      expect(result.skipBackTarget).toBe(0);
+    });
+
+    it("clamps skip forward to the duration at the end of the file", () => {
+      const result = resolvePlayback(chapters, 170, 180);
+      expect(result.skipForwardTarget).toBe(180);
+    });
+
+    it("skip targets work with no chapters", () => {
+      const result = resolvePlayback([], 10, 180);
+      expect(result.skipBackTarget).toBe(0);
+      expect(result.skipForwardTarget).toBe(10 + SKIP_SECONDS);
+    });
+  });
+});

--- a/app/utils/chapters.test.ts
+++ b/app/utils/chapters.test.ts
@@ -6,6 +6,7 @@ import {
   PREVIOUS_CHAPTER_RESTART_THRESHOLD_SECONDS,
   resolveChapters,
   resolvePlayback,
+  resolveSkipTarget,
   SKIP_SECONDS,
 } from "./chapters";
 
@@ -206,5 +207,33 @@ describe("resolvePlayback", () => {
       expect(result.skipBackTarget).toBe(0);
       expect(result.skipForwardTarget).toBe(10 + SKIP_SECONDS);
     });
+  });
+});
+
+describe("resolveSkipTarget", () => {
+  it("skips forward by the delta", () => {
+    expect(resolveSkipTarget(100, SKIP_SECONDS, 180)).toBe(100 + SKIP_SECONDS);
+  });
+
+  it("skips backward by a negative delta", () => {
+    expect(resolveSkipTarget(100, -SKIP_SECONDS, 180)).toBe(100 - SKIP_SECONDS);
+  });
+
+  it("clamps a backward skip to 0", () => {
+    expect(resolveSkipTarget(10, -SKIP_SECONDS, 180)).toBe(0);
+  });
+
+  it("clamps a forward skip to the duration", () => {
+    expect(resolveSkipTarget(170, SKIP_SECONDS, 180)).toBe(180);
+  });
+
+  it("leaves the upper bound open while the duration is unknown so a forward skip still advances", () => {
+    // Duration not yet loaded (0): the forward skip must advance rather than
+    // snapping back to 0.
+    expect(resolveSkipTarget(100, SKIP_SECONDS, 0)).toBe(100 + SKIP_SECONDS);
+  });
+
+  it("still clamps a backward skip to 0 when the duration is unknown", () => {
+    expect(resolveSkipTarget(10, -SKIP_SECONDS, 0)).toBe(0);
   });
 });

--- a/app/utils/chapters.ts
+++ b/app/utils/chapters.ts
@@ -59,6 +59,24 @@ const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max);
 
 /**
+ * Computes a skip seek target by offsetting the current time by `deltaSeconds`
+ * (negative to skip back, positive to skip forward) and clamping the result to
+ * the playable range `[0, durationSeconds]`. The single source of truth for
+ * skip math, shared by the memoized playback state and the keyboard handler so
+ * both clamp identically. When the duration is not yet known (<= 0), the upper
+ * bound is left open so a forward skip still advances rather than snapping to 0.
+ */
+export function resolveSkipTarget(
+  currentTimeSeconds: number,
+  deltaSeconds: number,
+  durationSeconds: number,
+): number {
+  const target = currentTimeSeconds + deltaSeconds;
+  const upperBound = durationSeconds > 0 ? durationSeconds : Infinity;
+  return clamp(target, 0, upperBound);
+}
+
+/**
  * Resolves a list of model chapters into absolute second boundaries.
  *
  * Defensive against real-world data: chapters may arrive unsorted or missing a
@@ -134,14 +152,14 @@ export function resolvePlayback(
   currentTimeSeconds: number,
   durationSeconds: number,
 ): PlaybackState {
-  const skipBackTarget = clamp(
-    currentTimeSeconds - SKIP_SECONDS,
-    0,
+  const skipBackTarget = resolveSkipTarget(
+    currentTimeSeconds,
+    -SKIP_SECONDS,
     durationSeconds,
   );
-  const skipForwardTarget = clamp(
-    currentTimeSeconds + SKIP_SECONDS,
-    0,
+  const skipForwardTarget = resolveSkipTarget(
+    currentTimeSeconds,
+    SKIP_SECONDS,
     durationSeconds,
   );
 

--- a/app/utils/chapters.ts
+++ b/app/utils/chapters.ts
@@ -1,0 +1,192 @@
+// Pure, framework-free chapter and playback resolution for the audiobook
+// player. Nothing here touches React, the DOM, or the audio element — it takes
+// plain inputs (chapters, the current playback time, the file duration) and
+// returns plain data (resolved chapter boundaries and seek targets). This keeps
+// the logic unit-testable in complete isolation and decoupled from the player.
+//
+// UNIT CHOICE: the public interface of this module works in SECONDS, matching
+// the audio element's `currentTime` and the file's `audiobook_duration_seconds`.
+// Chapter starts arrive on the model as `start_timestamp_ms` (MILLISECONDS), so
+// the conversion to seconds happens here, at the boundary, when chapters are
+// resolved. Callers never deal with milliseconds.
+
+import type { Chapter } from "@/types";
+
+/** Seconds skipped by the skip-back / skip-forward controls (arrow keys). */
+export const SKIP_SECONDS = 30;
+
+/**
+ * Threshold, in seconds, for the smart previous-chapter rule: when more than
+ * this far into the current chapter, "previous" restarts the current chapter;
+ * otherwise it jumps to the prior chapter.
+ */
+export const PREVIOUS_CHAPTER_RESTART_THRESHOLD_SECONDS = 5;
+
+/** A chapter resolved into absolute second boundaries within the file. */
+export interface ResolvedChapter {
+  /** Zero-based index into the sorted, resolved chapter list. */
+  index: number;
+  title: string;
+  /** Start of the chapter, in seconds from the beginning of the file. */
+  startSeconds: number;
+  /**
+   * End of the chapter, in seconds. A chapter ends where the next begins; the
+   * last chapter ends at the file duration.
+   */
+  endSeconds: number;
+}
+
+/** The result of resolving playback state against the resolved chapter list. */
+export interface PlaybackState {
+  /** Index of the current chapter, or null when there are no chapters. */
+  currentChapterIndex: number | null;
+  /** The current chapter, or null when there are no chapters. */
+  currentChapter: ResolvedChapter | null;
+  /** Seek target (seconds) to advance to the next chapter, or null if none. */
+  nextChapterTarget: number | null;
+  /**
+   * Seek target (seconds) for the previous-chapter control, or null if there
+   * are no chapters. Follows the smart restart rule (see threshold constant).
+   */
+  previousChapterTarget: number | null;
+  /** Seek target (seconds) for skip-back, clamped to [0, duration]. */
+  skipBackTarget: number;
+  /** Seek target (seconds) for skip-forward, clamped to [0, duration]. */
+  skipForwardTarget: number;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+/**
+ * Resolves a list of model chapters into absolute second boundaries.
+ *
+ * Defensive against real-world data: chapters may arrive unsorted or missing a
+ * `start_timestamp_ms`. Chapters without a start are dropped (they have no
+ * position on the timeline); the remainder are sorted by start. If nothing is
+ * left, the file is treated as having no chapters and an empty list is returned.
+ * Each chapter ends where the next begins, and the last ends at `durationSeconds`.
+ *
+ * @param chapters The file's chapters (M4B chapters are flat, top-level only).
+ * @param durationSeconds Total file duration in seconds.
+ */
+export function resolveChapters(
+  chapters: Chapter[] | undefined,
+  durationSeconds: number,
+): ResolvedChapter[] {
+  if (!chapters || chapters.length === 0) return [];
+
+  const withStarts = chapters
+    .filter(
+      (c): c is Chapter & { start_timestamp_ms: number } =>
+        typeof c.start_timestamp_ms === "number",
+    )
+    .map((c) => ({
+      title: c.title,
+      startSeconds: c.start_timestamp_ms / 1000,
+    }))
+    .sort((a, b) => a.startSeconds - b.startSeconds);
+
+  if (withStarts.length === 0) return [];
+
+  return withStarts.map((c, index) => {
+    const next = withStarts[index + 1];
+    const endSeconds = next ? next.startSeconds : durationSeconds;
+    return {
+      index,
+      title: c.title,
+      startSeconds: c.startSeconds,
+      endSeconds,
+    };
+  });
+}
+
+/**
+ * Finds the current chapter: the last chapter whose start is at or before the
+ * current time. An exact boundary belongs to the chapter that starts there
+ * (i.e. the next chapter). Times before the first start clamp to the first
+ * chapter; times past the end stay on the last chapter. Returns null when there
+ * are no chapters.
+ */
+function findCurrentChapterIndex(
+  chapters: ResolvedChapter[],
+  currentTimeSeconds: number,
+): number | null {
+  if (chapters.length === 0) return null;
+  let index = 0;
+  for (let i = 0; i < chapters.length; i++) {
+    if (chapters[i].startSeconds <= currentTimeSeconds) {
+      index = i;
+    } else {
+      break;
+    }
+  }
+  return index;
+}
+
+/**
+ * Resolves all playback-derived state for the player from the resolved chapter
+ * list, the current time, and the file duration. Pure: same inputs always
+ * yield the same output.
+ */
+export function resolvePlayback(
+  chapters: ResolvedChapter[],
+  currentTimeSeconds: number,
+  durationSeconds: number,
+): PlaybackState {
+  const skipBackTarget = clamp(
+    currentTimeSeconds - SKIP_SECONDS,
+    0,
+    durationSeconds,
+  );
+  const skipForwardTarget = clamp(
+    currentTimeSeconds + SKIP_SECONDS,
+    0,
+    durationSeconds,
+  );
+
+  const currentChapterIndex = findCurrentChapterIndex(
+    chapters,
+    currentTimeSeconds,
+  );
+
+  if (currentChapterIndex === null) {
+    return {
+      currentChapterIndex: null,
+      currentChapter: null,
+      nextChapterTarget: null,
+      previousChapterTarget: null,
+      skipBackTarget,
+      skipForwardTarget,
+    };
+  }
+
+  const currentChapter = chapters[currentChapterIndex];
+
+  const nextChapter = chapters[currentChapterIndex + 1];
+  const nextChapterTarget = nextChapter ? nextChapter.startSeconds : null;
+
+  // Smart previous: if we are more than the threshold into the current chapter,
+  // restart it; otherwise jump to the prior chapter's start. On the first
+  // chapter there is no prior chapter, so it always restarts at 0.
+  const secondsIntoChapter = currentTimeSeconds - currentChapter.startSeconds;
+  const priorChapter = chapters[currentChapterIndex - 1];
+  let previousChapterTarget: number;
+  if (
+    secondsIntoChapter > PREVIOUS_CHAPTER_RESTART_THRESHOLD_SECONDS ||
+    !priorChapter
+  ) {
+    previousChapterTarget = currentChapter.startSeconds;
+  } else {
+    previousChapterTarget = priorChapter.startSeconds;
+  }
+
+  return {
+    currentChapterIndex,
+    currentChapter,
+    nextChapterTarget,
+    previousChapterTarget,
+    skipBackTarget,
+    skipForwardTarget,
+  };
+}

--- a/website/docs/supported-formats.md
+++ b/website/docs/supported-formats.md
@@ -18,7 +18,7 @@ fingerprints (cover pHash, text SimHash, etc.) — see
 
 ## Audiobooks
 
-- **M4B** — Full [metadata extraction](./metadata#m4b) including title, authors, narrators, series, chapters, cover art, language, and abridged status. Includes an in-app player with play/pause, a draggable seek bar, and elapsed/total time, showing the cover, title, author, and narrator
+- **M4B** — Full [metadata extraction](./metadata#m4b) including title, authors, narrators, series, chapters, cover art, language, and abridged status. Includes an in-app player with play/pause, a draggable seek bar, and elapsed/total time, showing the cover, title, author, and narrator. When the file has chapters, the player adds chapter navigation: a dropdown that jumps to a chapter's start, chapter markers along the seek bar, the current chapter shown and updated live as playback crosses a boundary, and previous/next chapter buttons (previous restarts the current chapter when more than about 5 seconds in, otherwise jumps to the prior chapter). It also has skip back and forward buttons (30 seconds), mapped to the left and right arrow keys. A file with no chapters plays normally with chapter navigation absent
 
 ## Comics
 


### PR DESCRIPTION
Closes #362

## Summary
- Adds a pure, framework-free chapter resolution module (`app/utils/chapters.ts`) that takes the file's chapters, the current playback time, and the file duration, and returns resolved chapter boundaries (`resolveChapters`) plus all playback-derived seek targets (`resolvePlayback`): current chapter index, next/previous chapter targets with the smart-restart rule, and clamped 30s skip targets. It does the millisecond-to-second conversion, sorting, and missing-start defensiveness at its boundary, and is unit-tested in complete isolation from React and jsdom.
- Wires the module into `M4BReader.tsx` to add a chapter dropdown (whose trigger doubles as the live current-chapter readout), seek-bar chapter markers, prev/next chapter buttons, 30s skip-back/forward buttons, and left/right arrow-key skipping. A file with no chapters renders the player normally with all chapter controls absent.
- Extends the M4B entry in `website/docs/supported-formats.md` to describe the new chapter navigation.

## Notes for reviewers
- Unit-conversion choice: the pure module's public interface is in seconds (matching the audio element and `audiobook_duration_seconds`); `start_timestamp_ms` is converted to seconds inside `resolveChapters` at the boundary.
- Where the module lives: `app/utils/chapters.ts`, alongside `app/utils/format.ts` (the existing home for pure player utils).
- Arrow-key / dropdown conflict: the Radix Select handles its own arrow navigation while open and stops propagation, so its keys never reach the document-level keydown listener. The global handler also guards on INPUT/TEXTAREA/contentEditable and modifier keys, same as the existing Space handler.
- Staleness fix worth a reviewer's eye: arrow-key skip targets are computed from live `currentTimeRef`/`durationRef` (written eagerly in `seekTo`/`onTimeUpdate`), not from the memoized playback value, so two synchronous arrow presses compound correctly.
- UI decision: dropped the redundant standalone current-chapter `<p>` and let the dropdown trigger serve as the displayed/live-updating current chapter title.
- The first chapter marker (start 0) is intentionally not drawn since it sits at the seek-bar origin under the thumb.

## Test plan
- `app/utils/chapters.test.ts` covers every enumerated acceptance case in pure isolation: empty/undefined/missing-start chapters resolve to no chapters; single chapter spans the whole file; multi-chapter boundaries end where the next begins and the last ends at duration; out-of-order chapters get sorted; current chapter is the last start at-or-before time with exact boundaries belonging to the next chapter; before-first clamps to first and past-end stays on last; the smart-previous threshold on both sides plus first-chapter restart-to-0; and skip clamping at both ends.
- `app/components/pages/M4BReader.test.tsx` adds a chaptered fixture and component tests: the dropdown jumps to a chapter start; the current-chapter readout updates across a boundary; markers render at correct positions; next/prev/skip buttons work; arrow-key skip and clamping work; and a no-chapters file renders the player with chapter navigation absent. All pre-existing tests are untouched and still pass.
- Run `pnpm vitest run app/utils/chapters.test.ts app/components/pages/M4BReader.test.tsx` (48 tests pass).