### PR TITLE
[Backend] Add omnibus series ranges

### DIFF
--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -337,6 +337,7 @@ Check existing queries in `pkg/books/service.go` for reference. Common aliases: 
 
 ### Sidecars
 
+- **Series number groups are atomic:** `series_number`, `series_number_end`, and `series_number_unit` must always come from one metadata source. Copy, merge, clear, validate, and sidecar-overlay all three together. An end requires a finite start, both endpoints must be finite, and external ranges require end greater than start. Malformed external groups are discarded as a whole.
 - Sidecar metadata files kept for every file parsed into the system
 - Don't store non-modifiable intrinsic properties (e.g., bitrate, duration)
 - Source fields (e.g., title_source, name_source) shouldn't be saved into the sidecar

--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -223,6 +223,9 @@ func (h *handler) update(c echo.Context) error {
 	if err := c.Bind(&params); err != nil {
 		return errors.WithStack(err)
 	}
+	if err := validateSeriesInputs(params.Series); err != nil {
+		return errcodes.BadRequest(err.Error())
+	}
 
 	// Fetch the book.
 	book, err := h.bookService.RetrieveBook(ctx, RetrieveBookOptions{
@@ -435,6 +438,7 @@ func (h *handler) update(c echo.Context) error {
 				BookID:           book.ID,
 				SeriesID:         seriesRecord.ID,
 				SeriesNumber:     seriesInput.Number,
+				SeriesNumberEnd:  seriesInput.NumberEnd,
 				SeriesNumberUnit: seriesInput.SeriesNumberUnit,
 				SortOrder:        i + 1,
 			}

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -2333,10 +2333,38 @@ func TestUpdateBook_SeriesNumberRange_PersistsAndReturnsEnd(t *testing.T) {
 	require.NotNil(t, response.BookSeries[0].SeriesNumberEnd)
 	assert.InDelta(t, 3.0, *response.BookSeries[0].SeriesNumberEnd, 0.001)
 
+	var wireResponse struct {
+		BookSeries []map[string]json.RawMessage `json:"book_series"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &wireResponse))
+	require.Len(t, wireResponse.BookSeries, 1)
+	assert.Contains(t, wireResponse.BookSeries[0], "series_number_end")
+	assert.NotContains(t, wireResponse.BookSeries[0], "seriesNumberEnd")
+
 	var bs models.BookSeries
 	require.NoError(t, db.NewSelect().Model(&bs).Where("book_id = ?", book.ID).Scan(ctx))
 	require.NotNil(t, bs.SeriesNumberEnd)
 	assert.InDelta(t, 3.0, *bs.SeriesNumberEnd, 0.001)
+}
+
+func TestUpdateBook_SeriesNumberRange_RejectsInvalidRangeBeforePersistence(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, book, _ := seedBookAndFile(t, db, "Collected Stories", nil, nil, models.FileRoleMain)
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+	body := `{"series":[{"name":"Saga","number":3,"number_end":2}]}`
+	e := setupTestServer(t, db)
+	req := httptest.NewRequest(http.MethodPost, "/books/"+strconv.Itoa(book.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusBadRequest, rr.Code, "response body: %s", rr.Body.String())
+
+	count, err := db.NewSelect().Model((*models.BookSeries)(nil)).Where("book_id = ?", book.ID).Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count)
 }
 
 func TestUpdateBook_SeriesNumberUnit_StoresChapterUnit(t *testing.T) {

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -2312,6 +2312,33 @@ func TestUpdateFile_IsPreferredCover_ClearingPreferred(t *testing.T) {
 	assert.False(t, f.IsPreferredCover, "preferred should be cleared")
 }
 
+func TestUpdateBook_SeriesNumberRange_PersistsAndReturnsEnd(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, book, _ := seedBookAndFile(t, db, "Collected Stories", nil, nil, models.FileRoleMain)
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+	body := `{"series":[{"name":"Saga","number":1,"number_end":3,"series_number_unit":"volume"}]}`
+	e := setupTestServer(t, db)
+	req := httptest.NewRequest(http.MethodPost, "/books/"+strconv.Itoa(book.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, e, req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	var response models.Book
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	require.Len(t, response.BookSeries, 1)
+	require.NotNil(t, response.BookSeries[0].SeriesNumberEnd)
+	assert.InDelta(t, 3.0, *response.BookSeries[0].SeriesNumberEnd, 0.001)
+
+	var bs models.BookSeries
+	require.NoError(t, db.NewSelect().Model(&bs).Where("book_id = ?", book.ID).Scan(ctx))
+	require.NotNil(t, bs.SeriesNumberEnd)
+	assert.InDelta(t, 3.0, *bs.SeriesNumberEnd, 0.001)
+}
+
 func TestUpdateBook_SeriesNumberUnit_StoresChapterUnit(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/books/merge.go
+++ b/pkg/books/merge.go
@@ -606,6 +606,7 @@ func (svc *Service) createBookFromFile(ctx context.Context, file *models.File, s
 				BookID:           book.ID,
 				SeriesID:         bs.SeriesID,
 				SeriesNumber:     bs.SeriesNumber,
+				SeriesNumberEnd:  bs.SeriesNumberEnd,
 				SeriesNumberUnit: bs.SeriesNumberUnit,
 				SortOrder:        bs.SortOrder,
 			}

--- a/pkg/books/merge_test.go
+++ b/pkg/books/merge_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/robinjoseph08/golib/pointerutil"
 	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/books/review"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -193,8 +194,27 @@ func TestMoveFilesToBook_CreateNewBook(t *testing.T) {
 	_, err := db.NewInsert().Model(lp).Exec(ctx)
 	require.NoError(t, err)
 
-	// Create source book with a file
+	// Create source book with a file and a complete omnibus number group.
 	sourceBook, sourceFile1 := setupTestBookWithFile(t, db, library, "Source Book")
+	series := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Saga",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Saga",
+		SortNameSource: models.DataSourceManual,
+	}
+	_, err = db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+	unit := models.SeriesNumberUnitVolume
+	_, err = db.NewInsert().Model(&models.BookSeries{
+		BookID:           sourceBook.ID,
+		SeriesID:         series.ID,
+		SeriesNumber:     pointerutil.Float64(1),
+		SeriesNumberEnd:  pointerutil.Float64(3),
+		SeriesNumberUnit: &unit,
+		SortOrder:        1,
+	}).Exec(ctx)
+	require.NoError(t, err)
 
 	// Create a second file in a DIFFERENT subdirectory
 	// This simulates a scenario where we're splitting a file that's in its own subdirectory
@@ -247,6 +267,15 @@ func TestMoveFilesToBook_CreateNewBook(t *testing.T) {
 	assert.Equal(t, library.ID, result.TargetBook.LibraryID)
 	assert.Equal(t, newFileDir, result.TargetBook.Filepath)
 	assert.Equal(t, "New Book", result.TargetBook.Title)
+
+	var copiedSeries models.BookSeries
+	require.NoError(t, db.NewSelect().Model(&copiedSeries).Where("book_id = ?", result.TargetBook.ID).Scan(ctx))
+	require.NotNil(t, copiedSeries.SeriesNumber)
+	assert.InDelta(t, 1.0, *copiedSeries.SeriesNumber, 0.001)
+	require.NotNil(t, copiedSeries.SeriesNumberEnd)
+	assert.InDelta(t, 3.0, *copiedSeries.SeriesNumberEnd, 0.001)
+	require.NotNil(t, copiedSeries.SeriesNumberUnit)
+	assert.Equal(t, unit, *copiedSeries.SeriesNumberUnit)
 
 	// Verify source book still exists with the remaining file
 	var remainingFiles []models.File

--- a/pkg/books/series_validation.go
+++ b/pkg/books/series_validation.go
@@ -1,0 +1,46 @@
+package books
+
+import (
+	"errors"
+	"math"
+)
+
+var (
+	errSeriesNumberEndWithoutStart = errors.New("series number end requires a start")
+	errSeriesNumberNotFinite       = errors.New("series number must be finite")
+	errSeriesNumberEndNotFinite    = errors.New("series number end must be finite")
+	errSeriesNumberEndBeforeStart  = errors.New("series number end must not be less than the start")
+)
+
+func validateSeriesInputs(inputs []SeriesInput) error {
+	for i := range inputs {
+		input := &inputs[i]
+		if input.Number == nil {
+			if input.NumberEnd != nil {
+				return errSeriesNumberEndWithoutStart
+			}
+			input.SeriesNumberUnit = nil
+			continue
+		}
+		if !isFiniteSeriesNumber(*input.Number) {
+			return errSeriesNumberNotFinite
+		}
+		if input.NumberEnd == nil {
+			continue
+		}
+		if !isFiniteSeriesNumber(*input.NumberEnd) {
+			return errSeriesNumberEndNotFinite
+		}
+		if *input.NumberEnd < *input.Number {
+			return errSeriesNumberEndBeforeStart
+		}
+		if *input.NumberEnd == *input.Number {
+			input.NumberEnd = nil
+		}
+	}
+	return nil
+}
+
+func isFiniteSeriesNumber(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}

--- a/pkg/books/series_validation_test.go
+++ b/pkg/books/series_validation_test.go
@@ -1,0 +1,53 @@
+package books
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateSeriesInputs(t *testing.T) {
+	t.Parallel()
+
+	unit := "volume"
+	tests := []struct {
+		name        string
+		input       SeriesInput
+		wantErr     bool
+		wantEndNil  bool
+		wantUnitNil bool
+	}{
+		{name: "single number", input: SeriesInput{Name: "Series", Number: float64Pointer(1)}, wantEndNil: true},
+		{name: "range", input: SeriesInput{Name: "Series", Number: float64Pointer(1), NumberEnd: float64Pointer(3)}},
+		{name: "equal normalizes to single", input: SeriesInput{Name: "Series", Number: float64Pointer(2), NumberEnd: float64Pointer(2)}, wantEndNil: true},
+		{name: "end before start", input: SeriesInput{Name: "Series", Number: float64Pointer(3), NumberEnd: float64Pointer(2)}, wantErr: true},
+		{name: "end without start", input: SeriesInput{Name: "Series", NumberEnd: float64Pointer(2)}, wantErr: true},
+		{name: "non finite start", input: SeriesInput{Name: "Series", Number: float64Pointer(math.Inf(1))}, wantErr: true},
+		{name: "non finite end", input: SeriesInput{Name: "Series", Number: float64Pointer(1), NumberEnd: float64Pointer(math.NaN())}, wantErr: true},
+		{name: "unit without start clears group", input: SeriesInput{Name: "Series", SeriesNumberUnit: &unit}, wantEndNil: true, wantUnitNil: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			inputs := []SeriesInput{tt.input}
+			err := validateSeriesInputs(inputs)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantEndNil {
+				assert.Nil(t, inputs[0].NumberEnd)
+			}
+			if tt.wantUnitNil {
+				assert.Nil(t, inputs[0].SeriesNumberUnit)
+			}
+		})
+	}
+}
+
+func float64Pointer(value float64) *float64 { return &value }

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -45,7 +45,7 @@ type ListBooksOptions struct {
 	ReviewedFilter string   // "" (default = all), "needs_review", "reviewed"
 
 	// Sort overrides the default ordering. When nil and SeriesID is set,
-	// books are ordered by series_number ASC + sort_title ASC. When nil
+	// single-numbered books precede ranges, then endpoints and sort title order. When nil
 	// and SeriesID is not set, the service falls back to
 	// sortspec.BuiltinDefault (date_added DESC) so all surfaces (REST,
 	// OPDS, eReader, gallery) share the same "newest first" default.
@@ -370,11 +370,12 @@ func (svc *Service) listBooksWithTotal(ctx context.Context, opts ListBooksOption
 		q = q.Order("b.id ASC")
 
 	case opts.SeriesID != nil:
-		// When filtering by series, order by series_number then sort_title.
-		// Series listings are a distinct use case from the general "newest
-		// first" fallback — readers of a series expect #1, #2, #3 order,
-		// not most-recently-added.
-		q = q.Order("bs_filter.series_number ASC", "b.sort_title ASC")
+		// Keep omnibus ranges after single-numbered books, then order each
+		// group by its start, endpoint, and title.
+		q = q.OrderExpr("(bs_filter.series_number_end IS NOT NULL) ASC").
+			Order("bs_filter.series_number ASC").
+			OrderExpr("COALESCE(bs_filter.series_number_end, bs_filter.series_number) ASC").
+			Order("b.sort_title ASC")
 
 	default:
 		// No explicit caller Sort, not a series listing, not the internal
@@ -763,7 +764,7 @@ func (svc *Service) GetFirstBookInSeriesByID(ctx context.Context, seriesID int) 
 		Relation("Files").
 		Join("INNER JOIN book_series bs ON bs.book_id = b.id").
 		Where("bs.series_id = ?", seriesID).
-		OrderExpr("CASE WHEN bs.series_number = CAST(bs.series_number AS INTEGER) THEN 0 ELSE 1 END ASC, bs.series_number ASC, b.title ASC").
+		OrderExpr("(bs.series_number_end IS NOT NULL) ASC, CASE WHEN bs.series_number = CAST(bs.series_number AS INTEGER) THEN 0 ELSE 1 END ASC, bs.series_number ASC, COALESCE(bs.series_number_end, bs.series_number) ASC, b.title ASC").
 		Limit(1).
 		Scan(ctx)
 	if err != nil {
@@ -779,8 +780,8 @@ func (svc *Service) GetFirstBookInSeriesByID(ctx context.Context, seriesID int) 
 // GetFirstBooksFilesForSeries returns the files of each series' first book,
 // keyed by series ID. Uses two queries regardless of input size: one window-
 // function query to find the first book per series, then one query to load
-// files for those books. The first-book ordering matches GetFirstBookInSeriesByID
-// (whole numbers before fractions, then series_number, then title).
+// files for those books. The first-book ordering matches GetFirstBookInSeriesByID:
+// singles before ranges, then whole numbers, start, endpoint, and title.
 func (svc *Service) GetFirstBooksFilesForSeries(ctx context.Context, seriesIDs []int) (map[int][]*models.File, error) {
 	if len(seriesIDs) == 0 {
 		return nil, nil
@@ -799,8 +800,10 @@ func (svc *Service) GetFirstBooksFilesForSeries(ctx context.Context, seriesIDs [
 				ROW_NUMBER() OVER (
 					PARTITION BY bs.series_id
 					ORDER BY
+						(bs.series_number_end IS NOT NULL) ASC,
 						CASE WHEN bs.series_number = CAST(bs.series_number AS INTEGER) THEN 0 ELSE 1 END ASC,
 						bs.series_number ASC,
+						COALESCE(bs.series_number_end, bs.series_number) ASC,
 						b.title ASC
 				) AS rn
 			FROM book_series bs

--- a/pkg/books/service_first_book_test.go
+++ b/pkg/books/service_first_book_test.go
@@ -122,6 +122,35 @@ func TestGetFirstBookInSeriesByID_PrefersSingleNumberOverOmnibus(t *testing.T) {
 	assert.Equal(t, books[1].ID, first.ID)
 }
 
+func TestGetFirstBooksFilesForSeries_PrefersSingleNumberOverOmnibus(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, _ := setupTestLibraryAndBook(t, db)
+	series := &models.Series{
+		LibraryID: library.ID, Name: "Bulk Omnibus Series", NameSource: models.DataSourceFilepath,
+		SortName: "Bulk Omnibus Series", SortNameSource: models.DataSourceFilepath,
+	}
+	_, err := db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+
+	books := seedSeriesBooks(t, db, library, series.ID, []struct {
+		Title        string
+		SeriesNumber *float64
+	}{
+		{Title: "Omnibus One to Three", SeriesNumber: ptrFloat64(1)},
+		{Title: "Book Two", SeriesNumber: ptrFloat64(2)},
+	})
+	_, err = db.NewUpdate().Table("book_series").Set("series_number_end = 3").Where("book_id = ?", books[0].ID).Exec(ctx)
+	require.NoError(t, err)
+
+	filesBySeries, err := NewService(db).GetFirstBooksFilesForSeries(ctx, []int{series.ID})
+	require.NoError(t, err)
+	require.Len(t, filesBySeries[series.ID], 1)
+	assert.Equal(t, "/fake/Book Two.epub", filesBySeries[series.ID][0].Filepath)
+}
+
 func TestGetFirstBookInSeriesByID_UsesRangeEndpointTieBreaker(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/books/service_first_book_test.go
+++ b/pkg/books/service_first_book_test.go
@@ -90,6 +90,71 @@ func TestGetFirstBookInSeriesByID_PrefersWholeNumberOverPrequel(t *testing.T) {
 	assert.Equal(t, books[1].ID, first.ID, "should pick Book One (1) over Prequel (0.5)")
 }
 
+func TestGetFirstBookInSeriesByID_PrefersSingleNumberOverOmnibus(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, _ := setupTestLibraryAndBook(t, db)
+	series := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Omnibus Series",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "Omnibus Series",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err := db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+
+	books := seedSeriesBooks(t, db, library, series.ID, []struct {
+		Title        string
+		SeriesNumber *float64
+	}{
+		{Title: "Omnibus One to Three", SeriesNumber: ptrFloat64(1)},
+		{Title: "Book Two", SeriesNumber: ptrFloat64(2)},
+	})
+	_, err = db.NewUpdate().Table("book_series").Set("series_number_end = 3").Where("book_id = ?", books[0].ID).Exec(ctx)
+	require.NoError(t, err)
+
+	svc := NewService(db)
+	first, err := svc.GetFirstBookInSeriesByID(ctx, series.ID)
+	require.NoError(t, err)
+	assert.Equal(t, books[1].ID, first.ID)
+}
+
+func TestGetFirstBookInSeriesByID_UsesRangeEndpointTieBreaker(t *testing.T) {
+	t.Parallel()
+	db := setupTestDB(t)
+	ctx := context.Background()
+
+	library, _ := setupTestLibraryAndBook(t, db)
+	series := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Omnibus Only",
+		NameSource:     string(models.DataSourceFilepath),
+		SortName:       "Omnibus Only",
+		SortNameSource: string(models.DataSourceFilepath),
+	}
+	_, err := db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+
+	books := seedSeriesBooks(t, db, library, series.ID, []struct {
+		Title        string
+		SeriesNumber *float64
+	}{
+		{Title: "A Longer Omnibus", SeriesNumber: ptrFloat64(1)},
+		{Title: "Z Shorter Omnibus", SeriesNumber: ptrFloat64(1)},
+	})
+	_, err = db.NewUpdate().Table("book_series").Set("series_number_end = 4").Where("book_id = ?", books[0].ID).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewUpdate().Table("book_series").Set("series_number_end = 3").Where("book_id = ?", books[1].ID).Exec(ctx)
+	require.NoError(t, err)
+
+	first, err := NewService(db).GetFirstBookInSeriesByID(ctx, series.ID)
+	require.NoError(t, err)
+	assert.Equal(t, books[1].ID, first.ID)
+}
+
 func TestGetFirstBookInSeriesByID_FallsBackToFractionalWhenNoWholeNumbers(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/pkg/books/service_sort_test.go
+++ b/pkg/books/service_sort_test.go
@@ -93,6 +93,47 @@ func TestListBooks_SortByTitleAsc(t *testing.T) {
 	assert.Equal(t, cheese.ID, got[2].ID)
 }
 
+func TestListBooks_SortByPrimarySeriesPlacesOmnibusesAfterSingles(t *testing.T) {
+	t.Parallel()
+
+	db := setupBooksTestDB(t)
+	svc := NewService(db)
+	lib := seedLibrary(t, db, "Books")
+	ctx := context.Background()
+	now := time.Now()
+
+	seriesRecord := &models.Series{
+		LibraryID:      lib.ID,
+		Name:           "Saga",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Saga",
+		SortNameSource: models.DataSourceManual,
+	}
+	_, err := db.NewInsert().Model(seriesRecord).Exec(ctx)
+	require.NoError(t, err)
+
+	single := seedBook(t, db, lib, "Single Two", "Single Two", now)
+	omnibus := seedBook(t, db, lib, "Omnibus One to Three", "Omnibus One to Three", now)
+	_, err = db.NewInsert().Model(&models.BookSeries{
+		BookID: single.ID, SeriesID: seriesRecord.ID, SeriesNumber: float64Pointer(2), SortOrder: 1,
+	}).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.BookSeries{
+		BookID: omnibus.ID, SeriesID: seriesRecord.ID, SeriesNumber: float64Pointer(1),
+		SeriesNumberEnd: float64Pointer(3), SortOrder: 1,
+	}).Exec(ctx)
+	require.NoError(t, err)
+
+	got, _, err := svc.ListBooksWithTotal(ctx, ListBooksOptions{
+		LibraryID: &lib.ID,
+		Sort:      []sortspec.SortLevel{{Field: sortspec.FieldSeries, Direction: sortspec.DirAsc}},
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, single.ID, got[0].ID)
+	assert.Equal(t, omnibus.ID, got[1].ID)
+}
+
 // TestListBooks_SortByDateAddedDesc confirms the primary use case for the
 // frontend's builtin default.
 func TestListBooks_SortByDateAddedDesc(t *testing.T) {

--- a/pkg/books/types.go
+++ b/pkg/books/types.go
@@ -56,6 +56,7 @@ type AuthorInput struct {
 type SeriesInput struct {
 	Name             string   `json:"name" validate:"required,max=200"`
 	Number           *float64 `json:"number,omitempty"`
+	NumberEnd        *float64 `json:"number_end,omitempty"`
 	SeriesNumberUnit *string  `json:"series_number_unit,omitempty" validate:"omitempty,oneof=volume chapter" tstype:"SeriesNumberUnit"`
 }
 

--- a/pkg/downloadcache/filename.go
+++ b/pkg/downloadcache/filename.go
@@ -2,13 +2,12 @@ package downloadcache
 
 import (
 	"fmt"
-	"math"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/seriesnum"
 )
 
 // volumePattern matches volume indicators in titles (e.g., "v1", "V2", "vol. 3").
@@ -49,7 +48,7 @@ func FormatDownloadFilename(book *models.Book, file *models.File) string {
 	// Pad volume numbers for lexicographic sorting, then sanitize
 	title := sanitizeFilename(padVolumeNumber(titleSource))
 	author := getFirstAuthorName(book)
-	series, number := getFirstSeries(book)
+	series, number, numberEnd := getFirstSeries(book)
 	narrator := getFirstNarratorName(file)
 	ext := file.FileType
 
@@ -65,7 +64,7 @@ func FormatDownloadFilename(book *models.Book, file *models.File) string {
 	if series != "" && !titleHasVolume {
 		seriesPart := sanitizeFilename(series)
 		if number != nil {
-			seriesPart += " #" + formatSeriesNumber(*number)
+			seriesPart += " #" + seriesnum.FormatRange(*number, numberEnd)
 		}
 		parts = append(parts, seriesPart)
 		parts = append(parts, "-")
@@ -126,11 +125,11 @@ func getFirstNarratorName(file *models.File) string {
 	return ""
 }
 
-// getFirstSeries returns the name and number of the first series by sort order.
-// Returns empty string and nil if no series.
-func getFirstSeries(book *models.Book) (string, *float64) {
+// getFirstSeries returns the name and number range of the first series by sort order.
+// Returns an empty name and nil numbers if there is no series.
+func getFirstSeries(book *models.Book) (string, *float64, *float64) {
 	if len(book.BookSeries) == 0 {
-		return "", nil
+		return "", nil, nil
 	}
 
 	// Sort series by SortOrder
@@ -142,19 +141,16 @@ func getFirstSeries(book *models.Book) (string, *float64) {
 
 	first := series[0]
 	if first.Series != nil {
-		return first.Series.Name, first.SeriesNumber
+		return first.Series.Name, first.SeriesNumber, first.SeriesNumberEnd
 	}
-	return "", nil
+	return "", nil, nil
 }
 
 // formatSeriesNumber formats a series number for display.
 // Whole numbers are displayed without decimal (e.g., "1").
 // Non-whole numbers keep their decimal (e.g., "1.5").
 func formatSeriesNumber(n float64) string {
-	if n == math.Floor(n) {
-		return strconv.Itoa(int(n))
-	}
-	return fmt.Sprintf("%g", n)
+	return seriesnum.FormatRange(n, nil)
 }
 
 // sanitizeFilename removes or replaces characters that are not valid in filenames.
@@ -217,7 +213,7 @@ func FormatKepubDownloadFilename(book *models.Book, file *models.File) string {
 	// Pad volume numbers for lexicographic sorting, then sanitize for Kobo
 	title := sanitizeKoboFilename(padVolumeNumber(titleSource))
 	author := sanitizeKoboFilename(getFirstAuthorName(book))
-	series, number := getFirstSeries(book)
+	series, number, numberEnd := getFirstSeries(book)
 
 	var parts []string
 
@@ -233,7 +229,7 @@ func FormatKepubDownloadFilename(book *models.Book, file *models.File) string {
 	if series != "" && !titleHasVolume {
 		seriesPart := sanitizeKoboFilename(series)
 		if number != nil {
-			seriesPart += " " + formatSeriesNumber(*number)
+			seriesPart += " " + seriesnum.FormatRange(*number, numberEnd)
 		}
 		parts = append(parts, seriesPart)
 		parts = append(parts, "-")

--- a/pkg/downloadcache/filename.go
+++ b/pkg/downloadcache/filename.go
@@ -59,9 +59,10 @@ func FormatDownloadFilename(book *models.Book, file *models.File) string {
 		parts = append(parts, fmt.Sprintf("[%s]", sanitizeFilename(author)))
 	}
 
-	// Add series and number if available, unless title already has a volume number
+	// A title volume marker suppresses a redundant single position, but an
+	// omnibus still needs its complete range represented in the filename.
 	titleHasVolume := volumePattern.MatchString(titleSource)
-	if series != "" && !titleHasVolume {
+	if series != "" && (!titleHasVolume || numberEnd != nil) {
 		seriesPart := sanitizeFilename(series)
 		if number != nil {
 			seriesPart += " #" + seriesnum.FormatRange(*number, numberEnd)
@@ -223,10 +224,11 @@ func FormatKepubDownloadFilename(book *models.Book, file *models.File) string {
 		parts = append(parts, "-")
 	}
 
-	// Add series and number if available, unless title already has a volume number
-	// Use plain number format instead of # (Kobo doesn't like #)
+	// A title volume marker suppresses a redundant single position, but an
+	// omnibus still needs its complete range represented in the filename.
+	// Use plain number format instead of # (Kobo doesn't like #).
 	titleHasVolume := volumePattern.MatchString(titleSource)
-	if series != "" && !titleHasVolume {
+	if series != "" && (!titleHasVolume || numberEnd != nil) {
 		seriesPart := sanitizeKoboFilename(series)
 		if number != nil {
 			seriesPart += " " + seriesnum.FormatRange(*number, numberEnd)

--- a/pkg/downloadcache/filename_test.go
+++ b/pkg/downloadcache/filename_test.go
@@ -93,6 +93,17 @@ func TestFormatDownloadFilename(t *testing.T) {
 			expected: "[Author] Series #1.5 - Interlude.epub",
 		},
 		{
+			name: "omnibus series range",
+			book: &models.Book{
+				Title: "Collected Stories",
+				BookSeries: []*models.BookSeries{
+					{SortOrder: 0, SeriesNumber: pointerutil.Float64(1), SeriesNumberEnd: pointerutil.Float64(3), Series: &models.Series{Name: "Series"}},
+				},
+			},
+			file:     &models.File{FileType: "epub"},
+			expected: "Series #1-3 - Collected Stories.epub",
+		},
+		{
 			name: "multiple authors - picks first by sort order",
 			book: &models.Book{
 				Title: "Collaboration",

--- a/pkg/downloadcache/filename_test.go
+++ b/pkg/downloadcache/filename_test.go
@@ -104,6 +104,17 @@ func TestFormatDownloadFilename(t *testing.T) {
 			expected: "Series #1-3 - Collected Stories.epub",
 		},
 		{
+			name: "omnibus range remains visible when title has a volume marker",
+			book: &models.Book{
+				Title: "Series v1",
+				BookSeries: []*models.BookSeries{
+					{SortOrder: 0, SeriesNumber: pointerutil.Float64(1), SeriesNumberEnd: pointerutil.Float64(3), Series: &models.Series{Name: "Series"}},
+				},
+			},
+			file:     &models.File{FileType: "epub"},
+			expected: "Series #1-3 - Series v001.epub",
+		},
+		{
 			name: "multiple authors - picks first by sort order",
 			book: &models.Book{
 				Title: "Collaboration",
@@ -606,6 +617,20 @@ func TestFormatKepubDownloadFilename(t *testing.T) {
 			},
 			file:     &models.File{FileType: "cbz"},
 			expected: "Author - My Manga v001.kepub.epub",
+		},
+		{
+			name: "omnibus range remains visible when title has a volume marker",
+			book: &models.Book{
+				Title: "My Manga v1",
+				Authors: []*models.Author{
+					{SortOrder: 0, Person: &models.Person{Name: "Author"}},
+				},
+				BookSeries: []*models.BookSeries{
+					{SortOrder: 0, SeriesNumber: pointerutil.Float64(1), SeriesNumberEnd: pointerutil.Float64(3), Series: &models.Series{Name: "My Manga"}},
+				},
+			},
+			file:     &models.File{FileType: "cbz"},
+			expected: "Author - My Manga 1-3 - My Manga v001.kepub.epub",
 		},
 		{
 			name: "real world case that was breaking",

--- a/pkg/downloadcache/fingerprint.go
+++ b/pkg/downloadcache/fingerprint.go
@@ -76,6 +76,7 @@ type FingerprintNarrator struct {
 type FingerprintSeries struct {
 	Name      string   `json:"name"`
 	Number    *float64 `json:"number,omitempty"`
+	NumberEnd *float64 `json:"number_end,omitempty"`
 	SortOrder int      `json:"sort_order"`
 }
 
@@ -272,6 +273,7 @@ func ComputeFingerprint(book *models.Book, file *models.File) (*Fingerprint, err
 				fp.Series = append(fp.Series, FingerprintSeries{
 					Name:      s.Series.Name,
 					Number:    s.SeriesNumber,
+					NumberEnd: s.SeriesNumberEnd,
 					SortOrder: s.SortOrder,
 				})
 			}

--- a/pkg/downloadcache/fingerprint_test.go
+++ b/pkg/downloadcache/fingerprint_test.go
@@ -398,6 +398,24 @@ func TestFingerprintHash(t *testing.T) {
 		assert.NotEqual(t, hash1, hash2)
 	})
 
+	t.Run("different series number end produces different hash", func(t *testing.T) {
+		fp1 := &Fingerprint{
+			Title:  "Test",
+			Series: []FingerprintSeries{{Name: "Series", Number: pointerutil.Float64(1), NumberEnd: pointerutil.Float64(3), SortOrder: 0}},
+		}
+		fp2 := &Fingerprint{
+			Title:  "Test",
+			Series: []FingerprintSeries{{Name: "Series", Number: pointerutil.Float64(1), NumberEnd: pointerutil.Float64(4), SortOrder: 0}},
+		}
+
+		hash1, err1 := fp1.Hash()
+		hash2, err2 := fp2.Hash()
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		assert.NotEqual(t, hash1, hash2)
+	})
+
 	t.Run("different narrators produce different hash", func(t *testing.T) {
 		fp1 := &Fingerprint{
 			Title:     "Test",

--- a/pkg/downloadcache/fingerprint_test.go
+++ b/pkg/downloadcache/fingerprint_test.go
@@ -278,6 +278,32 @@ func TestComputeFingerprint(t *testing.T) {
 	})
 }
 
+func TestComputeFingerprint_SeriesRangeEndChangesHash(t *testing.T) {
+	t.Parallel()
+
+	book := &models.Book{
+		Title: "Collected Stories",
+		BookSeries: []*models.BookSeries{{
+			Series:          &models.Series{Name: "Saga"},
+			SeriesNumber:    pointerutil.Float64(1),
+			SeriesNumberEnd: pointerutil.Float64(3),
+		}},
+	}
+	file := &models.File{}
+	first, err := ComputeFingerprint(book, file)
+	require.NoError(t, err)
+	firstHash, err := first.Hash()
+	require.NoError(t, err)
+
+	book.BookSeries[0].SeriesNumberEnd = pointerutil.Float64(4)
+	second, err := ComputeFingerprint(book, file)
+	require.NoError(t, err)
+	secondHash, err := second.Hash()
+	require.NoError(t, err)
+
+	assert.NotEqual(t, firstHash, secondHash)
+}
+
 func TestFingerprintHash(t *testing.T) {
 	t.Parallel()
 	t.Run("same fingerprint produces same hash", func(t *testing.T) {

--- a/pkg/kobo/handlers_test.go
+++ b/pkg/kobo/handlers_test.go
@@ -191,6 +191,7 @@ func TestBuildBookMetadata_WithRelations(t *testing.T) {
 	personName := "Test Author"
 	description := "A test description"
 	seriesNumber := 3.0
+	seriesNumberEnd := 5.0
 
 	book := &models.Book{
 		ID:          1,
@@ -201,8 +202,9 @@ func TestBuildBookMetadata_WithRelations(t *testing.T) {
 		},
 		BookSeries: []*models.BookSeries{
 			{
-				Series:       &models.Series{Name: "Test Series"},
-				SeriesNumber: &seriesNumber,
+				Series:          &models.Series{Name: "Test Series"},
+				SeriesNumber:    &seriesNumber,
+				SeriesNumberEnd: &seriesNumberEnd,
 			},
 		},
 	}
@@ -218,5 +220,5 @@ func TestBuildBookMetadata_WithRelations(t *testing.T) {
 	assert.Equal(t, personName, metadata.ContributorRoles[0].Name)
 	assert.NotNil(t, metadata.Series)
 	assert.Equal(t, "Test Series", metadata.Series.Name)
-	assert.InDelta(t, 3.0, metadata.Series.Number, 0.001)
+	assert.InDelta(t, 3.0, metadata.Series.Number, 0.001, "Kobo numeric metadata uses the range start only")
 }

--- a/pkg/kobo/handlers_test.go
+++ b/pkg/kobo/handlers_test.go
@@ -221,4 +221,5 @@ func TestBuildBookMetadata_WithRelations(t *testing.T) {
 	assert.NotNil(t, metadata.Series)
 	assert.Equal(t, "Test Series", metadata.Series.Name)
 	assert.InDelta(t, 3.0, metadata.Series.Number, 0.001, "Kobo numeric metadata uses the range start only")
+	assert.InDelta(t, 3.0, metadata.Series.NumberFloat, 0.001, "Kobo floating-point metadata uses the range start only")
 }

--- a/pkg/mediafile/mediafile.go
+++ b/pkg/mediafile/mediafile.go
@@ -31,12 +31,13 @@ type ParsedChapter struct {
 }
 
 type ParsedMetadata struct {
-	Title        string         `json:"title"`
-	Subtitle     string         `json:"subtitle"` // from M4B freeform SUBTITLE atom
-	Authors      []ParsedAuthor `json:"authors"`
-	Narrators    []string       `json:"narrators"`
-	Series       string         `json:"series"`
-	SeriesNumber *float64       `json:"series_number,omitempty"`
+	Title           string         `json:"title"`
+	Subtitle        string         `json:"subtitle"` // from M4B freeform SUBTITLE atom
+	Authors         []ParsedAuthor `json:"authors"`
+	Narrators       []string       `json:"narrators"`
+	Series          string         `json:"series"`
+	SeriesNumber    *float64       `json:"series_number,omitempty"`
+	SeriesNumberEnd *float64       `json:"series_number_end,omitempty"`
 	// SeriesNumberUnit indicates whether SeriesNumber refers to a volume or a
 	// chapter. CBZ-only — null for other formats. Valid values: "volume", "chapter".
 	SeriesNumberUnit *string    `json:"series_number_unit,omitempty" tstype:"SeriesNumberUnit"`

--- a/pkg/migrations/20260721000000_add_series_number_end.go
+++ b/pkg/migrations/20260721000000_add_series_number_end.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	up := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE book_series ADD COLUMN series_number_end REAL`)
+		return errors.WithStack(err)
+	}
+
+	down := func(_ context.Context, db *bun.DB) error {
+		_, err := db.Exec(`ALTER TABLE book_series DROP COLUMN series_number_end`)
+		return errors.WithStack(err)
+	}
+
+	Migrations.MustRegister(up, down)
+}

--- a/pkg/models/series.go
+++ b/pkg/models/series.go
@@ -40,6 +40,7 @@ type BookSeries struct {
 	SeriesID         int      `bun:",nullzero" json:"series_id"`
 	Series           *Series  `bun:"rel:belongs-to,join:series_id=id" json:"series,omitempty" tstype:"Series"`
 	SeriesNumber     *float64 `json:"series_number,omitempty"`
+	SeriesNumberEnd  *float64 `json:"series_number_end,omitempty"`
 	SeriesNumberUnit *string  `json:"series_number_unit,omitempty" tstype:"SeriesNumberUnit"`
 	SortOrder        int      `bun:",nullzero" json:"sort_order"`
 }

--- a/pkg/opds/service.go
+++ b/pkg/opds/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/shishobooks/shisho/pkg/people"
 	"github.com/shishobooks/shisho/pkg/series"
+	"github.com/shishobooks/shisho/pkg/seriesnum"
 	"github.com/shishobooks/shisho/pkg/sortspec"
 	"github.com/uptrace/bun"
 )
@@ -724,7 +725,7 @@ func (svc *Service) bookToEntryWithKepub(baseURL string, book *models.Book, cove
 		for _, bs := range book.BookSeries {
 			if bs.Series != nil {
 				if bs.SeriesNumber != nil {
-					seriesParts = append(seriesParts, fmt.Sprintf("%s #%.0f", bs.Series.Name, *bs.SeriesNumber))
+					seriesParts = append(seriesParts, fmt.Sprintf("%s #%s", bs.Series.Name, seriesnum.FormatRange(*bs.SeriesNumber, bs.SeriesNumberEnd)))
 				} else {
 					seriesParts = append(seriesParts, bs.Series.Name)
 				}

--- a/pkg/opds/service_test.go
+++ b/pkg/opds/service_test.go
@@ -126,6 +126,24 @@ func TestBookToEntry_LanguageAndPublisher(t *testing.T) {
 	}
 }
 
+func TestBookToEntry_SeriesRangeInSummary(t *testing.T) {
+	t.Parallel()
+
+	start, end := 1.0, 3.0
+	book := &models.Book{
+		ID:    1,
+		Title: "Collected Stories",
+		BookSeries: []*models.BookSeries{{
+			Series:          &models.Series{Name: "Saga"},
+			SeriesNumber:    &start,
+			SeriesNumberEnd: &end,
+		}},
+	}
+
+	entry := (&Service{}).bookToEntryWithKepub("http://example.com/opds/v1", book, "", nil, false)
+	assert.Equal(t, "Saga #1-3", entry.Summary)
+}
+
 // TestBookToEntry_CoverLinkUsesOPDSPath verifies that the cover image link
 // in an OPDS entry stays inside the /opds/v1 path. The cover endpoint must
 // live under the OPDS group so it can authenticate via Basic Auth and so

--- a/pkg/series/handlers_books_test.go
+++ b/pkg/series/handlers_books_test.go
@@ -124,21 +124,28 @@ func TestSeriesBooks_DefaultPagination(t *testing.T) {
 	assert.Equal(t, "Book 01", resp.Items[0].Title, "books must be ordered by series number")
 }
 
-func TestSeriesBooks_OmnibusesSortAfterSinglesAndByEndpoint(t *testing.T) {
+func TestSeriesBooks_OmnibusOrderingMatrix(t *testing.T) {
 	t.Parallel()
 	db := setupSeriesTestDB(t)
 	ctx := context.Background()
-	seriesID := seedSeriesWithBooks(t, db, []string{"Single One", "Omnibus Long", "Single Two", "Omnibus Short"})
+	titles := []string{
+		"Single One Beta", "Omnibus Long", "Single Two", "Omnibus Short",
+		"Fractional Prequel", "Unnumbered", "Single One Alpha",
+	}
+	seriesID := seedSeriesWithBooks(t, db, titles)
 
 	updates := []struct {
 		title string
-		start float64
+		start *float64
 		end   *float64
 	}{
-		{title: "Single One", start: 1},
-		{title: "Omnibus Long", start: 1, end: float64Pointer(4)},
-		{title: "Single Two", start: 2},
-		{title: "Omnibus Short", start: 1, end: float64Pointer(3)},
+		{title: "Single One Beta", start: float64Pointer(1)},
+		{title: "Omnibus Long", start: float64Pointer(1), end: float64Pointer(4)},
+		{title: "Single Two", start: float64Pointer(2)},
+		{title: "Omnibus Short", start: float64Pointer(1), end: float64Pointer(3)},
+		{title: "Fractional Prequel", start: float64Pointer(0.5)},
+		{title: "Unnumbered"},
+		{title: "Single One Alpha", start: float64Pointer(1)},
 	}
 	for _, update := range updates {
 		_, err := db.NewUpdate().
@@ -158,10 +165,15 @@ func TestSeriesBooks_OmnibusesSortAfterSinglesAndByEndpoint(t *testing.T) {
 		Items []models.Book `json:"items"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Len(t, resp.Items, 4)
-	assert.Equal(t, []string{"Single One", "Single Two", "Omnibus Short", "Omnibus Long"}, []string{
-		resp.Items[0].Title, resp.Items[1].Title, resp.Items[2].Title, resp.Items[3].Title,
-	})
+	require.Len(t, resp.Items, len(titles))
+	got := make([]string, len(resp.Items))
+	for i := range resp.Items {
+		got[i] = resp.Items[i].Title
+	}
+	assert.Equal(t, []string{
+		"Unnumbered", "Fractional Prequel", "Single One Alpha", "Single One Beta",
+		"Single Two", "Omnibus Short", "Omnibus Long",
+	}, got)
 }
 
 func float64Pointer(value float64) *float64 { return &value }

--- a/pkg/series/handlers_books_test.go
+++ b/pkg/series/handlers_books_test.go
@@ -124,6 +124,48 @@ func TestSeriesBooks_DefaultPagination(t *testing.T) {
 	assert.Equal(t, "Book 01", resp.Items[0].Title, "books must be ordered by series number")
 }
 
+func TestSeriesBooks_OmnibusesSortAfterSinglesAndByEndpoint(t *testing.T) {
+	t.Parallel()
+	db := setupSeriesTestDB(t)
+	ctx := context.Background()
+	seriesID := seedSeriesWithBooks(t, db, []string{"Single One", "Omnibus Long", "Single Two", "Omnibus Short"})
+
+	updates := []struct {
+		title string
+		start float64
+		end   *float64
+	}{
+		{title: "Single One", start: 1},
+		{title: "Omnibus Long", start: 1, end: float64Pointer(4)},
+		{title: "Single Two", start: 2},
+		{title: "Omnibus Short", start: 1, end: float64Pointer(3)},
+	}
+	for _, update := range updates {
+		_, err := db.NewUpdate().
+			Table("book_series").
+			Set("series_number = ?", update.start).
+			Set("series_number_end = ?", update.end).
+			Where("book_id = (SELECT id FROM books WHERE title = ?)", update.title).
+			Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	h := newSeriesHandler(db)
+	rec := getSeriesBooks(t, h, seriesID, "")
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp struct {
+		Items []models.Book `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Items, 4)
+	assert.Equal(t, []string{"Single One", "Single Two", "Omnibus Short", "Omnibus Long"}, []string{
+		resp.Items[0].Title, resp.Items[1].Title, resp.Items[2].Title, resp.Items[3].Title,
+	})
+}
+
+func float64Pointer(value float64) *float64 { return &value }
+
 func TestSeriesBooks_ExplicitLimitOffset(t *testing.T) {
 	t.Parallel()
 	db := setupSeriesTestDB(t)

--- a/pkg/seriesnum/seriesnum.go
+++ b/pkg/seriesnum/seriesnum.go
@@ -1,0 +1,52 @@
+// Package seriesnum parses and formats single series numbers and contiguous ranges.
+package seriesnum
+
+import (
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var rangePattern = regexp.MustCompile(`^([+-]?(?:\d+(?:\.\d*)?|\.\d+))(?:\s*[-–—]\s*([+-]?(?:\d+(?:\.\d*)?|\.\d+)))?$`)
+
+// ParseRange parses a single series number or a strictly increasing contiguous
+// range separated by a hyphen, en dash, or em dash.
+func ParseRange(s string) (start float64, end *float64, ok bool) {
+	matches := rangePattern.FindStringSubmatch(strings.TrimSpace(s))
+	if matches == nil {
+		return 0, nil, false
+	}
+
+	start, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil || !isFinite(start) {
+		return 0, nil, false
+	}
+	if matches[2] == "" {
+		return start, nil, true
+	}
+
+	endValue, err := strconv.ParseFloat(matches[2], 64)
+	if err != nil || !isFinite(endValue) || endValue <= start {
+		return 0, nil, false
+	}
+	return start, &endValue, true
+}
+
+// FormatRange formats whole endpoints as integers and other endpoints as
+// decimals, joining a range with a hyphen.
+func FormatRange(start float64, end *float64) string {
+	formatted := formatNumber(start)
+	if end != nil {
+		formatted += "-" + formatNumber(*end)
+	}
+	return formatted
+}
+
+func formatNumber(value float64) string {
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}
+
+func isFinite(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}

--- a/pkg/seriesnum/seriesnum_test.go
+++ b/pkg/seriesnum/seriesnum_test.go
@@ -1,0 +1,93 @@
+package seriesnum
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		wantStart float64
+		wantEnd   *float64
+		wantOK    bool
+	}{
+		{name: "integer", input: "1", wantStart: 1, wantOK: true},
+		{name: "decimal", input: "1.5", wantStart: 1.5, wantOK: true},
+		{name: "hyphen", input: "1-3", wantStart: 1, wantEnd: float64Ptr(3), wantOK: true},
+		{name: "hyphen spaces", input: "1 - 3", wantStart: 1, wantEnd: float64Ptr(3), wantOK: true},
+		{name: "en dash", input: "1–3", wantStart: 1, wantEnd: float64Ptr(3), wantOK: true},
+		{name: "em dash spaces", input: "1 — 3", wantStart: 1, wantEnd: float64Ptr(3), wantOK: true},
+		{name: "decimal range", input: "1.5-2.5", wantStart: 1.5, wantEnd: float64Ptr(2.5), wantOK: true},
+		{name: "surrounding spaces", input: " 1-3 ", wantStart: 1, wantEnd: float64Ptr(3), wantOK: true},
+		{name: "non contiguous", input: "1,2,3", wantOK: false},
+		{name: "equal", input: "1-1", wantOK: false},
+		{name: "reversed", input: "3-1", wantOK: false},
+		{name: "missing end", input: "1-", wantOK: false},
+		{name: "infinity", input: "Inf", wantOK: false},
+		{name: "range infinity", input: "1-Inf", wantOK: false},
+		{name: "nan", input: "NaN", wantOK: false},
+		{name: "empty", input: "", wantOK: false},
+		{name: "text", input: "first", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			start, end, ok := ParseRange(tt.input)
+			assert.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				return
+			}
+			assert.InDelta(t, tt.wantStart, start, 0.000001)
+			if tt.wantEnd == nil {
+				assert.Nil(t, end)
+			} else {
+				require.NotNil(t, end)
+				assert.InDelta(t, *tt.wantEnd, *end, 0.000001)
+			}
+		})
+	}
+}
+
+func TestFormatRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		start float64
+		end   *float64
+		want  string
+	}{
+		{name: "integer", start: 1, want: "1"},
+		{name: "decimal", start: 1.5, want: "1.5"},
+		{name: "integer range", start: 1, end: float64Ptr(3), want: "1-3"},
+		{name: "decimal range", start: 1.25, end: float64Ptr(3.5), want: "1.25-3.5"},
+		{name: "large exact integer", start: 1000, end: float64Ptr(1002), want: "1000-1002"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, FormatRange(tt.start, tt.end))
+		})
+	}
+}
+
+func TestParseRangeRejectsNonFiniteNumericValues(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		assert.False(t, isFinite(value))
+	}
+}
+
+func float64Ptr(v float64) *float64 { return &v }

