### PR TITLE
[Fix] Write edited M4B chapters to the QuickTime chapter track

### DIFF
--- a/pkg/filegen/m4b_test.go
+++ b/pkg/filegen/m4b_test.go
@@ -855,6 +855,59 @@ func TestM4BGenerator_Generate(t *testing.T) {
 		assert.Equal(t, "Source Chapter 3", meta.Chapters[2].Title)
 	})
 
+	t.Run("download writes file chapters over a source QuickTime track", func(t *testing.T) {
+		t.Parallel()
+		testgen.SkipIfNoFFmpeg(t)
+		dir := testgen.TempDir(t, "m4b-gen-*")
+
+		// A faststart source that already carries a QuickTime chapter track with
+		// its own titles, like a real Audible export. This is the path the
+		// download bug lived on: the QuickTime track masked the file's edited
+		// chapters because only chpl was rewritten.
+		srcPath := testgen.GenerateM4B(t, dir, "source.m4b", testgen.M4BOptions{
+			Title:     "Test Book",
+			Duration:  10.0,
+			Faststart: true,
+			Chapters: []testgen.M4BChapter{
+				{Title: "Source Chapter 1", Start: 0.0},
+				{Title: "Source Chapter 2", Start: 5.0},
+			},
+		})
+
+		destPath := filepath.Join(dir, "dest.m4b")
+
+		ts1 := int64(0)
+		ts2 := int64(3000)
+		ts3 := int64(7000)
+		book := &models.Book{
+			Title: "Test Book",
+			Authors: []*models.Author{
+				{SortOrder: 0, Person: &models.Person{Name: "Author"}},
+			},
+		}
+		file := &models.File{
+			FileType: models.FileTypeM4B,
+			Chapters: []*models.Chapter{
+				{Title: "Edited One", SortOrder: 0, StartTimestampMs: &ts1},
+				{Title: "Edited Two", SortOrder: 1, StartTimestampMs: &ts2},
+				{Title: "Edited Three", SortOrder: 2, StartTimestampMs: &ts3},
+			},
+		}
+
+		gen := &M4BGenerator{}
+		require.NoError(t, gen.Generate(context.Background(), srcPath, destPath, book, file))
+
+		// ParseFull reads the QuickTime track preferentially, so reading back the
+		// edited titles (not the source's two) proves the QuickTime track was
+		// rebuilt through the whole download pipeline, not just chpl.
+		meta, err := mp4.ParseFull(destPath)
+		require.NoError(t, err)
+		require.Len(t, meta.Chapters, 3, "expected the 3 file-model chapters, not the source's 2")
+		assert.Equal(t, "Edited One", meta.Chapters[0].Title)
+		assert.Equal(t, "Edited Two", meta.Chapters[1].Title)
+		assert.Equal(t, "Edited Three", meta.Chapters[2].Title)
+	})
+
 	t.Run("chapter order follows StartTimestampMs when SortOrder disagrees", func(t *testing.T) {
 		t.Parallel()
 		testgen.SkipIfNoFFmpeg(t)

--- a/pkg/mp4/CLAUDE.md
+++ b/pkg/mp4/CLAUDE.md
@@ -214,23 +214,27 @@ play while lenient players may limp along.
   and `TestWriteToFile_MdatFirstLayoutLeavesChunkOffsetsUnchanged` (no
   over-shift) in `writer_chunkoffset_test.go`.
 
-**QuickTime chapter-track rebuild on write — CRITICAL.**
+**QuickTime chapter-track rebuild on write (CRITICAL).**
 M4B files store chapters in TWO places: a **QuickTime text chapter track** (an
 audio `trak` references a separate text `trak` via `tref/chap`) and a **Nero
 `chpl`** box. Players, ffprobe, and Shisho's own reader (`readChapters` tries
 QuickTime first) prefer the QuickTime track. So writing chapters only to `chpl`
 (the old behavior) left the user's edited titles/timings masked by the stale
-source titles still sitting in the QuickTime track — the visible "manual chapters
-don't show up in the downloaded audiobook" bug.
+source titles still sitting in the QuickTime track. That was the visible "manual
+chapters don't show up in the downloaded audiobook" bug.
 
 `writeMetadataToBytes` now rebuilds the QuickTime chapter text track from
 `metadata.Chapters` (in `writer_chapters.go`) in addition to writing `chpl`:
 
-- The existing chapter text `trak` is located by its media handler type
-  (`mdia/hdlr` == `text`). Its `tkhd`/`edts`/`mdhd`/`hdlr`/`stsd` are preserved
-  verbatim (so the audio track's `tref/chap` reference and the track ID stay
-  valid); only the `stts`/`stsc`/`stsz` tables are regenerated and the chunk
-  offset is emitted as a 64-bit `co64` (overflow-safe).
+- The existing chapter text `trak` is located the same way the reader does: by
+  resolving the audio track's `tref/chap` reference to a track ID and matching
+  the `tkhd` track ID (falling back to the first `mdia/hdlr` == `text` track when
+  there is no `tref/chap`). Matching by ID keeps the writer in agreement with the
+  reader when a file has more than one text track. Its `tkhd`/`edts`/`mdhd`/
+  `hdlr`/`stsd` are preserved verbatim (so the audio track's `tref/chap`
+  reference and the track ID stay valid); only the `stts`/`stsc`/`stsz` tables
+  are regenerated and the chunk offset is emitted as a 64-bit `co64`
+  (overflow-safe).
 - **The audio `mdat` is never touched.** The new chapter text samples
   (`[uint16 len][utf8 title][12-byte encd atom]`, matching ffmpeg/Apple) are
   written into a **new trailing `mdat` appended at EOF**. The original chapter

--- a/pkg/mp4/CLAUDE.md
+++ b/pkg/mp4/CLAUDE.md
@@ -178,11 +178,11 @@ Uses `mp4.WriteToFile()` for atomic writes.
 | URL | `com.shisho:url` | file.URL |
 | Cover | `covr` | Image with type flag (13=JPEG, 14=PNG) |
 | Media Type | `stik` | Always `2` (audiobook) |
+| Chapters | QuickTime `tref/chap` text track AND Nero `chpl` | `metadata.Chapters` (see below) |
 
 **Preserved from Source:**
 - Year, copyright, encoder
 - Duration, bitrate
-- Chapters
 - Unknown atoms (e.g., `aART`, `cprt`)
 - All freeform atoms not explicitly overwritten
 
@@ -213,6 +213,48 @@ play while lenient players may limp along.
   `TestWriteToFile_FaststartLayoutPreservesAudioChunkOffsets` (shifts correctly)
   and `TestWriteToFile_MdatFirstLayoutLeavesChunkOffsetsUnchanged` (no
   over-shift) in `writer_chunkoffset_test.go`.
+
+**QuickTime chapter-track rebuild on write — CRITICAL.**
+M4B files store chapters in TWO places: a **QuickTime text chapter track** (an
+audio `trak` references a separate text `trak` via `tref/chap`) and a **Nero
+`chpl`** box. Players, ffprobe, and Shisho's own reader (`readChapters` tries
+QuickTime first) prefer the QuickTime track. So writing chapters only to `chpl`
+(the old behavior) left the user's edited titles/timings masked by the stale
+source titles still sitting in the QuickTime track — the visible "manual chapters
+don't show up in the downloaded audiobook" bug.
+
+`writeMetadataToBytes` now rebuilds the QuickTime chapter text track from
+`metadata.Chapters` (in `writer_chapters.go`) in addition to writing `chpl`:
+
+- The existing chapter text `trak` is located by its media handler type
+  (`mdia/hdlr` == `text`). Its `tkhd`/`edts`/`mdhd`/`hdlr`/`stsd` are preserved
+  verbatim (so the audio track's `tref/chap` reference and the track ID stay
+  valid); only the `stts`/`stsc`/`stsz` tables are regenerated and the chunk
+  offset is emitted as a 64-bit `co64` (overflow-safe).
+- **The audio `mdat` is never touched.** The new chapter text samples
+  (`[uint16 len][utf8 title][12-byte encd atom]`, matching ffmpeg/Apple) are
+  written into a **new trailing `mdat` appended at EOF**. The original chapter
+  samples are left as harmless dead bytes inside the audio `mdat` (nothing
+  references them).
+- **Offset interaction with the faststart shift:** the chapter track's `co64`
+  points at the trailing `mdat`, a different base than the audio `stco` (which
+  the faststart shift moves by the moov delta). The writer parks a safe
+  placeholder in the `co64` so the shift cannot underflow it, then patches the
+  real absolute trailing-`mdat` offset after reassembly. So the audio offsets are
+  shifted by the moov delta; the chapter `co64` is set absolutely.
+- **Scope:** this rebuilds an *existing* chapter text track. A source with no
+  QuickTime track (only `chpl`, or no chapters) keeps the `chpl`-only path
+  (`rebuildChapterTextTrack` returns `ok=false`); `chpl` is the correct fallback
+  there since no stale QuickTime track masks it. Synthesizing a brand-new
+  QuickTime track from scratch (which would require editing the audio track's
+  `tref` and `mvhd` next-track-id) is intentionally out of scope.
+- **Note:** the rebuilt track's `tkhd`/`mdhd` durations are left as-is; players
+  derive chapter boundaries from the sample table (`stts`), so a stale track
+  duration is cosmetic. Validated against a real Audible export and via ffprobe.
+- Regression tests in `writer_chapters_test.go` (titles, timestamps, count
+  changes, mdat-first layout, ffprobe-visible + clean-decode) and the two-table
+  audio-integrity guard `TestWriteToFile_FaststartWithChaptersPreservesAudioAndChapters`
+  in `writer_chunkoffset_test.go`.
 
 **Series Formatting:**
 - With number: `"Series Name #1"` or `"Series Name #1.5"`

