### PR TITLE
[Test] Stub Audnexus HTTP transport to fix flaky service tests

### DIFF
--- a/pkg/audnexus/CLAUDE.md
+++ b/pkg/audnexus/CLAUDE.md
@@ -37,3 +37,7 @@ Uses `books:write` rather than `books:read` because the only legitimate use is s
 ## Caching
 
 In-memory `map[string]*cacheEntry` protected by `sync.RWMutex`, TTL 24h. No persistence across restarts. The cache is small (one entry per ASIN), and Audnexus data rarely changes, so there's no eviction beyond TTL.
+
+## Testing
+
+Tests inject a stubbed `http.RoundTripper` via `ServiceConfig.HTTPClient` (`stubService` + `respondWith` in `service_test.go`) to serve canned upstream responses. Do not use a live `httptest.NewServer` for the upstream: under CI load the localhost connection can race the response, so `http.Client.Do` returns a connection error that maps to `upstream_error` instead of the status the test set, making status-mapping tests (e.g. the 429/503 → `rate_limited` cases) flaky. `httptest.NewRequest`/`NewRecorder` for driving the Echo handler are fine; those don't open a socket.

--- a/pkg/audnexus/handlers_test.go
+++ b/pkg/audnexus/handlers_test.go
@@ -3,7 +3,6 @@ package audnexus
 import (
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,15 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestHandler(t *testing.T, upstreamStatus int, upstreamBody string) *handler {
-	t.Helper()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(upstreamStatus)
-		_, _ = io.WriteString(w, upstreamBody)
-	}))
-	t.Cleanup(upstream.Close)
-
-	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+// newTestHandler builds a handler whose service serves the given canned upstream
+// response through a stubbed transport (see stubService), avoiding a real socket
+// that can flake under CI load.
+func newTestHandler(upstreamStatus int, upstreamBody string) *handler {
+	svc := stubService(ServiceConfig{}, respondWith(upstreamStatus, upstreamBody))
 	return &handler{service: svc}
 }
 
