### PR TITLE
[Frontend] Add omnibus series range editing

### DIFF
--- a/app/components/library/BookEditDialog.test.tsx
+++ b/app/components/library/BookEditDialog.test.tsx
@@ -63,7 +63,10 @@ describe("BookEditDialog handleSubmit sort title logic", () => {
   });
 });
 
-function makeBook(fileType: "cbz" | "epub"): Book {
+function makeBook(
+  fileType: "cbz" | "epub",
+  series: { numberEnd?: number; unit?: "volume" | "chapter" } = {},
+): Book {
   return {
     id: 1,
     title: "Test Book",
@@ -76,6 +79,8 @@ function makeBook(fileType: "cbz" | "epub"): Book {
         book_id: 1,
         series_id: 42,
         series_number: 1,
+        series_number_end: series.numberEnd,
+        series_number_unit: series.unit,
         series: { id: 42, library_id: 1, name: "Test Series" },
       } as never,
     ],
@@ -90,9 +95,9 @@ function makeBook(fileType: "cbz" | "epub"): Book {
   } as unknown as Book;
 }
 
-function renderDialog(book: Book) {
+function renderDialog(book: Book, onOpenChange = vi.fn()) {
   return render(
-    <BookEditDialog book={book} onOpenChange={vi.fn()} open={true} />,
+    <BookEditDialog book={book} onOpenChange={onOpenChange} open={true} />,
   );
 }
 
@@ -111,8 +116,10 @@ describe("BookEditDialog series range editing", () => {
       }),
     );
     await user.type(screen.getByLabelText("End"), "3");
+    await user.click(screen.getByLabelText("Unit"));
+    await user.click(screen.getByRole("option", { name: "Chapter" }));
 
-    expect(screen.getByText("Vol. 1-3")).toBeInTheDocument();
+    expect(screen.getByText("Ch. 1-3")).toBeInTheDocument();
 
     await user.keyboard("{Escape}");
     await user.click(screen.getByRole("button", { name: "Save Changes" }));
@@ -125,6 +132,49 @@ describe("BookEditDialog series range editing", () => {
             {
               name: "Test Series",
               number: 1,
+              number_end: 3,
+              series_number_unit: "chapter",
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  it("loads and preserves an existing range when the start changes", async () => {
+    mocks.updateBook.mockClear();
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+      delay: null,
+    });
+    renderDialog(makeBook("cbz", { numberEnd: 3 }));
+
+    expect(screen.getByText("Vol. 1-3")).toBeInTheDocument();
+    const start = screen.getByLabelText("Series number for Test Series");
+    await user.clear(start);
+    await user.click(
+      screen.getByRole("button", {
+        name: "Advanced settings for Test Series",
+      }),
+    );
+    expect(screen.getByLabelText("End")).toHaveValue(3);
+    expect(
+      screen.getByText("Enter a start number before setting an end or unit."),
+    ).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await user.type(start, "2");
+    expect(screen.getByText("Vol. 2-3")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+    await waitFor(() => {
+      expect(mocks.updateBook).toHaveBeenCalledWith({
+        id: "1",
+        payload: {
+          series: [
+            {
+              name: "Test Series",
+              number: 2,
               number_end: 3,
             },
           ],
@@ -152,6 +202,47 @@ describe("BookEditDialog series range editing", () => {
     expect(screen.getByText("Unsaved Changes")).toBeInTheDocument();
   });
 
+  it("protects an edited range when Cancel is clicked", async () => {
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+      delay: null,
+    });
+    renderDialog(makeBook("cbz"), onOpenChange);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Advanced settings for Test Series",
+      }),
+    );
+    await user.type(screen.getByLabelText("End"), "3");
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByText("Unsaved Changes")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("prevents saving a range whose end is below its start", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+      delay: null,
+    });
+    renderDialog(makeBook("cbz"));
+
+    const advancedButton = screen.getByRole("button", {
+      name: "Advanced settings for Test Series",
+    });
+    expect(advancedButton).toHaveAttribute("title", "Advanced series settings");
+    await user.click(advancedButton);
+    await user.type(screen.getByLabelText("End"), "0");
+
+    expect(
+      screen.getByText("End must be greater than or equal to the start."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Save Changes").closest("button")).toBeDisabled();
+  });
+
   it("hides the unit control for a non-CBZ book", async () => {
     const user = userEvent.setup({
       advanceTimers: vi.advanceTimersByTime,
@@ -167,5 +258,7 @@ describe("BookEditDialog series range editing", () => {
 
     expect(screen.getByLabelText("End")).toBeInTheDocument();
     expect(screen.queryByText("Unit")).not.toBeInTheDocument();
+    await user.type(screen.getByLabelText("End"), "3");
+    expect(screen.getByText("1-3")).toBeInTheDocument();
   });
 });

--- a/app/components/library/BookEditDialog.test.tsx
+++ b/app/components/library/BookEditDialog.test.tsx
@@ -147,9 +147,9 @@ describe("BookEditDialog series range editing", () => {
       advanceTimers: vi.advanceTimersByTime,
       delay: null,
     });
-    renderDialog(makeBook("cbz", { numberEnd: 3 }));
+    renderDialog(makeBook("cbz", { numberEnd: 3, unit: "chapter" }));
 
-    expect(screen.getByText("Vol. 1-3")).toBeInTheDocument();
+    expect(screen.getByText("Ch. 1-3")).toBeInTheDocument();
     const start = screen.getByLabelText("Series number for Test Series");
     await user.clear(start);
     await user.click(
@@ -161,6 +161,9 @@ describe("BookEditDialog series range editing", () => {
     expect(
       screen.getByText("Enter a start number before setting an end or unit."),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText("Unit")).toBeEnabled();
+    await user.click(screen.getByLabelText("Unit"));
+    await user.click(screen.getByRole("option", { name: "Unspecified" }));
 
     await user.keyboard("{Escape}");
     await user.type(start, "2");

--- a/app/components/library/BookEditDialog.test.tsx
+++ b/app/components/library/BookEditDialog.test.tsx
@@ -133,6 +133,25 @@ describe("BookEditDialog series range editing", () => {
     });
   });
 
+  it("protects an edited range end as an unsaved change", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+      delay: null,
+    });
+    renderDialog(makeBook("cbz"));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Advanced settings for Test Series",
+      }),
+    );
+    await user.type(screen.getByLabelText("End"), "3");
+    await user.keyboard("{Escape}");
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByText("Unsaved Changes")).toBeInTheDocument();
+  });
+
   it("hides the unit control for a non-CBZ book", async () => {
     const user = userEvent.setup({
       advanceTimers: vi.advanceTimersByTime,

--- a/app/components/library/BookEditDialog.test.tsx
+++ b/app/components/library/BookEditDialog.test.tsx
@@ -1,92 +1,152 @@
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 
+import { FileRoleMain, type Book } from "@/types";
 import { forTitle } from "@/utils/sortname";
+
+import { BookEditDialog } from "./BookEditDialog";
+
+const mocks = vi.hoisted(() => ({
+  updateBook: vi.fn().mockResolvedValue(undefined),
+  setBookReview: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/hooks/queries/books", () => ({
+  useUpdateBook: () => ({ mutateAsync: mocks.updateBook, isPending: false }),
+}));
+
+vi.mock("@/hooks/queries/entity-search", () => ({
+  useAuthorSearch: () => ({ data: [], isLoading: false }),
+  useGenreItemCounts: () => new Map(),
+  useGenreSearch: () => ({ data: [], isLoading: false }),
+  useSeriesSearch: () => ({ data: [], isLoading: false }),
+  useTagItemCounts: () => new Map(),
+  useTagSearch: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("@/hooks/queries/review", () => ({
+  useReviewCriteria: () => ({ data: undefined }),
+  useSetBookReview: () => ({
+    mutateAsync: mocks.setBookReview,
+    isPending: false,
+  }),
+}));
 
 /**
  * Tests for BookEditDialog handleSubmit sort title logic.
  *
- * The bug: handleSubmit compares sortTitle (semantic state) against book.sort_title (live prop),
- * but hasChanges compares effective sort title (sortTitle || forTitle(title)) against
- * initialValues.sortTitle (snapshot). This creates an inconsistency where:
- *
- * 1. User changes title from "The Book" to "A Book"
- * 2. sortTitle state stays "" (auto mode)
- * 3. hasChanges detects: effectiveSortTitle changed ("Book, The" -> "Book, A")
- * 4. BUG: handleSubmit says: sortTitle ("") === book.sort_title || "" ("") - no change!
- *
- * The fix: handleSubmit should compare effective sort title against initialValues.sortTitle,
- * consistent with hasChanges.
+ * The fixed logic compares the effective sort title against the snapshot from
+ * when the dialog opened, matching the hasChanges calculation.
  */
 describe("BookEditDialog handleSubmit sort title logic", () => {
-  // FIXED shouldIncludeSortTitle logic - compares effective values against snapshot
   const shouldIncludeSortTitle = (
-    sortTitle: string, // semantic state value
-    _bookSortTitle: string | undefined, // not used in fixed code!
-    initialSortTitle: string, // snapshot from when dialog opened
-    title: string, // current title
+    sortTitle: string,
+    _bookSortTitle: string | undefined,
+    initialSortTitle: string,
+    title: string,
   ): boolean => {
-    // FIXED: Compare effective sort title against initialValues.sortTitle (snapshot)
-    // This is consistent with hasChanges computation
     const effectiveSortTitle = sortTitle || forTitle(title);
     return effectiveSortTitle !== initialSortTitle;
   };
 
-  it("should include sort_title in payload when title changes (in auto mode)", () => {
-    // Scenario:
-    // 1. Dialog opens with title="The Book", sort_title="Book, The" (auto-generated)
-    // 2. User changes title to "A Book" (but leaves sort title in auto mode)
-    // 3. Effective sort title is now "Book, A"
-    // 4. hasChanges correctly detects this as a change
-    // 5. BUG: handleSubmit doesn't include sort_title in payload because:
-    //    sortTitle ("") === book.sort_title || "" ("") -> false (wait, that's wrong too)
-    //
-    // Actually let me trace through more carefully:
-    // - Initial: book.sort_title = "Book, The", sortTitle state = "" (auto mode)
-    // - User changes title to "A Book"
-    // - hasChanges: effectiveSortTitle = forTitle("A Book") = "Book, A"
-    //   initialValues.sortTitle = "Book, The" -> hasChanges = true
-    // - handleSubmit: sortTitle ("") !== book.sort_title || "" ("Book, The") -> true
-    //
-    // Hmm, actually that would work. Let me think about the actual bug case...
-    //
-    // The bug case is when book.sort_title is null/undefined (never manually set):
-    // - Initial: book.sort_title = undefined, sortTitle state = "" (auto mode)
-    // - User changes title from "The Book" to "A Book"
-    // - hasChanges: effectiveSortTitle = forTitle("A Book") = "Book, A"
-    //   initialValues.sortTitle = forTitle("The Book") = "Book, The" -> hasChanges = true
-    // - handleSubmit: sortTitle ("") !== book.sort_title || "" ("") -> false
-    //   BUG: Won't include sort_title even though effective sort title changed!
-
-    const sortTitle = ""; // auto mode
-    const bookSortTitle = undefined; // never manually set
-    const title = "A Book"; // user changed title
-    const initialSortTitle = forTitle("The Book"); // "Book, The"
-
-    const result = shouldIncludeSortTitle(
-      sortTitle,
-      bookSortTitle,
-      initialSortTitle,
-      title,
-    );
-
-    // FIXED: Now correctly returns true because effective sort title changed
-    expect(result).toBe(true);
+  it("should include sort_title in payload when title changes in auto mode", () => {
+    expect(
+      shouldIncludeSortTitle("", undefined, forTitle("The Book"), "A Book"),
+    ).toBe(true);
   });
 
-  it("should NOT include sort_title when nothing changed", () => {
-    const sortTitle = ""; // auto mode, unchanged
-    const bookSortTitle = undefined;
-    const title = "The Book"; // title unchanged
-    const initialSortTitle = forTitle("The Book"); // "Book, The"
+  it("should not include sort_title when nothing changed", () => {
+    expect(
+      shouldIncludeSortTitle("", undefined, forTitle("The Book"), "The Book"),
+    ).toBe(false);
+  });
+});
 
-    const result = shouldIncludeSortTitle(
-      sortTitle,
-      bookSortTitle,
-      initialSortTitle,
-      title,
+function makeBook(fileType: "cbz" | "epub"): Book {
+  return {
+    id: 1,
+    title: "Test Book",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    library_id: 1,
+    book_series: [
+      {
+        id: 1,
+        book_id: 1,
+        series_id: 42,
+        series_number: 1,
+        series: { id: 42, library_id: 1, name: "Test Series" },
+      } as never,
+    ],
+    files: [
+      {
+        id: 10,
+        file_role: FileRoleMain,
+        file_type: fileType,
+        reviewed: true,
+      } as never,
+    ],
+  } as unknown as Book;
+}
+
+function renderDialog(book: Book) {
+  return render(
+    <BookEditDialog book={book} onOpenChange={vi.fn()} open={true} />,
+  );
+}
+
+describe("BookEditDialog series range editing", () => {
+  it("includes an edited range end in the update payload", async () => {
+    mocks.updateBook.mockClear();
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+      delay: null,
+    });
+    renderDialog(makeBook("cbz"));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Advanced settings for Test Series",
+      }),
+    );
+    await user.type(screen.getByLabelText("End"), "3");
+
+    expect(screen.getByText("Vol. 1-3")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(mocks.updateBook).toHaveBeenCalledWith({
+        id: "1",
+        payload: {
+          series: [
+            {
+              name: "Test Series",
+              number: 1,
+              number_end: 3,
+            },
+          ],
+        },
+      });
+    });
+  });
+
+  it("hides the unit control for a non-CBZ book", async () => {
+    const user = userEvent.setup({
+      advanceTimers: vi.advanceTimersByTime,
+      delay: null,
+    });
+    renderDialog(makeBook("epub"));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Advanced settings for Test Series",
+      }),
     );
 
-    // Should return false - no change
-    expect(result).toBe(false);
+    expect(screen.getByLabelText("End")).toBeInTheDocument();
+    expect(screen.queryByText("Unit")).not.toBeInTheDocument();
   });
 });

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -732,7 +732,9 @@ export function BookEditDialog({
                             >
                               <SelectTrigger
                                 className="cursor-pointer"
-                                disabled={entry.number === ""}
+                                disabled={
+                                  entry.number === "" && entry.unit === ""
+                                }
                                 id={`series-number-unit-${idx}`}
                               >
                                 <SelectValue placeholder="Unit" />

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -204,7 +204,7 @@ export function BookEditDialog({
       subtitle: initialSubtitle,
       description: initialDescription,
       authors: initialAuthors,
-      series: initialSeries,
+      series: initialSeries.map((entry) => ({ ...entry })),
       genres: [...initialGenres].sort(),
       tags: [...initialTags].sort(),
       reviewOverride: initialReviewOverride,
@@ -411,7 +411,7 @@ export function BookEditDialog({
       subtitle,
       description,
       authors: [...authors],
-      series: [...seriesEntries],
+      series: seriesEntries.map((entry) => ({ ...entry })),
       genres: [...genres].sort(),
       tags: [...tags].sort(),
       reviewOverride: draftReviewOverride,
@@ -609,12 +609,20 @@ export function BookEditDialog({
                   entry.numberEnd === ""
                     ? undefined
                     : parseFloat(entry.numberEnd);
+                const summary = Number.isFinite(parsedNumber)
+                  ? formatSeriesNumber(
+                      parsedNumber,
+                      Number.isFinite(parsedEnd) ? parsedEnd : undefined,
+                      entry.unit || null,
+                      hasCBZFiles ? "cbz" : null,
+                    )
+                  : "";
 
                 return (
                   <>
                     <Input
                       aria-label={`Series number for ${entry.name}`}
-                      className="w-24"
+                      className="w-16 sm:w-24"
                       onChange={(e) =>
                         handleSeriesNumberChange(idx, e.target.value)
                       }
@@ -623,14 +631,14 @@ export function BookEditDialog({
                       type="number"
                       value={entry.number}
                     />
-                    {showSummary && Number.isFinite(parsedNumber) && (
-                      <Badge className="whitespace-nowrap" variant="secondary">
-                        {formatSeriesNumber(
-                          parsedNumber,
-                          Number.isFinite(parsedEnd) ? parsedEnd : undefined,
-                          entry.unit || null,
-                          hasCBZFiles ? "cbz" : null,
-                        )}
+                    {showSummary && summary && (
+                      <Badge
+                        className="max-w-20 sm:max-w-28"
+                        variant="secondary"
+                      >
+                        <span className="truncate" title={summary}>
+                          {summary}
+                        </span>
                       </Badge>
                     )}
                     <Popover modal>

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -1,11 +1,12 @@
 import equal from "fast-deep-equal";
-import { Loader2 } from "lucide-react";
+import { Loader2, Settings2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { SortableEntityList } from "@/components/common/SortableEntityList";
 import { SortNameInput } from "@/components/common/SortNameInput";
 import { ExtractSubtitleButton } from "@/components/library/ExtractSubtitleButton";
 import { ReviewPanel } from "@/components/library/ReviewPanel";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DialogBody,
@@ -19,6 +20,11 @@ import { FormDialog } from "@/components/ui/form-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MultiSelectCombobox } from "@/components/ui/MultiSelectCombobox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -52,6 +58,7 @@ import {
   type SeriesInput,
 } from "@/types";
 import { AUTHOR_ROLES } from "@/utils/authorRoles";
+import { formatSeriesNumber } from "@/utils/seriesNumber";
 import { forTitle } from "@/utils/sortname";
 
 interface BookEditDialogProps {
@@ -63,6 +70,7 @@ interface BookEditDialogProps {
 interface SeriesEntry {
   name: string;
   number: string;
+  numberEnd: string;
   unit: "" | "volume" | "chapter"; // "" means unspecified
 }
 
@@ -86,6 +94,7 @@ export function BookEditDialog({
       (bs): SeriesEntry => ({
         name: bs.series?.name || "",
         number: bs.series_number?.toString() || "",
+        numberEnd: bs.series_number_end?.toString() || "",
         unit: bs.series_number_unit ?? "",
       }),
     ) || [],
@@ -153,6 +162,7 @@ export function BookEditDialog({
       book.book_series?.map((bs) => ({
         name: bs.series?.name || "",
         number: bs.series_number?.toString() || "",
+        numberEnd: bs.series_number_end?.toString() || "",
         unit: bs.series_number_unit ?? "",
       })) || [];
     const initialGenres =
@@ -257,7 +267,10 @@ export function BookEditDialog({
     const name = "__create" in next ? next.__create : next.name;
     if (!name.trim()) return;
     if (seriesEntries.some((s) => s.name === name)) return;
-    setSeriesEntries([...seriesEntries, { name, number: "", unit: "" }]);
+    setSeriesEntries([
+      ...seriesEntries,
+      { name, number: "", numberEnd: "", unit: "" },
+    ]);
   };
 
   const handleRemoveSeries = (index: number) => {
@@ -267,6 +280,12 @@ export function BookEditDialog({
   const handleSeriesNumberChange = (index: number, value: string) => {
     const updated = [...seriesEntries];
     updated[index].number = value;
+    setSeriesEntries(updated);
+  };
+
+  const handleSeriesNumberEndChange = (index: number, value: string) => {
+    const updated = [...seriesEntries];
+    updated[index].numberEnd = value;
     setSeriesEntries(updated);
   };
 
@@ -325,6 +344,7 @@ export function BookEditDialog({
         (bs): SeriesEntry => ({
           name: bs.series?.name || "",
           number: bs.series_number?.toString() || "",
+          numberEnd: bs.series_number_end?.toString() || "",
           unit: bs.series_number_unit ?? "",
         }),
       ) || [];
@@ -334,6 +354,7 @@ export function BookEditDialog({
         .map((s) => ({
           name: s.name,
           number: s.number !== "" ? parseFloat(s.number) : undefined,
+          number_end: s.numberEnd !== "" ? parseFloat(s.numberEnd) : undefined,
           series_number_unit: s.unit !== "" ? s.unit : undefined,
         }));
     }
@@ -578,41 +599,119 @@ export function BookEditDialog({
               onAppend={handleAppendSeries}
               onRemove={handleRemoveSeries}
               onReorder={setSeriesEntries}
-              renderExtras={(entry, idx) => (
-                <>
-                  <Input
-                    className="w-24"
-                    onChange={(e) =>
-                      handleSeriesNumberChange(idx, e.target.value)
-                    }
-                    placeholder="#"
-                    type="number"
-                    value={entry.number}
-                  />
-                  <div className="w-32">
-                    <Select
-                      onValueChange={(value) =>
-                        handleSeriesUnitChange(
-                          idx,
-                          value === "unspecified"
-                            ? ""
-                            : (value as "volume" | "chapter"),
-                        )
+              renderExtras={(entry, idx) => {
+                const showSummary =
+                  entry.number !== "" &&
+                  (entry.numberEnd !== "" ||
+                    (hasCBZFiles && entry.unit !== ""));
+                const parsedNumber = parseFloat(entry.number);
+                const parsedEnd =
+                  entry.numberEnd === ""
+                    ? undefined
+                    : parseFloat(entry.numberEnd);
+
+                return (
+                  <>
+                    <Input
+                      aria-label={`Series number for ${entry.name}`}
+                      className="w-24"
+                      onChange={(e) =>
+                        handleSeriesNumberChange(idx, e.target.value)
                       }
-                      value={entry.unit === "" ? "unspecified" : entry.unit}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Unit" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="unspecified">Unspecified</SelectItem>
-                        <SelectItem value="volume">Volume</SelectItem>
-                        <SelectItem value="chapter">Chapter</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </>
-              )}
+                      placeholder="#"
+                      step="any"
+                      type="number"
+                      value={entry.number}
+                    />
+                    {showSummary && Number.isFinite(parsedNumber) && (
+                      <Badge className="whitespace-nowrap" variant="secondary">
+                        {formatSeriesNumber(
+                          parsedNumber,
+                          Number.isFinite(parsedEnd) ? parsedEnd : undefined,
+                          entry.unit || null,
+                          hasCBZFiles ? "cbz" : null,
+                        )}
+                      </Badge>
+                    )}
+                    <Popover modal>
+                      <PopoverTrigger asChild>
+                        <Button
+                          aria-label={`Advanced settings for ${entry.name}`}
+                          size="icon"
+                          type="button"
+                          variant="ghost"
+                        >
+                          <Settings2 className="h-4 w-4" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent align="end" className="w-64 space-y-4">
+                        <div className="space-y-2">
+                          <Label htmlFor={`series-number-end-${idx}`}>
+                            End
+                          </Label>
+                          <Input
+                            id={`series-number-end-${idx}`}
+                            onChange={(e) =>
+                              handleSeriesNumberEndChange(idx, e.target.value)
+                            }
+                            placeholder="#"
+                            step="any"
+                            type="number"
+                            value={entry.numberEnd}
+                          />
+                        </div>
+                        {hasCBZFiles && (
+                          <div className="space-y-2">
+                            <Label htmlFor={`series-number-unit-${idx}`}>
+                              Unit
+                            </Label>
+                            <Select
+                              onValueChange={(value) =>
+                                handleSeriesUnitChange(
+                                  idx,
+                                  value === "unspecified"
+                                    ? ""
+                                    : (value as "volume" | "chapter"),
+                                )
+                              }
+                              value={
+                                entry.unit === "" ? "unspecified" : entry.unit
+                              }
+                            >
+                              <SelectTrigger
+                                className="cursor-pointer"
+                                id={`series-number-unit-${idx}`}
+                              >
+                                <SelectValue placeholder="Unit" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem
+                                  className="cursor-pointer"
+                                  value="unspecified"
+                                >
+                                  Unspecified
+                                </SelectItem>
+                                <SelectItem
+                                  className="cursor-pointer"
+                                  value="volume"
+                                >
+                                  Volume
+                                </SelectItem>
+                                <SelectItem
+                                  className="cursor-pointer"
+                                  value="chapter"
+                                >
+                                  Chapter
+                                </SelectItem>
+                              </SelectContent>
+                            </Select>
+                          </div>
+                        )}
+                      </PopoverContent>
+                    </Popover>
+                  </>
+                );
+              }}
             />
           </div>
 

--- a/app/components/library/BookEditDialog.tsx
+++ b/app/components/library/BookEditDialog.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DialogBody,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -72,6 +73,26 @@ interface SeriesEntry {
   number: string;
   numberEnd: string;
   unit: "" | "volume" | "chapter"; // "" means unspecified
+}
+
+function getSeriesRangeError(entry: SeriesEntry): string | null {
+  if (entry.number === "") {
+    if (entry.numberEnd !== "" || entry.unit !== "") {
+      return "Enter a start number before setting an end or unit.";
+    }
+    return null;
+  }
+
+  const start = Number(entry.number);
+  const end = Number(entry.numberEnd);
+  if (!Number.isFinite(start)) return "Start must be a valid number.";
+  if (entry.numberEnd !== "" && !Number.isFinite(end)) {
+    return "End must be a valid number.";
+  }
+  if (entry.numberEnd !== "" && end < start) {
+    return "End must be greater than or equal to the start.";
+  }
+  return null;
 }
 
 export function BookEditDialog({
@@ -298,7 +319,13 @@ export function BookEditDialog({
     setSeriesEntries(updated);
   };
 
+  const hasInvalidSeriesRange = seriesEntries.some(
+    (entry) => getSeriesRangeError(entry) !== null,
+  );
+
   const handleSubmit = async () => {
+    if (hasInvalidSeriesRange) return;
+
     const payload: {
       title?: string;
       sort_title?: string;
@@ -609,6 +636,7 @@ export function BookEditDialog({
                   entry.numberEnd === ""
                     ? undefined
                     : parseFloat(entry.numberEnd);
+                const rangeError = getSeriesRangeError(entry);
                 const summary = Number.isFinite(parsedNumber)
                   ? formatSeriesNumber(
                       parsedNumber,
@@ -646,6 +674,7 @@ export function BookEditDialog({
                         <Button
                           aria-label={`Advanced settings for ${entry.name}`}
                           size="icon"
+                          title="Advanced series settings"
                           type="button"
                           variant="ghost"
                         >
@@ -658,6 +687,12 @@ export function BookEditDialog({
                             End
                           </Label>
                           <Input
+                            aria-describedby={
+                              rangeError
+                                ? `series-number-error-${idx}`
+                                : undefined
+                            }
+                            aria-invalid={rangeError ? true : undefined}
                             id={`series-number-end-${idx}`}
                             onChange={(e) =>
                               handleSeriesNumberEndChange(idx, e.target.value)
@@ -667,6 +702,15 @@ export function BookEditDialog({
                             type="number"
                             value={entry.numberEnd}
                           />
+                          {rangeError && (
+                            <p
+                              className="text-xs text-destructive"
+                              id={`series-number-error-${idx}`}
+                              role="alert"
+                            >
+                              {rangeError}
+                            </p>
+                          )}
                         </div>
                         {hasCBZFiles && (
                           <div className="space-y-2">
@@ -688,6 +732,7 @@ export function BookEditDialog({
                             >
                               <SelectTrigger
                                 className="cursor-pointer"
+                                disabled={entry.number === ""}
                                 id={`series-number-unit-${idx}`}
                               >
                                 <SelectValue placeholder="Unit" />
@@ -784,15 +829,13 @@ export function BookEditDialog({
         </DialogBody>
 
         <DialogFooter>
+          <DialogClose asChild>
+            <Button size="sm" variant="outline">
+              Cancel
+            </Button>
+          </DialogClose>
           <Button
-            onClick={() => onOpenChange(false)}
-            size="sm"
-            variant="outline"
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={updateBookMutation.isPending}
+            disabled={updateBookMutation.isPending || hasInvalidSeriesRange}
             onClick={handleSubmit}
             size="sm"
           >

--- a/app/components/library/BookItem.test.tsx
+++ b/app/components/library/BookItem.test.tsx
@@ -92,6 +92,30 @@ describe("BookItem — Series number badge", () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
+  it("shows the complete range in the badge", () => {
+    const book = makeBook({
+      book_series: [
+        {
+          id: 1,
+          book_id: 1,
+          series_id: seriesId,
+          series_number: 1,
+          series_number_end: 3,
+        } as never,
+      ],
+      files: [
+        {
+          id: 10,
+          file_role: FileRoleMain,
+          file_type: "epub",
+          reviewed: true,
+        } as never,
+      ],
+    });
+    render(wrap(<BookItem book={book} libraryId="1" seriesId={seriesId} />));
+    expect(screen.getByText("1-3", { selector: "span" })).toBeInTheDocument();
+  });
+
   it("hides badge when series_number is null", () => {
     const book = makeBook({
       book_series: [

--- a/app/components/library/BookItem.tsx
+++ b/app/components/library/BookItem.tsx
@@ -106,6 +106,7 @@ const BookItem = ({
     ? book.book_series?.find((bs) => bs.series_id === seriesId)
     : undefined;
   const seriesNumber = seriesEntry?.series_number;
+  const seriesNumberEnd = seriesEntry?.series_number_end;
   const seriesNumberUnit = seriesEntry?.series_number_unit;
   const anyCBZ = hasAnyCBZFile(book);
 
@@ -305,6 +306,7 @@ const BookItem = ({
                 <span className="inline-flex items-center justify-center align-text-top min-w-5 h-[18px] px-[5px] bg-primary text-primary-foreground rounded text-[11px] font-extrabold tabular-nums tracking-tight mr-1.5">
                   {formatSeriesNumber(
                     seriesNumber,
+                    seriesNumberEnd,
                     seriesNumberUnit,
                     anyCBZ ? "cbz" : null,
                   )}

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -498,7 +498,7 @@ export function IdentifyBookDialog({
                                     <p className="text-xs text-muted-foreground font-medium mt-0.5">
                                       {result.series}
                                       {result.series_number != null &&
-                                        ` ${formatSeriesNumber(result.series_number, result.series_number_unit, selectedFileType)}`}
+                                        ` ${formatSeriesNumber(result.series_number, null, result.series_number_unit, selectedFileType)}`}
                                     </p>
                                   )}
                                 </div>

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -1437,7 +1437,7 @@ export function IdentifyReviewForm({
                             (s) =>
                               `${s.name}${
                                 s.number
-                                  ? ` ${formatSeriesNumber(parseFloat(s.number), s.unit || null, anyCBZ ? "cbz" : null)}`
+                                  ? ` ${formatSeriesNumber(parseFloat(s.number), null, s.unit || null, anyCBZ ? "cbz" : null)}`
                                   : ""
                               }`,
                           )

--- a/app/components/pages/BookDetail.tsx
+++ b/app/components/pages/BookDetail.tsx
@@ -1211,6 +1211,7 @@ const BookDetail = () => {
                         <Badge className="text-xs" variant="outline">
                           {formatSeriesNumber(
                             bs.series_number,
+                            bs.series_number_end,
                             bs.series_number_unit,
                             anyCBZ ? "cbz" : null,
                           )}

--- a/app/utils/seriesNumber.test.ts
+++ b/app/utils/seriesNumber.test.ts
@@ -3,22 +3,39 @@ import { describe, expect, it } from "vitest";
 import { formatSeriesNumber } from "./seriesNumber";
 
 describe("formatSeriesNumber", () => {
+  it("renders a bare range", () => {
+    expect(formatSeriesNumber(1, 3, null, "epub")).toBe("1-3");
+  });
+
   it("renders volume for CBZ with volume unit", () => {
-    expect(formatSeriesNumber(5, "volume", "cbz")).toBe("Vol. 5");
+    expect(formatSeriesNumber(5, null, "volume", "cbz")).toBe("Vol. 5");
   });
+
+  it("renders a volume range for CBZ", () => {
+    expect(formatSeriesNumber(1, 3, "volume", "cbz")).toBe("Vol. 1-3");
+  });
+
   it("renders chapter for CBZ with chapter unit", () => {
-    expect(formatSeriesNumber(42, "chapter", "cbz")).toBe("Ch. 42");
+    expect(formatSeriesNumber(42, null, "chapter", "cbz")).toBe("Ch. 42");
   });
+
+  it("renders a chapter range for CBZ", () => {
+    expect(formatSeriesNumber(5, 8, "chapter", "cbz")).toBe("Ch. 5-8");
+  });
+
   it("defaults null unit to volume for CBZ", () => {
-    expect(formatSeriesNumber(5, null, "cbz")).toBe("Vol. 5");
+    expect(formatSeriesNumber(5, null, null, "cbz")).toBe("Vol. 5");
   });
+
   it("uses bare number for non-CBZ", () => {
-    expect(formatSeriesNumber(3, null, "epub")).toBe("3");
+    expect(formatSeriesNumber(3, null, null, "epub")).toBe("3");
   });
+
   it("returns empty for null number", () => {
-    expect(formatSeriesNumber(null, null, "cbz")).toBe("");
+    expect(formatSeriesNumber(null, 3, null, "cbz")).toBe("");
   });
+
   it("formats fractional", () => {
-    expect(formatSeriesNumber(7.5, "chapter", "cbz")).toBe("Ch. 7.5");
+    expect(formatSeriesNumber(7.5, null, "chapter", "cbz")).toBe("Ch. 7.5");
   });
 });

--- a/app/utils/seriesNumber.ts
+++ b/app/utils/seriesNumber.ts
@@ -2,13 +2,17 @@ import type { SeriesNumberUnit } from "@/types/generated/models";
 
 export function formatSeriesNumber(
   number: number | null | undefined,
+  end: number | null | undefined,
   unit: SeriesNumberUnit | null | undefined,
   fileType: string | null | undefined,
 ): string {
   if (number === null || number === undefined) return "";
+
+  const range =
+    end === null || end === undefined ? `${number}` : `${number}-${end}`;
   if (fileType === "cbz") {
-    if (unit === "chapter") return `Ch. ${number}`;
-    return `Vol. ${number}`;
+    if (unit === "chapter") return `Ch. ${range}`;
+    return `Vol. ${range}`;
   }
-  return `${number}`;
+  return range;
 }

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -45,7 +45,7 @@ A book can belong to multiple series, each with an optional series number. Serie
 
 In series listings, individually numbered books appear before omnibuses. Omnibuses are then ordered by their range start and end. Download filenames and OPDS descriptions display the complete range. Kobo sync and EPUB metadata use the range start because their numeric series fields cannot represent an end.
 
-The API, [book sidecars](./sidecar-files#book-sidecar-format), and web book editor can set and preserve ranges. In the book editor, the start stays inline while the advanced settings button on each series row opens the optional end field. An ordinary scan preserves a sidecar-backed range. Refresh and reset intentionally discard cached sidecars, so a format that only supplies the start can reduce the range to a single number.
+The API, [book sidecars](./sidecar-files#book-sidecar-format), and web book editor can set and preserve ranges. In the book editor, the start stays inline while the advanced settings button on each series row opens the optional end field. The end must be greater than or equal to the start. An ordinary scan preserves a sidecar-backed range. Refresh and reset intentionally discard cached sidecars, so a format that only supplies the start can reduce the range to a single number.
 
 ### Genres and Tags
 

--- a/website/docs/metadata.md
+++ b/website/docs/metadata.md
@@ -45,7 +45,7 @@ A book can belong to multiple series, each with an optional series number. Serie
 
 In series listings, individually numbered books appear before omnibuses. Omnibuses are then ordered by their range start and end. Download filenames and OPDS descriptions display the complete range. Kobo sync and EPUB metadata use the range start because their numeric series fields cannot represent an end.
 
-The API and [book sidecars](./sidecar-files#book-sidecar-format) can set and preserve ranges. The current web book editor only exposes a single series number. An ordinary scan preserves a sidecar-backed range. Refresh and reset intentionally discard cached sidecars, so a format that only supplies the start can reduce the range to a single number.
+The API, [book sidecars](./sidecar-files#book-sidecar-format), and web book editor can set and preserve ranges. In the book editor, the start stays inline while the advanced settings button on each series row opens the optional end field. An ordinary scan preserves a sidecar-backed range. Refresh and reset intentionally discard cached sidecars, so a format that only supplies the start can reduce the range to a single number.
 
 ### Genres and Tags
 
@@ -302,7 +302,7 @@ CBZ books have an additional field — **series number unit** — that records w
 
 Ambiguous indicators (`#001`, bare trailing numbers) default to **volume** to preserve historical behavior.
 
-**Other sources:** Plugin metadata and [sidecar files](./sidecar-files) can also supply the unit via a `unit` field on the series entry. Manual edits via the book edit dialog let you change the unit using the unit dropdown next to the series number field.
+**Other sources:** Plugin metadata and [sidecar files](./sidecar-files) can also supply the unit via a `unit` field on the series entry. For books with a CBZ file, the advanced settings button on each series row in the book edit dialog includes the unit dropdown. Books without a CBZ file do not show this control.
 
 **CBZ books with no unit set** render as volumes for backward compatibility — the unit field being `null` is treated the same as `volume` in the reader and in file organization.
 


### PR DESCRIPTION
Closes #403

## Summary
- Added omnibus series range editing with inline start numbers and per-row advanced popovers for end values and CBZ-only units.
- Added compact range summaries and end-aware formatting across the book gallery and detail views.
- Preserved range changes in FormDialog state, validated invalid ranges, and wired end and unit values into update payloads.
- Updated the metadata documentation for range editing and constraints.

## Test plan
- Run `pnpm vitest run app/utils/seriesNumber.test.ts app/components/library/BookItem.test.tsx app/components/library/BookEditDialog.test.tsx`.
- Verify bare and CBZ-prefixed range formatting.
- Verify BookItem range badges and edit-dialog range and unit payloads.
- Verify Unit is hidden for non-CBZ books and range edits trigger unsaved-change protection.
- Run `mise lint:js` and `mise check:quiet`.
