### PR TITLE
[Docs] Record plugin API surface decision in ADR 0004 and add Resync to glossary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ filename := filepath.Base(fullPath)
 file.CoverImageFilename = &filename
 ```
 
-**JSON field naming is snake_case** — All JSON request/response payloads use `snake_case` (e.g., `created_at`, not `createdAt`). Go struct tags: `json:"snake_case_name"`.
+**JSON field naming is snake_case** — All JSON request/response payloads use `snake_case` (e.g., `created_at`, not `createdAt`). Go struct tags: `json:"snake_case_name"`. Exception: plugin manifest and repository-index passthrough fields keep their camelCase wire format (see the Plugin API surface amendment in ADR 0004).
 
 **API types are generated from Go via tygo (no anonymous responses, no hand-written TS).** Go is the single source of truth for every request and response shape. See ADR 0004 (`docs/adr/0004-tygo-generated-api-types.md`) for the rationale. The rules:
 - Every request and response payload is a named, exported Go struct in the package's `types.go`. No handler returns an anonymous struct, `echo.Map`, or `map[string]any`. A response that conveys nothing the client cannot already derive returns `204 No Content` instead of a body.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,6 +59,10 @@ An interactive workflow where a user matches a book against an external source (
 **Merge**:
 Combining two resources of the same type into one, transferring all associations from the source to the target and deleting the source.
 
+**Resync**:
+Re-running the scan pipeline for an existing book or file, in one of three modes: scan (pick up new metadata without overwriting manual edits), refresh (re-scan as if new, re-enriching via plugins), or reset (clear all metadata including manual edits and re-scan from file metadata only, without plugins).
+_Avoid_: rescan (in code; UI copy may still say "Rescan")
+
 **Sidecar**:
 A `.metadata.json` file placed alongside a book or file that provides metadata overrides.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,7 +61,7 @@ Combining two resources of the same type into one, transferring all associations
 
 **Resync**:
 Re-running the scan pipeline for an existing book or file, in one of three modes: scan (pick up new metadata without overwriting manual edits), refresh (re-scan as if new, re-enriching via plugins), or reset (clear all metadata including manual edits and re-scan from file metadata only, without plugins).
-_Avoid_: rescan (in code; UI copy may still say "Rescan")
+_Avoid_: rescan (in new code; some existing frontend identifiers and UI copy still say "Rescan")
 
 **Sidecar**:
 A `.metadata.json` file placed alongside a book or file that provides metadata overrides.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,7 +61,7 @@ Combining two resources of the same type into one, transferring all associations
 
 **Resync**:
 Re-running the scan pipeline for an existing book or file, in one of three modes: scan (pick up new metadata without overwriting manual edits), refresh (re-scan as if new, re-enriching via plugins), or reset (clear all metadata including manual edits and re-scan from file metadata only, without plugins).
-_Avoid_: rescan (in new code; some existing frontend identifiers and UI copy still say "Rescan")
+_Avoid_: rescan (in new code; some existing identifiers, comments, and docs/UI copy still say "Rescan")
 
 **Sidecar**:
 A `.metadata.json` file placed alongside a book or file that provides metadata overrides.

--- a/docs/adr/0004-tygo-generated-api-types.md
+++ b/docs/adr/0004-tygo-generated-api-types.md
@@ -123,8 +123,8 @@ TypeScript duplicates. Concretely:
 ### Plugin API surface (amendment, June 2026)
 
 PRD #341 originally excluded "Plugin SDK types" from this work, which left the
-plugin HTTP API (the largest remaining surface, roughly 15 hand-written types
-in `app/hooks/queries/plugins.ts`) outside the convention. The follow-up audit
+plugin HTTP API (the largest remaining surface, roughly 15 hand-written wire
+types in `app/hooks/queries/plugins.ts`) outside the convention. The follow-up audit
 resolved the boundary: **if it crosses the HTTP API, Go owns it and tygo
 generates it.** That includes manifest-shaped types (capabilities, config
 schema, available-plugin listings), which are generated from Go's parsed

--- a/docs/adr/0004-tygo-generated-api-types.md
+++ b/docs/adr/0004-tygo-generated-api-types.md
@@ -145,10 +145,15 @@ Alternatives considered for the manifest-shaped types:
   the existing "SDK must stay in sync with Go" rule; that is a separate
   boundary and is not changed by this decision.
 
-One documented exemption: manifest passthrough keeps its camelCase wire format
-rather than the project's snake_case JSON convention, because the manifest
-format itself is camelCase and changing the wire shape is a breaking change
-out of scope for type generation.
+One documented exemption: manifest and repository-index passthrough keeps its
+camelCase wire format rather than the project's snake_case JSON convention,
+because those source formats are camelCase and changing the wire shape is a
+breaking change out of scope for type generation. Server-added fields on the
+same responses keep snake_case (the available-plugin listing already mixes
+`imageUrl` with `is_official`).
+
+Implementation of this amendment is tracked in #383 (plugin API surface
+end-to-end through tygo) and #384 (remaining type-boundary stragglers).
 
 ## Consequences
 

--- a/docs/adr/0004-tygo-generated-api-types.md
+++ b/docs/adr/0004-tygo-generated-api-types.md
@@ -120,6 +120,36 @@ TypeScript duplicates. Concretely:
    needed type is missing, the fix is to add or correct the Go struct and
    regenerate, not to write the type in TypeScript.
 
+### Plugin API surface (amendment, June 2026)
+
+PRD #341 originally excluded "Plugin SDK types" from this work, which left the
+plugin HTTP API (the largest remaining surface, roughly 15 hand-written types
+in `app/hooks/queries/plugins.ts`) outside the convention. The follow-up audit
+resolved the boundary: **if it crosses the HTTP API, Go owns it and tygo
+generates it.** That includes manifest-shaped types (capabilities, config
+schema, available-plugin listings), which are generated from Go's parsed
+representation of the manifest, not from the SDK.
+
+Alternatives considered for the manifest-shaped types:
+
+- **Keep hand-written mirrors in the frontend.** Preserves the drift mechanism
+  this ADR exists to eliminate, on the largest remaining surface. Rejected.
+- **Import them from `packages/plugin-sdk`.** Single-sources the types but
+  couples the app build to the plugin-author contract, which describes a
+  different boundary (plugin author to server) and includes constructs the
+  frontend never sees. The app has no dependency on the SDK today. Rejected.
+- **Generate from Go's parsed representation (chosen).** What the frontend
+  receives is the server's parsed, normalized form of the manifest, delivered
+  over the same HTTP API as every other response, so the same rule applies.
+  The SDK's `manifest.d.ts` remains the plugin-author contract, governed by
+  the existing "SDK must stay in sync with Go" rule; that is a separate
+  boundary and is not changed by this decision.
+
+One documented exemption: manifest passthrough keeps its camelCase wire format
+rather than the project's snake_case JSON convention, because the manifest
+format itself is camelCase and changing the wire shape is a breaking change
+out of scope for type generation.
+
 ## Consequences
 
 - The frontend's generated types become trustworthy. Removing the manual

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -270,7 +270,7 @@ Request → Authenticate → RequirePermission → RequireLibraryAccess → Hand
 
 ### API Conventions
 
-- **JSON field naming**: All JSON request and response payloads use `snake_case` for field names (e.g., `created_at`, `last_accessed_at`, not `createdAt`)
+- **JSON field naming**: All JSON request and response payloads use `snake_case` for field names (e.g., `created_at`, `last_accessed_at`, not `createdAt`). Exception: plugin manifest and repository-index passthrough fields keep their camelCase wire format (see the Plugin API surface amendment in ADR 0004)
 - Go struct tags should use `json:"snake_case_name"` format
 
 - **Response shapes are named Go structs generated to TS via tygo (no anonymous responses).** Go is the single source of truth for every request and response shape; the frontend imports the generated type and never restates it. See ADR 0004 (`docs/adr/0004-tygo-generated-api-types.md`). Rules:


### PR DESCRIPTION
## Summary
- Amends ADR 0004 with the plugin API surface decision from the post-#341 audit: if it crosses the HTTP API, Go owns it and tygo generates it, including manifest-shaped types as Go parses them. Records the three alternatives considered and the camelCase wire-format exemption for manifest and repository-index passthrough (server-added fields stay snake_case). The SDK manifest contract is a separate boundary and stays untouched. Implementation is tracked in #383 and #384.
- Notes the camelCase exception next to the snake_case JSON naming rule in root CLAUDE.md and pkg/CLAUDE.md so the rule and its one exemption travel together.
- Adds the Resync workflow term to CONTEXT.md (canonical code term is Resync, not Rescan) with the semantics of the three modes.

## Test plan
- Docs-only change; prettier passes on all four files
- Factual claims verified against the codebase during review (wire-type count in plugins.ts, no app dependency on the SDK, camelCase manifest/repository-index tags, mode semantics against RescanDialog and resolveScanMode)