--- a/pkg/mp4/writer.go
+++ b/pkg/mp4/writer.go
@@ -172,6 +172,18 @@ func writeMetadataToBytes(input []byte, metadata *Metadata) ([]byte, error) {
 	// Append the rebuilt chapter samples as a trailing mdat and point the
 	// chapter track's co64 at the sample data (after the mdat's 8-byte header).
 	if chapterMdat != nil {
+		// A box with a size-0 header means "extends to EOF" and is only legal as
+		// the last box. Appending the chapter mdat after one would make that box
+		// swallow it for strict parsers, so rewrite its size to a concrete value
+		// first. (The audio chunk offsets are unaffected: only the 4-byte size
+		// header changes, not any sample bytes.)
+		last := boxes[len(boxes)-1]
+		if binary.BigEndian.Uint32(input[last.offset:last.offset+4]) == 0 && last.size <= math.MaxUint32 {
+			lastOutputStart := len(outBytes) - last.size
+			// #nosec G115 -- last.size bounded by math.MaxUint32 above
+			binary.BigEndian.PutUint32(outBytes[lastOutputStart:lastOutputStart+4], uint32(last.size))
+		}
+
 		mdatBox := buildBox("mdat", chapterMdat.sampleData)
 		sampleDataOffset := len(outBytes) + 8
 		patchPos := moovOutputStart + 8 + chapterMdat.co64FieldOffset

--- a/pkg/mp4/writer.go
+++ b/pkg/mp4/writer.go
@@ -122,7 +122,29 @@ func writeMetadataToBytes(input []byte, metadata *Metadata) ([]byte, error) {
 
 	// Rebuild moov with the new metadata (find and replace udta/meta/ilst).
 	origContent := input[moov.offset+moov.headerSize : moov.offset+moov.size]
-	newMoov := buildBox("moov", replaceIlstInContent(origContent, metadata))
+	moovContent := replaceIlstInContent(origContent, metadata)
+
+	// Rebuild the QuickTime chapter text track from the chapters so the user's
+	// edited titles/timings land in the track players read preferentially, not
+	// only the Nero chpl box. The new text samples go into a trailing mdat
+	// (appended below), leaving the audio mdat untouched; the chapter track's
+	// co64 offset is patched to that mdat once its position is known.
+	var chapterMdat *rebuiltChapterTrack
+	if len(metadata.Chapters) > 0 {
+		if rebuilt, ok := rebuildChapterTextTrack(moovContent, metadata.Chapters); ok {
+			moovContent = rebuilt.moovContent
+			chapterMdat = &rebuilt
+		}
+	}
+
+	newMoov := buildBox("moov", moovContent)
+
+	// Park a safe placeholder in the chapter track's co64 entry so the faststart
+	// shift below cannot underflow it; the real absolute offset is written after
+	// reassembly. len(input) exceeds any moov-resize delta in magnitude.
+	if chapterMdat != nil {
+		binary.BigEndian.PutUint64(newMoov[8+chapterMdat.co64FieldOffset:], uint64(len(input)))
+	}
 
 	// Only when moov precedes mdat does rewriting moov relocate the audio.
 	if haveMdat && moov.offset < firstMdatOffset {
@@ -136,15 +158,29 @@ func writeMetadataToBytes(input []byte, metadata *Metadata) ([]byte, error) {
 
 	// Reassemble the file in original box order, substituting the rebuilt moov.
 	var output bytes.Buffer
+	moovOutputStart := 0
 	for _, b := range boxes {
 		if b.offset == moov.offset {
+			moovOutputStart = output.Len()
 			output.Write(newMoov)
 		} else {
 			output.Write(input[b.offset : b.offset+b.size])
 		}
 	}
+	outBytes := output.Bytes()
 
-	return output.Bytes(), nil
+	// Append the rebuilt chapter samples as a trailing mdat and point the
+	// chapter track's co64 at the sample data (after the mdat's 8-byte header).
+	if chapterMdat != nil {
+		mdatBox := buildBox("mdat", chapterMdat.sampleData)
+		sampleDataOffset := len(outBytes) + 8
+		patchPos := moovOutputStart + 8 + chapterMdat.co64FieldOffset
+		// #nosec G115 -- file offset is non-negative and within int64 range
+		binary.BigEndian.PutUint64(outBytes[patchPos:patchPos+8], uint64(sampleDataOffset))
+		outBytes = append(outBytes, mdatBox...)
+	}
+
+	return outBytes, nil
 }
 
 // topLevelBox describes a box at the root of the file.

--- a/pkg/mp4/writer.go
+++ b/pkg/mp4/writer.go
@@ -176,9 +176,12 @@ func writeMetadataToBytes(input []byte, metadata *Metadata) ([]byte, error) {
 		// the last box. Appending the chapter mdat after one would make that box
 		// swallow it for strict parsers, so rewrite its size to a concrete value
 		// first. (The audio chunk offsets are unaffected: only the 4-byte size
-		// header changes, not any sample bytes.)
+		// header changes, not any sample bytes.) Skip moov: it was rebuilt to a
+		// different length than its source box, so len(outBytes)-last.size would
+		// not locate its start.
 		last := boxes[len(boxes)-1]
-		if binary.BigEndian.Uint32(input[last.offset:last.offset+4]) == 0 && last.size <= math.MaxUint32 {
+		if last.offset != moov.offset &&
+			binary.BigEndian.Uint32(input[last.offset:last.offset+4]) == 0 && last.size <= math.MaxUint32 {
 			lastOutputStart := len(outBytes) - last.size
 			// #nosec G115 -- last.size bounded by math.MaxUint32 above
 			binary.BigEndian.PutUint32(outBytes[lastOutputStart:lastOutputStart+4], uint32(last.size))

--- a/pkg/mp4/writer_chapters.go
+++ b/pkg/mp4/writer_chapters.go
@@ -87,11 +87,31 @@ func rebuildChapterTextTrack(moovContent []byte, chapters []Chapter) (rebuiltCha
 		return rebuiltChapterTrack{}, false
 	}
 
+	// Identify the chapter track the same way the reader and players do: the
+	// track the audio track's tref/chap reference points at. Matching by track
+	// ID (rather than "first text-handler track") keeps the writer in agreement
+	// with the reader when a file carries more than one text track.
 	chapterIdx := -1
-	for i, b := range boxes {
-		if b.typ == "trak" && isChapterTextTrak(moovContent[b.start:b.end]) {
-			chapterIdx = i
-			break
+	if targetID, ok := chapterTrackIDFromTref(moovContent, boxes); ok {
+		for i, b := range boxes {
+			if b.typ != "trak" {
+				continue
+			}
+			trak := moovContent[b.start:b.end]
+			if id, idOK := tkhdTrackID(trak); idOK && id == targetID && isChapterTextTrak(trak) {
+				chapterIdx = i
+				break
+			}
+		}
+	}
+	// Fall back to the first text-handler track when there is no tref/chap
+	// reference to resolve.
+	if chapterIdx == -1 {
+		for i, b := range boxes {
+			if b.typ == "trak" && isChapterTextTrak(moovContent[b.start:b.end]) {
+				chapterIdx = i
+				break
+			}
 		}
 	}
 	if chapterIdx == -1 {
@@ -120,6 +140,71 @@ func rebuildChapterTextTrack(moovContent []byte, chapters []Chapter) (rebuiltCha
 		sampleData:      res.sampleData,
 		co64FieldOffset: co64FieldOffset,
 	}, true
+}
+
+// chapterTrackIDFromTref returns the track ID referenced by the first
+// tref/chap box found among the moov's traks (the audio track points at its
+// chapter track this way). Mirrors how readQuickTimeChapters locates the track.
+func chapterTrackIDFromTref(moovContent []byte, boxes []childBox) (uint32, bool) {
+	for _, b := range boxes {
+		if b.typ != "trak" {
+			continue
+		}
+		trak := moovContent[b.start:b.end]
+		tboxes, err := childBoxes(trak[8:])
+		if err != nil {
+			continue
+		}
+		for _, tb := range tboxes {
+			if tb.typ != "tref" {
+				continue
+			}
+			tref := trak[8+tb.start : 8+tb.end]
+			refs, err := childBoxes(tref[8:])
+			if err != nil {
+				continue
+			}
+			for _, rb := range refs {
+				if rb.typ == "chap" {
+					chap := tref[8+rb.start : 8+rb.end]
+					if len(chap) >= 12 {
+						return binary.BigEndian.Uint32(chap[8:12]), true
+					}
+				}
+			}
+		}
+	}
+	return 0, false
+}
+
+// tkhdTrackID extracts the track ID from a trak's tkhd box.
+// Layout: size(4) type(4) version(1) flags(3) then, for v0, creation(4)
+// modification(4) track_id(4); for v1, creation(8) modification(8) track_id(4).
+func tkhdTrackID(trak []byte) (uint32, bool) {
+	boxes, err := childBoxes(trak[8:])
+	if err != nil {
+		return 0, false
+	}
+	for _, b := range boxes {
+		if b.typ != "tkhd" {
+			continue
+		}
+		box := trak[8+b.start : 8+b.end]
+		if len(box) < 9 {
+			return 0, false
+		}
+		if box[8] == 1 {
+			if len(box) < 32 {
+				return 0, false
+			}
+			return binary.BigEndian.Uint32(box[28:32]), true
+		}
+		if len(box) < 24 {
+			return 0, false
+		}
+		return binary.BigEndian.Uint32(box[20:24]), true
+	}
+	return 0, false
 }
 
 // isChapterTextTrak reports whether a trak is a text track (mdia/hdlr handler
@@ -160,7 +245,7 @@ func hdlrHandlerType(box []byte) string {
 }
 
 // chapterRebuildResult is the common return of the per-box rebuild helpers: the
-// new box bytes, the chapter sample data discovered beneath it, and co64Rel —
+// new box bytes, the chapter sample data discovered beneath it, and co64Rel,
 // the offset of the chapter track's co64 value relative to the start of the
 // returned box.
 type chapterRebuildResult struct {

--- a/pkg/mp4/writer_chapters.go
+++ b/pkg/mp4/writer_chapters.go
@@ -1,0 +1,408 @@
+package mp4
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// rebuiltChapterTrack is the result of regenerating a QuickTime chapter text
+// track from a set of chapters.
+type rebuiltChapterTrack struct {
+	// moovContent is the moov box's children with the chapter track's sample
+	// tables and timing rebuilt from the new chapters.
+	moovContent []byte
+	// sampleData is the concatenated text samples for the rebuilt track. The
+	// caller writes these into a trailing mdat and patches the chapter track's
+	// co64 entry to that mdat's absolute offset.
+	sampleData []byte
+	// co64FieldOffset is the byte offset, within moovContent, of the rebuilt
+	// chapter track's 8-byte co64 chunk-offset value.
+	co64FieldOffset int
+}
+
+// childBox is a box located within a parent's content buffer.
+type childBox struct {
+	typ        string
+	start      int // offset within the buffer where the box (header) starts
+	end        int // offset within the buffer where the box ends
+	headerSize int
+}
+
+// childBoxes scans the sibling boxes within a container's content buffer.
+func childBoxes(buf []byte) ([]childBox, error) {
+	var boxes []childBox
+	offset := 0
+	for offset+8 <= len(buf) {
+		size := int(binary.BigEndian.Uint32(buf[offset:]))
+		headerSize := 8
+		switch size {
+		case 1:
+			if offset+16 > len(buf) {
+				return nil, errors.New("truncated 64-bit box header")
+			}
+			size64 := binary.BigEndian.Uint64(buf[offset+8:])
+			if size64 > uint64(len(buf)) {
+				return nil, errors.New("box size exceeds buffer length")
+			}
+			// #nosec G115 -- bounds checked against len(buf) above
+			size = int(size64)
+			headerSize = 16
+		case 0:
+			size = len(buf) - offset
+		}
+		if size < headerSize || offset+size > len(buf) {
+			return nil, errors.New("invalid box size")
+		}
+		boxes = append(boxes, childBox{
+			typ:        string(buf[offset+4 : offset+8]),
+			start:      offset,
+			end:        offset + size,
+			headerSize: headerSize,
+		})
+		offset += size
+	}
+	return boxes, nil
+}
+
+// rebuildChapterTextTrack finds the QuickTime chapter text track inside moov
+// content and replaces its sample tables (stts/stsc/stsz, emitting a 64-bit
+// co64) and sample data with ones built from chapters. Audiobook players and
+// ffprobe read this track in preference to the Nero chpl box, so the user's
+// edited chapter titles and timings must land here, not only in chpl.
+//
+// The chapter sample bytes are returned separately for the caller to append as
+// a trailing mdat; the co64 entry holds a placeholder offset the caller patches
+// to that mdat's absolute file position. The audio mdat is never touched, so
+// the audio chunk offsets are governed solely by the existing moov-resize shift.
+//
+// Returns ok=false (content unchanged) when the source has no chapter text track
+// to rebuild, in which case the caller keeps the chpl-only behavior.
+func rebuildChapterTextTrack(moovContent []byte, chapters []Chapter) (rebuiltChapterTrack, bool) {
+	boxes, err := childBoxes(moovContent)
+	if err != nil {
+		return rebuiltChapterTrack{}, false
+	}
+
+	chapterIdx := -1
+	for i, b := range boxes {
+		if b.typ == "trak" && isChapterTextTrak(moovContent[b.start:b.end]) {
+			chapterIdx = i
+			break
+		}
+	}
+	if chapterIdx == -1 {
+		return rebuiltChapterTrack{}, false
+	}
+
+	origTrak := moovContent[boxes[chapterIdx].start:boxes[chapterIdx].end]
+	res, ok := rebuildChapterTrak(origTrak, chapters)
+	if !ok {
+		return rebuiltChapterTrack{}, false
+	}
+
+	var result bytes.Buffer
+	co64FieldOffset := -1
+	for i, b := range boxes {
+		if i == chapterIdx {
+			co64FieldOffset = result.Len() + res.co64Rel
+			result.Write(res.box)
+		} else {
+			result.Write(moovContent[b.start:b.end])
+		}
+	}
+
+	return rebuiltChapterTrack{
+		moovContent:     result.Bytes(),
+		sampleData:      res.sampleData,
+		co64FieldOffset: co64FieldOffset,
+	}, true
+}
+
+// isChapterTextTrak reports whether a trak is a text track (mdia/hdlr handler
+// type "text"), which is how QuickTime chapter tracks are tagged.
+func isChapterTextTrak(trak []byte) bool {
+	if len(trak) < 8 {
+		return false
+	}
+	boxes, err := childBoxes(trak[8:])
+	if err != nil {
+		return false
+	}
+	for _, b := range boxes {
+		if b.typ != "mdia" {
+			continue
+		}
+		mdia := trak[8+b.start : 8+b.end]
+		mboxes, err := childBoxes(mdia[8:])
+		if err != nil {
+			return false
+		}
+		for _, mb := range mboxes {
+			if mb.typ == "hdlr" {
+				return hdlrHandlerType(mdia[8+mb.start:8+mb.end]) == "text"
+			}
+		}
+	}
+	return false
+}
+
+// hdlrHandlerType extracts the 4-character handler type from an hdlr box.
+// Layout: size(4) type(4) version(1) flags(3) pre_defined(4) handler_type(4) ...
+func hdlrHandlerType(box []byte) string {
+	if len(box) < 20 {
+		return ""
+	}
+	return string(box[16:20])
+}
+
+// chapterRebuildResult is the common return of the per-box rebuild helpers: the
+// new box bytes, the chapter sample data discovered beneath it, and co64Rel —
+// the offset of the chapter track's co64 value relative to the start of the
+// returned box.
+type chapterRebuildResult struct {
+	box        []byte
+	sampleData []byte
+	co64Rel    int
+}
+
+// replaceChapterChild rebuilds a container box by replacing its single child of
+// type childType via rebuildFn and copying every other child verbatim, threading
+// the co64 offset up from the rebuilt subtree. It is the shared spine of the
+// trak -> mdia -> minf descent toward the chapter track's stbl.
+func replaceChapterChild(boxType string, container []byte, childType string,
+	rebuildFn func(child []byte) (chapterRebuildResult, bool),
+) (chapterRebuildResult, bool) {
+	boxes, err := childBoxes(container[8:])
+	if err != nil {
+		return chapterRebuildResult{}, false
+	}
+	var content bytes.Buffer
+	co64Rel := -1
+	var sampleData []byte
+	for _, b := range boxes {
+		child := container[8+b.start : 8+b.end]
+		if b.typ == childType {
+			res, cok := rebuildFn(child)
+			if !cok {
+				return chapterRebuildResult{}, false
+			}
+			co64Rel = content.Len() + res.co64Rel
+			content.Write(res.box)
+			sampleData = res.sampleData
+		} else {
+			content.Write(child)
+		}
+	}
+	if co64Rel == -1 {
+		return chapterRebuildResult{}, false
+	}
+	return chapterRebuildResult{
+		box:        buildBox(boxType, content.Bytes()),
+		sampleData: sampleData,
+		co64Rel:    8 + co64Rel,
+	}, true
+}
+
+// rebuildChapterTrak rebuilds a chapter text trak, replacing the sample tables
+// and timing while preserving tkhd/edts verbatim so the audio track's tref/chap
+// reference and the chapter track ID stay valid.
+func rebuildChapterTrak(trak []byte, chapters []Chapter) (chapterRebuildResult, bool) {
+	return replaceChapterChild("trak", trak, "mdia", func(mdia []byte) (chapterRebuildResult, bool) {
+		return rebuildChapterMdia(mdia, chapters)
+	})
+}
+
+// rebuildChapterMdia reads the media timescale and rebuilds the minf within.
+func rebuildChapterMdia(mdia []byte, chapters []Chapter) (chapterRebuildResult, bool) {
+	timescale := uint32(0)
+	if boxes, err := childBoxes(mdia[8:]); err == nil {
+		for _, b := range boxes {
+			if b.typ == "mdhd" {
+				timescale = parseMdhdTimescale(mdia[8+b.start : 8+b.end])
+			}
+		}
+	}
+	if timescale == 0 {
+		timescale = 1000
+	}
+	return replaceChapterChild("mdia", mdia, "minf", func(minf []byte) (chapterRebuildResult, bool) {
+		return replaceChapterChild("minf", minf, "stbl", func(stbl []byte) (chapterRebuildResult, bool) {
+			return rebuildChapterStbl(stbl, chapters, timescale)
+		})
+	})
+}
+
+// rebuildChapterStbl preserves stsd (and any non-table boxes) and regenerates
+// the stts/stsc/stsz/co64 sample tables from the chapters. The chunk offset is a
+// placeholder; the caller patches it once the trailing mdat position is known.
+func rebuildChapterStbl(stbl []byte, chapters []Chapter, timescale uint32) (chapterRebuildResult, bool) {
+	boxes, err := childBoxes(stbl[8:])
+	if err != nil {
+		return chapterRebuildResult{}, false
+	}
+
+	stts, stsc, stsz, co64, data := buildChapterSampleTables(chapters, timescale)
+
+	// Preserve everything except the chunk/sample tables we regenerate.
+	regenerated := map[string]bool{
+		"stts": true, "stsc": true, "stsz": true, "stz2": true, "stco": true, "co64": true,
+	}
+	var content bytes.Buffer
+	for _, b := range boxes {
+		if regenerated[b.typ] {
+			continue
+		}
+		content.Write(stbl[8+b.start : 8+b.end])
+	}
+	content.Write(stts)
+	content.Write(stsc)
+	content.Write(stsz)
+	co64Start := content.Len()
+	content.Write(co64)
+
+	// co64 layout: header(8) version+flags(4) entry_count(4) then the 8-byte
+	// offset value, so the value sits 16 bytes into the co64 box.
+	return chapterRebuildResult{
+		box:        buildBox("stbl", content.Bytes()),
+		sampleData: data,
+		co64Rel:    8 + co64Start + 16,
+	}, true
+}
+
+// buildChapterSampleTables builds the stts, stsc, stsz, and co64 boxes plus the
+// concatenated text sample bytes for a chapter text track. All samples are
+// placed in a single chunk; the co64 offset is left as a placeholder (0).
+func buildChapterSampleTables(chapters []Chapter, timescale uint32) (stts, stsc, stsz, co64, sampleData []byte) {
+	n := len(chapters)
+
+	var data bytes.Buffer
+	sizes := make([]uint32, n)
+	for i, ch := range chapters {
+		sample := buildChapterTextSample(ch.Title)
+		// #nosec G115 -- sample length is bounded by buildChapterTextSample
+		sizes[i] = uint32(len(sample))
+		data.Write(sample)
+	}
+
+	deltas := computeChapterDeltas(chapters, timescale)
+
+	var sttsBody bytes.Buffer
+	sttsBody.Write([]byte{0, 0, 0, 0}) // version + flags
+	// #nosec G115 -- chapter count is bounded by practical limits
+	_ = binary.Write(&sttsBody, binary.BigEndian, uint32(n)) // entry_count
+	for i := 0; i < n; i++ {
+		_ = binary.Write(&sttsBody, binary.BigEndian, uint32(1)) // sample_count
+		_ = binary.Write(&sttsBody, binary.BigEndian, deltas[i]) // sample_delta
+	}
+	stts = buildBox("stts", sttsBody.Bytes())
+
+	var stscBody bytes.Buffer
+	stscBody.Write([]byte{0, 0, 0, 0})                       // version + flags
+	_ = binary.Write(&stscBody, binary.BigEndian, uint32(1)) // entry_count
+	_ = binary.Write(&stscBody, binary.BigEndian, uint32(1)) // first_chunk
+	// #nosec G115 -- chapter count is bounded by practical limits
+	_ = binary.Write(&stscBody, binary.BigEndian, uint32(n)) // samples_per_chunk
+	_ = binary.Write(&stscBody, binary.BigEndian, uint32(1)) // sample_description_index
+	stsc = buildBox("stsc", stscBody.Bytes())
+
+	var stszBody bytes.Buffer
+	stszBody.Write([]byte{0, 0, 0, 0})                       // version + flags
+	_ = binary.Write(&stszBody, binary.BigEndian, uint32(0)) // sample_size = 0 (per-sample sizes follow)
+	// #nosec G115 -- chapter count is bounded by practical limits
+	_ = binary.Write(&stszBody, binary.BigEndian, uint32(n)) // sample_count
+	for _, s := range sizes {
+		_ = binary.Write(&stszBody, binary.BigEndian, s)
+	}
+	stsz = buildBox("stsz", stszBody.Bytes())
+
+	var co64Body bytes.Buffer
+	co64Body.Write([]byte{0, 0, 0, 0})                       // version + flags
+	_ = binary.Write(&co64Body, binary.BigEndian, uint32(1)) // entry_count
+	_ = binary.Write(&co64Body, binary.BigEndian, uint64(0)) // chunk offset (placeholder)
+	co64 = buildBox("co64", co64Body.Bytes())
+
+	return stts, stsc, stsz, co64, data.Bytes()
+}
+
+// buildChapterTextSample encodes a chapter title as a QuickTime text sample: a
+// 2-byte big-endian length prefix, the UTF-8 text, then a 12-byte "encd"
+// text-encoding atom. The encd atom mirrors what ffmpeg and Apple write for
+// chapter samples; readers that only want the title (Shisho's own, ffprobe)
+// ignore it, but emitting it keeps the samples byte-shaped like real audiobooks
+// for stricter players.
+func buildChapterTextSample(title string) []byte {
+	b := []byte(title)
+	// Reserve room for the 12-byte encd atom so the title itself can still be
+	// the full uint16 range.
+	if len(b) > math.MaxUint16 {
+		b = b[:math.MaxUint16]
+	}
+	sample := make([]byte, 2+len(b)+12)
+	// #nosec G115 -- length clamped to MaxUint16 above
+	binary.BigEndian.PutUint16(sample[0:2], uint16(len(b)))
+	copy(sample[2:], b)
+	encd := sample[2+len(b):]
+	binary.BigEndian.PutUint32(encd[0:4], 12) // box size
+	copy(encd[4:8], "encd")                   // box type
+	binary.BigEndian.PutUint32(encd[8:12], 0x00000100)
+	return sample
+}
+
+// computeChapterDeltas converts chapter start/end times into per-sample
+// durations (in media timescale units). Deltas are taken from the gaps between
+// consecutive starts so that a reader accumulating them reproduces the start
+// times; the final sample runs to the last chapter's end.
+func computeChapterDeltas(chapters []Chapter, timescale uint32) []uint32 {
+	n := len(chapters)
+	deltas := make([]uint32, n)
+	starts := make([]int64, n)
+	for i, ch := range chapters {
+		starts[i] = durationToUnits(ch.Start, timescale)
+	}
+	for i := 0; i < n; i++ {
+		var d int64
+		if i < n-1 {
+			d = starts[i+1] - starts[i]
+		} else {
+			d = durationToUnits(chapters[i].End, timescale) - starts[i]
+		}
+		if d < 1 {
+			d = 1
+		}
+		if d > math.MaxUint32 {
+			d = math.MaxUint32
+		}
+		// #nosec G115 -- clamped to [1, MaxUint32] above
+		deltas[i] = uint32(d)
+	}
+	return deltas
+}
+
+// durationToUnits converts a duration to media timescale units.
+func durationToUnits(d time.Duration, timescale uint32) int64 {
+	if d <= 0 {
+		return 0
+	}
+	return int64(math.Round(d.Seconds() * float64(timescale)))
+}
+
+// parseMdhdTimescale extracts the timescale field from an mdhd box.
+// Layout (v0): size(4) type(4) version(1) flags(3) creation(4) modification(4) timescale(4) ...
+// Layout (v1): ... creation(8) modification(8) timescale(4) ...
+func parseMdhdTimescale(box []byte) uint32 {
+	if len(box) < 24 {
+		return 0
+	}
+	version := box[8]
+	if version == 1 {
+		if len(box) < 32 {
+			return 0
+		}
+		return binary.BigEndian.Uint32(box[28:32])
+	}
+	return binary.BigEndian.Uint32(box[20:24])
+}

--- a/pkg/mp4/writer_chapters.go
+++ b/pkg/mp4/writer_chapters.go
@@ -440,7 +440,10 @@ func buildChapterTextSample(title string) []byte {
 // computeChapterDeltas converts chapter start/end times into per-sample
 // durations (in media timescale units). Deltas are taken from the gaps between
 // consecutive starts so that a reader accumulating them reproduces the start
-// times; the final sample runs to the last chapter's end.
+// times; the final sample runs to the last chapter's end. A QuickTime chapter
+// track tiles the timeline from 0, so a non-zero start on the first chapter is
+// absorbed (the first sample begins at 0); the Nero chpl box still carries the
+// absolute first timestamp.
 func computeChapterDeltas(chapters []Chapter, timescale uint32) []uint32 {
 	n := len(chapters)
 	deltas := make([]uint32, n)

--- a/pkg/mp4/writer_chapters_test.go
+++ b/pkg/mp4/writer_chapters_test.go
@@ -1,0 +1,262 @@
+package mp4_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shishobooks/shisho/internal/testgen"
+	"github.com/shishobooks/shisho/pkg/mp4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWriteToFile_RewritesQuickTimeChapterTrackTitles is the regression test for
+// the "manual chapters don't show up in the downloaded audiobook" bug.
+//
+// Real Audible/Apple exports carry chapters in TWO stores: a QuickTime text
+// chapter track (audio trak -> tref/chap -> a text trak) AND a Nero chpl box.
+// The writer used to rewrite only the chpl box and copy the QuickTime track
+// verbatim. Players (and Shisho's own reader, and ffprobe) prefer the QuickTime
+// track, so the user's edited titles in chpl were masked by the stale source
+// titles in the QuickTime track.
+//
+// The contract: after a metadata rewrite, the chapters the user saved must be
+// the ones the QuickTime chapter track reports.
+func TestWriteToFile_RewritesQuickTimeChapterTrackTitles(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	dir := testgen.TempDir(t, "mp4-qtchapters-*")
+
+	// ffmpeg emits a QuickTime chapter text track for these, mirroring the
+	// generic numeric titles an Audible export ships with.
+	srcPath := testgen.GenerateM4B(t, dir, "src.m4b", testgen.M4BOptions{
+		Title:     "Bossypants",
+		Duration:  10.0,
+		Faststart: true,
+		Chapters: []testgen.M4BChapter{
+			{Title: "001", Start: 0.0},
+			{Title: "002", Start: 3.0},
+			{Title: "003", Start: 7.0},
+		},
+	})
+
+	meta, err := mp4.ParseFull(srcPath)
+	require.NoError(t, err)
+	// Sanity: the reader is seeing the QuickTime track's titles in the source.
+	require.Len(t, meta.Chapters, 3)
+	require.Equal(t, "001", meta.Chapters[0].Title, "source should carry generic QuickTime titles")
+
+	// Simulate the user's manual chapter edits in Shisho.
+	meta.Chapters = []mp4.Chapter{
+		{Title: "Opening Credits", Start: 0, End: 3 * time.Second},
+		{Title: "Origin Story", Start: 3 * time.Second, End: 7 * time.Second},
+		{Title: "Growing Up and Liking It", Start: 7 * time.Second, End: 10 * time.Second},
+	}
+
+	destPath := filepath.Join(dir, "dest.m4b")
+	require.NoError(t, mp4.WriteToFile(srcPath, destPath, meta))
+
+	out, err := mp4.ParseFull(destPath)
+	require.NoError(t, err)
+	require.Len(t, out.Chapters, 3)
+	assert.Equal(t, "Opening Credits", out.Chapters[0].Title)
+	assert.Equal(t, "Origin Story", out.Chapters[1].Title)
+	assert.Equal(t, "Growing Up and Liking It", out.Chapters[2].Title)
+}
+
+// TestWriteToFile_ChaptersVisibleToExternalPlayers proves the rewritten chapters
+// are what an actual player sees (ffprobe reads the QuickTime track, the same
+// one Apple Books/Bound prefer) and that relocating the chapter samples did not
+// corrupt the audio (ffmpeg decodes with zero errors).
+func TestWriteToFile_ChaptersVisibleToExternalPlayers(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	dir := testgen.TempDir(t, "mp4-qtchapters-ext-*")
+
+	srcPath := testgen.GenerateM4B(t, dir, "src.m4b", testgen.M4BOptions{
+		Title:     "Bossypants",
+		Duration:  10.0,
+		Faststart: true,
+		Chapters: []testgen.M4BChapter{
+			{Title: "001", Start: 0.0},
+			{Title: "002", Start: 4.0},
+		},
+	})
+
+	meta, err := mp4.ParseFull(srcPath)
+	require.NoError(t, err)
+	meta.Chapters = []mp4.Chapter{
+		{Title: "Opening Credits", Start: 0, End: 4 * time.Second},
+		{Title: "Origin Story", Start: 4 * time.Second, End: 10 * time.Second},
+	}
+
+	destPath := filepath.Join(dir, "dest.m4b")
+	require.NoError(t, mp4.WriteToFile(srcPath, destPath, meta))
+
+	assert.Equal(t, []string{"Opening Credits", "Origin Story"},
+		readChaptersWithFFprobe(t, destPath),
+		"an external player must see the user's edited chapter titles")
+	assertDecodesCleanly(t, destPath)
+}
+
+// assertDecodesCleanly runs the file through ffmpeg's decoder and fails if it
+// reports any error. This is the strongest available proof that relocating the
+// chapter track left the audio mdat and its chunk offsets intact (the #393
+// failure mode surfaced here as "channel element ... is not allocated").
+func assertDecodesCleanly(t *testing.T, path string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "ffmpeg", "-v", "error", "-i", path, "-f", "null", "-")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "ffmpeg decode failed: %s", output)
+	require.Empty(t, strings.TrimSpace(string(output)), "ffmpeg reported decode errors: %s", output)
+}
+
+// readChaptersWithFFprobe returns chapter titles in order as ffprobe reports
+// them, which reads the QuickTime chapter track in preference to the Nero chpl.
+func readChaptersWithFFprobe(t *testing.T, path string) []string {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "ffprobe",
+		"-v", "error", "-show_chapters", "-of", "compact", path)
+	output, err := cmd.Output()
+	require.NoError(t, err)
+
+	var titles []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		const marker = "tag:title="
+		if idx := strings.Index(line, marker); idx >= 0 {
+			titles = append(titles, line[idx+len(marker):])
+		}
+	}
+	return titles
+}
+
+// TestWriteToFile_RewritesChapterTimestamps verifies the rebuilt chapter track
+// carries the DB timestamps, not the source's, so a user who re-timed chapters
+// sees the new boundaries.
+func TestWriteToFile_RewritesChapterTimestamps(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	dir := testgen.TempDir(t, "mp4-qtchapters-ts-*")
+
+	srcPath := testgen.GenerateM4B(t, dir, "src.m4b", testgen.M4BOptions{
+		Title:     "Bossypants",
+		Duration:  10.0,
+		Faststart: true,
+		Chapters: []testgen.M4BChapter{
+			{Title: "001", Start: 0.0},
+			{Title: "002", Start: 5.0},
+		},
+	})
+
+	meta, err := mp4.ParseFull(srcPath)
+	require.NoError(t, err)
+	meta.Chapters = []mp4.Chapter{
+		{Title: "One", Start: 0, End: 2 * time.Second},
+		{Title: "Two", Start: 2 * time.Second, End: 6 * time.Second},
+		{Title: "Three", Start: 6 * time.Second, End: 10 * time.Second},
+	}
+
+	destPath := filepath.Join(dir, "dest.m4b")
+	require.NoError(t, mp4.WriteToFile(srcPath, destPath, meta))
+
+	out, err := mp4.ParseFull(destPath)
+	require.NoError(t, err)
+	require.Len(t, out.Chapters, 3)
+	assert.InDelta(t, 0, out.Chapters[0].Start.Milliseconds(), 50)
+	assert.InDelta(t, 2000, out.Chapters[1].Start.Milliseconds(), 50)
+	assert.InDelta(t, 6000, out.Chapters[2].Start.Milliseconds(), 50)
+}
+
+// TestWriteToFile_ChapterCountDiffersFromSource verifies the rebuilt track is
+// sized to the DB chapters, whether the user removed chapters (fewer than the
+// source's QuickTime track) or added them (more).
+func TestWriteToFile_ChapterCountDiffersFromSource(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+
+	build := func(t *testing.T, dbChapters []mp4.Chapter) []mp4.Chapter {
+		t.Helper()
+		dir := testgen.TempDir(t, "mp4-qtchapters-count-*")
+		srcPath := testgen.GenerateM4B(t, dir, "src.m4b", testgen.M4BOptions{
+			Title:     "Bossypants",
+			Duration:  12.0,
+			Faststart: true,
+			Chapters: []testgen.M4BChapter{
+				{Title: "001", Start: 0.0},
+				{Title: "002", Start: 4.0},
+				{Title: "003", Start: 8.0},
+			},
+		})
+		meta, err := mp4.ParseFull(srcPath)
+		require.NoError(t, err)
+		meta.Chapters = dbChapters
+		destPath := filepath.Join(dir, "dest.m4b")
+		require.NoError(t, mp4.WriteToFile(srcPath, destPath, meta))
+		assertDecodesCleanly(t, destPath)
+		out, err := mp4.ParseFull(destPath)
+		require.NoError(t, err)
+		return out.Chapters
+	}
+
+	t.Run("fewer than source", func(t *testing.T) {
+		t.Parallel()
+		got := build(t, []mp4.Chapter{
+			{Title: "Solo", Start: 0, End: 12 * time.Second},
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, "Solo", got[0].Title)
+	})
+
+	t.Run("more than source", func(t *testing.T) {
+		t.Parallel()
+		got := build(t, []mp4.Chapter{
+			{Title: "A", Start: 0, End: 3 * time.Second},
+			{Title: "B", Start: 3 * time.Second, End: 6 * time.Second},
+			{Title: "C", Start: 6 * time.Second, End: 9 * time.Second},
+			{Title: "D", Start: 9 * time.Second, End: 12 * time.Second},
+		})
+		require.Len(t, got, 4)
+		assert.Equal(t, []string{"A", "B", "C", "D"},
+			[]string{got[0].Title, got[1].Title, got[2].Title, got[3].Title})
+	})
+}
+
+// TestWriteToFile_MdatFirstLayoutRewritesChapterTrack covers the non-faststart
+// layout (mdat before moov, ffmpeg's default). The audio mdat does not move, so
+// no audio offset shift happens, but the chapter track must still be rebuilt
+// from the DB chapters and the file must decode cleanly.
+func TestWriteToFile_MdatFirstLayoutRewritesChapterTrack(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	dir := testgen.TempDir(t, "mp4-qtchapters-mdatfirst-*")
+
+	srcPath := testgen.GenerateM4B(t, dir, "src.m4b", testgen.M4BOptions{
+		Title:    "Bossypants",
+		Duration: 8.0,
+		// Faststart omitted: mdat comes before moov.
+		Chapters: []testgen.M4BChapter{
+			{Title: "001", Start: 0.0},
+			{Title: "002", Start: 4.0},
+		},
+	})
+
+	meta, err := mp4.ParseFull(srcPath)
+	require.NoError(t, err)
+	meta.Chapters = []mp4.Chapter{
+		{Title: "Intro", Start: 0, End: 4 * time.Second},
+		{Title: "Body", Start: 4 * time.Second, End: 8 * time.Second},
+	}
+
+	destPath := filepath.Join(dir, "dest.m4b")
+	require.NoError(t, mp4.WriteToFile(srcPath, destPath, meta))
+
+	out, err := mp4.ParseFull(destPath)
+	require.NoError(t, err)
+	require.Len(t, out.Chapters, 2)
+	assert.Equal(t, "Intro", out.Chapters[0].Title)
+	assert.Equal(t, "Body", out.Chapters[1].Title)
+	assertDecodesCleanly(t, destPath)
+}

--- a/pkg/mp4/writer_chapters_test.go
+++ b/pkg/mp4/writer_chapters_test.go
@@ -3,6 +3,7 @@ package mp4_test
 import (
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -133,6 +134,29 @@ func readChaptersWithFFprobe(t *testing.T, path string) []string {
 	return titles
 }
 
+// readChapterEndTimesWithFFprobe returns each chapter's end time (in seconds) in
+// order, as ffprobe reports them from the QuickTime chapter track.
+func readChapterEndTimesWithFFprobe(t *testing.T, path string) []float64 {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "ffprobe",
+		"-v", "error", "-show_chapters", "-of", "compact", path)
+	output, err := cmd.Output()
+	require.NoError(t, err)
+
+	var ends []float64
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		for _, field := range strings.Split(line, "|") {
+			const marker = "end_time="
+			if strings.HasPrefix(field, marker) {
+				v, perr := strconv.ParseFloat(field[len(marker):], 64)
+				require.NoError(t, perr)
+				ends = append(ends, v)
+			}
+		}
+	}
+	return ends
+}
+
 // TestWriteToFile_RewritesChapterTimestamps verifies the rebuilt chapter track
 // carries the DB timestamps, not the source's, so a user who re-timed chapters
 // sees the new boundaries.
@@ -168,6 +192,55 @@ func TestWriteToFile_RewritesChapterTimestamps(t *testing.T) {
 	assert.InDelta(t, 0, out.Chapters[0].Start.Milliseconds(), 50)
 	assert.InDelta(t, 2000, out.Chapters[1].Start.Milliseconds(), 50)
 	assert.InDelta(t, 6000, out.Chapters[2].Start.Milliseconds(), 50)
+}
+
+// TestWriteToFile_RewritesNonContiguousChapterTimestamps guards the timing math
+// for chapters that are not back-to-back. The rebuilt track's per-sample deltas
+// must come from the gaps between consecutive starts (so a reader accumulating
+// them reproduces the starts), not from each chapter's own End-Start span. A
+// regression to per-chapter End-Start would still pass the contiguous-chapter
+// tests but diverge here.
+func TestWriteToFile_RewritesNonContiguousChapterTimestamps(t *testing.T) {
+	t.Parallel()
+	testgen.SkipIfNoFFmpeg(t)
+	dir := testgen.TempDir(t, "mp4-qtchapters-gap-*")
+
+	srcPath := testgen.GenerateM4B(t, dir, "src.m4b", testgen.M4BOptions{
+		Title:     "Bossypants",
+		Duration:  10.0,
+		Faststart: true,
+		Chapters: []testgen.M4BChapter{
+			{Title: "001", Start: 0.0},
+			{Title: "002", Start: 5.0},
+		},
+	})
+
+	meta, err := mp4.ParseFull(srcPath)
+	require.NoError(t, err)
+	// Gaps between chapters: End[i] != Start[i+1].
+	meta.Chapters = []mp4.Chapter{
+		{Title: "One", Start: 0, End: 1 * time.Second},
+		{Title: "Two", Start: 3 * time.Second, End: 5 * time.Second},
+		{Title: "Three", Start: 7 * time.Second, End: 10 * time.Second},
+	}
+
+	destPath := filepath.Join(dir, "dest.m4b")
+	require.NoError(t, mp4.WriteToFile(srcPath, destPath, meta))
+
+	out, err := mp4.ParseFull(destPath)
+	require.NoError(t, err)
+	require.Len(t, out.Chapters, 3)
+	// Starts must be reproduced from the gap-based deltas. Under an End-Start
+	// regression these would come back as 0, 1000, 3000.
+	assert.InDelta(t, 0, out.Chapters[0].Start.Milliseconds(), 50)
+	assert.InDelta(t, 3000, out.Chapters[1].Start.Milliseconds(), 50)
+	assert.InDelta(t, 7000, out.Chapters[2].Start.Milliseconds(), 50)
+
+	// The final sample's delta comes from the last chapter's End, which ffprobe
+	// reports as the last chapter's end time.
+	ends := readChapterEndTimesWithFFprobe(t, destPath)
+	require.NotEmpty(t, ends)
+	assert.InDelta(t, 10.0, ends[len(ends)-1], 0.1, "last chapter must end at the final End time")
 }
 
 // TestWriteToFile_ChapterCountDiffersFromSource verifies the rebuilt track is

--- a/pkg/mp4/writer_chunkoffset_test.go
+++ b/pkg/mp4/writer_chunkoffset_test.go
@@ -101,12 +101,15 @@ func TestWriteToFile_MdatFirstLayoutLeavesChunkOffsetsUnchanged(t *testing.T) {
 	assertChunkOffsetsLocateSameAudio(t, srcPath, destPath)
 }
 
-// TestWriteToFile_FaststartWithChaptersShiftsAllTrackOffsets covers the
-// realistic case: a real audiobook has a chapter track in addition to the audio
-// track, so the moov holds two stco tables, both pointing into mdat. Both must
-// be shifted on rewrite — a fix that only shifted the first track would still
-// corrupt the chapter track. The audio-only fixtures cannot catch that.
-func TestWriteToFile_FaststartWithChaptersShiftsAllTrackOffsets(t *testing.T) {
+// TestWriteToFile_FaststartWithChaptersPreservesAudioAndChapters covers the
+// realistic case: a real audiobook has a chapter text track in addition to the
+// audio track, so the moov holds two chunk-offset tables. On rewrite the audio
+// track's offsets must still be shifted to follow the audio when moov grows
+// (the #393 guarantee), while the chapter text track is rebuilt from the
+// chapters and relocated into a trailing mdat. A regression that failed to shift
+// the audio track would corrupt the audio; audio-only fixtures cannot catch the
+// two-table case.
+func TestWriteToFile_FaststartWithChaptersPreservesAudioAndChapters(t *testing.T) {
 	t.Parallel()
 	testgen.SkipIfNoFFmpeg(t)
 	dir := testgen.TempDir(t, "mp4-faststart-chapters-*")
@@ -143,7 +146,18 @@ func TestWriteToFile_FaststartWithChaptersShiftsAllTrackOffsets(t *testing.T) {
 	destMoov, _ := boxPositions(t, destPath)
 	require.Greater(t, destMoov.size, srcMoov.size, "moov must grow")
 
-	assertChunkOffsetsLocateSameAudio(t, srcPath, destPath)
+	// The audio track's chunk offsets must still locate the same audio bytes.
+	// The chapter track's offset is excluded because it is intentionally
+	// rebuilt and moved into a trailing mdat, not shifted in place.
+	assertAudioChunkOffsetsLocateSameAudio(t, srcPath, destPath)
+
+	// And the chapters must survive the rebuild, read back from the QuickTime
+	// track that players prefer.
+	out, err := mp4.ParseFull(destPath)
+	require.NoError(t, err)
+	require.Len(t, out.Chapters, 2)
+	assert.Equal(t, "Chapter One", out.Chapters[0].Title)
+	assert.Equal(t, "Chapter Two", out.Chapters[1].Title)
 }
 
 type boxPos struct {
@@ -279,6 +293,10 @@ func countChunkOffsetTables(t *testing.T, data []byte) int {
 
 // assertChunkOffsetsLocateSameAudio verifies that every chunk offset in dest
 // points at the same audio bytes the corresponding source offset points at.
+// Use this only for fixtures with no chapter text track, where every offset
+// belongs to the audio track. With a chapter track present, use
+// assertAudioChunkOffsetsLocateSameAudio instead, since the chapter track is
+// deliberately rebuilt and relocated.
 func assertChunkOffsetsLocateSameAudio(t *testing.T, srcPath, destPath string) {
 	t.Helper()
 	src, err := os.ReadFile(srcPath)
@@ -289,6 +307,29 @@ func assertChunkOffsetsLocateSameAudio(t *testing.T, srcPath, destPath string) {
 	srcOffs := collectChunkOffsets(t, src)
 	destOffs := collectChunkOffsets(t, dest)
 	require.NotEmpty(t, srcOffs, "source must have chunk offsets")
+	assertOffsetsLocateSameBytes(t, src, dest, srcOffs, destOffs)
+}
+
+// assertAudioChunkOffsetsLocateSameAudio is the chapter-aware variant: it
+// compares only the offsets belonging to audio (handler "soun") tracks, so it
+// ignores the chapter text track that the writer rebuilds into a trailing mdat.
+func assertAudioChunkOffsetsLocateSameAudio(t *testing.T, srcPath, destPath string) {
+	t.Helper()
+	src, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	dest, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+
+	srcOffs := audioChunkOffsets(t, src)
+	destOffs := audioChunkOffsets(t, dest)
+	require.NotEmpty(t, srcOffs, "source must have audio chunk offsets")
+	assertOffsetsLocateSameBytes(t, src, dest, srcOffs, destOffs)
+}
+
+// assertOffsetsLocateSameBytes checks that each dest offset points at the same
+// 64-byte window as the corresponding source offset.
+func assertOffsetsLocateSameBytes(t *testing.T, src, dest []byte, srcOffs, destOffs []uint64) {
+	t.Helper()
 	require.Len(t, destOffs, len(srcOffs), "chunk count must be preserved")
 
 	const window = 64
@@ -308,5 +349,107 @@ func assertChunkOffsetsLocateSameAudio(t *testing.T, srcPath, destPath string) {
 		assert.Equal(t, src[so:so+w], dest[do:do+w],
 			"chunk %d: rewritten offset %d does not point at the same audio bytes as source offset %d",
 			i, do, so)
+	}
+}
+
+// audioChunkOffsets returns the chunk offsets that belong to audio (handler
+// "soun") tracks, in document order.
+func audioChunkOffsets(t *testing.T, data []byte) []uint64 {
+	t.Helper()
+	var out []uint64
+	moov := firstBoxBody(data, "moov")
+	require.NotNil(t, moov, "moov box not found")
+	walkChildBoxes(moov, func(typ string, body []byte) {
+		if typ != "trak" {
+			return
+		}
+		if trackHandlerType(body) == "soun" {
+			collectStcoCo64Bodies(body, &out)
+		}
+	})
+	return out
+}
+
+// trackHandlerType returns a trak's media handler type (e.g. "soun", "text").
+// body is the trak box content (after the 8-byte box header).
+func trackHandlerType(body []byte) string {
+	mdia := firstBoxBody(body, "mdia")
+	if mdia == nil {
+		return ""
+	}
+	hdlr := firstBoxBody(mdia, "hdlr")
+	if len(hdlr) < 12 {
+		return ""
+	}
+	// hdlr content: version(1) flags(3) pre_defined(4) handler_type(4) ...
+	return string(hdlr[8:12])
+}
+
+// collectStcoCo64Bodies walks buf (a box content buffer) and appends every
+// stco/co64 chunk offset it finds, recursing into the usual sample-table
+// container boxes.
+func collectStcoCo64Bodies(buf []byte, out *[]uint64) {
+	walkChildBoxes(buf, func(typ string, body []byte) {
+		switch typ {
+		case "stco":
+			if len(body) < 8 {
+				return
+			}
+			count := int(binary.BigEndian.Uint32(body[4:8]))
+			p := 8
+			for i := 0; i < count && p+4 <= len(body); i++ {
+				*out = append(*out, uint64(binary.BigEndian.Uint32(body[p:p+4])))
+				p += 4
+			}
+		case "co64":
+			if len(body) < 8 {
+				return
+			}
+			count := int(binary.BigEndian.Uint32(body[4:8]))
+			p := 8
+			for i := 0; i < count && p+8 <= len(body); i++ {
+				*out = append(*out, binary.BigEndian.Uint64(body[p:p+8]))
+				p += 8
+			}
+		case "mdia", "minf", "stbl", "edts":
+			collectStcoCo64Bodies(body, out)
+		}
+	})
+}
+
+// firstBoxBody returns the content (after the header) of the first child box of
+// the given type within buf, or nil if absent.
+func firstBoxBody(buf []byte, typ string) []byte {
+	var found []byte
+	walkChildBoxes(buf, func(t string, body []byte) {
+		if found == nil && t == typ {
+			found = body
+		}
+	})
+	return found
+}
+
+// walkChildBoxes iterates the immediate child boxes of buf, calling fn with each
+// box's type and its content (after the box header).
+func walkChildBoxes(buf []byte, fn func(typ string, body []byte)) {
+	off := 0
+	for off+8 <= len(buf) {
+		size := int(binary.BigEndian.Uint32(buf[off:]))
+		hdr := 8
+		switch size {
+		case 1:
+			if off+16 > len(buf) {
+				return
+			}
+			size = int(binary.BigEndian.Uint64(buf[off+8:]))
+			hdr = 16
+		case 0:
+			size = len(buf) - off
+		}
+		if size < hdr || off+size > len(buf) {
+			return
+		}
+		fn(string(buf[off+4:off+8]), buf[off+hdr:off+size])
+		off += size
 	}
 }

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -247,7 +247,7 @@ Extracted from iTunes-style MP4 atoms:
 - **Abridged**: from the Tone freeform atom `com.pilabor.tone:ABRIDGED` (`true`/`false`, or `1`/`0`)
 - **Technical**: duration, bitrate, codec from media stream data
 - **Cover**: from the `covr` atom
-- **Chapters**: from the `chpl` chapter list atom
+- **Chapters**: from the QuickTime chapter track (the `tref/chap` text track), falling back to the Nero `chpl` chapter list atom. Edited chapters are written back into downloaded M4B files to both stores (the QuickTime track that players such as Apple Books and Bound read, and the `chpl` atom) so your player's chapter navigation reflects your edits.
 
 ### PDF
 


### PR DESCRIPTION
## Summary
- Edited chapters in downloaded M4B files were being written only to the Nero `chpl` box. The QuickTime text chapter track (`tref/chap`), which players like Apple Books and Bound, ffprobe, and Shisho's own reader all read preferentially, was copied verbatim from the source, so the original stale titles masked the user's edits. This is the follow-up to #393 (which fixed playability but not chapters).
- `writeMetadataToBytes` now rebuilds the QuickTime chapter text track from `metadata.Chapters` in addition to `chpl`. It reuses the existing text track (preserving `tkhd`/`mdhd`/`hdlr`/`stsd` and the track ID, so the audio track's `tref/chap` reference stays valid), regenerates `stts`/`stsc`/`stsz` with a 64-bit `co64`, and writes the new text samples into a new trailing `mdat` so the audio `mdat` is never touched.
- Offsets reconcile with #393: the audio `stco` still shifts by the moov-resize delta in faststart layout, while the chapter `co64` is patched absolutely to the trailing `mdat`.
- Scope: this rebuilds an existing QuickTime chapter track (every Audible/Apple export). A source with no QuickTime track keeps the `chpl`-only path, which players fall back to correctly. Synthesizing a brand-new track from scratch (which would require editing the audio `tref` and `mvhd`) is intentionally deferred.

## Test plan
- `go test ./pkg/mp4/ ./pkg/filegen/` passes, including new tests in `writer_chapters_test.go`: titles land in the QuickTime track, timestamps are rewritten, chapter count can grow or shrink relative to the source, the mdat-first layout is handled, and ffprobe sees the edited titles while ffmpeg decodes with zero errors.
- Updated `TestWriteToFile_FaststartWithChaptersPreservesAudioAndChapters` guards the two-table case: audio chunk offsets still locate the same audio bytes, and the chapters survive the rebuild.
- Verified against a real 158MB Audible export: ffprobe reads the edited titles from the QuickTime track and the file decodes cleanly.
- `mise lint` clean, `go test ./pkg/mp4/ -race` clean.
- To verify end to end: edit an M4B's chapters in Shisho, download it, and confirm your player shows the edited chapter titles and timings.