### PR TITLE
[Fix] Prevent horizontal overflow on the book detail page on mobile

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -287,7 +287,7 @@ For rows with multiple pieces of info (stats, actions), stack on mobile:
   </div>
 
   {/* Stats + actions row - must wrap (see below) */}
-  <div className="flex flex-wrap items-center gap-2 gap-y-1 min-w-0 text-xs text-muted-foreground pl-6">
+  <div className="flex flex-wrap items-center gap-x-2 gap-y-1 min-w-0 text-xs text-muted-foreground pl-6">
     <span>8h 44m</span>
     <span className="text-muted-foreground/50">·</span>
     <span>64 kbps</span>

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -286,8 +286,8 @@ For rows with multiple pieces of info (stats, actions), stack on mobile:
     <span className="truncate min-w-0 flex-1">{name}</span>
   </div>
 
-  {/* Stats row - separate line gives name room to breathe */}
-  <div className="flex items-center gap-2 text-xs text-muted-foreground pl-6">
+  {/* Stats + actions row - must wrap (see below) */}
+  <div className="flex flex-wrap items-center gap-2 gap-y-1 min-w-0 text-xs text-muted-foreground pl-6">
     <span>8h 44m</span>
     <span className="text-muted-foreground/50">·</span>
     <span>64 kbps</span>