--- a/pkg/sidecar/sidecar.go
+++ b/pkg/sidecar/sidecar.go
@@ -237,6 +237,7 @@ func BookSidecarFromModel(book *models.Book) *BookSidecar {
 				Name:      bs.Series.Name,
 				SortName:  bs.Series.SortName,
 				Number:    bs.SeriesNumber,
+				NumberEnd: bs.SeriesNumberEnd,
 				Unit:      bs.SeriesNumberUnit,
 				SortOrder: bs.SortOrder,
 			})

--- a/pkg/sidecar/sidecar_test.go
+++ b/pkg/sidecar/sidecar_test.go
@@ -617,23 +617,46 @@ func floatPtr(f float64) *float64 {
 	return &f
 }
 
-func TestSeriesMetadataUnitRoundTrip(t *testing.T) {
+func TestSeriesMetadataNumberGroupRoundTrip(t *testing.T) {
 	t.Parallel()
 	chapterUnit := "chapter"
 	original := SeriesMetadata{
-		Name:   "One Piece",
-		Number: floatPtr(42),
-		Unit:   &chapterUnit,
+		Name:      "One Piece",
+		Number:    floatPtr(42),
+		NumberEnd: floatPtr(45),
+		Unit:      &chapterUnit,
 	}
 
 	data, err := json.Marshal(original)
 	require.NoError(t, err)
+	assert.Contains(t, string(data), `"number_end":45`)
 	assert.Contains(t, string(data), `"unit":"chapter"`)
 
 	var decoded SeriesMetadata
 	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.NotNil(t, decoded.Number)
+	assert.InDelta(t, 42.0, *decoded.Number, 0.001)
+	require.NotNil(t, decoded.NumberEnd)
+	assert.InDelta(t, 45.0, *decoded.NumberEnd, 0.001)
 	require.NotNil(t, decoded.Unit)
 	assert.Equal(t, "chapter", *decoded.Unit)
+}
+
+func TestBookSidecarFromModelPreservesSeriesNumberGroup(t *testing.T) {
+	t.Parallel()
+
+	unit := "volume"
+	book := &models.Book{BookSeries: []*models.BookSeries{{
+		Series:           &models.Series{Name: "Saga"},
+		SeriesNumber:     floatPtr(1),
+		SeriesNumberEnd:  floatPtr(3),
+		SeriesNumberUnit: &unit,
+	}}}
+
+	got := BookSidecarFromModel(book)
+	require.Len(t, got.Series, 1)
+	require.NotNil(t, got.Series[0].NumberEnd)
+	assert.InDelta(t, 3.0, *got.Series[0].NumberEnd, 0.001)
 }
 
 // =============================================================================

--- a/pkg/sidecar/types.go
+++ b/pkg/sidecar/types.go
@@ -60,6 +60,7 @@ type SeriesMetadata struct {
 	Name      string   `json:"name"`
 	SortName  string   `json:"sort_name,omitempty"`
 	Number    *float64 `json:"number,omitempty"`
+	NumberEnd *float64 `json:"number_end,omitempty"`
 	Unit      *string  `json:"unit,omitempty"` // models.SeriesNumberUnitVolume or models.SeriesNumberUnitChapter; CBZ only
 	SortOrder int      `json:"sort_order,omitempty"`
 }

--- a/pkg/sortspec/sql.go
+++ b/pkg/sortspec/sql.go
@@ -9,8 +9,8 @@ import (
 // to q.OrderExpr(clause.Expression).
 //
 // Each user-visible sort level produces ONE OrderClause, except the
-// series level which expands to two (series sort name, then series
-// number ASC).
+// series level which expands to four (name, range discriminator, start,
+// and endpoint).
 //
 // Expressions are built from the whitelisted field branches in
 // OrderClauses and never embed user input, so no parameter args are
@@ -30,7 +30,7 @@ func OrderClauses(levels []SortLevel) []OrderClause {
 		return nil
 	}
 
-	out := make([]OrderClause, 0, len(levels)+1) // +1 for the series expansion
+	out := make([]OrderClause, 0, len(levels)+3) // +3 for the series expansion
 	for _, l := range levels {
 		switch l.Field {
 		case FieldTitle:
@@ -49,31 +49,23 @@ func OrderClauses(levels []SortLevel) []OrderClause {
 			out = append(out, nullsLast(expr, l.Direction))
 
 		case FieldSeries:
-			// Primary series sort name, then series number (always ASC
-			// within a series). Books with no series row sort last.
-			//
-			// "Primary" series is picked by bs.sort_order ASC (consistent
-			// with how pkg/books/service.go selects the primary series
-			// elsewhere). bs.series_number is the position *within* a
-			// specific series (e.g., "#3 in Stormlight") and is not
-			// meaningful for choosing which series is primary when a
-			// book belongs to multiple series. The outer-level sort still
-			// uses the primary series's series_number so that books in
-			// the same series sort by their position within it.
+			// Pick one primary membership by sort order, then sort by its
+			// series name and position. Omnibus ranges follow singles in the
+			// same series and use the endpoint as a final numeric tie-breaker.
 			nameExpr := `(SELECT s.sort_name
                           FROM book_series bs
                           JOIN series s ON s.id = bs.series_id
                           WHERE bs.book_id = b.id
                           ORDER BY bs.sort_order ASC, bs.id ASC
                           LIMIT 1)`
-			numExpr := `(SELECT bs.series_number
-                         FROM book_series bs
-                         WHERE bs.book_id = b.id
-                         ORDER BY bs.sort_order ASC, bs.id ASC
-                         LIMIT 1)`
+			rangeExpr := primarySeriesValue(`(bs.series_number_end IS NOT NULL)`)
+			startExpr := primarySeriesValue("bs.series_number")
+			endExpr := primarySeriesValue("COALESCE(bs.series_number_end, bs.series_number)")
 			out = append(out,
 				nullsLast(nameExpr, l.Direction),
-				nullsLast(numExpr, DirAsc),
+				nullsLast(rangeExpr, DirAsc),
+				nullsLast(startExpr, DirAsc),
+				nullsLast(endExpr, DirAsc),
 			)
 
 		case FieldDateAdded:
@@ -90,6 +82,14 @@ func OrderClauses(levels []SortLevel) []OrderClause {
 		}
 	}
 	return out
+}
+
+func primarySeriesValue(valueExpr string) string {
+	return fmt.Sprintf(`(SELECT %s
+                         FROM book_series bs
+                         WHERE bs.book_id = b.id
+                         ORDER BY bs.sort_order ASC, bs.id ASC
+                         LIMIT 1)`, valueExpr)
 }
 
 // nullsLast wraps a column/expression with both the NULLS-LAST

--- a/pkg/sortspec/sql_test.go
+++ b/pkg/sortspec/sql_test.go
@@ -28,31 +28,35 @@ func TestOrderClauses_DescDirection(t *testing.T) {
 	assert.Equal(t, "b.created_at IS NULL, b.created_at DESC", got[0].Expression)
 }
 
-func TestOrderClauses_SeriesExpandsToTwo(t *testing.T) {
+func TestOrderClauses_SeriesIncludesOmnibusOrdering(t *testing.T) {
 	t.Parallel()
 
 	got := OrderClauses([]SortLevel{
 		{Field: FieldSeries, Direction: DirDesc},
 	})
 
-	// Series expands to (series name, then series number). The number
-	// clause is always ASC regardless of the user's chosen direction —
-	// "Stormlight #1 before #2" is not a user preference.
-	assert.Len(t, got, 2)
-	assert.Contains(t, got[0].Expression, "series") // sort name expression
+	// Series expands to name, range discriminator, start, and endpoint.
+	// Position clauses are always ASC regardless of the chosen name direction.
+	assert.Len(t, got, 4)
+	assert.Contains(t, got[0].Expression, "series")
 	assert.Contains(t, got[0].Expression, "DESC")
-	assert.Contains(t, got[1].Expression, "series_number")
+	assert.Contains(t, got[1].Expression, "series_number_end IS NOT NULL")
 	assert.Contains(t, got[1].Expression, "ASC")
+	assert.Contains(t, got[2].Expression, "series_number")
+	assert.Contains(t, got[2].Expression, "ASC")
+	assert.Contains(t, got[3].Expression, "COALESCE")
+	assert.Contains(t, got[3].Expression, "series_number_end")
+	assert.Contains(t, got[3].Expression, "ASC")
 
-	// Both inner subqueries must pick the "primary" series via
+	// Every inner subquery must pick the "primary" series via
 	// bs.sort_order (consistent with pkg/books/service.go), NOT
 	// bs.series_number — series_number is the position within a single
 	// series and is not meaningful for choosing which of multiple series
 	// is primary. Regression guard for the Task 5 review fix.
-	assert.Contains(t, got[0].Expression, "ORDER BY bs.sort_order ASC, bs.id ASC")
-	assert.Contains(t, got[1].Expression, "ORDER BY bs.sort_order ASC, bs.id ASC")
-	assert.NotContains(t, got[0].Expression, "ORDER BY bs.series_number ASC, bs.id ASC")
-	assert.NotContains(t, got[1].Expression, "ORDER BY bs.series_number ASC, bs.id ASC")
+	for _, clause := range got {
+		assert.Contains(t, clause.Expression, "ORDER BY bs.sort_order ASC, bs.id ASC")
+		assert.NotContains(t, clause.Expression, "ORDER BY bs.series_number ASC, bs.id ASC")
+	}
 }
 
 func TestOrderClauses_NewestFileFallback(t *testing.T) {

--- a/pkg/worker/scan_enricher_test.go
+++ b/pkg/worker/scan_enricher_test.go
@@ -2,11 +2,13 @@ package worker
 
 import (
 	"context"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/robinjoseph08/golib/pointerutil"
 	"github.com/shishobooks/shisho/pkg/books/review"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
@@ -286,6 +288,67 @@ func TestMergeEnrichedMetadata_ChaptersFallbackFromFile(t *testing.T) {
 	require.Len(t, enrichedMeta.Chapters, 1)
 	assert.Equal(t, "File Chapter 1", enrichedMeta.Chapters[0].Title)
 	assert.Equal(t, fileSource, enrichedMeta.FieldDataSources["chapters"])
+}
+
+func TestMergeEnrichedMetadata_SeriesNumberGroupIsAtomic(t *testing.T) {
+	t.Parallel()
+
+	volume := models.SeriesNumberUnitVolume
+	chapter := models.SeriesNumberUnitChapter
+	target := &mediafile.ParsedMetadata{
+		SeriesNumber:     pointerutil.Float64(1),
+		SeriesNumberUnit: &volume,
+	}
+	enrichment := &mediafile.ParsedMetadata{
+		SeriesNumber:     pointerutil.Float64(2),
+		SeriesNumberEnd:  pointerutil.Float64(4),
+		SeriesNumberUnit: &chapter,
+	}
+
+	mergeEnrichedMetadata(target, enrichment, "plugin:test/enricher")
+
+	assert.InDelta(t, 1.0, *target.SeriesNumber, 0.001)
+	assert.Nil(t, target.SeriesNumberEnd)
+	assert.Equal(t, volume, *target.SeriesNumberUnit)
+}
+
+func TestMergeEnrichedMetadata_CopiesCompleteSeriesNumberGroup(t *testing.T) {
+	t.Parallel()
+
+	unit := models.SeriesNumberUnitVolume
+	target := &mediafile.ParsedMetadata{}
+	enrichment := &mediafile.ParsedMetadata{
+		SeriesNumber:     pointerutil.Float64(1),
+		SeriesNumberEnd:  pointerutil.Float64(3),
+		SeriesNumberUnit: &unit,
+	}
+
+	mergeEnrichedMetadata(target, enrichment, "plugin:test/enricher")
+
+	require.NotNil(t, target.SeriesNumber)
+	assert.InDelta(t, 1.0, *target.SeriesNumber, 0.001)
+	require.NotNil(t, target.SeriesNumberEnd)
+	assert.InDelta(t, 3.0, *target.SeriesNumberEnd, 0.001)
+	require.NotNil(t, target.SeriesNumberUnit)
+	assert.Equal(t, unit, *target.SeriesNumberUnit)
+}
+
+func TestMergeEnrichedMetadata_DiscardsMalformedSeriesNumberGroup(t *testing.T) {
+	t.Parallel()
+
+	unit := models.SeriesNumberUnitVolume
+	tests := []mediafile.ParsedMetadata{
+		{SeriesNumberEnd: pointerutil.Float64(3), SeriesNumberUnit: &unit},
+		{SeriesNumber: pointerutil.Float64(3), SeriesNumberEnd: pointerutil.Float64(1), SeriesNumberUnit: &unit},
+		{SeriesNumber: pointerutil.Float64(math.Inf(1)), SeriesNumberUnit: &unit},
+	}
+	for _, enrichment := range tests {
+		target := &mediafile.ParsedMetadata{}
+		mergeEnrichedMetadata(target, &enrichment, "plugin:test/enricher")
+		assert.Nil(t, target.SeriesNumber)
+		assert.Nil(t, target.SeriesNumberEnd)
+		assert.Nil(t, target.SeriesNumberUnit)
+	}
 }
 
 // TestMergeEnrichedMetadata_AllFields verifies that all content fields are

--- a/pkg/worker/scan_helpers.go
+++ b/pkg/worker/scan_helpers.go
@@ -197,6 +197,12 @@ func shouldApplySeriesSidecar(incoming []sidecar.SeriesMetadata, existing []*mod
 	if forceRefresh || len(incoming) == 0 {
 		return false
 	}
+	for _, membership := range incoming {
+		groupPresent := membership.Number != nil || membership.NumberEnd != nil || membership.Unit != nil
+		if groupPresent && !validSeriesNumberGroup(membership.Number, membership.NumberEnd, membership.Unit) {
+			return false
+		}
+	}
 	if seriesSidecarMatches(incoming, existing) {
 		return false
 	}
@@ -227,6 +233,17 @@ func equalFloatPointers(a, b *float64) bool {
 
 func equalStringPointers(a, b *string) bool {
 	return a == nil && b == nil || a != nil && b != nil && *a == *b
+}
+
+func applySeriesNumberUnit(metadata *mediafile.ParsedMetadata, unit, source string) {
+	if metadata == nil || unit == "" || metadata.SeriesNumber == nil || metadata.SeriesNumberUnit != nil {
+		return
+	}
+	if metadata.SourceForField("series") != source {
+		return
+	}
+	u := unit
+	metadata.SeriesNumberUnit = &u
 }
 
 // fileIdentifierKeys returns canonical comparison keys for a set of stored

--- a/pkg/worker/scan_helpers.go
+++ b/pkg/worker/scan_helpers.go
@@ -154,6 +154,81 @@ func shouldApplySidecarRelationship(newItems, existingItems []string, existingSo
 	return sidecarPriority < existingPriority
 }
 
+func shouldUpdateParsedSeries(incoming *mediafile.ParsedMetadata, existing []*models.BookSeries, existingSource string, forceRefresh bool) bool {
+	if incoming == nil || incoming.Series == "" {
+		return false
+	}
+	newSource := incoming.SourceForField("series")
+	if len(existing) != 1 || existing[0].Series == nil || existing[0].Series.Name != incoming.Series {
+		existingNames := make([]string, 0, len(existing))
+		for _, membership := range existing {
+			if membership.Series != nil {
+				existingNames = append(existingNames, membership.Series.Name)
+			}
+		}
+		return shouldUpdateRelationship([]string{incoming.Series}, existingNames, newSource, existingSource, forceRefresh)
+	}
+
+	// A partially present or invalid external group must never mutate storage.
+	groupPresent := incoming.SeriesNumber != nil || incoming.SeriesNumberEnd != nil || incoming.SeriesNumberUnit != nil
+	if groupPresent && !validSeriesNumberGroup(incoming.SeriesNumber, incoming.SeriesNumberEnd, incoming.SeriesNumberUnit) {
+		return false
+	}
+	current := existing[0]
+	groupMatches := equalFloatPointers(incoming.SeriesNumber, current.SeriesNumber) &&
+		equalFloatPointers(incoming.SeriesNumberEnd, current.SeriesNumberEnd) &&
+		equalStringPointers(incoming.SeriesNumberUnit, current.SeriesNumberUnit)
+	if groupMatches {
+		return forceRefresh && newSource != existingSource
+	}
+	if !groupPresent {
+		return forceRefresh
+	}
+	if forceRefresh {
+		return true
+	}
+	if existingSource == "" {
+		existingSource = models.DataSourceFilepath
+	}
+	return models.GetDataSourcePriority(newSource) <= models.GetDataSourcePriority(existingSource)
+}
+
+func shouldApplySeriesSidecar(incoming []sidecar.SeriesMetadata, existing []*models.BookSeries, existingSource string, forceRefresh bool) bool {
+	if forceRefresh || len(incoming) == 0 {
+		return false
+	}
+	if seriesSidecarMatches(incoming, existing) {
+		return false
+	}
+	if existingSource == "" {
+		existingSource = models.DataSourceFilepath
+	}
+	return models.GetDataSourcePriority(models.DataSourceSidecar) < models.GetDataSourcePriority(existingSource)
+}
+
+func seriesSidecarMatches(incoming []sidecar.SeriesMetadata, existing []*models.BookSeries) bool {
+	if len(incoming) != len(existing) {
+		return false
+	}
+	for i := range incoming {
+		if existing[i].Series == nil || incoming[i].Name != existing[i].Series.Name ||
+			!equalFloatPointers(incoming[i].Number, existing[i].SeriesNumber) ||
+			!equalFloatPointers(incoming[i].NumberEnd, existing[i].SeriesNumberEnd) ||
+			!equalStringPointers(incoming[i].Unit, existing[i].SeriesNumberUnit) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalFloatPointers(a, b *float64) bool {
+	return a == nil && b == nil || a != nil && b != nil && *a == *b
+}
+
+func equalStringPointers(a, b *string) bool {
+	return a == nil && b == nil || a != nil && b != nil && *a == *b
+}
+
 // fileIdentifierKeys returns canonical comparison keys for a set of stored
 // file identifiers. Centralizing this in one helper (rather than inlining the
 // key construction at each diff site) ensures that both sides of a scan diff

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/sidecar"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -563,6 +564,54 @@ func TestShouldApplySidecarScalar(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldUpdateParsedSeries_NumberGroupUsesSourcePriority(t *testing.T) {
+	t.Parallel()
+
+	existing := []*models.BookSeries{{
+		Series:          &models.Series{Name: "Saga"},
+		SeriesNumber:    seriesFloatPtr(1),
+		SeriesNumberEnd: seriesFloatPtr(3),
+	}}
+	pluginRange := &mediafile.ParsedMetadata{
+		Series: "Saga", SeriesNumber: seriesFloatPtr(2), SeriesNumberEnd: seriesFloatPtr(4),
+		DataSource: models.DataSourcePlugin,
+	}
+	fileSingle := &mediafile.ParsedMetadata{
+		Series: "Saga", SeriesNumber: seriesFloatPtr(1), DataSource: models.DataSourceFileMetadata,
+	}
+	malformed := &mediafile.ParsedMetadata{
+		Series: "Saga", SeriesNumber: seriesFloatPtr(4), SeriesNumberEnd: seriesFloatPtr(2),
+		DataSource: models.DataSourcePlugin,
+	}
+
+	assert.True(t, shouldUpdateParsedSeries(pluginRange, existing, models.DataSourceFileMetadata, false))
+	assert.False(t, shouldUpdateParsedSeries(fileSingle, existing, models.DataSourceManual, false))
+	assert.False(t, shouldUpdateParsedSeries(malformed, existing, models.DataSourceFileMetadata, true))
+}
+
+func TestShouldApplySeriesSidecar_NumberGroupChanges(t *testing.T) {
+	t.Parallel()
+
+	unit := models.SeriesNumberUnitVolume
+	existing := []*models.BookSeries{{
+		Series:           &models.Series{Name: "Saga"},
+		SeriesNumber:     seriesFloatPtr(1),
+		SeriesNumberUnit: &unit,
+	}}
+	incoming := []sidecar.SeriesMetadata{{
+		Name:      "Saga",
+		Number:    seriesFloatPtr(1),
+		NumberEnd: seriesFloatPtr(3),
+		Unit:      &unit,
+	}}
+
+	assert.True(t, shouldApplySeriesSidecar(incoming, existing, models.DataSourceFileMetadata, false))
+	assert.False(t, shouldApplySeriesSidecar(incoming, existing, models.DataSourceManual, false))
+	assert.False(t, shouldApplySeriesSidecar(incoming, existing, models.DataSourceFileMetadata, true))
+}
+
+func seriesFloatPtr(value float64) *float64 { return &value }
 
 func TestShouldApplySidecarRelationship(t *testing.T) {
 	t.Parallel()

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -611,6 +611,39 @@ func TestShouldApplySeriesSidecar_NumberGroupChanges(t *testing.T) {
 	assert.False(t, shouldApplySeriesSidecar(incoming, existing, models.DataSourceFileMetadata, true))
 }
 
+func TestShouldApplySeriesSidecar_RejectsMalformedNumberGroup(t *testing.T) {
+	t.Parallel()
+
+	existing := []*models.BookSeries{{
+		Series:          &models.Series{Name: "Saga"},
+		SeriesNumber:    seriesFloatPtr(1),
+		SeriesNumberEnd: seriesFloatPtr(3),
+	}}
+	incoming := []sidecar.SeriesMetadata{{
+		Name:      "Saga",
+		Number:    seriesFloatPtr(4),
+		NumberEnd: seriesFloatPtr(2),
+	}}
+
+	assert.False(t, shouldApplySeriesSidecar(incoming, existing, models.DataSourceFileMetadata, false))
+}
+
+func TestApplySeriesNumberUnit_RequiresMatchingSource(t *testing.T) {
+	t.Parallel()
+
+	metadata := &mediafile.ParsedMetadata{
+		SeriesNumber: seriesFloatPtr(1),
+		DataSource:   models.DataSourcePlugin,
+	}
+
+	applySeriesNumberUnit(metadata, models.SeriesNumberUnitVolume, models.DataSourceFilepath)
+	assert.Nil(t, metadata.SeriesNumberUnit)
+
+	applySeriesNumberUnit(metadata, models.SeriesNumberUnitVolume, models.DataSourcePlugin)
+	require.NotNil(t, metadata.SeriesNumberUnit)
+	assert.Equal(t, models.SeriesNumberUnitVolume, *metadata.SeriesNumberUnit)
+}
+
 func seriesFloatPtr(value float64) *float64 { return &value }
 
 func TestShouldApplySidecarRelationship(t *testing.T) {

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -1086,21 +1087,15 @@ func (w *Worker) scanFileCore(
 
 		// Update series relationship (from metadata)
 		if metadata.Series != "" {
-			newSeriesNames := []string{metadata.Series}
-			existingSeriesNames := make([]string, 0, len(book.BookSeries))
 			existingSeriesSource := ""
 			for _, bs := range book.BookSeries {
-				if bs.Series != nil {
-					existingSeriesNames = append(existingSeriesNames, bs.Series.Name)
-					// Use the first series's name source for comparison
-					if existingSeriesSource == "" {
-						existingSeriesSource = bs.Series.NameSource
-					}
+				if bs.Series != nil && existingSeriesSource == "" {
+					existingSeriesSource = bs.Series.NameSource
 				}
 			}
 
 			seriesSource := metadata.SourceForField("series")
-			if shouldUpdateRelationship(newSeriesNames, existingSeriesNames, seriesSource, existingSeriesSource, forceRefresh) {
+			if shouldUpdateParsedSeries(metadata, book.BookSeries, existingSeriesSource, forceRefresh) {
 				logInfo("updating series", logger.Data{"new_count": 1, "old_count": len(book.BookSeries)})
 
 				// Collect series for batch insert (replaces immediate delete + create)
@@ -1116,11 +1111,15 @@ func (w *Worker) scanFileCore(
 				if err != nil {
 					logWarn("failed to find/create series", logger.Data{"name": metadata.Series, "error": err.Error()})
 				} else {
+					seriesNumber, seriesNumberEnd, seriesNumberUnit := externalSeriesNumberGroup(
+						metadata.SeriesNumber, metadata.SeriesNumberEnd, metadata.SeriesNumberUnit,
+					)
 					relUpdates.BookSeries = append(relUpdates.BookSeries, &models.BookSeries{
 						BookID:           book.ID,
 						SeriesID:         seriesRecord.ID,
-						SeriesNumber:     metadata.SeriesNumber,
-						SeriesNumberUnit: metadata.SeriesNumberUnit,
+						SeriesNumber:     seriesNumber,
+						SeriesNumberEnd:  seriesNumberEnd,
+						SeriesNumberUnit: seriesNumberUnit,
 						SortOrder:        1,
 					})
 				}
@@ -1134,18 +1133,14 @@ func (w *Worker) scanFileCore(
 					sidecarSeriesNames = append(sidecarSeriesNames, s.Name)
 				}
 			}
-			existingSeriesNames := make([]string, 0, len(book.BookSeries))
 			existingSeriesSource := ""
 			for _, bs := range book.BookSeries {
-				if bs.Series != nil {
-					existingSeriesNames = append(existingSeriesNames, bs.Series.Name)
-					if existingSeriesSource == "" {
-						existingSeriesSource = bs.Series.NameSource
-					}
+				if bs.Series != nil && existingSeriesSource == "" {
+					existingSeriesSource = bs.Series.NameSource
 				}
 			}
 
-			if len(sidecarSeriesNames) > 0 && shouldApplySidecarRelationship(sidecarSeriesNames, existingSeriesNames, existingSeriesSource, forceRefresh) {
+			if len(sidecarSeriesNames) > 0 && shouldApplySeriesSidecar(bookSidecarData.Series, book.BookSeries, existingSeriesSource, forceRefresh) {
 				logInfo("updating series from sidecar", logger.Data{"new_count": len(bookSidecarData.Series), "old_count": len(book.BookSeries)})
 
 				// Collect series for batch insert (replaces any metadata collection)
@@ -1166,11 +1161,15 @@ func (w *Worker) scanFileCore(
 						logWarn("failed to find/create series", logger.Data{"name": sidecarSeries.Name, "error": err.Error()})
 						continue
 					}
+					seriesNumber, seriesNumberEnd, seriesNumberUnit := externalSeriesNumberGroup(
+						sidecarSeries.Number, sidecarSeries.NumberEnd, sidecarSeries.Unit,
+					)
 					relUpdates.BookSeries = append(relUpdates.BookSeries, &models.BookSeries{
 						BookID:           book.ID,
 						SeriesID:         seriesRecord.ID,
-						SeriesNumber:     sidecarSeries.Number,
-						SeriesNumberUnit: sidecarSeries.Unit,
+						SeriesNumber:     seriesNumber,
+						SeriesNumberEnd:  seriesNumberEnd,
+						SeriesNumberUnit: seriesNumberUnit,
 						SortOrder:        i + 1,
 					})
 				}
@@ -3372,6 +3371,23 @@ func mergeFileParserFallback(target, fileParsed *mediafile.ParsedMetadata, fileT
 	}
 }
 
+func externalSeriesNumberGroup(start, end *float64, unit *string) (*float64, *float64, *string) {
+	if !validSeriesNumberGroup(start, end, unit) {
+		return nil, nil, nil
+	}
+	return start, end, unit
+}
+
+func validSeriesNumberGroup(start, end *float64, unit *string) bool {
+	if start == nil || math.IsNaN(*start) || math.IsInf(*start, 0) {
+		return false
+	}
+	if end != nil && (math.IsNaN(*end) || math.IsInf(*end, 0) || *end <= *start) {
+		return false
+	}
+	return unit == nil || *unit == models.SeriesNumberUnitVolume || *unit == models.SeriesNumberUnitChapter
+}
+
 // mergeEnrichedMetadata applies fields from enrichment result to the target
 // only if the target field is currently empty/zero. Tracks which source
 // provided each field in target.FieldDataSources.
@@ -3399,13 +3415,17 @@ func mergeEnrichedMetadata(target, enrichment *mediafile.ParsedMetadata, source 
 		target.Series = enrichment.Series
 		target.FieldDataSources["series"] = source
 	}
-	if target.SeriesNumber == nil && enrichment.SeriesNumber != nil {
-		target.SeriesNumber = enrichment.SeriesNumber
-		target.FieldDataSources["series"] = source
-	}
-	if target.SeriesNumberUnit == nil && enrichment.SeriesNumberUnit != nil {
-		target.SeriesNumberUnit = enrichment.SeriesNumberUnit
-		target.FieldDataSources["series"] = source
+	if target.SeriesNumber == nil {
+		// The start, end, and unit are one atomic group. Fill the complete
+		// group from one source only, and discard malformed external groups.
+		target.SeriesNumberEnd = nil
+		target.SeriesNumberUnit = nil
+		if validSeriesNumberGroup(enrichment.SeriesNumber, enrichment.SeriesNumberEnd, enrichment.SeriesNumberUnit) {
+			target.SeriesNumber = enrichment.SeriesNumber
+			target.SeriesNumberEnd = enrichment.SeriesNumberEnd
+			target.SeriesNumberUnit = enrichment.SeriesNumberUnit
+			target.FieldDataSources["series"] = source
+		}
 	}
 	if len(target.Genres) == 0 && len(enrichment.Genres) > 0 {
 		target.Genres = enrichment.Genres
@@ -3472,7 +3492,7 @@ func mergeEnrichedMetadata(target, enrichment *mediafile.ParsedMetadata, source 
 // Undeclared fields (returned but not in manifest) are zeroed with a log warning.
 // Disabled fields (declared but user disabled) are zeroed silently.
 // Field groupings:
-//   - "series" or "seriesNumber" controls both series name and seriesNumber.
+//   - "series" or "seriesNumber" controls the series name and complete number group.
 //   - "cover" controls coverData, coverMimeType, and coverPage.
 func filterMetadataFields(
 	md *mediafile.ParsedMetadata,
@@ -3535,6 +3555,12 @@ func filterMetadataFields(
 				"field":  "seriesNumber",
 			})
 		}
+		if result.SeriesNumberEnd != nil {
+			logWarn("enricher returned undeclared field", logger.Data{
+				"plugin": pluginID,
+				"field":  "seriesNumberEnd",
+			})
+		}
 		if result.SeriesNumberUnit != nil {
 			logWarn("enricher returned undeclared field", logger.Data{
 				"plugin": pluginID,
@@ -3545,6 +3571,7 @@ func filterMetadataFields(
 	if !seriesAllowed {
 		result.Series = ""
 		result.SeriesNumber = nil
+		result.SeriesNumberEnd = nil
 		result.SeriesNumberUnit = nil
 	}
 

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -861,10 +861,7 @@ func (w *Worker) scanFileCore(
 		if models.GetDataSourcePriority(titleSource) >= models.DataSourceFileMetadataPriority {
 			if normalizedTitle, unit, hasNumber := fileutils.NormalizeSeriesNumberInTitle(title, file.FileType); hasNumber {
 				title = normalizedTitle
-				if unit != "" && metadata.SeriesNumberUnit == nil {
-					u := unit
-					metadata.SeriesNumberUnit = &u
-				}
+				applySeriesNumberUnit(metadata, unit, titleSource)
 			}
 		}
 		if shouldUpdateScalar(title, book.Title, titleSource, book.TitleSource, forceRefresh) {
@@ -2314,7 +2311,7 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 		// For root-level files, compute the expected organized folder path so that
 		// multiple root-level files with the same title/author will share a book.
 		// This ensures "Wind and Truth.epub" and "Wind and Truth.m4b" become one book.
-		title, _ := deriveInitialTitle(path, isRootLevelFile, metadata)
+		title := deriveInitialTitle(path, isRootLevelFile, metadata)
 		var authorNames []string
 		for _, author := range metadata.Authors {
 			authorNames = append(authorNames, author.Name)
@@ -2353,7 +2350,7 @@ func (w *Worker) scanFileCreateNew(ctx context.Context, opts ScanOptions, cache 
 		book = existingBook
 	} else {
 		// Derive initial title from filepath or metadata
-		title, _ := deriveInitialTitle(path, isRootLevelFile, metadata)
+		title := deriveInitialTitle(path, isRootLevelFile, metadata)
 		titleSource := models.DataSourceFilepath
 		if metadata != nil && strings.TrimSpace(metadata.Title) != "" {
 			titleSource = metadata.SourceForField("title")
@@ -2643,18 +2640,17 @@ func (w *Worker) discoverAndCreateSupplements(
 // For CBZ files, series number indicators like "#007" are normalized to "v007"
 // and chapter indicators like "Ch.5" are normalized to "c005"; parenthesized
 // metadata like "(2020) (Digital) (group)" is removed.
-// Returns the derived title and the parsed series number unit ("volume", "chapter", or "").
-func deriveInitialTitle(path string, isRootLevelFile bool, metadata *mediafile.ParsedMetadata) (string, string) {
+func deriveInitialTitle(path string, isRootLevelFile bool, metadata *mediafile.ParsedMetadata) string {
 	fileType := strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
 
 	// If metadata has a title, use it
 	if metadata != nil {
 		if trimmedTitle := strings.TrimSpace(metadata.Title); trimmedTitle != "" {
 			// Normalize series number indicators in metadata title
-			if normalizedTitle, unit, hasNumber := fileutils.NormalizeSeriesNumberInTitle(trimmedTitle, fileType); hasNumber {
-				return normalizedTitle, unit
+			if normalizedTitle, _, hasNumber := fileutils.NormalizeSeriesNumberInTitle(trimmedTitle, fileType); hasNumber {
+				return normalizedTitle
 			}
-			return trimmedTitle, ""
+			return trimmedTitle
 		}
 	}
 
@@ -2684,11 +2680,11 @@ func deriveInitialTitle(path string, isRootLevelFile bool, metadata *mediafile.P
 	}
 
 	// Normalize series number indicators in filepath-based title
-	if normalizedTitle, unit, hasNumber := fileutils.NormalizeSeriesNumberInTitle(title, fileType); hasNumber {
-		return normalizedTitle, unit
+	if normalizedTitle, _, hasNumber := fileutils.NormalizeSeriesNumberInTitle(title, fileType); hasNumber {
+		return normalizedTitle
 	}
 
-	return title, ""
+	return title
 }
 
 // removeFileSidecar deletes the file sidecar at filePath. ENOENT is silent;
@@ -2766,14 +2762,9 @@ func applyFilepathFallbacks(metadata *mediafile.ParsedMetadata, filePath, bookPa
 	// Title fallback
 	if strings.TrimSpace(metadata.Title) == "" {
 		// Pass nil metadata so deriveInitialTitle uses filepath only (we already confirmed Title is empty)
-		derivedTitle, derivedUnit := deriveInitialTitle(filePath, isRootLevelFile, nil)
+		derivedTitle := deriveInitialTitle(filePath, isRootLevelFile, nil)
 		metadata.Title = derivedTitle
 		setSource("title")
-		if derivedUnit != "" && metadata.SeriesNumberUnit == nil {
-			u := derivedUnit
-			metadata.SeriesNumberUnit = &u
-			setSource("series")
-		}
 	}
 
 	// Authors fallback

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -1114,6 +1114,7 @@ func (w *Worker) scanFileCore(
 					relUpdates.BookSeries = append(relUpdates.BookSeries, &models.BookSeries{
 						BookID:           book.ID,
 						SeriesID:         seriesRecord.ID,
+						Series:           seriesRecord,
 						SeriesNumber:     seriesNumber,
 						SeriesNumberEnd:  seriesNumberEnd,
 						SeriesNumberUnit: seriesNumberUnit,
@@ -1130,14 +1131,22 @@ func (w *Worker) scanFileCore(
 					sidecarSeriesNames = append(sidecarSeriesNames, s.Name)
 				}
 			}
+			existingSeries := book.BookSeries
 			existingSeriesSource := ""
-			for _, bs := range book.BookSeries {
+			for _, bs := range existingSeries {
 				if bs.Series != nil && existingSeriesSource == "" {
 					existingSeriesSource = bs.Series.NameSource
 				}
 			}
+			// Compare the sidecar against any metadata replacement staged above,
+			// not only the stale stored relations. This lets the higher-priority
+			// sidecar cancel a lower-priority replacement in the same scan.
+			if relUpdates.DeleteSeries {
+				existingSeries = relUpdates.BookSeries
+				existingSeriesSource = metadata.SourceForField("series")
+			}
 
-			if len(sidecarSeriesNames) > 0 && shouldApplySeriesSidecar(bookSidecarData.Series, book.BookSeries, existingSeriesSource, forceRefresh) {
+			if len(sidecarSeriesNames) > 0 && shouldApplySeriesSidecar(bookSidecarData.Series, existingSeries, existingSeriesSource, forceRefresh) {
 				logInfo("updating series from sidecar", logger.Data{"new_count": len(bookSidecarData.Series), "old_count": len(book.BookSeries)})
 
 				// Collect series for batch insert (replaces any metadata collection)
@@ -1164,6 +1173,7 @@ func (w *Worker) scanFileCore(
 					relUpdates.BookSeries = append(relUpdates.BookSeries, &models.BookSeries{
 						BookID:           book.ID,
 						SeriesID:         seriesRecord.ID,
+						Series:           seriesRecord,
 						SeriesNumber:     seriesNumber,
 						SeriesNumberEnd:  seriesNumberEnd,
 						SeriesNumberUnit: seriesNumberUnit,

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -4805,6 +4805,21 @@ func TestApplyFilepathFallbacks_PopulatesSeriesFromTitle(t *testing.T) {
 	assert.NotEmpty(t, metadata.Series)
 }
 
+func TestApplyFilepathFallbacks_DoesNotMixUnitIntoPluginSeriesGroup(t *testing.T) {
+	t.Parallel()
+
+	metadata := &mediafile.ParsedMetadata{
+		Series:       "Plugin Series",
+		SeriesNumber: seriesFloatPtr(1),
+		DataSource:   models.DataSourcePlugin,
+	}
+
+	applyFilepathFallbacks(metadata, "/library/My Series v3.cbz", "/library/My Series v3", "cbz", true)
+
+	assert.Nil(t, metadata.SeriesNumberUnit)
+	assert.Equal(t, models.DataSourcePlugin, metadata.SourceForField("series"))
+}
+
 // =============================================================================
 // resetBookFileState tests
 // =============================================================================

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -2659,6 +2659,58 @@ func TestScanFileCore_SidecarReading_BookTitle(t *testing.T) {
 	assert.Equal(t, models.DataSourceSidecar, result.Book.TitleSource)
 }
 
+func TestScanFileCore_SidecarSeriesRangeOverridesSameNamedFileMetadata(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+	bookDir := testgen.CreateSubDir(t, libraryPath, "Test Book")
+	book := &models.Book{
+		LibraryID:    1,
+		Filepath:     bookDir,
+		Title:        "Test Book",
+		TitleSource:  models.DataSourceEPUBMetadata,
+		SortTitle:    "Test Book",
+		AuthorSource: models.DataSourceFilepath,
+	}
+	require.NoError(t, tc.bookService.CreateBook(tc.ctx, book))
+	file := &models.File{
+		LibraryID: 1, BookID: book.ID, Filepath: filepath.Join(bookDir, "test.epub"),
+		FileType: models.FileTypeEPUB, FilesizeBytes: 1000,
+	}
+	require.NoError(t, tc.bookService.CreateFile(tc.ctx, file))
+	series := &models.Series{
+		LibraryID: 1, Name: "Saga", NameSource: models.DataSourceEPUBMetadata,
+		SortName: "Saga", SortNameSource: models.DataSourceEPUBMetadata,
+	}
+	_, err := tc.db.NewInsert().Model(series).Exec(tc.ctx)
+	require.NoError(t, err)
+	membership := &models.BookSeries{
+		BookID: book.ID, SeriesID: series.ID, Series: series,
+		SeriesNumber: seriesFloatPtr(1), SortOrder: 1,
+	}
+	_, err = tc.db.NewInsert().Model(membership).Exec(tc.ctx)
+	require.NoError(t, err)
+	book.BookSeries = []*models.BookSeries{membership}
+
+	require.NoError(t, sidecar.WriteBookSidecar(bookDir, &sidecar.BookSidecar{
+		Series: []sidecar.SeriesMetadata{{
+			Name: "Saga", Number: seriesFloatPtr(1), NumberEnd: seriesFloatPtr(3), SortOrder: 1,
+		}},
+	}))
+
+	_, err = tc.worker.scanFileCore(tc.ctx, file, book, &mediafile.ParsedMetadata{DataSource: models.DataSourceEPUBMetadata}, false, true, nil, nil)
+	require.NoError(t, err)
+
+	var got models.BookSeries
+	require.NoError(t, tc.db.NewSelect().Model(&got).Where("book_id = ?", book.ID).Scan(tc.ctx))
+	require.NotNil(t, got.SeriesNumber)
+	assert.InDelta(t, 1.0, *got.SeriesNumber, 0.001)
+	require.NotNil(t, got.SeriesNumberEnd)
+	assert.InDelta(t, 3.0, *got.SeriesNumberEnd, 0.001)
+}
+
 // TestScanFileCore_SidecarPriority_OverridesFileMetadata verifies that sidecar
 // files DO override data from file metadata sources (sidecar has higher priority).
 func TestScanFileCore_SidecarPriority_OverridesFileMetadata(t *testing.T) {

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -2670,25 +2670,27 @@ func TestScanFileCore_SidecarSeriesRangeOverridesSameNamedFileMetadata(t *testin
 		LibraryID:    1,
 		Filepath:     bookDir,
 		Title:        "Test Book",
-		TitleSource:  models.DataSourceEPUBMetadata,
+		TitleSource:  models.DataSourceCBZMetadata,
 		SortTitle:    "Test Book",
 		AuthorSource: models.DataSourceFilepath,
 	}
 	require.NoError(t, tc.bookService.CreateBook(tc.ctx, book))
 	file := &models.File{
-		LibraryID: 1, BookID: book.ID, Filepath: filepath.Join(bookDir, "test.epub"),
-		FileType: models.FileTypeEPUB, FilesizeBytes: 1000,
+		LibraryID: 1, BookID: book.ID, Filepath: filepath.Join(bookDir, "test.cbz"),
+		FileType: models.FileTypeCBZ, FilesizeBytes: 1000,
 	}
 	require.NoError(t, tc.bookService.CreateFile(tc.ctx, file))
 	series := &models.Series{
-		LibraryID: 1, Name: "Saga", NameSource: models.DataSourceEPUBMetadata,
-		SortName: "Saga", SortNameSource: models.DataSourceEPUBMetadata,
+		LibraryID: 1, Name: "Saga", NameSource: models.DataSourceCBZMetadata,
+		SortName: "Saga", SortNameSource: models.DataSourceCBZMetadata,
 	}
 	_, err := tc.db.NewInsert().Model(series).Exec(tc.ctx)
 	require.NoError(t, err)
+	unit := models.SeriesNumberUnitVolume
 	membership := &models.BookSeries{
 		BookID: book.ID, SeriesID: series.ID, Series: series,
-		SeriesNumber: seriesFloatPtr(1), SortOrder: 1,
+		SeriesNumber: seriesFloatPtr(1), SeriesNumberEnd: seriesFloatPtr(3),
+		SeriesNumberUnit: &unit, SortOrder: 1,
 	}
 	_, err = tc.db.NewInsert().Model(membership).Exec(tc.ctx)
 	require.NoError(t, err)
@@ -2696,11 +2698,14 @@ func TestScanFileCore_SidecarSeriesRangeOverridesSameNamedFileMetadata(t *testin
 
 	require.NoError(t, sidecar.WriteBookSidecar(bookDir, &sidecar.BookSidecar{
 		Series: []sidecar.SeriesMetadata{{
-			Name: "Saga", Number: seriesFloatPtr(1), NumberEnd: seriesFloatPtr(3), SortOrder: 1,
+			Name: "Saga", Number: seriesFloatPtr(1), NumberEnd: seriesFloatPtr(3), Unit: &unit, SortOrder: 1,
 		}},
 	}))
 
-	_, err = tc.worker.scanFileCore(tc.ctx, file, book, &mediafile.ParsedMetadata{DataSource: models.DataSourceEPUBMetadata}, false, true, nil, nil)
+	metadata := &mediafile.ParsedMetadata{
+		Series: "Saga", SeriesNumber: seriesFloatPtr(1), DataSource: models.DataSourceCBZMetadata,
+	}
+	_, err = tc.worker.scanFileCore(tc.ctx, file, book, metadata, false, true, nil, nil)
 	require.NoError(t, err)
 
 	var got models.BookSeries
@@ -2709,6 +2714,8 @@ func TestScanFileCore_SidecarSeriesRangeOverridesSameNamedFileMetadata(t *testin
 	assert.InDelta(t, 1.0, *got.SeriesNumber, 0.001)
 	require.NotNil(t, got.SeriesNumberEnd)
 	assert.InDelta(t, 3.0, *got.SeriesNumberEnd, 0.001)
+	require.NotNil(t, got.SeriesNumberUnit)
+	assert.Equal(t, unit, *got.SeriesNumberUnit)
 }
 
 // TestScanFileCore_SidecarPriority_OverridesFileMetadata verifies that sidecar

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -41,7 +41,11 @@ People represent both **authors** and **narrators**. The same person record is s
 
 ### Series
 
-A book can belong to multiple series, each with an optional series number. Series numbers support decimals (e.g., `1.5` for a side story between books 1 and 2).
+A book can belong to multiple series, each with an optional series number. Series numbers support decimals (for example, `1.5` for a side story between books 1 and 2) and contiguous omnibus ranges such as `1-3`. A range is stored as one series membership with a start and end, not as a separate membership for every covered number.
+
+In series listings, individually numbered books appear before omnibuses. Omnibuses are then ordered by their range start and end. Download filenames and OPDS descriptions display the complete range. Kobo sync and EPUB metadata use the range start because their numeric series fields cannot represent an end.
+
+The API and [book sidecars](./sidecar-files#book-sidecar-format) can set and preserve ranges. The current web book editor only exposes a single series number. An ordinary scan preserves a sidecar-backed range. Refresh and reset intentionally discard cached sidecars, so a format that only supplies the start can reduce the range to a single number.
 
 ### Genres and Tags
 
@@ -87,7 +91,7 @@ Searches by identifier accept any of the cosmetic variants above — you can pas
 | Relationship | Type | Notes |
 |-------------|------|-------|
 | Book &harr; Authors | Many-to-many | A book can have multiple authors; an author can appear on multiple books |
-| Book &harr; Series | Many-to-many | A book can be in multiple series, each with its own number |
+| Book &harr; Series | Many-to-many | A book can be in multiple series, each with its own single number or contiguous omnibus range |
 | Book &harr; Genres | Many-to-many | |
 | Book &harr; Tags | Many-to-many | |
 | Book &rarr; Files | One-to-many | A book has one or more files |

--- a/website/docs/sidecar-files.md
+++ b/website/docs/sidecar-files.md
@@ -56,7 +56,8 @@ There are two types of sidecar files, corresponding to the two levels of [metada
   "series": [
     {
       "name": "Classic American Literature",
-      "number": 5,
+      "number": 1,
+      "number_end": 3,
       "unit": "volume",
       "sort_order": 0
     }
@@ -65,6 +66,8 @@ There are two types of sidecar files, corresponding to the two levels of [metada
   "tags": ["american-literature", "1920s"]
 }
 ```
+
+The optional `number_end` field records the end of a contiguous omnibus range. It requires `number`, must be greater than `number`, and moves with `number` and `unit` as one group. Omit `number_end` for a normal single-numbered book. Malformed number groups are ignored together rather than partially applied.
 
 The `unit` field on series entries is optional and applies to CBZ files only. Valid values are `"volume"` and `"chapter"`. When omitted, CBZ files default to volume rendering. Non-CBZ files always ignore this field (it is stored as `null`).
 


### PR DESCRIPTION
Closes #402

## Summary
- Adds the additive `series_number_end` schema and complete backend support for omnibus ranges across API validation, persistence, ordering, sidecars, scanner merging, Move Files, downloads, OPDS, Kobo, and cache fingerprints.
- Treats series start, end, and unit as an atomic metadata group. Omnibuses sort after single-numbered entries, database-backed displays show full ranges, and Kobo remains start-only.
- Preserves sidecar ranges during ordinary scans while keeping refresh and reset behavior unchanged. Editing UI, embedded format round-tripping, and plugin SDK changes remain intentionally out of scope.

## Test plan
- Run `mise db:rollback && mise db:migrate`.
- Run `mise check:quiet`.
- Verify exhaustive range parsing and formatting for tolerant separators, malformed and non-finite values, reversed ranges, and decimal formatting.
- Verify API validation, equality normalization, persistence, and read-back.
- Verify list, cover, and primary-series ordering across singles, omnibuses, endpoints, fractional positions, unnumbered entries, and title ties.
- Verify sidecar round-trip and atomic metadata-group merge and overlay behavior.
- Verify full range download and OPDS output, Kobo start-only output, cache invalidation, and Move Files preservation.