@@ -41,7 +36,7 @@ func invokeHandler(t *testing.T, h *handler, asin string) (statusCode int, body 
 
 func TestHandler_GetChapters_Success(t *testing.T) {
 	t.Parallel()
-	h := newTestHandler(t, http.StatusOK, `{"asin":"B0036UC2LO","chapters":[{"title":"C1","startOffsetMs":0,"lengthMs":1000}]}`)
+	h := newTestHandler(http.StatusOK, `{"asin":"B0036UC2LO","chapters":[{"title":"C1","startOffsetMs":0,"lengthMs":1000}]}`)
 	status, body, err := invokeHandler(t, h, "B0036UC2LO")
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, status)
@@ -55,7 +50,7 @@ func TestHandler_GetChapters_Success(t *testing.T) {
 
 func TestHandler_GetChapters_InvalidASIN(t *testing.T) {
 	t.Parallel()
-	h := newTestHandler(t, http.StatusOK, `{}`)
+	h := newTestHandler(http.StatusOK, `{}`)
 	_, _, err := invokeHandler(t, h, "short")
 	require.Error(t, err)
 	ec := asErrcodesError(t, err)
@@ -64,7 +59,7 @@ func TestHandler_GetChapters_InvalidASIN(t *testing.T) {
 
 func TestHandler_GetChapters_NotFound(t *testing.T) {
 	t.Parallel()
-	h := newTestHandler(t, http.StatusNotFound, ``)
+	h := newTestHandler(http.StatusNotFound, ``)
 	_, _, err := invokeHandler(t, h, "B0036UC2LO")
 	require.Error(t, err)
 	ec := asErrcodesError(t, err)
@@ -73,7 +68,7 @@ func TestHandler_GetChapters_NotFound(t *testing.T) {
 
 func TestHandler_GetChapters_UpstreamError(t *testing.T) {
 	t.Parallel()
-	h := newTestHandler(t, http.StatusInternalServerError, ``)
+	h := newTestHandler(http.StatusInternalServerError, ``)
 	_, _, err := invokeHandler(t, h, "B0036UC2LO")
 	require.Error(t, err)
 	ec := asErrcodesError(t, err)

--- a/pkg/audnexus/service_test.go
+++ b/pkg/audnexus/service_test.go
@@ -2,8 +2,10 @@ package audnexus
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -11,6 +13,39 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// roundTripFunc adapts a function to an http.RoundTripper so tests can serve
+// canned responses without a real socket. The live httptest servers this
+// replaced could flake under CI load: when the localhost connection raced the
+// response, http.Client.Do returned a connection error that the service maps to
+// upstream_error, instead of the status the test set (observed on the 503 case
+// of TestService_GetChapters_RateLimited).
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// stubService builds a Service whose HTTP client routes every request through
+// rt instead of the network.
+func stubService(cfg ServiceConfig, rt roundTripFunc) *Service {
+	cfg.HTTPClient = &http.Client{Transport: rt}
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = "http://audnexus.test"
+	}
+	return NewService(cfg)
+}
+
+// respondWith returns a transport that serves the given status and body.
+func respondWith(status int, body string) roundTripFunc {
+	return func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Status:     fmt.Sprintf("%d %s", status, http.StatusText(status)),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	}
+}
 
 func TestService_GetChapters_InvalidASIN(t *testing.T) {
 	t.Parallel()
@@ -39,24 +74,24 @@ func TestService_GetChapters_InvalidASIN(t *testing.T) {
 
 func TestService_GetChapters_NormalizesASINToUppercase(t *testing.T) {
 	t.Parallel()
-	// Valid lowercase ASIN should pass validation (and would reach upstream,
-	// which we're not testing here — but it must not return invalid_asin).
-	svc := NewService(ServiceConfig{})
+	// A valid lowercase ASIN must pass validation and reach upstream rather than
+	// being rejected as invalid_asin. The transport asserts the ASIN arrived
+	// normalized to uppercase in the request path.
+	svc := stubService(ServiceConfig{}, func(r *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/books/B0036UC2LO/chapters", r.URL.Path)
+		return respondWith(http.StatusOK, `{"asin":"B0036UC2LO","chapters":[]}`)(r)
+	})
 	_, err := svc.GetChapters(context.Background(), "b0036uc2lo")
-	if e := AsAudnexusError(err); e != nil {
-		assert.NotEqual(t, ErrCodeInvalidASIN, e.Code, "lowercase ASIN should normalize to valid")
-	}
+	require.NoError(t, err)
 }
 
 func TestService_GetChapters_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc := stubService(ServiceConfig{UserAgent: "Shisho/test"}, func(r *http.Request) (*http.Response, error) {
 		assert.Equal(t, "/books/B0036UC2LO/chapters", r.URL.Path)
 		assert.Equal(t, "Shisho/test", r.Header.Get("User-Agent"))
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{
+		return respondWith(http.StatusOK, `{
 			"asin": "B0036UC2LO",
 			"isAccurate": true,
 			"runtimeLengthMs": 163938000,
@@ -66,13 +101,7 @@ func TestService_GetChapters_HappyPath(t *testing.T) {
 				{"title": "Prelude", "startOffsetMs": 0, "lengthMs": 272000},
 				{"title": "Prologue", "startOffsetMs": 272000, "lengthMs": 1063000}
 			]
-		}`))
-	}))
-	defer upstream.Close()
-
-	svc := NewService(ServiceConfig{
-		BaseURL:   upstream.URL,
-		UserAgent: "Shisho/test",
+		}`)(r)
 	})
 
 	resp, err := svc.GetChapters(context.Background(), "B0036UC2LO")
@@ -91,12 +120,7 @@ func TestService_GetChapters_HappyPath(t *testing.T) {
 
 func TestService_GetChapters_NotFound(t *testing.T) {
 	t.Parallel()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer upstream.Close()
-
-	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	svc := stubService(ServiceConfig{}, respondWith(http.StatusNotFound, ""))
 	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
 	require.Error(t, err)
 	assert.Equal(t, ErrCodeNotFound, AsAudnexusError(err).Code)
@@ -104,12 +128,7 @@ func TestService_GetChapters_NotFound(t *testing.T) {
 
 func TestService_GetChapters_UpstreamError_5xx(t *testing.T) {
 	t.Parallel()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer upstream.Close()
-
-	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	svc := stubService(ServiceConfig{}, respondWith(http.StatusInternalServerError, ""))
 	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
 	require.Error(t, err)
 	assert.Equal(t, ErrCodeUpstreamError, AsAudnexusError(err).Code)
@@ -128,12 +147,7 @@ func TestService_GetChapters_RateLimited(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(tc.status)
-			}))
-			defer upstream.Close()
-
-			svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+			svc := stubService(ServiceConfig{}, respondWith(tc.status, ""))
 			_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
 			require.Error(t, err)
 			assert.Equal(t, ErrCodeRateLimited, AsAudnexusError(err).Code)
@@ -143,13 +157,7 @@ func TestService_GetChapters_RateLimited(t *testing.T) {
 
 func TestService_GetChapters_InvalidJSON(t *testing.T) {
 	t.Parallel()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`not json`))
-	}))
-	defer upstream.Close()
-
-	svc := NewService(ServiceConfig{BaseURL: upstream.URL})
+	svc := stubService(ServiceConfig{}, respondWith(http.StatusOK, "not json"))
 	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
 	require.Error(t, err)
 	assert.Equal(t, ErrCodeUpstreamError, AsAudnexusError(err).Code)
@@ -157,15 +165,11 @@ func TestService_GetChapters_InvalidJSON(t *testing.T) {
 
 func TestService_GetChapters_Timeout(t *testing.T) {
 	t.Parallel()
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(200 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer upstream.Close()
-
-	svc := NewService(ServiceConfig{
-		BaseURL:    upstream.URL,
-		HTTPClient: &http.Client{Timeout: 50 * time.Millisecond},
+	// http.Client.Timeout surfaces as a context.DeadlineExceeded from the
+	// transport; the service must classify that as a timeout rather than a
+	// generic upstream error.
+	svc := stubService(ServiceConfig{}, func(*http.Request) (*http.Response, error) {
+		return nil, context.DeadlineExceeded
 	})
 	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
 	require.Error(t, err)
@@ -175,14 +179,10 @@ func TestService_GetChapters_Timeout(t *testing.T) {
 func TestService_GetChapters_CacheHit(t *testing.T) {
 	t.Parallel()
 	var hits int32
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	svc := stubService(ServiceConfig{CacheTTL: time.Hour}, func(r *http.Request) (*http.Response, error) {
 		atomic.AddInt32(&hits, 1)
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"asin":"B0036UC2LO","chapters":[]}`))
-	}))
-	defer upstream.Close()
-
-	svc := NewService(ServiceConfig{BaseURL: upstream.URL, CacheTTL: time.Hour})
+		return respondWith(http.StatusOK, `{"asin":"B0036UC2LO","chapters":[]}`)(r)
+	})
 
 	// First call hits upstream.
 	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