@@ -297,6 +297,8 @@ For rows with multiple pieces of info (stats, actions), stack on mobile:
   </div>
 </div>
 ```
+
+**Stat + action rows must wrap.** A single-line stats/actions row with no `flex-wrap` packs its widest content into one non-shrinking row. For audiobooks that is duration, bitrate, codec, and filesize plus the download/listen/more buttons, which exceeds the content column on a narrow viewport, bleeds past the container, and (because the shared `LibraryLayout` `<main>` has no `overflow-x-hidden`) becomes page-level horizontal scroll. Always give these rows `flex-wrap` plus `gap-y-1` (wrapped-row spacing) and `min-w-0` so the stats and buttons wrap instead of overflowing. This bit `BookDetail.tsx`'s mobile file row (issue #398). Prefer per-element wrapping/breaking (`break-words`, `break-all`, `min-w-0`, grid `minmax(0,1fr)` value tracks) over a blanket `overflow-x-hidden` clip, which can mask other bugs and clip popovers.
 
 ### Dot Separators for Stats
 

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -397,7 +397,7 @@ const FileRow = ({
             bitrate, codec, filesize) plus three action buttons, which would
             otherwise overflow the content column and force page-level
             horizontal scroll on narrow viewports. */}
-        <div className="flex md:hidden flex-wrap items-center gap-2 gap-y-1 min-w-0 text-xs text-muted-foreground">
+        <div className="flex md:hidden flex-wrap items-center gap-x-2 gap-y-1 min-w-0 text-xs text-muted-foreground">
           {/* M4B stats */}
           {file.audiobook_duration_seconds && (
             <>

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -392,8 +392,12 @@ const FileRow = ({
           </div>
         </div>
 
-        {/* Stats and actions - mobile only (separate row) */}
-        <div className="flex md:hidden items-center gap-2 text-xs text-muted-foreground">
+        {/* Stats and actions - mobile only (separate row).
+            Must wrap: audiobooks carry the widest stat payload (duration,
+            bitrate, codec, filesize) plus three action buttons, which would
+            otherwise overflow the content column and force page-level
+            horizontal scroll on narrow viewports. */}
+        <div className="flex md:hidden flex-wrap items-center gap-2 gap-y-1 min-w-0 text-xs text-muted-foreground">
           {/* M4B stats */}
           {file.audiobook_duration_seconds && (
             <>
@@ -551,7 +555,7 @@ const FileRow = ({
           <div className="flex items-center gap-1 flex-wrap">
             <span className="text-xs text-muted-foreground">Narrated by</span>
             {file.narrators.map((narrator, index) => (
-              <span className="text-xs" key={narrator.id}>
+              <span className="text-xs min-w-0 break-words" key={narrator.id}>
                 <Link
                   className="hover:underline"
                   to={`/libraries/${libraryId}/people/${narrator.person_id}`}
@@ -568,12 +572,12 @@ const FileRow = ({
         {isExpanded && hasExpandableMetadata && (
           <div className="mt-2 bg-muted/50 rounded-md p-3 text-xs space-y-2">
             {/* Publisher, Released, URL */}
-            <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+            <div className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-1">
               {file.publisher && (
                 <>
                   <span className="text-muted-foreground">Publisher</span>
                   <Link
-                    className="hover:underline"
+                    className="hover:underline break-words"
                     to={`/libraries/${libraryId}/publishers/${file.publisher.id}`}
                   >
                     {file.publisher.name}
@@ -633,7 +637,7 @@ const FileRow = ({
             {/* Identifiers */}
             {file.identifiers && file.identifiers.length > 0 && (
               <div className="pt-2 border-t border-border/50">
-                <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+                <div className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-4 gap-y-1">
                   {file.identifiers.map((id, idx) => {
                     const url = getIdentifierUrl(
                       id.type,
@@ -647,7 +651,7 @@ const FileRow = ({
                         </span>
                         {url ? (
                           <a
-                            className="font-mono select-all text-primary hover:underline"
+                            className="font-mono select-all text-primary hover:underline break-all"
                             href={url}
                             rel="noopener noreferrer"
                             target="_blank"
@@ -655,7 +659,7 @@ const FileRow = ({
                             {id.value}
                           </a>
                         ) : (
-                          <span className="font-mono select-all">
+                          <span className="font-mono select-all break-all">
                             {id.value}
                           </span>
                         )}
@@ -1051,7 +1055,9 @@ const BookDetail = () => {
         <div className="lg:col-span-2 space-y-4 md:space-y-6">
           <div>
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-2">
-              <h1 className="text-2xl font-semibold">{book.title}</h1>
+              <h1 className="text-2xl font-semibold min-w-0 break-words">
+                {book.title}
+              </h1>
               {/*
                 The relative wrapper exists so AddToListPopover can be opened
                 from the dropdown menu's "Add to list" item: its trigger is an
@@ -1126,15 +1132,17 @@ const BookDetail = () => {
               </div>
             </div>
             {book.sort_title && book.sort_title !== book.title && (
-              <p className="text-sm text-muted-foreground italic">
+              <p className="text-sm text-muted-foreground italic break-words">
                 Sort title: {book.sort_title}
               </p>
             )}
             {book.subtitle && (
-              <p className="text-lg text-muted-foreground">{book.subtitle}</p>
+              <p className="text-lg text-muted-foreground break-words">
+                {book.subtitle}
+              </p>
             )}
             {book.description && (
-              <p className="text-sm text-muted-foreground mt-3 whitespace-pre-wrap">
+              <p className="text-sm text-muted-foreground mt-3 whitespace-pre-wrap break-words">
                 {book.description}
               </p>
             )}
@@ -1276,13 +1284,13 @@ const BookDetail = () => {
               </div>
               <div>
                 <p className="font-semibold">Library</p>
-                <p className="text-muted-foreground">
+                <p className="text-muted-foreground break-words">
                   {book.library?.name || `Library ${book.library_id}`}
                 </p>
               </div>
               <div>
                 <p className="font-semibold">File Path</p>
-                <p className="text-muted-foreground">
+                <p className="text-muted-foreground break-words">
                   {book.filepath.split("/").map((segment, i, arr) => (
                     <React.Fragment key={i}>
                       {segment}

--- a/e2e/book-detail-overflow.spec.ts
+++ b/e2e/book-detail-overflow.spec.ts
@@ -12,7 +12,7 @@
  *
  * Running:
  *   pnpm e2e:chromium e2e/book-detail-overflow.spec.ts   # Chromium only
- *   mise test:e2e -- book-detail-overflow                # Both browsers
+ *   pnpm exec playwright test book-detail-overflow        # Both browsers
  */
 
 import type { Page } from "@playwright/test";
@@ -97,10 +97,18 @@ test.describe("Book detail overflow", () => {
       waitUntil: "domcontentloaded",
     });
 
-    // Wait for the file row to render — the Files heading only appears once the
+    // Wait for the file row to render. The Files heading only appears once the
     // book data resolves, which guarantees the stats/actions row is present.
     await expect(
-      page.getByRole("heading", { name: "Files (1)" }),
+      page.getByRole("heading", { name: "Files (1)", exact: true }),
+    ).toBeVisible();
+
+    // The audiobook stat payload must actually render. Otherwise the overflow
+    // check below could pass for the wrong reason (no stats means nothing wide
+    // enough to overflow). The mobile stats row renders the bitrate inline from
+    // audiobook_bitrate_bps, so assert the visible copy is present.
+    await expect(
+      page.getByText("128 kbps").filter({ visible: true }),
     ).toBeVisible();
 
     // The document must not be scrollable horizontally.

--- a/e2e/book-detail-overflow.spec.ts
+++ b/e2e/book-detail-overflow.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * E2E regression test for horizontal overflow on the book detail page.
+ *
+ * Issue #398: on mobile viewports the book detail page could render slightly
+ * wider than the screen for some audiobooks, adding a horizontal scrollbar.
+ * Audiobooks (M4B) reproduce it because they carry the widest per-file stat
+ * payload (duration, bitrate, codec, filesize) plus three action buttons in a
+ * single non-wrapping row.
+ *
+ * Layout overflow cannot be asserted in jsdom (no layout engine), so this lives
+ * as an E2E test where a real browser computes scrollWidth/clientWidth.
+ *
+ * Running:
+ *   pnpm e2e:chromium e2e/book-detail-overflow.spec.ts   # Chromium only
+ *   mise test:e2e -- book-detail-overflow                # Both browsers
+ */
+
+import type { Page } from "@playwright/test";
+
+import { expect, getApiBaseURL, request, test } from "./fixtures";
+
+interface TestData {
+  libraryId: number;
+}
+
+let testData: TestData;
+
+const USERNAME = "overflowtest";
+const PASSWORD = "password123";
+
+test.describe("Book detail overflow", () => {
+  test.beforeAll(async ({ browser }) => {
+    const apiBaseURL = getApiBaseURL(browser.browserType().name());
+    const apiContext = await request.newContext({ baseURL: apiBaseURL });
+
+    // Clean slate
+    await apiContext.delete("/test/ereader");
+    await apiContext.delete("/test/users");
+
+    await apiContext.post("/test/users", {
+      data: { username: USERNAME, password: PASSWORD },
+    });
+
+    const libraryResp = await apiContext.post("/test/libraries", {
+      data: { name: "Overflow Test Library" },
+    });
+    const library = (await libraryResp.json()) as { id: number };
+
+    testData = { libraryId: library.id };
+    await apiContext.dispose();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const apiBaseURL = getApiBaseURL(browser.browserType().name());
+    const apiContext = await request.newContext({ baseURL: apiBaseURL });
+    await apiContext.delete("/test/ereader");
+    await apiContext.delete("/test/users");
+    await apiContext.dispose();
+  });
+
+  // Helper: log in through the login form.
+  async function login(page: Page) {
+    await page.goto("/login", { waitUntil: "domcontentloaded" });
+    await page.getByLabel("Username").fill(USERNAME);
+    await page.getByLabel("Password").fill(PASSWORD);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await page.waitForURL(/\/settings\/libraries|\/libraries\//);
+  }
+
+  test("audiobook with full stats and a long title does not force horizontal scroll on mobile", async ({
+    page,
+    apiContext,
+  }) => {
+    // Seed an M4B audiobook carrying the full per-file stat payload plus a
+    // long title with unbroken tokens. Both the stats/actions row and the
+    // title are unbounded-content nodes that could push the page wider than
+    // the viewport.
+    const bookResp = await apiContext.post("/test/books", {
+      data: {
+        libraryId: testData.libraryId,
+        title:
+          "The Complete Unabridged Chronicles of Antidisestablishmentarianism Pneumonoultramicroscopicsilicovolcanoconiosis",
+        fileType: "m4b",
+        name: "The Complete Unabridged Chronicles of Antidisestablishmentarianism Pneumonoultramicroscopicsilicovolcanoconiosis",
+        fileSize: 268435456, // 256 MB
+        audiobookDurationSeconds: 31480, // 8h 44m
+        audiobookBitrateBps: 128000, // 128 kbps
+        audiobookCodec: "aac",
+      },
+    });
+    const book = (await bookResp.json()) as { id: number; fileId: number };
+
+    await login(page);
+
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto(`/libraries/${testData.libraryId}/books/${book.id}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    // Wait for the file row to render — the Files heading only appears once the
+    // book data resolves, which guarantees the stats/actions row is present.
+    await expect(
+      page.getByRole("heading", { name: "Files (1)" }),
+    ).toBeVisible();
+
+    // The document must not be scrollable horizontally.
+    const noOverflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth <=
+        document.documentElement.clientWidth,
+    );
+    expect(noOverflow).toBe(true);
+  });
+});

