### PR TITLE
[Backend] Close remaining tygo type-boundary gaps from the #341 audit

### DIFF
--- a/app/components/contexts/Auth/AuthProvider.tsx
+++ b/app/components/contexts/Auth/AuthProvider.tsx
@@ -1,15 +1,12 @@
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 
 import { API } from "@/libraries/api";
+import type { StatusResponse } from "@/types";
 
 import { AuthContext, type AuthUser } from "./context";
 
 interface AuthProviderProps {
   children: ReactNode;
-}
-
-interface AuthStatusResponse {
-  needs_setup: boolean;
 }
 
 const AuthProvider = ({ children }: AuthProviderProps) => {
@@ -20,10 +17,7 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
   const checkAuthStatus = useCallback(async () => {
     try {
       // First check if setup is needed
-      const status = await API.request<AuthStatusResponse>(
-        "GET",
-        "/auth/status",
-      );
+      const status = await API.request<StatusResponse>("GET", "/auth/status");
       setNeedsSetup(status.needs_setup);
 
       if (status.needs_setup) {
@@ -77,7 +71,7 @@ const AuthProvider = ({ children }: AuthProviderProps) => {
     (libraryId: number) => {
       if (!user) return false;
       // If library_access is null/undefined, user has access to all libraries
-      if (user.library_access === null || user.library_access === undefined) {
+      if (!user.library_access) {
         return true;
       }
       // Otherwise, check if the library is in the access list

--- a/app/components/contexts/Auth/context.ts
+++ b/app/components/contexts/Auth/context.ts
@@ -1,15 +1,10 @@
 import { createContext } from "react";
 
-export interface AuthUser {
-  id: number;
-  username: string;
-  email?: string;
-  role_id: number;
-  role_name: string;
-  permissions: string[];
-  library_access?: number[] | null; // null/undefined = all libraries, empty = none, populated = specific libraries
-  must_change_password: boolean;
-}
+import type { MeResponse } from "@/types";
+
+// The authenticated user is exactly the GET /auth/me response shape. Alias the
+// generated type rather than restate it so it can never drift from the backend.
+export type AuthUser = MeResponse;
 
 export interface AuthContextValue {
   user: AuthUser | null;

--- a/app/components/pages/AdminLogs.tsx
+++ b/app/components/pages/AdminLogs.tsx
@@ -76,6 +76,7 @@ const AdminLogs = () => {
             <SelectItem value="info">Info</SelectItem>
             <SelectItem value="warn">Warn</SelectItem>
             <SelectItem value="error">Error</SelectItem>
+            <SelectItem value="fatal">Fatal</SelectItem>
           </SelectContent>
         </Select>
         <Input

--- a/app/components/pages/CreateUser.tsx
+++ b/app/components/pages/CreateUser.tsx
@@ -129,7 +129,7 @@ const CreateUser = () => {
         role_id: roleId,
         require_password_reset: requirePasswordReset,
         all_library_access: allLibraryAccess,
-        library_ids: allLibraryAccess ? undefined : selectedLibraries,
+        library_ids: allLibraryAccess ? [] : selectedLibraries,
       });
 
       toast.success("User created successfully!");

--- a/app/components/pages/Setup.tsx
+++ b/app/components/pages/Setup.tsx
@@ -14,17 +14,7 @@ import { useNavigateAfterSave } from "@/hooks/useNavigateAfterSave";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { API } from "@/libraries/api";
-
-interface SetupResponse {
-  id: number;
-  username: string;
-  email?: string;
-  role_id: number;
-  role_name: string;
-  permissions: string[];
-  library_access?: number[] | null;
-  must_change_password: boolean;
-}
+import type { MeResponse } from "@/types";
 
 // Initial values for the setup form - stored once to compare against
 const INITIAL_VALUES = {
@@ -97,7 +87,7 @@ const Setup = () => {
 
     setIsLoading(true);
     try {
-      const userData = await API.request<SetupResponse>("POST", "/auth/setup", {
+      const userData = await API.request<MeResponse>("POST", "/auth/setup", {
         username,
         email: email.trim() || null,
         password,
@@ -121,7 +111,7 @@ const Setup = () => {
   const handleCreateDevAdmin = async () => {
     setIsDevLoading(true);
     try {
-      const userData = await API.request<SetupResponse>("POST", "/auth/setup", {
+      const userData = await API.request<MeResponse>("POST", "/auth/setup", {
         username: "admin",
         email: null,
         password: "adminadmin",

--- a/app/components/pages/UserDetail.tsx
+++ b/app/components/pages/UserDetail.tsx
@@ -194,7 +194,7 @@ const UserDetail = () => {
         payload: {
           current_password: isSelf ? currentPassword : undefined,
           new_password: newPassword,
-          require_password_reset: isSelf ? undefined : requirePasswordReset,
+          require_password_reset: isSelf ? false : requirePasswordReset,
         },
       });
       toast.success("Password reset successfully");

--- a/app/hooks/queries/audnexus.ts
+++ b/app/hooks/queries/audnexus.ts
@@ -1,24 +1,14 @@
 import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
+import type { AudnexusChapter, AudnexusChaptersResponse } from "@/types";
+
+// Re-exported so existing importers (audnexusChapterUtils, FetchChaptersDialog)
+// can keep importing these from the hook module.
+export type { AudnexusChapter, AudnexusChaptersResponse };
 
 export enum QueryKey {
   AudnexusChapters = "AudnexusChapters",
-}
-
-export interface AudnexusChapter {
-  title: string;
-  start_offset_ms: number;
-  length_ms: number;
-}
-
-export interface AudnexusChaptersResponse {
-  asin: string;
-  is_accurate: boolean;
-  runtime_length_ms: number;
-  brand_intro_duration_ms: number;
-  brand_outro_duration_ms: number;
-  chapters: AudnexusChapter[];
 }
 
 /**

--- a/app/hooks/queries/auth.ts
+++ b/app/hooks/queries/auth.ts
@@ -5,23 +5,20 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
+import type { LoginPayload, MeResponse, StatusResponse } from "@/types";
 
 export enum QueryKey {
   AuthStatus = "AuthStatus",
   AuthMe = "AuthMe",
 }
 
-interface AuthStatusResponse {
-  needs_setup: boolean;
-}
-
 export const useAuthStatus = (
   options: Omit<
-    UseQueryOptions<AuthStatusResponse, ShishoAPIError>,
+    UseQueryOptions<StatusResponse, ShishoAPIError>,
     "queryKey" | "queryFn"
   > = {},
 ) => {
-  return useQuery<AuthStatusResponse, ShishoAPIError>({
+  return useQuery<StatusResponse, ShishoAPIError>({
     ...options,
     queryKey: [QueryKey.AuthStatus],
     queryFn: ({ signal }) => {
@@ -30,23 +27,8 @@ export const useAuthStatus = (
   });
 };
 
-interface LoginPayload {
-  username: string;
-  password: string;
-}
-
-interface LoginResponse {
-  id: number;
-  username: string;
-  email?: string;
-  role_id: number;
-  role_name: string;
-  permissions: string[];
-  must_change_password: boolean;
-}
-
 export const useLogin = () => {
-  return useMutation<LoginResponse, ShishoAPIError, LoginPayload>({
+  return useMutation<MeResponse, ShishoAPIError, LoginPayload>({
     mutationFn: (payload) => {
       return API.request("POST", "/auth/login", payload);
     },

--- a/app/hooks/queries/chapters.ts
+++ b/app/hooks/queries/chapters.ts
@@ -6,14 +6,10 @@ import {
 } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Chapter, ChapterInput } from "@/types";
+import type { Chapter, ChapterInput, ChaptersResponse } from "@/types";
 
 export enum QueryKey {
   FileChapters = "FileChapters",
-}
-
-interface ChaptersResponse {
-  chapters: Chapter[];
 }
 
 export const useFileChapters = (

--- a/app/hooks/queries/review.ts
+++ b/app/hooks/queries/review.ts
@@ -1,27 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { API, ShishoAPIError } from "@/libraries/api";
-import type { Book, File, ReviewOverride } from "@/types";
+import type {
+  Book,
+  File,
+  PutReviewCriteriaPayload,
+  ReviewCriteriaResponse,
+  ReviewOverride,
+} from "@/types";
 
 import { QueryKey as BooksQueryKey } from "./books";
 
 export enum QueryKey {
   ReviewCriteria = "ReviewCriteria",
-}
-
-export interface ReviewCriteriaResponse {
-  book_fields: string[];
-  audio_fields: string[];
-  universal_candidates: string[];
-  audio_candidates: string[];
-  override_count: number;
-  main_file_count: number;
-}
-
-export interface UpdateReviewCriteriaVariables {
-  book_fields: string[];
-  audio_fields: string[];
-  clear_overrides: boolean;
 }
 
 export const useReviewCriteria = () =>
@@ -33,7 +24,7 @@ export const useReviewCriteria = () =>
 
 export const useUpdateReviewCriteria = () => {
   const queryClient = useQueryClient();
-  return useMutation<void, ShishoAPIError, UpdateReviewCriteriaVariables>({
+  return useMutation<void, ShishoAPIError, PutReviewCriteriaPayload>({
     mutationFn: (payload) =>
       API.request("PUT", "/settings/review-criteria", payload, null),
     onSuccess: () => {

--- a/app/hooks/queries/users.ts
+++ b/app/hooks/queries/users.ts
@@ -8,10 +8,14 @@ import {
 import { API, ShishoAPIError } from "@/libraries/api";
 import type {
   CreateRolePayload,
+  CreateUserPayload,
   ListRolesResponse,
+  ListUsersQuery,
   ListUsersResponse,
+  ResetPasswordPayload,
   Role,
   UpdateRolePayload,
+  UpdateUserPayload,
   User,
 } from "@/types";
 
@@ -38,11 +42,6 @@ export const useUser = (
   });
 };
 
-interface ListUsersQuery {
-  limit?: number;
-  offset?: number;
-}
-
 export const useUsers = (
   query: ListUsersQuery = {},
   options: Omit<
@@ -59,16 +58,6 @@ export const useUsers = (
   });
 };
 
-interface CreateUserPayload {
-  username: string;
-  email?: string;
-  password: string;
-  role_id: number;
-  library_ids?: number[];
-  all_library_access?: boolean;
-  require_password_reset?: boolean;
-}
-
 export const useCreateUser = () => {
   const queryClient = useQueryClient();
 
@@ -81,15 +70,6 @@ export const useCreateUser = () => {
     },
   });
 };
-
-interface UpdateUserPayload {
-  username?: string;
-  email?: string;
-  role_id?: number;
-  is_active?: boolean;
-  library_ids?: number[];
-  all_library_access?: boolean;
-}
 
 interface UpdateUserVariables {
   id: string;
@@ -109,12 +89,6 @@ export const useUpdateUser = () => {
     },
   });
 };
-
-interface ResetPasswordPayload {
-  current_password?: string;
-  new_password: string;
-  require_password_reset?: boolean;
-}
 
 interface ResetPasswordVariables {
   id: string;

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -61,8 +61,6 @@ export {
 export {
   type UserSettingsResponse,
   type UserSettingsPayload,
-  type LibrarySettingsResponse,
-  type UpdateLibrarySettingsPayload,
   type ReviewCriteriaResponse,
   type PutReviewCriteriaPayload,
 } from "./generated/settings";

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -55,8 +55,16 @@ export {
 } from "./generated/publishers";
 export * from "./generated/chapters";
 export {
+  type Response as AudnexusChaptersResponse,
+  type Chapter as AudnexusChapter,
+} from "./generated/audnexus";
+export {
   type UserSettingsResponse,
   type UserSettingsPayload,
+  type LibrarySettingsResponse,
+  type UpdateLibrarySettingsPayload,
+  type ReviewCriteriaResponse,
+  type PutReviewCriteriaPayload,
 } from "./generated/settings";
 export {
   type CreateListPayload,

--- a/docs/adr/0004-tygo-generated-api-types.md
+++ b/docs/adr/0004-tygo-generated-api-types.md
@@ -83,16 +83,16 @@ TypeScript duplicates. Concretely:
    its computed extras (`book_count`, `aliases`) with no Go-side duplication.
    The model must be embedded **by value** (`models.Genre`), not by pointer: a
    pointer embed (`*models.Genre`) generates `extends Partial<Genre>`, which
-   wrongly marks every inherited field optional. The embed requires two additions
-   to the package's `tygo.yaml` entry: a `frontmatter` import of the embedded
-   model, and a `type_mappings` entry mapping the package-qualified selector to
-   the bare interface name (for example `models.Genre: "Genre"`). Without the
-   mapping tygo emits `extends models.Genre`, an unresolved reference; without
-   the frontmatter the bare name is undefined. When a response **reshapes** a
-   model relation (the metadata
-   entities return `aliases` as `[]string` rather than the model's
-   `PersonAlias[]`; publisher detail returns a flattened `children` rather than
-   the model's `Publisher[]`), the model's relation field is excluded from
+   wrongly marks every inherited field optional. The embed requires two
+   additions to the package's `tygo.yaml` entry: a `frontmatter` import of the
+   embedded model, and a `type_mappings` entry mapping the package-qualified
+   selector to the bare interface name (for example `models.Genre: "Genre"`).
+   Without the mapping tygo emits `extends models.Genre`, an unresolved
+   reference; without the frontmatter the bare name is undefined. When a
+   response **reshapes** a model relation (the metadata entities return
+   `aliases` as `[]string` rather than the model's `PersonAlias[]`; publisher
+   detail returns a flattened `children` rather than the model's `Publisher[]`),
+   the model's relation field is excluded from
    TypeScript generation with `tstype:"-"` so the response's field is the only
    one and the `extends` does not collide. This is verified safe only when no
    consumer reads that relation as objects; both `aliases` and publisher

--- a/docs/adr/0004-tygo-generated-api-types.md
+++ b/docs/adr/0004-tygo-generated-api-types.md
@@ -81,8 +81,15 @@ TypeScript duplicates. Concretely:
    not by re-listing fields.** tygo flattens such an embed into a TypeScript
    `extends`, so a response like `GenreResponse` carries every model field plus
    its computed extras (`book_count`, `aliases`) with no Go-side duplication.
-   This requires a `frontmatter` import of the embedded model in the package's
-   `tygo.yaml` entry. When a response **reshapes** a model relation (the metadata
+   The model must be embedded **by value** (`models.Genre`), not by pointer: a
+   pointer embed (`*models.Genre`) generates `extends Partial<Genre>`, which
+   wrongly marks every inherited field optional. The embed requires two additions
+   to the package's `tygo.yaml` entry: a `frontmatter` import of the embedded
+   model, and a `type_mappings` entry mapping the package-qualified selector to
+   the bare interface name (for example `models.Genre: "Genre"`). Without the
+   mapping tygo emits `extends models.Genre`, an unresolved reference; without
+   the frontmatter the bare name is undefined. When a response **reshapes** a
+   model relation (the metadata
    entities return `aliases` as `[]string` rather than the model's
    `PersonAlias[]`; publisher detail returns a flattened `children` rather than
    the model's `Publisher[]`), the model's relation field is excluded from

--- a/pkg/books/handlers_review.go
+++ b/pkg/books/handlers_review.go
@@ -10,17 +10,6 @@ import (
 	"github.com/shishobooks/shisho/pkg/models"
 )
 
-// SetReviewPayload is the request body for PATCH /books/files/:id/review.
-type SetReviewPayload struct {
-	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
-}
-
-// BulkSetReviewPayload is the request body for POST /books/bulk/review.
-type BulkSetReviewPayload struct {
-	BookIDs  []int   `json:"book_ids" validate:"required,min=1,max=500"`
-	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed"`
-}
-
 // setFileReview sets or clears the review override for a single file.
 func (h *handler) setFileReview(c echo.Context) error {
 	id, err := strconv.Atoi(c.Param("id"))

--- a/pkg/books/types.go
+++ b/pkg/books/types.go
@@ -24,7 +24,7 @@ type ListBooksResponse struct {
 }
 
 // SetReviewPayload is the request body for the file and book review-override
-// endpoints (PATCH /books/files/:id/review, POST /books/:id/review).
+// endpoints (PATCH /books/files/:id/review, PATCH /books/:id/review).
 type SetReviewPayload struct {
 	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed" tstype:"ReviewOverride"`
 }

--- a/pkg/books/types.go
+++ b/pkg/books/types.go
@@ -23,6 +23,18 @@ type ListBooksResponse struct {
 	Total int            `json:"total"`
 }
 
+// SetReviewPayload is the request body for the file and book review-override
+// endpoints (PATCH /books/files/:id/review, POST /books/:id/review).
+type SetReviewPayload struct {
+	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed" tstype:"ReviewOverride"`
+}
+
+// BulkSetReviewPayload is the request body for POST /books/bulk/review.
+type BulkSetReviewPayload struct {
+	BookIDs  []int   `json:"book_ids" validate:"required,min=1,max=500"`
+	Override *string `json:"override" validate:"omitempty,oneof=reviewed unreviewed" tstype:"ReviewOverride"`
+}
+
 type UpdateBookPayload struct {
 	Title       *string       `json:"title,omitempty" mod:"trim" validate:"omitempty,min=1,max=300"`
 	SortTitle   *string       `json:"sort_title,omitempty" validate:"omitempty,max=300"`

--- a/pkg/chapters/handlers.go
+++ b/pkg/chapters/handlers.go
@@ -43,9 +43,7 @@ func (h *handler) list(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, map[string]any{
-		"chapters": chapters,
-	}))
+	return errors.WithStack(c.JSON(http.StatusOK, ChaptersResponse{Chapters: chapters}))
 }
 
 func (h *handler) replace(c echo.Context) error {
@@ -103,9 +101,7 @@ func (h *handler) replace(c echo.Context) error {
 		_ = sidecar.WriteFileSidecarWithChapters(fileWithRelations, updatedChapters)
 	}
 
-	return errors.WithStack(c.JSON(http.StatusOK, map[string]any{
-		"chapters": updatedChapters,
-	}))
+	return errors.WithStack(c.JSON(http.StatusOK, ChaptersResponse{Chapters: updatedChapters}))
 }
 
 // validateChapters validates chapter data against file constraints.

--- a/pkg/chapters/types.go
+++ b/pkg/chapters/types.go
@@ -5,6 +5,8 @@ import "github.com/shishobooks/shisho/pkg/models"
 // ChaptersResponse is the response body for the chapter list and replace
 // endpoints. ListChapters returns a nested tree, so each chapter carries its
 // Children populated.
+//
+//nolint:revive // ChaptersResponse name follows the {Entity}Response convention (ADR 0004)
 type ChaptersResponse struct {
 	Chapters []*models.Chapter `json:"chapters" tstype:"Chapter[]"`
 }

--- a/pkg/chapters/types.go
+++ b/pkg/chapters/types.go
@@ -1,5 +1,14 @@
 package chapters
 
+import "github.com/shishobooks/shisho/pkg/models"
+
+// ChaptersResponse is the response body for the chapter list and replace
+// endpoints. ListChapters returns a nested tree, so each chapter carries its
+// Children populated.
+type ChaptersResponse struct {
+	Chapters []*models.Chapter `json:"chapters" tstype:"Chapter[]"`
+}
+
 // ChapterInput represents a chapter in API requests.
 type ChapterInput struct {
 	Title            string         `json:"title"`

--- a/pkg/genres/handlers.go
+++ b/pkg/genres/handlers.go
@@ -225,10 +225,7 @@ func (h *handler) books(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	response := map[string]any{
-		"items": books,
-		"total": total,
-	}
+	response := ListGenreBooksResponse{Items: books, Total: total}
 
 	return errors.WithStack(c.JSON(http.StatusOK, response))
 }

--- a/pkg/genres/types.go
+++ b/pkg/genres/types.go
@@ -18,6 +18,12 @@ type ListGenresResponse struct {
 	Total int             `json:"total"`
 }
 
+// ListGenreBooksResponse is the envelope for the genre books sub-resource.
+type ListGenreBooksResponse struct {
+	Items []*models.Book `json:"items" tstype:"Book[]"`
+	Total int            `json:"total"`
+}
+
 type ListGenresQuery struct {
 	Limit     int     `query:"limit" json:"limit,omitempty" default:"24" validate:"min=1,max=50"`
 	Offset    int     `query:"offset" json:"offset,omitempty" validate:"min=0"`

--- a/pkg/roles/types.go
+++ b/pkg/roles/types.go
@@ -28,6 +28,6 @@ type UpdateRolePayload struct {
 
 // ListRolesQuery represents the query parameters for listing roles.
 type ListRolesQuery struct {
-	Limit  int `query:"limit" default:"50"`
-	Offset int `query:"offset" default:"0"`
+	Limit  int `query:"limit" json:"limit,omitempty" default:"50"`
+	Offset int `query:"offset" json:"offset,omitempty" default:"0"`
 }

--- a/pkg/settings/review_criteria_handlers.go
+++ b/pkg/settings/review_criteria_handlers.go
@@ -19,21 +19,6 @@ type reviewCriteriaHandler struct {
 	appSettingsService *appsettings.Service
 }
 
-type reviewCriteriaResponse struct {
-	BookFields          []string `json:"book_fields"`
-	AudioFields         []string `json:"audio_fields"`
-	UniversalCandidates []string `json:"universal_candidates"`
-	AudioCandidates     []string `json:"audio_candidates"`
-	OverrideCount       int      `json:"override_count"`
-	MainFileCount       int      `json:"main_file_count"`
-}
-
-type putReviewCriteriaPayload struct {
-	BookFields     []string `json:"book_fields" validate:"required"`
-	AudioFields    []string `json:"audio_fields" validate:"required"`
-	ClearOverrides bool     `json:"clear_overrides"`
-}
-
 func (h *reviewCriteriaHandler) getReviewCriteria(c echo.Context) error {
 	ctx := c.Request().Context()
 
@@ -42,7 +27,7 @@ func (h *reviewCriteriaHandler) getReviewCriteria(c echo.Context) error {
 		return errors.WithStack(err)
 	}
 
-	resp := reviewCriteriaResponse{
+	resp := ReviewCriteriaResponse{
 		BookFields:          criteria.BookFields,
 		AudioFields:         criteria.AudioFields,
 		UniversalCandidates: review.UniversalCandidates,
@@ -69,7 +54,7 @@ func (h *reviewCriteriaHandler) getReviewCriteria(c echo.Context) error {
 }
 
 func (h *reviewCriteriaHandler) putReviewCriteria(c echo.Context) error {
-	var payload putReviewCriteriaPayload
+	var payload PutReviewCriteriaPayload
 	if err := c.Bind(&payload); err != nil {
 		return errors.WithStack(err)
 	}

--- a/pkg/settings/review_criteria_handlers_test.go
+++ b/pkg/settings/review_criteria_handlers_test.go
@@ -54,7 +54,7 @@ func TestGetReviewCriteria_ReturnsDefault(t *testing.T) {
 	require.NoError(t, h.getReviewCriteria(c))
 	assert.Equal(t, http.StatusOK, rec.Code)
 
-	var body reviewCriteriaResponse
+	var body ReviewCriteriaResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 
 	// Default criteria seeded by review.Default()

--- a/pkg/settings/types.go
+++ b/pkg/settings/types.go
@@ -94,3 +94,20 @@ type UpdateLibrarySettingsPayload struct {
 type LibrarySettingsResponse struct {
 	SortSpec *string `json:"sort_spec"`
 }
+
+// ReviewCriteriaResponse is the response for GET /settings/review-criteria.
+type ReviewCriteriaResponse struct {
+	BookFields          []string `json:"book_fields"`
+	AudioFields         []string `json:"audio_fields"`
+	UniversalCandidates []string `json:"universal_candidates"`
+	AudioCandidates     []string `json:"audio_candidates"`
+	OverrideCount       int      `json:"override_count"`
+	MainFileCount       int      `json:"main_file_count"`
+}
+
+// PutReviewCriteriaPayload is the request body for PUT /settings/review-criteria.
+type PutReviewCriteriaPayload struct {
+	BookFields     []string `json:"book_fields" validate:"required"`
+	AudioFields    []string `json:"audio_fields" validate:"required"`
+	ClearOverrides bool     `json:"clear_overrides"`
+}

--- a/pkg/users/types.go
+++ b/pkg/users/types.go
@@ -38,6 +38,6 @@ type ResetPasswordPayload struct {
 
 // ListUsersQuery represents the query parameters for listing users.
 type ListUsersQuery struct {
-	Limit  int `query:"limit" default:"50"`
-	Offset int `query:"offset" default:"0"`
+	Limit  int `query:"limit" json:"limit,omitempty" default:"50"`
+	Offset int `query:"offset" json:"offset,omitempty" default:"0"`
 }

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -26,7 +26,7 @@ packages:
   - path: "github.com/shishobooks/shisho/pkg/books"
     output_path: "app/types/generated/books.ts"
     frontmatter: |
-      import { AuthorRole, Book, FileRole, ReviewedFilter, SeriesNumberUnit } from "@/types";
+      import { AuthorRole, Book, FileRole, ReviewOverride, ReviewedFilter, SeriesNumberUnit } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/config"
@@ -96,7 +96,7 @@ packages:
   - path: "github.com/shishobooks/shisho/pkg/genres"
     output_path: "app/types/generated/genres.ts"
     frontmatter: |
-      import { Genre } from "@/types";
+      import { Book, Genre } from "@/types";
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/tags"
@@ -117,6 +117,12 @@ packages:
       - model.go
   - path: "github.com/shishobooks/shisho/pkg/chapters"
     output_path: "app/types/generated/chapters.ts"
+    frontmatter: |
+      import { Chapter } from "@/types";
+    include_files:
+      - types.go
+  - path: "github.com/shishobooks/shisho/pkg/audnexus"
+    output_path: "app/types/generated/audnexus.ts"
     include_files:
       - types.go
   - path: "github.com/shishobooks/shisho/pkg/lists"


### PR DESCRIPTION
## Summary
- Closes the API surfaces that still escaped the Go-via-tygo single-source-of-truth convention while auditing #341: the genres `/books` sub-resource (`map[string]any` to `ListGenreBooksResponse`), the chapters list/replace endpoints (`map[string]any` to `ChaptersResponse`), review-criteria (unexported structs exported and relocated to `settings/types.go`), and the review payloads (relocated to `books/types.go` with a `tstype:"ReviewOverride"` hint).
- Wires `pkg/audnexus` into tygo and switches the frontend audnexus, chapters, review, auth, and users hooks to import the generated types, deleting the hand-written duplicates. This fixes a latent `LoginResponse` drift bug where the hand-written type silently dropped `library_access`.
- Documents the `type_mappings` and embed-by-value requirements in ADR 0004, and adds the missing `fatal` option to the AdminLogs level filter (the backend already supported it).

All response JSON is byte-identical; the only behavior changes are the additive `fatal` filter option and the now-correct `library_access` typing on the login response.

Deliberately deferred (not clean dedups): `librarySettings.ts` and `resync.ts` keep local types that capture nullability/narrowing the generated types do not.

## Test plan
- `mise tygo` regenerates cleanly, `go build ./...` succeeds, and `golangci-lint` reports 0 issues
- Full Go test suite passes (genres, chapters, settings, books, auth, users, roles all green)
- `tsc`, eslint, and prettier pass; frontend unit tests pass
- Verify the chapters list/replace, genre books list, review-criteria GET/PUT, and audnexus chapter-fetch endpoints return the same JSON as before
- Confirm the AdminLogs level filter now offers a Fatal option