@@ -200,14 +200,10 @@ func TestService_GetChapters_CacheHit(t *testing.T) {
 func TestService_GetChapters_CacheExpires(t *testing.T) {
 	t.Parallel()
 	var hits int32
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	svc := stubService(ServiceConfig{CacheTTL: 10 * time.Millisecond}, func(r *http.Request) (*http.Response, error) {
 		atomic.AddInt32(&hits, 1)
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"asin":"B0036UC2LO","chapters":[]}`))
-	}))
-	defer upstream.Close()
-
-	svc := NewService(ServiceConfig{BaseURL: upstream.URL, CacheTTL: 10 * time.Millisecond})
+		return respondWith(http.StatusOK, `{"asin":"B0036UC2LO","chapters":[]}`)(r)
+	})
 
 	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
 	time.Sleep(20 * time.Millisecond)
@@ -219,13 +215,10 @@ func TestService_GetChapters_CacheExpires(t *testing.T) {
 func TestService_GetChapters_ErrorsNotCached(t *testing.T) {
 	t.Parallel()
 	var hits int32
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	svc := stubService(ServiceConfig{CacheTTL: time.Hour}, func(r *http.Request) (*http.Response, error) {
 		atomic.AddInt32(&hits, 1)
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer upstream.Close()
-
-	svc := NewService(ServiceConfig{BaseURL: upstream.URL, CacheTTL: time.Hour})
+		return respondWith(http.StatusInternalServerError, "")(r)
+	})
 
 	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")
 	_, _ = svc.GetChapters(context.Background(), "B0036UC2LO")

--- a/pkg/audnexus/service_test.go
+++ b/pkg/audnexus/service_test.go
@@ -163,17 +163,51 @@ func TestService_GetChapters_InvalidJSON(t *testing.T) {
 	assert.Equal(t, ErrCodeUpstreamError, AsAudnexusError(err).Code)
 }
 
+// timeoutError reports a timeout without being context.DeadlineExceeded, so it
+// exercises the isTimeout (Timeout() bool) classification branch specifically.
+type timeoutError struct{}
+
+func (timeoutError) Error() string { return "simulated i/o timeout" }
+func (timeoutError) Timeout() bool { return true }
+
 func TestService_GetChapters_Timeout(t *testing.T) {
 	t.Parallel()
-	// http.Client.Timeout surfaces as a context.DeadlineExceeded from the
-	// transport; the service must classify that as a timeout rather than a
-	// generic upstream error.
+	// The service classifies a timeout via `errors.Is(err, DeadlineExceeded) ||
+	// isTimeout(err)`. Cover both disjuncts: http.Client.Timeout surfaces as a
+	// context.DeadlineExceeded, while a transport/dial timeout surfaces as a
+	// net.Error reporting Timeout() == true that is not DeadlineExceeded.
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"deadline_exceeded", context.DeadlineExceeded},
+		{"net_timeout", timeoutError{}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc := stubService(ServiceConfig{}, func(*http.Request) (*http.Response, error) {
+				return nil, tc.err
+			})
+			_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
+			require.Error(t, err)
+			assert.Equal(t, ErrCodeTimeout, AsAudnexusError(err).Code)
+		})
+	}
+}
+
+func TestService_GetChapters_ContextCanceled(t *testing.T) {
+	t.Parallel()
+	// A canceled request must propagate as context.Canceled, not be reclassified
+	// as a timeout or upstream error, so callers (and the handler) can tell
+	// user-initiated cancellation apart from a real failure.
 	svc := stubService(ServiceConfig{}, func(*http.Request) (*http.Response, error) {
-		return nil, context.DeadlineExceeded
+		return nil, context.Canceled
 	})
 	_, err := svc.GetChapters(context.Background(), "B0036UC2LO")
-	require.Error(t, err)
-	assert.Equal(t, ErrCodeTimeout, AsAudnexusError(err).Code)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, AsAudnexusError(err), "canceled error must not be wrapped as *Error")
 }
 
 func TestService_GetChapters_CacheHit(t *testing.T) {


### PR DESCRIPTION
## Summary
- The `pkg/audnexus` service and handler tests stood up live `httptest.NewServer` upstreams and ran the real HTTP client against them. Under CI load the localhost connection can race the response, so `http.Client.Do` returns a connection error that the service maps to `upstream_error` instead of the status the test set. This surfaced on master as `TestService_GetChapters_RateLimited/503_service_unavailable` expecting `rate_limited` but getting `upstream_error` (seen on PR #394's CI).
- Inject a stubbed `http.RoundTripper` via the existing `ServiceConfig.HTTPClient` (new `stubService` + `respondWith` helpers) so every upstream request is served in-process with no socket. The status-to-error mapping, cache-counting, timeout, and handler tests are now deterministic.
- Also converts `TestService_GetChapters_NormalizesASINToUppercase`, which previously made a real network call to the live `api.audnex.us`, and `handlers_test.go`'s `newTestHandler`, which used the same live-server pattern.
- Documented the convention (stub the transport, never a live upstream server) in `pkg/audnexus/CLAUDE.md`. The `httptest.NewRequest`/`NewRecorder` calls that drive the Echo handler stay, since they don't open a socket.

This is a test-only change; no production code is touched.

## Test plan
- `go test ./pkg/audnexus/` passes; the package now runs in ~0.03s (was ~0.36s) with no network.
- Ran `go test ./pkg/audnexus/ -count=300 -race` and `-count=500` green, exercising the previously-flaky paths repeatedly with no failures.
- `mise lint` clean.