--- a/pkg/testutils/handlers.go
+++ b/pkg/testutils/handlers.go
@@ -183,6 +183,13 @@ type createBookRequest struct {
 	SeriesID  *int   `json:"seriesId"` // Optional series
 	FileSize  *int64 `json:"fileSize"` // Optional file size in bytes
 	PageCount *int   `json:"pageCount"`
+	// Optional file name (the file-level title shown in the file row).
+	Name *string `json:"name"`
+	// Optional M4B audiobook stats. These drive the widest per-file stat
+	// payload in the book detail file row (duration, bitrate, codec).
+	AudiobookDurationSeconds *float64 `json:"audiobookDurationSeconds"`
+	AudiobookBitrateBps      *int     `json:"audiobookBitrateBps"`
+	AudiobookCodec           *string  `json:"audiobookCodec"`
 }
 
 // createBookResponse is the response body for creating a test book.
@@ -242,15 +249,19 @@ func (h *handler) createBook(c echo.Context) error {
 	}
 
 	file := &models.File{
-		LibraryID:     req.LibraryID,
-		BookID:        book.ID,
-		Filepath:      filepath + "." + fileType,
-		FileType:      fileType,
-		FileRole:      models.FileRoleMain,
-		FilesizeBytes: fileSize,
-		PageCount:     req.PageCount,
-		CreatedAt:     now,
-		UpdatedAt:     now,
+		LibraryID:                req.LibraryID,
+		BookID:                   book.ID,
+		Filepath:                 filepath + "." + fileType,
+		FileType:                 fileType,
+		FileRole:                 models.FileRoleMain,
+		FilesizeBytes:            fileSize,
+		PageCount:                req.PageCount,
+		Name:                     req.Name,
+		AudiobookDurationSeconds: req.AudiobookDurationSeconds,
+		AudiobookBitrateBps:      req.AudiobookBitrateBps,
+		AudiobookCodec:           req.AudiobookCodec,
+		CreatedAt:                now,
+		UpdatedAt:                now,
 	}
 
 	_, err = h.db.NewInsert().Model(file).Exec(ctx)


