### PR TITLE
[Fix] Patch M4B chunk offsets when moov is rewritten ahead of mdat

### DIFF
--- a/internal/testgen/m4b.go
+++ b/internal/testgen/m4b.go
@@ -140,8 +140,16 @@ func GenerateM4B(t *testing.T, dir, filename string, opts M4BOptions) string {
 	args = append(args,
 		"-c:a", "aac",
 		"-b:a", "64k",
-		path,
 	)
+
+	// Faststart moves moov ahead of mdat. This is the layout that exposes the
+	// chunk-offset rewrite bug: growing moov shifts mdat, so stco/co64 offsets
+	// must be patched to follow the audio.
+	if opts.Faststart {
+		args = append(args, "-movflags", "+faststart")
+	}
+
+	args = append(args, path)
 
 	cmd := exec.CommandContext(t.Context(), "ffmpeg", args...)
 	output, err := cmd.CombinedOutput()

--- a/internal/testgen/testgen.go
+++ b/internal/testgen/testgen.go
@@ -60,6 +60,10 @@ type M4BOptions struct {
 	AlbumArtist string // Album artist (different from artist)
 	Comment     string // Comment/description
 	Chapters    []M4BChapter
+	// Faststart writes the file with `-movflags +faststart`, placing the moov
+	// box before mdat. This mirrors the layout Audible/Apple Books exports use
+	// and is required to exercise the chunk-offset rewrite path in mp4.Write.
+	Faststart bool
 }
 
 // TempDir creates a temporary directory for testing and registers cleanup.

--- a/pkg/mp4/CLAUDE.md
+++ b/pkg/mp4/CLAUDE.md
@@ -379,7 +379,8 @@ Custom atoms like `aART` (album artist), `cprt` (copyright) are preserved byte-f
 ```
 
 **Overflow Safety:**
-- File offsets clamped to prevent int64 overflow
+- Box offsets and sizes are bounds-checked against the buffer length while scanning (`topLevelBoxes`, `shiftChunkOffsetsInChildren`); 64-bit largesize boxes are rejected when they exceed the file length
+- Chunk-offset shifts are range-checked: a 32-bit `stco` entry that would exceed `uint32` (or drop below zero) after the shift returns an error instead of wrapping
 - Box sizes limited to prevent allocation bombs
 - UTF-16 decoding includes null terminator handling
 

--- a/pkg/mp4/CLAUDE.md
+++ b/pkg/mp4/CLAUDE.md
@@ -186,6 +186,34 @@ Uses `mp4.WriteToFile()` for atomic writes.
 - Unknown atoms (e.g., `aART`, `cprt`)
 - All freeform atoms not explicitly overwritten
 
+**Chunk-offset patching on moov resize (faststart layout) — CRITICAL.**
+Rewriting metadata rebuilds the `moov` box, which almost always changes its size
+(adding cover art grows it by hundreds of KB). When the source file is laid out
+**faststart** (`moov` before `mdat` — the layout Audible and Apple Books export,
+and what ffmpeg produces with `-movflags +faststart`), growing `moov` shifts
+`mdat` (and every box after `moov`) down by the size delta. The `stco`/`co64`
+chunk-offset tables inside `moov`'s sample tables hold **absolute file offsets**
+into `mdat`, so `writeMetadataToBytes` (`writer.go`) shifts every `stco`/`co64`
+entry by that same delta. Without this, the offsets keep pointing at the old
+positions — now inside the resized `moov` — and the AAC decoder reads metadata as
+audio (`channel element ... is not allocated`), so Apple Books / Bound refuse to
+play while lenient players may limp along.
+
+- Only `stco`/`co64` are shifted (the only boxes holding absolute file offsets);
+  the walk descends `moov → trak → mdia → minf → stbl` (plus `edts`).
+- The shift is applied **only when `moov` precedes the first `mdat`**. In
+  `mdat`-first layout (ffmpeg's default, no faststart) `mdat` doesn't move, so
+  offsets are left untouched.
+- 32-bit `stco` entries that would exceed `uint32` after the shift return an
+  error rather than silently corrupting (would require promoting to `co64`; only
+  reachable for files approaching 4 GiB).
+- **Test fixtures must use faststart to exercise this.** `testgen.GenerateM4B`
+  takes a `Faststart bool` option (`-movflags +faststart`); the default ffmpeg
+  output is `mdat`-first and cannot reproduce the bug. Regression tests:
+  `TestWriteToFile_FaststartLayoutPreservesAudioChunkOffsets` (shifts correctly)
+  and `TestWriteToFile_MdatFirstLayoutLeavesChunkOffsetsUnchanged` (no
+  over-shift) in `writer_chunkoffset_test.go`.
+
 **Series Formatting:**
 - With number: `"Series Name #1"` or `"Series Name #1.5"`
 - Without number: `"Series Name"`

--- a/pkg/mp4/writer.go
+++ b/pkg/mp4/writer.go
@@ -3,12 +3,11 @@ package mp4
 import (
 	"bytes"
 	"encoding/binary"
-	"io"
+	"math"
 	"os"
 	"strconv"
 	"strings"
 
-	gomp4 "github.com/abema/go-mp4"
 	"github.com/pkg/errors"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 )
@@ -87,69 +86,227 @@ func createBackup(path string) error {
 	return os.WriteFile(path+".bak", data, 0600)
 }
 
-// writeMetadataToBytes modifies the metadata in the MP4 data and returns the new bytes.
+// writeMetadataToBytes modifies the metadata in the MP4 data and returns the
+// new bytes.
+//
+// The moov box is rebuilt with the new metadata, which usually changes its size
+// (e.g. when cover art is added). When moov sits before mdat — the "faststart"
+// layout that Audible/Apple Books exports use — growing moov shifts mdat (and
+// every box after moov) down by the size delta. The stco/co64 chunk offset
+// tables inside moov hold absolute file offsets into mdat, so they must be
+// shifted by the same delta; otherwise they keep pointing at the old positions,
+// which now land inside the resized moov, and the audio becomes undecodable.
 func writeMetadataToBytes(input []byte, metadata *Metadata) ([]byte, error) {
-	r := bytes.NewReader(input)
-	var output bytes.Buffer
-
-	// Track whether we've written the moov box
-	moovWritten := false
-
-	_, err := gomp4.ReadBoxStructure(r, func(h *gomp4.ReadHandle) (interface{}, error) {
-		switch h.BoxInfo.Type {
-		case BoxTypeMoov:
-			// Rebuild moov with new metadata
-			moovBytes, err := rebuildMoov(r, h, metadata)
-			if err != nil {
-				return nil, err
-			}
-			output.Write(moovBytes)
-			moovWritten = true
-			return nil, nil
-
-		default:
-			// Copy the box as-is
-			boxBytes := input[h.BoxInfo.Offset : h.BoxInfo.Offset+h.BoxInfo.Size]
-			output.Write(boxBytes)
-			return nil, nil
-		}
-	})
-
+	boxes, err := topLevelBoxes(input)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	if !moovWritten {
+	var moov *topLevelBox
+	firstMdatOffset := 0
+	haveMdat := false
+	for i := range boxes {
+		switch boxes[i].typ {
+		case "moov":
+			moov = &boxes[i]
+		case "mdat":
+			if !haveMdat {
+				firstMdatOffset = boxes[i].offset
+				haveMdat = true
+			}
+		}
+	}
+	if moov == nil {
 		return nil, errors.New("moov box not found")
+	}
+
+	// Rebuild moov with the new metadata (find and replace udta/meta/ilst).
+	origContent := input[moov.offset+moov.headerSize : moov.offset+moov.size]
+	newMoov := buildBox("moov", replaceIlstInContent(origContent, metadata))
+
+	// Only when moov precedes mdat does rewriting moov relocate the audio.
+	if haveMdat && moov.offset < firstMdatOffset {
+		delta := int64(len(newMoov)) - int64(moov.size)
+		if delta != 0 {
+			if err := shiftChunkOffsets(newMoov, delta); err != nil {
+				return nil, errors.WithStack(err)
+			}
+		}
+	}
+
+	// Reassemble the file in original box order, substituting the rebuilt moov.
+	var output bytes.Buffer
+	for _, b := range boxes {
+		if b.offset == moov.offset {
+			output.Write(newMoov)
+		} else {
+			output.Write(input[b.offset : b.offset+b.size])
+		}
 	}
 
 	return output.Bytes(), nil
 }
 
-// rebuildMoov rebuilds the moov box with new metadata.
-func rebuildMoov(r *bytes.Reader, h *gomp4.ReadHandle, metadata *Metadata) ([]byte, error) {
-	// Read the original moov content
-	origStart := h.BoxInfo.Offset + h.BoxInfo.HeaderSize
-	origEnd := h.BoxInfo.Offset + h.BoxInfo.Size
+// topLevelBox describes a box at the root of the file.
+type topLevelBox struct {
+	typ        string
+	offset     int
+	size       int
+	headerSize int
+}
 
-	// Seek to moov content (safe conversion as file sizes are within int64 range)
-	if origStart > 1<<62 {
-		return nil, errors.New("file offset too large")
+// topLevelBoxes scans the root-level box structure of an MP4 file.
+func topLevelBoxes(input []byte) ([]topLevelBox, error) {
+	var boxes []topLevelBox
+	offset := 0
+	for offset+8 <= len(input) {
+		size := int(binary.BigEndian.Uint32(input[offset:]))
+		headerSize := 8
+		switch size {
+		case 1:
+			// 64-bit largesize follows the type field.
+			if offset+16 > len(input) {
+				return nil, errors.New("truncated 64-bit box header")
+			}
+			size64 := binary.BigEndian.Uint64(input[offset+8:])
+			if size64 > uint64(len(input)) {
+				return nil, errors.New("box size exceeds file length")
+			}
+			// #nosec G115 -- bounds checked against len(input) above
+			size = int(size64)
+			headerSize = 16
+		case 0:
+			// Box extends to EOF.
+			size = len(input) - offset
+		}
+		if size < headerSize || offset+size > len(input) {
+			return nil, errors.New("invalid box size")
+		}
+		boxes = append(boxes, topLevelBox{
+			typ:        string(input[offset+4 : offset+8]),
+			offset:     offset,
+			size:       size,
+			headerSize: headerSize,
+		})
+		offset += size
 	}
-	if _, err := r.Seek(int64(origStart), io.SeekStart); err != nil {
-		return nil, err
+	return boxes, nil
+}
+
+// chunkOffsetContainers are the box types on the path to the stco/co64 chunk
+// offset tables (trak → mdia → minf → stbl), plus edts which can sit between
+// trak and mdia. Only these are descended into when shifting offsets.
+var chunkOffsetContainers = map[string]bool{
+	"trak": true,
+	"mdia": true,
+	"minf": true,
+	"stbl": true,
+	"edts": true,
+}
+
+// shiftChunkOffsets adds delta to every stco/co64 chunk offset within the given
+// moov box (a complete box including its 8-byte header).
+func shiftChunkOffsets(moovBox []byte, delta int64) error {
+	if len(moovBox) < 8 {
+		return errors.New("moov box too small")
 	}
+	return shiftChunkOffsetsInChildren(moovBox[8:], delta)
+}
 
-	origContent := make([]byte, origEnd-origStart)
-	if _, err := io.ReadFull(r, origContent); err != nil {
-		return nil, err
+// shiftChunkOffsetsInChildren walks sibling boxes within a container's content,
+// recursing into known containers and patching stco/co64 tables.
+func shiftChunkOffsetsInChildren(buf []byte, delta int64) error {
+	offset := 0
+	for offset+8 <= len(buf) {
+		size := int(binary.BigEndian.Uint32(buf[offset:]))
+		headerSize := 8
+		switch size {
+		case 1:
+			if offset+16 > len(buf) {
+				return errors.New("truncated 64-bit box header in moov")
+			}
+			size64 := binary.BigEndian.Uint64(buf[offset+8:])
+			if size64 > uint64(len(buf)) {
+				return errors.New("box size exceeds moov length")
+			}
+			// #nosec G115 -- bounds checked against len(buf) above
+			size = int(size64)
+			headerSize = 16
+		case 0:
+			size = len(buf) - offset
+		}
+		if size < headerSize || offset+size > len(buf) {
+			return errors.New("invalid box size in moov")
+		}
+
+		typ := string(buf[offset+4 : offset+8])
+		switch {
+		case typ == "stco":
+			if err := shiftStco(buf[offset:offset+size], delta); err != nil {
+				return err
+			}
+		case typ == "co64":
+			if err := shiftCo64(buf[offset:offset+size], delta); err != nil {
+				return err
+			}
+		case chunkOffsetContainers[typ]:
+			if err := shiftChunkOffsetsInChildren(buf[offset+headerSize:offset+size], delta); err != nil {
+				return err
+			}
+		}
+		offset += size
 	}
+	return nil
+}
 
-	// Find and replace udta/meta/ilst within the moov content
-	newContent := replaceIlstInContent(origContent, metadata)
+// shiftStco adds delta to each 32-bit chunk offset in an stco box. It errors if
+// any shifted offset would not fit in a uint32 (which would require promoting
+// the table to 64-bit co64 entries — a rewrite this writer does not perform; it
+// only happens for files approaching 4 GiB).
+func shiftStco(box []byte, delta int64) error {
+	// box: size(4) + type(4) + version(1) + flags(3) + count(4) + entries(4 each)
+	if len(box) < 16 {
+		return errors.New("stco box too small")
+	}
+	count := int(binary.BigEndian.Uint32(box[12:16]))
+	pos := 16
+	for i := 0; i < count; i++ {
+		if pos+4 > len(box) {
+			return errors.New("stco box truncated")
+		}
+		shifted := int64(binary.BigEndian.Uint32(box[pos:pos+4])) + delta
+		if shifted < 0 || shifted > math.MaxUint32 {
+			return errors.New("chunk offset overflows uint32 after shift; co64 promotion not supported")
+		}
+		// #nosec G115 -- bounds checked against [0, math.MaxUint32] above
+		binary.BigEndian.PutUint32(box[pos:pos+4], uint32(shifted))
+		pos += 4
+	}
+	return nil
+}
 
-	// Build new moov box
-	return buildBox("moov", newContent), nil
+// shiftCo64 adds delta to each 64-bit chunk offset in a co64 box.
+func shiftCo64(box []byte, delta int64) error {
+	// box: size(4) + type(4) + version(1) + flags(3) + count(4) + entries(8 each)
+	if len(box) < 16 {
+		return errors.New("co64 box too small")
+	}
+	count := int(binary.BigEndian.Uint32(box[12:16]))
+	pos := 16
+	for i := 0; i < count; i++ {
+		if pos+8 > len(box) {
+			return errors.New("co64 box truncated")
+		}
+		// #nosec G115 -- chunk offsets are file positions, always within int64
+		shifted := int64(binary.BigEndian.Uint64(box[pos:pos+8])) + delta
+		if shifted < 0 {
+			return errors.New("chunk offset underflows below zero after shift")
+		}
+		// #nosec G115 -- shifted is guaranteed non-negative above
+		binary.BigEndian.PutUint64(box[pos:pos+8], uint64(shifted))
+		pos += 8
+	}
+	return nil
 }
 
 // replaceIlstInContent finds and replaces the ilst box within moov content.

--- a/pkg/mp4/writer_chunkoffset_test.go
+++ b/pkg/mp4/writer_chunkoffset_test.go
@@ -1,0 +1,230 @@
+package mp4_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/shishobooks/shisho/internal/testgen"
+	"github.com/shishobooks/shisho/pkg/mp4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteToFile_FaststartLayoutPreservesAudioChunkOffsets is the regression
+// test for the audiobook download corruption bug: M4B files with a faststart
+// layout (moov before mdat, as Audible/Apple Books export) became unplayable
+// after download because rewriting the metadata grows moov, shifts mdat down,
+// but left the stco/co64 chunk offset tables pointing at the old positions —
+// which now land inside the grown moov box. The decoder then reads metadata as
+// audio ("channel element is not allocated") and players refuse the file.
+//
+// The contract: after a metadata rewrite, every chunk offset must still point
+// at the same audio bytes it pointed at in the source.
+func TestWriteToFile_FaststartLayoutPreservesAudioChunkOffsets(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	dir := testgen.TempDir(t, "mp4-faststart-*")
+
+	srcPath := testgen.GenerateM4B(t, dir, "src.m4b", testgen.M4BOptions{
+		Title:     "Original Title",
+		Artist:    "Original Author",
+		Duration:  5.0,
+		Faststart: true,
+	})
+
+	// The fixture must really be moov-before-mdat, otherwise it doesn't
+	// exercise the bug.
+	srcMoov, srcMdat := boxPositions(t, srcPath)
+	require.Less(t, srcMoov.offset, srcMdat.offset,
+		"fixture must be faststart (moov before mdat) to exercise the bug")
+
+	meta, err := mp4.ParseFull(srcPath)
+	require.NoError(t, err)
+
+	// Grow moov by attaching a large cover so mdat is pushed down on rewrite.
+	meta.CoverData = bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 128*1024) // 512 KB
+	meta.CoverMimeType = "image/jpeg"
+
+	destPath := filepath.Join(dir, "dest.m4b")
+	require.NoError(t, mp4.WriteToFile(srcPath, destPath, meta))
+
+	// Sanity: moov must have actually grown, or the test proves nothing.
+	destMoov, _ := boxPositions(t, destPath)
+	require.Greater(t, destMoov.size, srcMoov.size,
+		"moov must grow for the test to exercise the shift")
+
+	assertChunkOffsetsLocateSameAudio(t, srcPath, destPath)
+}
+
+// TestWriteToFile_MdatFirstLayoutLeavesChunkOffsetsUnchanged guards against
+// over-correction: when mdat comes before moov (ffmpeg's default, non-faststart
+// layout), growing moov does not move mdat, so the chunk offsets must be left
+// exactly as they are.
+func TestWriteToFile_MdatFirstLayoutLeavesChunkOffsetsUnchanged(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	dir := testgen.TempDir(t, "mp4-mdatfirst-*")
+
+	srcPath := testgen.GenerateM4B(t, dir, "src.m4b", testgen.M4BOptions{
+		Title:    "Original Title",
+		Artist:   "Original Author",
+		Duration: 5.0,
+		// No Faststart: ffmpeg writes mdat before moov.
+	})
+
+	srcMoov, srcMdat := boxPositions(t, srcPath)
+	require.Greater(t, srcMoov.offset, srcMdat.offset,
+		"fixture must be mdat-first to exercise the guard")
+
+	meta, err := mp4.ParseFull(srcPath)
+	require.NoError(t, err)
+	meta.CoverData = bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 128*1024) // 512 KB
+	meta.CoverMimeType = "image/jpeg"
+
+	destPath := filepath.Join(dir, "dest.m4b")
+	require.NoError(t, mp4.WriteToFile(srcPath, destPath, meta))
+
+	destMoov, _ := boxPositions(t, destPath)
+	require.Greater(t, destMoov.size, srcMoov.size, "moov must grow for the guard to be meaningful")
+
+	src, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	dest, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	require.Equal(t, collectChunkOffsets(t, src), collectChunkOffsets(t, dest),
+		"mdat did not move, so chunk offsets must be untouched")
+
+	// And the audio is of course still where the offsets say it is.
+	assertChunkOffsetsLocateSameAudio(t, srcPath, destPath)
+}
+
+type boxPos struct {
+	offset int
+	size   int
+}
+
+// boxPositions returns the top-level moov and mdat box positions.
+func boxPositions(t *testing.T, path string) (moov, mdat boxPos) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	off := 0
+	for off+8 <= len(data) {
+		size := int(binary.BigEndian.Uint32(data[off:]))
+		hdr := 8
+		switch size {
+		case 1:
+			require.LessOrEqual(t, off+16, len(data), "truncated 64-bit box header")
+			size = int(binary.BigEndian.Uint64(data[off+8:]))
+			hdr = 16
+		case 0:
+			size = len(data) - off
+		}
+		require.GreaterOrEqual(t, size, hdr, "invalid box size")
+		require.LessOrEqual(t, off+size, len(data), "box extends past EOF")
+
+		switch string(data[off+4 : off+8]) {
+		case "moov":
+			moov = boxPos{offset: off, size: size}
+		case "mdat":
+			if mdat.size == 0 {
+				mdat = boxPos{offset: off, size: size}
+			}
+		}
+		off += size
+	}
+	return moov, mdat
+}
+
+// collectChunkOffsets walks the box tree and returns every stco (32-bit) and
+// co64 (64-bit) chunk offset in document order.
+func collectChunkOffsets(t *testing.T, data []byte) []uint64 {
+	t.Helper()
+	var out []uint64
+
+	var walk func(buf []byte)
+	walk = func(buf []byte) {
+		off := 0
+		for off+8 <= len(buf) {
+			size := int(binary.BigEndian.Uint32(buf[off:]))
+			hdr := 8
+			switch size {
+			case 1:
+				if off+16 > len(buf) {
+					return
+				}
+				size = int(binary.BigEndian.Uint64(buf[off+8:]))
+				hdr = 16
+			case 0:
+				size = len(buf) - off
+			}
+			if size < hdr || off+size > len(buf) {
+				return
+			}
+
+			typ := string(buf[off+4 : off+8])
+			switch typ {
+			case "stco", "co64":
+				// body: version(1) + flags(3) + entry_count(4) + entries
+				body := buf[off+hdr : off+size]
+				require.GreaterOrEqual(t, len(body), 8, "%s box too small", typ)
+				count := int(binary.BigEndian.Uint32(body[4:8]))
+				p := 8
+				for i := 0; i < count; i++ {
+					if typ == "stco" {
+						require.LessOrEqual(t, p+4, len(body), "stco truncated")
+						out = append(out, uint64(binary.BigEndian.Uint32(body[p:p+4])))
+						p += 4
+					} else {
+						require.LessOrEqual(t, p+8, len(body), "co64 truncated")
+						out = append(out, binary.BigEndian.Uint64(body[p:p+8]))
+						p += 8
+					}
+				}
+			case "moov", "trak", "mdia", "minf", "stbl", "edts":
+				walk(buf[off+hdr : off+size])
+			}
+			off += size
+		}
+	}
+	walk(data)
+	return out
+}
+
+// assertChunkOffsetsLocateSameAudio verifies that every chunk offset in dest
+// points at the same audio bytes the corresponding source offset points at.
+func assertChunkOffsetsLocateSameAudio(t *testing.T, srcPath, destPath string) {
+	t.Helper()
+	src, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	dest, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+
+	srcOffs := collectChunkOffsets(t, src)
+	destOffs := collectChunkOffsets(t, dest)
+	require.NotEmpty(t, srcOffs, "source must have chunk offsets")
+	require.Len(t, destOffs, len(srcOffs), "chunk count must be preserved")
+
+	const window = 64
+	for i := range srcOffs {
+		so := int(srcOffs[i])
+		do := int(destOffs[i])
+		require.LessOrEqual(t, so, len(src), "source offset %d past EOF (chunk %d)", so, i)
+		require.LessOrEqual(t, do, len(dest), "dest offset %d past EOF (chunk %d)", do, i)
+
+		w := window
+		if rem := len(src) - so; rem < w {
+			w = rem
+		}
+		if rem := len(dest) - do; rem < w {
+			w = rem
+		}
+		assert.Equal(t, src[so:so+w], dest[do:do+w],
+			"chunk %d: rewritten offset %d does not point at the same audio bytes as source offset %d",
+			i, do, so)
+	}
+}

--- a/pkg/mp4/writer_chunkoffset_test.go
+++ b/pkg/mp4/writer_chunkoffset_test.go
@@ -101,6 +101,51 @@ func TestWriteToFile_MdatFirstLayoutLeavesChunkOffsetsUnchanged(t *testing.T) {
 	assertChunkOffsetsLocateSameAudio(t, srcPath, destPath)
 }
 
+// TestWriteToFile_FaststartWithChaptersShiftsAllTrackOffsets covers the
+// realistic case: a real audiobook has a chapter track in addition to the audio
+// track, so the moov holds two stco tables, both pointing into mdat. Both must
+// be shifted on rewrite — a fix that only shifted the first track would still
+// corrupt the chapter track. The audio-only fixtures cannot catch that.
+func TestWriteToFile_FaststartWithChaptersShiftsAllTrackOffsets(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	dir := testgen.TempDir(t, "mp4-faststart-chapters-*")
+
+	srcPath := testgen.GenerateM4B(t, dir, "src.m4b", testgen.M4BOptions{
+		Title:     "Original Title",
+		Artist:    "Original Author",
+		Duration:  5.0,
+		Faststart: true,
+		Chapters: []testgen.M4BChapter{
+			{Title: "Chapter One", Start: 0},
+			{Title: "Chapter Two", Start: 2.0},
+		},
+	})
+
+	srcMoov, srcMdat := boxPositions(t, srcPath)
+	require.Less(t, srcMoov.offset, srcMdat.offset, "fixture must be faststart")
+
+	// The fixture must actually contain more than one chunk-offset table,
+	// otherwise this degrades to the single-track case and proves nothing.
+	src, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, countChunkOffsetTables(t, src), 2,
+		"fixture must have an audio track and a chapter track (two stco tables)")
+
+	meta, err := mp4.ParseFull(srcPath)
+	require.NoError(t, err)
+	meta.CoverData = bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, 128*1024) // 512 KB
+	meta.CoverMimeType = "image/jpeg"
+
+	destPath := filepath.Join(dir, "dest.m4b")
+	require.NoError(t, mp4.WriteToFile(srcPath, destPath, meta))
+
+	destMoov, _ := boxPositions(t, destPath)
+	require.Greater(t, destMoov.size, srcMoov.size, "moov must grow")
+
+	assertChunkOffsetsLocateSameAudio(t, srcPath, destPath)
+}
+
 type boxPos struct {
 	offset int
 	size   int
@@ -193,6 +238,43 @@ func collectChunkOffsets(t *testing.T, data []byte) []uint64 {
 	}
 	walk(data)
 	return out
+}
+
+// countChunkOffsetTables returns the number of stco/co64 boxes in the file.
+func countChunkOffsetTables(t *testing.T, data []byte) int {
+	t.Helper()
+	count := 0
+
+	var walk func(buf []byte)
+	walk = func(buf []byte) {
+		off := 0
+		for off+8 <= len(buf) {
+			size := int(binary.BigEndian.Uint32(buf[off:]))
+			hdr := 8
+			switch size {
+			case 1:
+				if off+16 > len(buf) {
+					return
+				}
+				size = int(binary.BigEndian.Uint64(buf[off+8:]))
+				hdr = 16
+			case 0:
+				size = len(buf) - off
+			}
+			if size < hdr || off+size > len(buf) {
+				return
+			}
+			switch string(buf[off+4 : off+8]) {
+			case "stco", "co64":
+				count++
+			case "moov", "trak", "mdia", "minf", "stbl", "edts":
+				walk(buf[off+hdr : off+size])
+			}
+			off += size
+		}
+	}
+	walk(data)
+	return count
 }
 
 // assertChunkOffsetsLocateSameAudio verifies that every chunk offset in dest

--- a/pkg/mp4/writer_internal_test.go
+++ b/pkg/mp4/writer_internal_test.go
@@ -1,0 +1,154 @@
+package mp4
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the chunk-offset shift helpers directly. The integration
+// tests in writer_chunkoffset_test.go can only produce small files that always
+// use 32-bit stco, so the co64 path and the overflow guard are unreachable from
+// there and are unit-tested here against hand-built boxes.
+
+// stcoBox builds an stco box (full box including header) from the given 32-bit
+// chunk offsets.
+func stcoBox(offsets ...uint32) []byte {
+	content := make([]byte, 8+4*len(offsets))
+	// content[0:4] = version + flags (zero)
+	// #nosec G115 -- test input, len is small
+	binary.BigEndian.PutUint32(content[4:8], uint32(len(offsets)))
+	for i, o := range offsets {
+		binary.BigEndian.PutUint32(content[8+4*i:], o)
+	}
+	return buildBox("stco", content)
+}
+
+// co64Box builds a co64 box (full box including header) from the given 64-bit
+// chunk offsets.
+func co64Box(offsets ...uint64) []byte {
+	content := make([]byte, 8+8*len(offsets))
+	// #nosec G115 -- test input, len is small
+	binary.BigEndian.PutUint32(content[4:8], uint32(len(offsets)))
+	for i, o := range offsets {
+		binary.BigEndian.PutUint64(content[8+8*i:], o)
+	}
+	return buildBox("co64", content)
+}
+
+func stcoOffsets(box []byte) []uint32 {
+	count := int(binary.BigEndian.Uint32(box[12:16]))
+	out := make([]uint32, count)
+	for i := 0; i < count; i++ {
+		out[i] = binary.BigEndian.Uint32(box[16+4*i:])
+	}
+	return out
+}
+
+func co64Offsets(box []byte) []uint64 {
+	count := int(binary.BigEndian.Uint32(box[12:16]))
+	out := make([]uint64, count)
+	for i := 0; i < count; i++ {
+		out[i] = binary.BigEndian.Uint64(box[16+8*i:])
+	}
+	return out
+}
+
+func TestShiftStco_AddsPositiveDelta(t *testing.T) {
+	t.Parallel()
+	box := stcoBox(1000, 2000, 3000)
+	require.NoError(t, shiftStco(box, 500))
+	assert.Equal(t, []uint32{1500, 2500, 3500}, stcoOffsets(box))
+}
+
+func TestShiftStco_AddsNegativeDelta(t *testing.T) {
+	t.Parallel()
+	box := stcoBox(1000, 2000)
+	require.NoError(t, shiftStco(box, -250))
+	assert.Equal(t, []uint32{750, 1750}, stcoOffsets(box))
+}
+
+func TestShiftStco_ErrorsWhenShiftOverflowsUint32(t *testing.T) {
+	t.Parallel()
+	box := stcoBox(math.MaxUint32 - 10)
+	err := shiftStco(box, 100)
+	require.Error(t, err, "an offset that would exceed uint32 must error, not wrap")
+}
+
+func TestShiftStco_ErrorsWhenShiftUnderflowsBelowZero(t *testing.T) {
+	t.Parallel()
+	box := stcoBox(10)
+	err := shiftStco(box, -100)
+	require.Error(t, err)
+}
+
+func TestShiftCo64_AddsDeltaTo64BitOffsets(t *testing.T) {
+	t.Parallel()
+	// Offsets above 4 GiB, only representable as co64.
+	box := co64Box(5_000_000_000, 8_000_000_000)
+	require.NoError(t, shiftCo64(box, 1_000))
+	assert.Equal(t, []uint64{5_000_001_000, 8_000_001_000}, co64Offsets(box))
+}
+
+func TestShiftCo64_ErrorsWhenShiftUnderflowsBelowZero(t *testing.T) {
+	t.Parallel()
+	box := co64Box(100)
+	err := shiftCo64(box, -200)
+	require.Error(t, err)
+}
+
+// TestShiftChunkOffsets_WalksNestedTracksAndBothTableTypes verifies the walker
+// descends moov → trak → mdia → minf → stbl and patches every stco/co64 it
+// finds, including a co64 table (which integration fixtures never produce).
+func TestShiftChunkOffsets_WalksNestedTracksAndBothTableTypes(t *testing.T) {
+	t.Parallel()
+
+	stbl := func(table []byte) []byte {
+		minf := buildBox("minf", table)
+		mdia := buildBox("mdia", minf)
+		return buildBox("trak", mdia)
+	}
+
+	audioTrak := stbl(buildBox("stbl", stcoBox(1000, 2000)))
+	chapterTrak := stbl(buildBox("stbl", co64Box(9_000_000_000)))
+
+	moov := buildBox("moov", append(append([]byte{}, audioTrak...), chapterTrak...))
+
+	require.NoError(t, shiftChunkOffsets(moov, 777))
+
+	got := collectAllOffsets(t, moov)
+	assert.Equal(t, []uint64{1777, 2777, 9_000_000_777}, got,
+		"both the audio stco and the chapter co64 must be shifted")
+}
+
+// collectAllOffsets walks a moov box and returns every stco/co64 entry in order.
+func collectAllOffsets(t *testing.T, moov []byte) []uint64 {
+	t.Helper()
+	var out []uint64
+	var walk func(buf []byte)
+	walk = func(buf []byte) {
+		off := 0
+		for off+8 <= len(buf) {
+			size := int(binary.BigEndian.Uint32(buf[off:]))
+			if size < 8 || off+size > len(buf) {
+				return
+			}
+			switch string(buf[off+4 : off+8]) {
+			case "stco":
+				for _, o := range stcoOffsets(buf[off : off+size]) {
+					out = append(out, uint64(o))
+				}
+			case "co64":
+				out = append(out, co64Offsets(buf[off:off+size])...)
+			case "moov", "trak", "mdia", "minf", "stbl", "edts":
+				walk(buf[off+8 : off+size])
+			}
+			off += size
+		}
+	}
+	walk(moov[8:])
+	return out
+}


### PR DESCRIPTION
## Summary
- Audiobooks downloaded from Shisho would not play in Apple Books or Bound when the source M4B used a faststart layout (moov before mdat, which is what Audible and Apple Books export). Rewriting metadata grows the moov box (cover art adds hundreds of KB), which shifts mdat down, but the stco/co64 chunk-offset tables (absolute file offsets into mdat) were copied verbatim and kept pointing at the old positions, now inside the resized moov. The AAC decoder then read metadata bytes as audio (`channel element ... is not allocated`) and strict players refused the file.
- `writeMetadataToBytes` now shifts every stco (32-bit) and co64 (64-bit) chunk offset by the moov-size delta when moov precedes mdat. The mdat-first layout is left untouched since mdat does not move there. 32-bit offsets that would overflow uint32 after the shift error out rather than corrupting (only reachable near 4 GiB). This covers both the download path (`mp4.WriteToFile`) and the in-place `mp4.Write` path.
- Tests previously missed this because the generator emitted mdat-first files (plain ffmpeg, no faststart), a layout where growing moov never relocates the audio. Added a `Faststart` option to `testgen.GenerateM4B` and two regression tests covering both layouts.

## Test plan
- `go test ./pkg/mp4/ ./pkg/filegen/` passes, including the new `TestWriteToFile_FaststartLayoutPreservesAudioChunkOffsets` (verified RED before the fix: the rewritten chunk offset pointed at injected cover bytes instead of audio) and `TestWriteToFile_MdatFirstLayoutLeavesChunkOffsetsUnchanged` (guards against over-shifting)
- Validated against a real faststart Audible export: after rewrite, moov grew and both stco tables (audio + chapter text track) shifted by exactly the moov delta to follow mdat; `ffmpeg -v error -i out.m4b -f null -` decodes cleanly with zero errors (vs. `channel element 3.12 is not allocated` on the broken download)
- `mise check:quiet` passes (lint, test, test:js:fast, lint:js)

Note: audiobooks already downloaded from a faststart source before this fix are corrupt and need re-downloading once this ships.