### PR DESCRIPTION
Closes #398

## Summary
- Fix the mobile horizontal-scroll bug on the book detail page. The root cause was the `flex md:hidden` mobile stats/actions row in `FileRow`, which packed an audiobook's duration, bitrate, codec, and filesize plus three action buttons into one non-wrapping row. On narrow viewports that row overflowed the content column, and because `LibraryLayout`'s `<main>` has no `overflow-x-hidden`, the bleed became page-level horizontal scroll. It now wraps with `flex-wrap gap-y-1 min-w-0`.
- Harden every other unbounded-content node on the page so nothing can force horizontal scroll: the title gets `min-w-0 break-words`; the subtitle, sort-title, and description get `break-words`; both expanded-detail grids use `grid-cols-[auto_minmax(0,1fr)]`; identifier values get `break-all`; the publisher, library, and file-path text get `break-words`; and the narrator name span gets `min-w-0 break-words`. No `md:`-and-up class changed, so the desktop layout is untouched. This favors per-element wrapping over a blanket `overflow-x-hidden` clip that could mask other bugs or clip popovers.
- Extend the test-only `/test/books` seed endpoint (`pkg/testutils/handlers.go`) with optional `name`, `audiobookDurationSeconds`, `audiobookBitrateBps`, and `audiobookCodec` fields so E2E can reproduce the widest audiobook file-row payload. All new fields are optional pointers, so existing seeds are unaffected.

## Test plan
- `mise e2e:chromium` runs the new `e2e/book-detail-overflow.spec.ts`, which seeds an M4B audiobook with full per-file stats and a long unbroken title, logs in, navigates to the book detail page at a 375px viewport, and asserts the document is not horizontally scrollable (`scrollWidth <= clientWidth`). The spec was confirmed red on master and green with this fix.
- `mise lint test` covers the Go test-endpoint change.
- `mise lint:js test:unit` covers the frontend change (eslint, prettier, tsc, and unit tests).
- `mise check:quiet` runs the full suite (Go lint and test, JS lint, unit tests, and chromium E2E).
