### PR TITLE
[Feature] Round-trip CBZ omnibus ranges

### DIFF
--- a/pkg/books/handlers.go
+++ b/pkg/books/handlers.go
@@ -90,6 +90,32 @@ type pluginManager interface {
 	RegisteredFileExtensions() map[string]struct{}
 }
 
+func seriesNumberGroupChangedForOrganization(oldMembership *models.BookSeries, newMembership *SeriesInput) bool {
+	var oldStart, oldEnd *float64
+	var oldUnit *string
+	if oldMembership != nil {
+		oldStart = oldMembership.SeriesNumber
+		oldEnd = oldMembership.SeriesNumberEnd
+		oldUnit = oldMembership.SeriesNumberUnit
+	}
+	var newStart, newEnd *float64
+	var newUnit *string
+	if newMembership != nil {
+		newStart = newMembership.Number
+		newEnd = newMembership.NumberEnd
+		newUnit = newMembership.SeriesNumberUnit
+	}
+	return !equalOptionalFloat(oldStart, newStart) || !equalOptionalFloat(oldEnd, newEnd) || !equalOptionalString(oldUnit, newUnit)
+}
+
+func equalOptionalFloat(a, b *float64) bool {
+	return a == nil && b == nil || a != nil && b != nil && *a == *b
+}
+
+func equalOptionalString(a, b *string) bool {
+	return a == nil && b == nil || a != nil && b != nil && *a == *b
+}
+
 func (h *handler) retrieve(c echo.Context) error {
 	ctx := c.Request().Context()
 	id, err := strconv.Atoi(c.Param("id"))
@@ -390,33 +416,15 @@ func (h *handler) update(c echo.Context) error {
 			}
 		}
 		if hasCBZFiles {
-			// Compare old and new series numbers
-			oldSeriesNum := float64(0)
-			if len(book.BookSeries) > 0 && book.BookSeries[0].SeriesNumber != nil {
-				oldSeriesNum = *book.BookSeries[0].SeriesNumber
-			}
-			newSeriesNum := float64(0)
-			if len(params.Series) > 0 && params.Series[0].Number != nil {
-				newSeriesNum = *params.Series[0].Number
-			}
-			if oldSeriesNum != newSeriesNum {
-				shouldOrganizeFiles = true
-			}
-
-			// Compare old and new series number units
-			var oldUnit *string
+			var oldMembership *models.BookSeries
 			if len(book.BookSeries) > 0 {
-				oldUnit = book.BookSeries[0].SeriesNumberUnit
+				oldMembership = book.BookSeries[0]
 			}
-			var newUnit *string
+			var newMembership *SeriesInput
 			if len(params.Series) > 0 {
-				newUnit = params.Series[0].SeriesNumberUnit
+				newMembership = &params.Series[0]
 			}
-			if (oldUnit == nil) != (newUnit == nil) {
-				shouldOrganizeFiles = true
-			} else if oldUnit != nil && newUnit != nil && *oldUnit != *newUnit {
-				shouldOrganizeFiles = true
-			}
+			shouldOrganizeFiles = shouldOrganizeFiles || seriesNumberGroupChangedForOrganization(oldMembership, newMembership)
 		}
 
 		// Delete existing series associations

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -2335,7 +2335,7 @@ func TestUpdateBook_SeriesNumberEndOnly_ReorganizesCBZ(t *testing.T) {
 
 	book := &models.Book{
 		LibraryID:       library.ID,
-		Title:           "Saga",
+		Title:           "Saga v001-003",
 		TitleSource:     models.DataSourceManual,
 		SortTitle:       "Saga",
 		SortTitleSource: models.DataSourceFilepath,
@@ -2364,6 +2364,9 @@ func TestUpdateBook_SeriesNumberEndOnly_ReorganizesCBZ(t *testing.T) {
 	}).Exec(ctx)
 	require.NoError(t, err)
 
+	epubPath := filepath.Join(oldBookDir, "Saga.epub")
+	require.NoError(t, os.WriteFile(epubPath, []byte("epub"), 0o644))
+	setupTestFile(t, db, book, models.FileTypeEPUB, epubPath)
 	cbzPath := filepath.Join(oldBookDir, "Saga.cbz")
 	require.NoError(t, os.WriteFile(cbzPath, []byte("cbz"), 0o644))
 	file := setupTestFile(t, db, book, models.FileTypeCBZ, cbzPath)
@@ -2377,7 +2380,7 @@ func TestUpdateBook_SeriesNumberEndOnly_ReorganizesCBZ(t *testing.T) {
 
 	var updatedFile models.File
 	require.NoError(t, db.NewSelect().Model(&updatedFile).Where("f.id = ?", file.ID).Scan(ctx))
-	assert.Equal(t, filepath.Join(libraryDir, "Saga v001-004", "Saga.cbz"), updatedFile.Filepath)
+	assert.Equal(t, filepath.Join(libraryDir, "Saga v001-004"), filepath.Dir(updatedFile.Filepath))
 	_, err = os.Stat(updatedFile.Filepath)
 	require.NoError(t, err)
 	_, err = os.Stat(oldBookDir)

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/labstack/echo/v4"
+	"github.com/robinjoseph08/golib/pointerutil"
 	"github.com/shishobooks/shisho/pkg/appsettings"
 	"github.com/shishobooks/shisho/pkg/auth"
 	"github.com/shishobooks/shisho/pkg/binder"
@@ -2310,6 +2311,23 @@ func TestUpdateFile_IsPreferredCover_ClearingPreferred(t *testing.T) {
 	var f models.File
 	require.NoError(t, db.NewSelect().Model(&f).Where("id = ?", file.ID).Scan(ctx))
 	assert.False(t, f.IsPreferredCover, "preferred should be cleared")
+}
+
+func TestSeriesNumberGroupChangedForOrganization_EndOnly(t *testing.T) {
+	t.Parallel()
+
+	oldMembership := &models.BookSeries{
+		SeriesNumber:     pointerutil.Float64(1),
+		SeriesNumberEnd:  pointerutil.Float64(3),
+		SeriesNumberUnit: pointerutil.String(models.SeriesNumberUnitVolume),
+	}
+	newMembership := SeriesInput{
+		Number:           pointerutil.Float64(1),
+		NumberEnd:        pointerutil.Float64(4),
+		SeriesNumberUnit: pointerutil.String(models.SeriesNumberUnitVolume),
+	}
+
+	assert.True(t, seriesNumberGroupChangedForOrganization(oldMembership, &newMembership))
 }
 
 func TestUpdateBook_SeriesNumberRange_PersistsAndReturnsEnd(t *testing.T) {

--- a/pkg/books/handlers_test.go
+++ b/pkg/books/handlers_test.go
@@ -2313,21 +2313,75 @@ func TestUpdateFile_IsPreferredCover_ClearingPreferred(t *testing.T) {
 	assert.False(t, f.IsPreferredCover, "preferred should be cleared")
 }
 
-func TestSeriesNumberGroupChangedForOrganization_EndOnly(t *testing.T) {
+func TestUpdateBook_SeriesNumberEndOnly_ReorganizesCBZ(t *testing.T) {
 	t.Parallel()
 
-	oldMembership := &models.BookSeries{
+	db := setupTestDB(t)
+	ctx := context.Background()
+	libraryDir := t.TempDir()
+	oldBookDir := filepath.Join(libraryDir, "Saga v001-003")
+	require.NoError(t, os.MkdirAll(oldBookDir, 0o755))
+
+	library := &models.Library{
+		Name:                     "Test Library",
+		CoverAspectRatio:         models.CoverAspectRatioBook,
+		DownloadFormatPreference: models.DownloadFormatOriginal,
+		OrganizeFileStructure:    true,
+	}
+	_, err := db.NewInsert().Model(library).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.LibraryPath{LibraryID: library.ID, Filepath: libraryDir}).Exec(ctx)
+	require.NoError(t, err)
+
+	book := &models.Book{
+		LibraryID:       library.ID,
+		Title:           "Saga",
+		TitleSource:     models.DataSourceManual,
+		SortTitle:       "Saga",
+		SortTitleSource: models.DataSourceFilepath,
+		AuthorSource:    models.DataSourceFilepath,
+		Filepath:        oldBookDir,
+	}
+	_, err = db.NewInsert().Model(book).Exec(ctx)
+	require.NoError(t, err)
+
+	series := &models.Series{
+		LibraryID:      library.ID,
+		Name:           "Saga",
+		NameSource:     models.DataSourceManual,
+		SortName:       "Saga",
+		SortNameSource: models.DataSourceFilepath,
+	}
+	_, err = db.NewInsert().Model(series).Exec(ctx)
+	require.NoError(t, err)
+	_, err = db.NewInsert().Model(&models.BookSeries{
+		BookID:           book.ID,
+		SeriesID:         series.ID,
 		SeriesNumber:     pointerutil.Float64(1),
 		SeriesNumberEnd:  pointerutil.Float64(3),
 		SeriesNumberUnit: pointerutil.String(models.SeriesNumberUnitVolume),
-	}
-	newMembership := SeriesInput{
-		Number:           pointerutil.Float64(1),
-		NumberEnd:        pointerutil.Float64(4),
-		SeriesNumberUnit: pointerutil.String(models.SeriesNumberUnitVolume),
-	}
+		SortOrder:        1,
+	}).Exec(ctx)
+	require.NoError(t, err)
 
-	assert.True(t, seriesNumberGroupChangedForOrganization(oldMembership, &newMembership))
+	cbzPath := filepath.Join(oldBookDir, "Saga.cbz")
+	require.NoError(t, os.WriteFile(cbzPath, []byte("cbz"), 0o644))
+	file := setupTestFile(t, db, book, models.FileTypeCBZ, cbzPath)
+	user := loadUserWithRole(t, db, setupTestUser(t, db, library.ID, true))
+
+	body := `{"series":[{"name":"Saga","number":1,"number_end":4,"series_number_unit":"volume"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/books/"+strconv.Itoa(book.ID), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := executeRequestWithUser(t, setupTestServer(t, db), req, user)
+	require.Equal(t, http.StatusOK, rr.Code, "response body: %s", rr.Body.String())
+
+	var updatedFile models.File
+	require.NoError(t, db.NewSelect().Model(&updatedFile).Where("f.id = ?", file.ID).Scan(ctx))
+	assert.Equal(t, filepath.Join(libraryDir, "Saga v001-004", "Saga.cbz"), updatedFile.Filepath)
+	_, err = os.Stat(updatedFile.Filepath)
+	require.NoError(t, err)
+	_, err = os.Stat(oldBookDir)
+	assert.True(t, os.IsNotExist(err))
 }
 
 func TestUpdateBook_SeriesNumberRange_PersistsAndReturnsEnd(t *testing.T) {

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -905,6 +905,16 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 		seriesNumberUnit = book.BookSeries[0].SeriesNumberUnit
 	}
 
+	// Use CBZ folder naming whenever the book has a main CBZ. Hybrid books must
+	// not change range behavior based on file creation order.
+	folderFileType := files[0].FileType
+	for _, file := range files {
+		if file.FileRole == models.FileRoleMain && file.FileType == models.FileTypeCBZ {
+			folderFileType = models.FileTypeCBZ
+			break
+		}
+	}
+
 	// Create organized name options from current book metadata
 	organizeOpts := fileutils.OrganizedNameOptions{
 		AuthorNames:      authorNames,
@@ -912,7 +922,7 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 		SeriesNumber:     seriesNumber,
 		SeriesNumberEnd:  seriesNumberEnd,
 		SeriesNumberUnit: seriesNumberUnit,
-		FileType:         files[0].FileType,
+		FileType:         folderFileType,
 	}
 
 	// Track path updates for database

--- a/pkg/books/service.go
+++ b/pkg/books/service.go
@@ -897,9 +897,11 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 
 	// Get series number and unit from first BookSeries entry (if any)
 	var seriesNumber *float64
+	var seriesNumberEnd *float64
 	var seriesNumberUnit *string
 	if len(book.BookSeries) > 0 {
 		seriesNumber = book.BookSeries[0].SeriesNumber
+		seriesNumberEnd = book.BookSeries[0].SeriesNumberEnd
 		seriesNumberUnit = book.BookSeries[0].SeriesNumberUnit
 	}
 
@@ -908,7 +910,9 @@ func (svc *Service) organizeBookFiles(ctx context.Context, book *models.Book) er
 		AuthorNames:      authorNames,
 		Title:            book.Title,
 		SeriesNumber:     seriesNumber,
+		SeriesNumberEnd:  seriesNumberEnd,
 		SeriesNumberUnit: seriesNumberUnit,
+		FileType:         files[0].FileType,
 	}
 
 	// Track path updates for database

--- a/pkg/cbz/CLAUDE.md
+++ b/pkg/cbz/CLAUDE.md
@@ -26,7 +26,7 @@ The ComicInfo.xml file follows the ComicRack schema.
 <ComicInfo>
   <Title>Comic Title</Title>
   <Series>Series Name</Series>
-  <Number>5</Number>           <!-- Issue number, can be decimal like "1.5" -->
+  <Number>5</Number>           <!-- Issue number, decimal like "1.5", or range like "1-3" -->
   <Volume>1</Volume>
   <Year>2024</Year>
   <Month>6</Month>
@@ -101,7 +101,7 @@ Multiple creators per role are comma-separated:
 |-------|-------------|-------|
 | Title | `<Title>` | Direct extraction |
 | Series | `<Series>` | Series name |
-| Series Number | `<Number>` | Parsed as float (supports decimals) |
+| Series Number | `<Number>` | Parsed as a single number or increasing range (supports decimals) |
 | Volume | `<Volume>` | Volume number |
 | Authors | 8 creator fields | Each role mapped to AuthorInfo with role |
 | Genres | `<Genre>` | Comma-separated, split into array |
@@ -120,7 +120,7 @@ Multiple creators per role are comma-separated:
 3. Use first image file alphabetically
 
 **Series Number Fallback:**
-If not in ComicInfo, regex patterns extract from filename: `#7`, `v7`, `c7`, `ch.7`, ` 7` at end of filename. Volume indicators (`v`, `#`, bare numbers) set the unit to `volume`; chapter indicators (`c`, `ch.`, `chapter`) set it to `chapter`.
+If not in ComicInfo, filename patterns extract single numbers and contiguous ranges such as `v01-03`, `vol. 1-3`, `#1-3`, bare `1-3`, `ch. 5-8`, and `c05-08`. Hyphen, en dash, and em dash separators are accepted on read. Volume indicators (`v`, `vol`, `volume`, `#`, bare numbers) set the unit to `volume`; chapter indicators (`c`, `ch.`, `chapter`) set it to `chapter`.
 
 **Data Source:** All extracted metadata tagged with `models.DataSourceCBZMetadata`
 
@@ -143,7 +143,7 @@ When generating CBZ files, Shisho:
 |-------|-------------------|--------|
 | Title | `<Title>` | book.Title |
 | Series | `<Series>` | Primary BookSeries (sorted by SortOrder) |
-| Number | `<Number>` | Primary series number |
+| Number | `<Number>` | Primary series number or range, formatted as `1-3` |
 | All 8 author roles | Role-specific elements | Authors mapped by role, comma-separated |
 | Genres | `<Genre>` | Comma-separated from BookGenres |
 | Tags | `<Tags>` | Comma-separated from BookTags |
@@ -244,16 +244,16 @@ Images are sorted **naturally** (page2 < page10) to determine page order.
 
 ## Filename Parsing for Series Number Unit
 
-CBZ filenames can encode either a volume (`v01`, `vol.5`, `volume 12`, `#001`, bare trailing number) or a chapter (`Ch.5`, `chapter 5`, `c042`). The scanner normalizes both into the title (`Title v003` for volumes, `Title c042` for chapters) and stores the parsed unit on `book_series.series_number_unit`.
+CBZ filenames can encode either a volume (`v01`, `vol.5`, `volume 12`, `#001`, bare trailing number) or a chapter (`Ch.5`, `chapter 5`, `c042`). Each form also accepts a strictly increasing contiguous range. The scanner normalizes them into the title (`Title v003` or `Title v001-003` for volumes, `Title c042` or `Title c005-008` for chapters) and stores the parsed start, end, and unit as one atomic group.
 
 Volume vs chapter is determined by the explicit indicator. Ambiguous indicators (`#001`, bare trailing numbers like `Title 5`) default to `volume` to preserve historical behavior; existing scanned files don't shift semantics on rescan.
 
 The pipeline lives in `pkg/fileutils/naming.go`:
 - `NormalizeSeriesNumberInTitle` — recognizes the indicators and produces a normalized title with the parsed unit.
-- `ExtractSeriesFromTitle` — splits a normalized title into series name and number, returning the unit alongside.
-- `formatSeriesNumber` / `IsOrganizedName` — handle the inverse, formatting numbers as `v{N}` or `c{N}` for organized filenames.
+- `ExtractSeriesFromTitle` — splits a normalized title into the series name, start, optional end, and unit.
+- `formatSeriesNumber` / `IsOrganizedName` — handle the inverse, formatting single numbers and ranges as `v{N}` or `c{N}` suffixes.
 
-When a library has file organization enabled, chapter-numbered files are renamed to `Title c042.cbz` and volume-numbered files to `Title v042.cbz` — the unit round-trips through organize → rescan.
+When a library has file organization enabled, chapter-numbered files use `Title c042.cbz` or `Title c005-008.cbz`, while volume-numbered files use `Title v042.cbz` or `Title v001-003.cbz`. Both endpoints and the unit round-trip through organization and rescanning.
 
 ## Scanner Integration
 
@@ -294,9 +294,10 @@ CBZ files can be converted to fixed-layout KePub for Kobo devices. See `pkg/kepu
 - Default to Writer field during generation
 - Parsed as writer role if found in Writer field
 
-**Decimal Series Numbers:**
-- `1.5` formatted as "1.5" (string)
-- `1.0` formatted as "1" (no decimal)
+**Decimal Series Numbers and Ranges:**
+- `1.5` is formatted as `1.5`
+- `1.0` is formatted as `1`
+- A range from `1.5` to `3.5` is formatted as `1.5-3.5` in ComicInfo and `v001.5-003.5` or `c001.5-003.5` in organized names
 
 **Missing ComicInfo.xml:**
 - Generator creates new ComicInfo.xml with all metadata

--- a/pkg/cbz/CLAUDE.md
+++ b/pkg/cbz/CLAUDE.md
@@ -253,7 +253,9 @@ The pipeline lives in `pkg/fileutils/naming.go`:
 - `ExtractSeriesFromTitle` — splits a normalized title into the series name, start, optional end, and unit.
 - `formatSeriesNumber` / `IsOrganizedName` — handle the inverse, formatting single numbers and ranges as `v{N}` or `c{N}` suffixes.
 
-When a library has file organization enabled, chapter-numbered files use `Title c042.cbz` or `Title c005-008.cbz`, while volume-numbered files use `Title v042.cbz` or `Title v001-003.cbz`. Both endpoints and the unit round-trip through organization and rescanning.
+When a library has file organization enabled, the range is a folder suffix: chapter-numbered books use layouts such as `Title c042/Title.cbz` or `Title c005-008/Title.cbz`, while volume-numbered books use `Title v042/Title.cbz` or `Title v001-003/Title.cbz`.
+
+ComicInfo `Number` round-trips the endpoints but cannot encode the volume/chapter unit. The unit round-trips only when the complete atomic group comes from one source that can represent it, such as the filename or sidecar. Shisho never combines ComicInfo endpoints with a filename-derived unit.
 
 ## Scanner Integration
 

--- a/pkg/cbz/cbz.go
+++ b/pkg/cbz/cbz.go
@@ -18,6 +18,7 @@ import (
 	"github.com/shishobooks/shisho/pkg/identifiers"
 	"github.com/shishobooks/shisho/pkg/mediafile"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/seriesnum"
 )
 
 type ComicInfo struct {
@@ -126,16 +127,17 @@ func Parse(path string) (*mediafile.ParsedMetadata, error) {
 	authors := []mediafile.ParsedAuthor{}
 	series := ""
 	var seriesNumber *float64
+	var seriesNumberEnd *float64
+	var seriesNumberUnit *string
 
 	if comicInfo != nil {
 		title = comicInfo.Title
 		series = comicInfo.Series
 
-		// Use series number from ComicInfo if available
-		if comicInfo.Number != "" {
-			if num, err := strconv.ParseFloat(comicInfo.Number, 64); err == nil {
-				seriesNumber = &num
-			}
+		// ComicInfo Number may contain either a single number or an omnibus range.
+		if start, end, ok := seriesnum.ParseRange(comicInfo.Number); ok {
+			seriesNumber = &start
+			seriesNumberEnd = end
 		}
 
 		// Collect all creator fields with their roles
@@ -223,12 +225,16 @@ func Parse(path string) (*mediafile.ParsedMetadata, error) {
 		}
 	}
 
-	// If no series number from ComicInfo, try to extract from filename
-	if seriesNumber == nil {
-		filename := filepath.Base(path)
-		if num := extractSeriesNumberFromFilename(filename); num != nil {
-			seriesNumber = num
-		}
+	// The filename provides a fallback number group and the volume/chapter unit.
+	// When ComicInfo has the number, retain its endpoints but still honor an
+	// explicit filename unit, matching the existing single-number behavior.
+	filenameStart, filenameEnd, filenameUnit := extractSeriesNumberFromFilename(filepath.Base(path))
+	if seriesNumber == nil && filenameStart != nil {
+		seriesNumber = filenameStart
+		seriesNumberEnd = filenameEnd
+	}
+	if filenameUnit != nil {
+		seriesNumberUnit = filenameUnit
 	}
 
 	// Extract language from LanguageISO
@@ -253,24 +259,26 @@ func Parse(path string) (*mediafile.ParsedMetadata, error) {
 	}
 
 	return &mediafile.ParsedMetadata{
-		Title:         title,
-		Authors:       authors,
-		Series:        series,
-		SeriesNumber:  seriesNumber,
-		Genres:        genres,
-		Tags:          tags,
-		Description:   description,
-		Publisher:     publisher,
-		URL:           url,
-		ReleaseDate:   releaseDate,
-		Language:      language,
-		CoverMimeType: coverMimeType,
-		CoverData:     coverData,
-		CoverPage:     coverPage,
-		PageCount:     pageCount,
-		DataSource:    models.DataSourceCBZMetadata,
-		Identifiers:   identifiersList,
-		Chapters:      chapters,
+		Title:            title,
+		Authors:          authors,
+		Series:           series,
+		SeriesNumber:     seriesNumber,
+		SeriesNumberEnd:  seriesNumberEnd,
+		SeriesNumberUnit: seriesNumberUnit,
+		Genres:           genres,
+		Tags:             tags,
+		Description:      description,
+		Publisher:        publisher,
+		URL:              url,
+		ReleaseDate:      releaseDate,
+		Language:         language,
+		CoverMimeType:    coverMimeType,
+		CoverData:        coverData,
+		CoverPage:        coverPage,
+		PageCount:        pageCount,
+		DataSource:       models.DataSourceCBZMetadata,
+		Identifiers:      identifiersList,
+		Chapters:         chapters,
 	}, nil
 }
 
@@ -394,29 +402,17 @@ func splitCreators(creators string) []string {
 // cbzParensRE matches parenthesized metadata sections like (2020), (Digital), (group).
 var cbzParensRE = regexp.MustCompile(`\([^)]*\)`)
 
-func extractSeriesNumberFromFilename(filename string) *float64 {
-	// Remove extension for processing
+func extractSeriesNumberFromFilename(filename string) (start, end *float64, unit *string) {
 	nameWithoutExt := strings.TrimSuffix(filename, filepath.Ext(filename))
+	nameWithoutExt = strings.TrimSpace(cbzParensRE.ReplaceAllString(nameWithoutExt, ""))
 
-	// Strip parenthesized metadata (year, quality, group) before matching volume
-	nameWithoutExt = cbzParensRE.ReplaceAllString(nameWithoutExt, "")
-	nameWithoutExt = strings.TrimSpace(nameWithoutExt)
-
-	// Try patterns: #7, v7, or just 7 at the end
-	patterns := []string{
-		`(?i)#(\d+(?:\.\d+)?)$`,   // matches #7 or #7.5
-		`(?i)v(\d+(?:\.\d+)?)$`,   // matches v7 or v7.5
-		`(?i)\s+(\d+(?:\.\d+)?)$`, // matches " 7" or " 7.5"
+	normalized, parsedUnit, ok := fileutils.NormalizeSeriesNumberInTitle(nameWithoutExt, models.FileTypeCBZ)
+	if !ok {
+		return nil, nil, nil
 	}
-
-	for _, pattern := range patterns {
-		re := regexp.MustCompile(pattern)
-		if matches := re.FindStringSubmatch(nameWithoutExt); len(matches) >= 2 {
-			if num, err := strconv.ParseFloat(matches[1], 64); err == nil {
-				return &num
-			}
-		}
+	_, start, end, parsedUnit, ok = fileutils.ExtractSeriesFromTitle(normalized, models.FileTypeCBZ)
+	if !ok {
+		return nil, nil, nil
 	}
-
-	return nil
+	return start, end, &parsedUnit
 }

--- a/pkg/cbz/cbz.go
+++ b/pkg/cbz/cbz.go
@@ -225,16 +225,15 @@ func Parse(path string) (*mediafile.ParsedMetadata, error) {
 		}
 	}
 
-	// The filename provides a fallback number group and the volume/chapter unit.
-	// When ComicInfo has the number, retain its endpoints but still honor an
-	// explicit filename unit, matching the existing single-number behavior.
-	filenameStart, filenameEnd, filenameUnit := extractSeriesNumberFromFilename(filepath.Base(path))
-	if seriesNumber == nil && filenameStart != nil {
-		seriesNumber = filenameStart
-		seriesNumberEnd = filenameEnd
-	}
-	if filenameUnit != nil {
-		seriesNumberUnit = filenameUnit
+	// The filename provides a fallback atomic number group only when ComicInfo
+	// does not provide one. Never combine endpoints and units from two sources.
+	if seriesNumber == nil {
+		filenameStart, filenameEnd, filenameUnit := extractSeriesNumberFromFilename(filepath.Base(path))
+		if filenameStart != nil {
+			seriesNumber = filenameStart
+			seriesNumberEnd = filenameEnd
+			seriesNumberUnit = filenameUnit
+		}
 	}
 
 	// Extract language from LanguageISO

--- a/pkg/cbz/cbz_test.go
+++ b/pkg/cbz/cbz_test.go
@@ -39,6 +39,36 @@ func TestParseCBZ_SeriesRange(t *testing.T) {
 	assert.InDelta(t, 3, *metadata.SeriesNumberEnd, 0.001)
 }
 
+func TestParseCBZ_ComicInfoRangeDoesNotMixFilenameUnit(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cbzPath := filepath.Join(tmpDir, "Saga c05-08.cbz")
+	f, err := os.Create(cbzPath)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+
+	imgWriter, err := zw.Create("page001.jpg")
+	require.NoError(t, err)
+	_, err = imgWriter.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0})
+	require.NoError(t, err)
+
+	comicInfoWriter, err := zw.Create("ComicInfo.xml")
+	require.NoError(t, err)
+	_, err = comicInfoWriter.Write([]byte(`<ComicInfo><Title>Saga</Title><Series>Saga</Series><Number>1-3</Number></ComicInfo>`))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+
+	metadata, err := Parse(cbzPath)
+	require.NoError(t, err)
+	require.NotNil(t, metadata.SeriesNumber)
+	require.NotNil(t, metadata.SeriesNumberEnd)
+	assert.InDelta(t, 1, *metadata.SeriesNumber, 0.001)
+	assert.InDelta(t, 3, *metadata.SeriesNumberEnd, 0.001)
+	assert.Nil(t, metadata.SeriesNumberUnit)
+}
+
 func TestParseCBZ_Identifiers(t *testing.T) {
 	t.Parallel()
 	// Create test CBZ with ComicInfo.xml containing GTIN

--- a/pkg/cbz/cbz_test.go
+++ b/pkg/cbz/cbz_test.go
@@ -10,6 +10,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseCBZ_SeriesRange(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cbzPath := filepath.Join(tmpDir, "Saga v01-03.cbz")
+	f, err := os.Create(cbzPath)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+
+	imgWriter, err := zw.Create("page001.jpg")
+	require.NoError(t, err)
+	_, err = imgWriter.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0})
+	require.NoError(t, err)
+
+	comicInfoWriter, err := zw.Create("ComicInfo.xml")
+	require.NoError(t, err)
+	_, err = comicInfoWriter.Write([]byte(`<ComicInfo><Title>Saga</Title><Series>Saga</Series><Number>1-3</Number></ComicInfo>`))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+
+	metadata, err := Parse(cbzPath)
+	require.NoError(t, err)
+	require.NotNil(t, metadata.SeriesNumber)
+	require.NotNil(t, metadata.SeriesNumberEnd)
+	assert.InDelta(t, 1, *metadata.SeriesNumber, 0.001)
+	assert.InDelta(t, 3, *metadata.SeriesNumberEnd, 0.001)
+}
+
 func TestParseCBZ_Identifiers(t *testing.T) {
 	t.Parallel()
 	// Create test CBZ with ComicInfo.xml containing GTIN
@@ -234,26 +263,45 @@ func TestExtractSeriesNumberFromFilename(t *testing.T) {
 		name     string
 		filename string
 		want     *float64
+		wantEnd  *float64
+		wantUnit *string
 	}{
-		{"v prefix", "Comic Title v2.cbz", floatPtr(2)},
-		{"v prefix with leading zeros", "Comic Title v02.cbz", floatPtr(2)},
-		{"hash prefix", "Comic Title #7.cbz", floatPtr(7)},
-		{"bare number", "Comic Title 3.cbz", floatPtr(3)},
-		{"decimal volume", "Comic Title v1.5.cbz", floatPtr(1.5)},
-		{"strips parenthesized metadata", "Comic Title v02 (2020) (Digital) (group).cbz", floatPtr(2)},
-		{"strips parens with hash", "Title #5 (HD) (Group).cbz", floatPtr(5)},
-		{"no volume number", "Comic Title.cbz", nil},
+		{"v prefix", "Comic Title v2.cbz", floatPtr(2), nil, stringPtr("volume")},
+		{"v range", "Comic Title v01-03.cbz", floatPtr(1), floatPtr(3), stringPtr("volume")},
+		{"vol range", "Comic Title vol. 1 - 3.cbz", floatPtr(1), floatPtr(3), stringPtr("volume")},
+		{"volume decimal range", "Comic Title volume 1.5—3.5.cbz", floatPtr(1.5), floatPtr(3.5), stringPtr("volume")},
+		{"hash range", "Comic Title #1–3.cbz", floatPtr(1), floatPtr(3), stringPtr("volume")},
+		{"bare range", "Comic Title 1-3.cbz", floatPtr(1), floatPtr(3), stringPtr("volume")},
+		{"chapter range", "Comic Title chapter 5-8.cbz", floatPtr(5), floatPtr(8), stringPtr("chapter")},
+		{"ch range", "Comic Title ch. 5 - 8.cbz", floatPtr(5), floatPtr(8), stringPtr("chapter")},
+		{"c range", "Comic Title c05-08.cbz", floatPtr(5), floatPtr(8), stringPtr("chapter")},
+		{"decimal volume", "Comic Title v1.5.cbz", floatPtr(1.5), nil, stringPtr("volume")},
+		{"strips parenthesized metadata", "Comic Title v02 (2020) (Digital) (group).cbz", floatPtr(2), nil, stringPtr("volume")},
+		{"reversed range rejected", "Comic Title v3-1.cbz", nil, nil, nil},
+		{"equal range rejected", "Comic Title c5-5.cbz", nil, nil, nil},
+		{"non-contiguous range rejected", "Comic Title v1,3.cbz", nil, nil, nil},
+		{"no volume number", "Comic Title.cbz", nil, nil, nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractSeriesNumberFromFilename(tt.filename)
+			t.Parallel()
+			got, gotEnd, gotUnit := extractSeriesNumberFromFilename(tt.filename)
 			if tt.want == nil {
 				assert.Nil(t, got)
 			} else {
 				require.NotNil(t, got)
 				assert.InDelta(t, *tt.want, *got, 0.001)
 			}
+			if tt.wantEnd == nil {
+				assert.Nil(t, gotEnd)
+			} else {
+				require.NotNil(t, gotEnd)
+				assert.InDelta(t, *tt.wantEnd, *gotEnd, 0.001)
+			}
+			assert.Equal(t, tt.wantUnit, gotUnit)
 		})
 	}
 }
+
+func stringPtr(value string) *string { return &value }

--- a/pkg/cbz/cbz_test.go
+++ b/pkg/cbz/cbz_test.go
@@ -69,6 +69,35 @@ func TestParseCBZ_ComicInfoRangeDoesNotMixFilenameUnit(t *testing.T) {
 	assert.Nil(t, metadata.SeriesNumberUnit)
 }
 
+func TestParseCBZ_FilenameRangeFallback(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cbzPath := filepath.Join(tmpDir, "Saga c05-08.cbz")
+	f, err := os.Create(cbzPath)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+	imgWriter, err := zw.Create("page001.jpg")
+	require.NoError(t, err)
+	_, err = imgWriter.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0})
+	require.NoError(t, err)
+	comicInfoWriter, err := zw.Create("ComicInfo.xml")
+	require.NoError(t, err)
+	_, err = comicInfoWriter.Write([]byte(`<ComicInfo><Title>Saga</Title><Series>Saga</Series></ComicInfo>`))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+
+	metadata, err := Parse(cbzPath)
+	require.NoError(t, err)
+	require.NotNil(t, metadata.SeriesNumber)
+	require.NotNil(t, metadata.SeriesNumberEnd)
+	require.NotNil(t, metadata.SeriesNumberUnit)
+	assert.InDelta(t, 5, *metadata.SeriesNumber, 0.001)
+	assert.InDelta(t, 8, *metadata.SeriesNumberEnd, 0.001)
+	assert.Equal(t, "chapter", *metadata.SeriesNumberUnit)
+}
+
 func TestParseCBZ_Identifiers(t *testing.T) {
 	t.Parallel()
 	// Create test CBZ with ComicInfo.xml containing GTIN

--- a/pkg/filegen/cbz.go
+++ b/pkg/filegen/cbz.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/shishobooks/shisho/pkg/kepub"
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/seriesnum"
 )
 
 // CBZGenerator generates CBZ comic book files with modified metadata.
@@ -352,7 +352,7 @@ func modifyCBZComicInfo(existing *cbzComicInfo, book *models.Book, file *models.
 			comicInfo.Series = first.Series.Name
 		}
 		if first.SeriesNumber != nil {
-			comicInfo.Number = formatCBZNumber(*first.SeriesNumber)
+			comicInfo.Number = seriesnum.FormatRange(*first.SeriesNumber, first.SeriesNumberEnd)
 		} else {
 			comicInfo.Number = ""
 		}
@@ -524,15 +524,6 @@ func readCBZZipFile(f *zip.File) ([]byte, error) {
 	defer r.Close()
 
 	return io.ReadAll(r)
-}
-
-// formatCBZNumber formats a float64 for series number.
-// Whole numbers display without decimal (e.g., "1"), decimals are preserved (e.g., "1.5").
-func formatCBZNumber(f float64) string {
-	if f == math.Floor(f) {
-		return strconv.Itoa(int(f))
-	}
-	return fmt.Sprintf("%g", f)
 }
 
 // selectGTIN selects the best identifier to use as GTIN (priority: ISBN-13 > ISBN-10 > Other > ASIN).

--- a/pkg/filegen/cbz_test.go
+++ b/pkg/filegen/cbz_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/robinjoseph08/golib/pointerutil"
+	"github.com/shishobooks/shisho/pkg/cbz"
 	"github.com/shishobooks/shisho/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -56,6 +57,36 @@ func TestCBZGenerator_Generate(t *testing.T) {
 		assert.Equal(t, "New Title", comicInfo.Title)
 		assert.Equal(t, "New Series", comicInfo.Series)
 		assert.Equal(t, "5", comicInfo.Number)
+	})
+
+	t.Run("writes and round-trips an omnibus series range", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		srcPath := filepath.Join(tmpDir, "source.cbz")
+		createTestCBZ(t, srcPath, testCBZOptions{title: "Collected Stories", series: "Saga", number: "1"})
+		destPath := filepath.Join(tmpDir, "dest.cbz")
+
+		book := &models.Book{
+			Title: "Collected Stories",
+			BookSeries: []*models.BookSeries{{
+				SortOrder:       0,
+				SeriesNumber:    pointerutil.Float64(1),
+				SeriesNumberEnd: pointerutil.Float64(3),
+				Series:          &models.Series{Name: "Saga"},
+			}},
+		}
+		file := &models.File{FileType: models.FileTypeCBZ}
+
+		gen := &CBZGenerator{}
+		require.NoError(t, gen.Generate(context.Background(), srcPath, destPath, book, file))
+		assert.Equal(t, "1-3", readComicInfoFromCBZ(t, destPath).Number)
+
+		parsed, err := cbz.Parse(destPath)
+		require.NoError(t, err)
+		require.NotNil(t, parsed.SeriesNumber)
+		require.NotNil(t, parsed.SeriesNumberEnd)
+		assert.InDelta(t, 1, *parsed.SeriesNumber, 0.001)
+		assert.InDelta(t, 3, *parsed.SeriesNumberEnd, 0.001)
 	})
 
 	t.Run("generates correct author roles", func(t *testing.T) {

--- a/pkg/fileutils/naming.go
+++ b/pkg/fileutils/naming.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/shishobooks/shisho/pkg/models"
+	"github.com/shishobooks/shisho/pkg/seriesnum"
 )
 
 // OrganizedNameOptions contains the data needed to generate organized file/folder names.
@@ -16,6 +16,7 @@ type OrganizedNameOptions struct {
 	NarratorNames    []string // Narrator names for M4B file naming
 	Title            string
 	SeriesNumber     *float64
+	SeriesNumberEnd  *float64
 	SeriesNumberUnit *string // for CBZ: models.SeriesNumberUnitVolume or models.SeriesNumberUnitChapter; nil treated as volume
 	FileType         string  // for determining number formatting
 }
@@ -31,23 +32,25 @@ func GenerateOrganizedFolderName(opts OrganizedNameOptions) string {
 		parts = append(parts, fmt.Sprintf("[%s]", author))
 	}
 
-	// Add title
-	if opts.Title != "" {
-		title := sanitizeForFilename(opts.Title)
-		parts = append(parts, title)
+	// Strip a normalized CBZ number from the title before applying the current
+	// atomic number group. This lets edits to either endpoint update the name
+	// instead of preserving a stale suffix.
+	title := opts.Title
+	if opts.SeriesNumber != nil && opts.FileType == models.FileTypeCBZ {
+		if seriesName, _, _, _, ok := ExtractSeriesFromTitle(title, opts.FileType); ok {
+			title = seriesName
+		}
+	}
+	if title != "" {
+		parts = append(parts, sanitizeForFilename(title))
 	}
 
-	// Add series number only for CBZ files (manga/comic). But only if the title
-	// doesn't already encode a number.
 	if opts.SeriesNumber != nil && opts.FileType == models.FileTypeCBZ {
-		existingNum, _ := extractSeriesNumberFromTitle(opts.Title)
-		if existingNum == nil {
-			unit := ""
-			if opts.SeriesNumberUnit != nil {
-				unit = *opts.SeriesNumberUnit
-			}
-			parts = append(parts, formatSeriesNumber(*opts.SeriesNumber, unit, opts.FileType))
+		unit := ""
+		if opts.SeriesNumberUnit != nil {
+			unit = *opts.SeriesNumberUnit
 		}
+		parts = append(parts, formatSeriesNumber(*opts.SeriesNumber, opts.SeriesNumberEnd, unit, opts.FileType))
 	}
 
 	name := strings.Join(parts, " ")
@@ -73,6 +76,7 @@ func GenerateOrganizedFileName(opts OrganizedNameOptions, originalFilepath strin
 
 	optsForFilename := opts
 	optsForFilename.SeriesNumber = nil
+	optsForFilename.SeriesNumberEnd = nil
 	optsForFilename.AuthorNames = nil
 	baseName := GenerateOrganizedFolderName(optsForFilename)
 
@@ -89,21 +93,15 @@ func GenerateOrganizedFileName(opts OrganizedNameOptions, originalFilepath strin
 // "v" for volume (and the empty-unit default), "c" for chapter. Non-CBZ files keep
 // the legacy "#N" form, which is currently unused since this helper is only invoked
 // for CBZ in GenerateOrganizedFolderName.
-func formatSeriesNumber(number float64, unit string, fileType string) string {
+func formatSeriesNumber(number float64, numberEnd *float64, unit string, fileType string) string {
 	if fileType == models.FileTypeCBZ {
 		prefix := "v"
 		if unit == models.SeriesNumberUnitChapter {
 			prefix = "c"
 		}
-		if number == float64(int(number)) {
-			return fmt.Sprintf("%s%d", prefix, int(number))
-		}
-		return fmt.Sprintf("%s%.1f", prefix, number)
+		return prefix + formatPaddedSeriesRange(number, numberEnd)
 	}
-	if number == float64(int(number)) {
-		return fmt.Sprintf("#%d", int(number))
-	}
-	return fmt.Sprintf("#%.1f", number)
+	return "#" + seriesnum.FormatRange(number, numberEnd)
 }
 
 // sanitizeForFilename removes or replaces characters that are not safe for filenames.
@@ -140,7 +138,7 @@ func IsOrganizedName(name string) bool {
 
 	// Basic pattern: starts with [Author] or contains series number indicators
 	authorPattern := regexp.MustCompile(`^\[.+\]`)
-	seriesNumberPattern := regexp.MustCompile(`([vc]\d+(?:\.\d+)?|#\d+(?:\.\d+)?)$`)
+	seriesNumberPattern := regexp.MustCompile(`([vc]\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?)?|#\d+(?:\.\d+)?)$`)
 
 	return authorPattern.MatchString(nameWithoutExt) || seriesNumberPattern.MatchString(nameWithoutExt)
 }
@@ -149,18 +147,23 @@ func IsOrganizedName(name string) bool {
 // Each entry pairs a compiled regexp with the unit it implies. First match wins;
 // explicit chapter patterns precede explicit volume patterns; ambiguous indicators
 // (#, bare numbers) default to volume to preserve historical behavior.
+const (
+	seriesNumberRE = `\d+(?:\.\d+)?`
+	seriesRangeRE  = seriesNumberRE + `(?:\s*[-–—]\s*` + seriesNumberRE + `)?`
+)
+
 var seriesNumberPatterns = []struct {
 	re   *regexp.Regexp
 	unit string
 }{
-	{regexp.MustCompile(`(?i)\s*chapter\s*(\d+(?:\.\d+)?)\s*$`), models.SeriesNumberUnitChapter},
-	{regexp.MustCompile(`(?i)\s*ch\.?\s*(\d+(?:\.\d+)?)\s*$`), models.SeriesNumberUnitChapter},
-	{regexp.MustCompile(`(?i)\s+c(\d+(?:\.\d+)?)\s*$`), models.SeriesNumberUnitChapter},
-	{regexp.MustCompile(`(?i)\s*#(\d+(?:\.\d+)?)\s*$`), models.SeriesNumberUnitVolume},
-	{regexp.MustCompile(`(?i)\s+v(\d+(?:\.\d+)?)\s*$`), models.SeriesNumberUnitVolume},
-	{regexp.MustCompile(`(?i)\s*vol\.?\s*(\d+(?:\.\d+)?)\s*$`), models.SeriesNumberUnitVolume},
-	{regexp.MustCompile(`(?i)\s*volume\s*(\d+(?:\.\d+)?)\s*$`), models.SeriesNumberUnitVolume},
-	{regexp.MustCompile(`\s+(\d+(?:\.\d+)?)\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s*chapter\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
+	{regexp.MustCompile(`(?i)\s*ch\.?\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
+	{regexp.MustCompile(`(?i)\s+c(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
+	{regexp.MustCompile(`(?i)\s*#(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s+v(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s*vol\.?\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s*volume\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`\s+(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
 }
 
 // NormalizeSeriesNumberInTitle normalizes volume- or chapter-style number
@@ -181,48 +184,59 @@ func NormalizeSeriesNumberInTitle(title string, fileType string) (string, string
 		if len(matches) < 2 {
 			continue
 		}
-		baseTitle := strings.TrimSpace(p.re.ReplaceAllString(title, ""))
-		number, err := strconv.ParseFloat(matches[1], 64)
-		if err != nil {
+		start, end, ok := seriesnum.ParseRange(matches[1])
+		if !ok {
 			continue
 		}
+		baseTitle := strings.TrimSpace(p.re.ReplaceAllString(title, ""))
 		prefix := "v"
 		if p.unit == models.SeriesNumberUnitChapter {
 			prefix = "c"
 		}
-		var normalized string
-		if number == float64(int(number)) {
-			normalized = fmt.Sprintf("%s %s%03d", baseTitle, prefix, int(number))
-		} else {
-			intPart := int(number)
-			fracStr := strconv.FormatFloat(number-float64(intPart), 'f', -1, 64)
-			// fracStr is "0.5"; strip the leading "0".
-			normalized = fmt.Sprintf("%s %s%03d%s", baseTitle, prefix, intPart, fracStr[1:])
-		}
+		normalized := fmt.Sprintf("%s %s%s", baseTitle, prefix, formatPaddedSeriesRange(start, end))
 		return strings.TrimSpace(normalized), p.unit, true
 	}
 
 	return title, "", false
 }
 
+func formatPaddedSeriesRange(start float64, end *float64) string {
+	formatted := formatPaddedSeriesEndpoint(start)
+	if end != nil {
+		formatted += "-" + formatPaddedSeriesEndpoint(*end)
+	}
+	return formatted
+}
+
+func formatPaddedSeriesEndpoint(number float64) string {
+	formatted := seriesnum.FormatRange(number, nil)
+	integer, fraction, hasFraction := strings.Cut(formatted, ".")
+	if len(integer) < 3 {
+		integer = strings.Repeat("0", 3-len(integer)) + integer
+	}
+	if hasFraction {
+		return integer + "." + fraction
+	}
+	return integer
+}
+
 // extractSeriesNumberFromTitle extracts a normalized series number suffix
-// ("v003" or "c042") from a title. Returns the number and unit, or (nil, "")
-// if no suffix is present.
-func extractSeriesNumberFromTitle(title string) (*float64, string) {
-	seriesNumberPattern := regexp.MustCompile(`\s+([vc])(\d+(?:\.\d+)?)\s*$`)
+// ("v003", "c042", or a range such as "v001-003") from a title.
+func extractSeriesNumberFromTitle(title string) (start, end *float64, unit string) {
+	seriesNumberPattern := regexp.MustCompile(`\s+([vc])(` + seriesRangeRE + `)\s*$`)
 	matches := seriesNumberPattern.FindStringSubmatch(title)
 	if len(matches) < 3 {
-		return nil, ""
+		return nil, nil, ""
 	}
-	number, err := strconv.ParseFloat(matches[2], 64)
-	if err != nil {
-		return nil, ""
+	startValue, end, ok := seriesnum.ParseRange(matches[2])
+	if !ok {
+		return nil, nil, ""
 	}
-	unit := models.SeriesNumberUnitVolume
+	unit = models.SeriesNumberUnitVolume
 	if strings.EqualFold(matches[1], "c") {
 		unit = models.SeriesNumberUnitChapter
 	}
-	return &number, unit
+	return &startValue, end, unit
 }
 
 // SplitNames splits a string of names by common delimiters (comma and semicolon),
@@ -245,30 +259,28 @@ func SplitNames(s string) []string {
 	return parts
 }
 
-// ExtractSeriesFromTitle extracts series name and number from a normalized CBZ title.
-// Returns the base title (series name), number, unit (models.SeriesNumberUnitVolume or models.SeriesNumberUnitChapter), and
-// whether extraction succeeded. Only applies to CBZ files with normalized "v{N}"
-// or "c{N}" suffixes.
-func ExtractSeriesFromTitle(title string, fileType string) (seriesName string, number *float64, unit string, ok bool) {
+// ExtractSeriesFromTitle extracts a series name and atomic number group from a
+// normalized CBZ title. It accepts "v{N}" / "c{N}" suffixes and their ranges.
+func ExtractSeriesFromTitle(title string, fileType string) (seriesName string, start, end *float64, unit string, ok bool) {
 	if fileType != models.FileTypeCBZ {
-		return "", nil, "", false
+		return "", nil, nil, "", false
 	}
-	seriesNumberPattern := regexp.MustCompile(`^(.+?)\s+([vc])(\d+(?:\.\d+)?)\s*$`)
+	seriesNumberPattern := regexp.MustCompile(`^(.+?)\s+([vc])(` + seriesRangeRE + `)\s*$`)
 	matches := seriesNumberPattern.FindStringSubmatch(title)
 	if len(matches) < 4 {
-		return "", nil, "", false
+		return "", nil, nil, "", false
 	}
 	seriesName = strings.TrimSpace(matches[1])
 	if seriesName == "" {
-		return "", nil, "", false
+		return "", nil, nil, "", false
 	}
-	parsed, err := strconv.ParseFloat(matches[3], 64)
-	if err != nil {
-		return "", nil, "", false
+	startValue, end, ok := seriesnum.ParseRange(matches[3])
+	if !ok {
+		return "", nil, nil, "", false
 	}
-	parsedUnit := models.SeriesNumberUnitVolume
+	unit = models.SeriesNumberUnitVolume
 	if strings.EqualFold(matches[2], "c") {
-		parsedUnit = models.SeriesNumberUnitChapter
+		unit = models.SeriesNumberUnitChapter
 	}
-	return seriesName, &parsed, parsedUnit, true
+	return seriesName, &startValue, end, unit, true
 }

--- a/pkg/fileutils/naming.go
+++ b/pkg/fileutils/naming.go
@@ -33,8 +33,8 @@ func GenerateOrganizedFolderName(opts OrganizedNameOptions) string {
 	}
 
 	// Strip a normalized CBZ number from the title before applying the current
-	// atomic number group. This lets edits to either endpoint update the name
-	// instead of preserving a stale suffix.
+	// atomic number group. This updates changed endpoints without treating a
+	// title suffix as disposable when no series membership exists.
 	title := opts.Title
 	if opts.SeriesNumber != nil && opts.FileType == models.FileTypeCBZ {
 		if seriesName, _, _, _, ok := ExtractSeriesFromTitle(title, opts.FileType); ok {
@@ -136,11 +136,21 @@ func IsOrganizedName(name string) bool {
 	// Remove extension for analysis
 	nameWithoutExt := strings.TrimSuffix(name, filepath.Ext(name))
 
-	// Basic pattern: starts with [Author] or contains series number indicators
-	authorPattern := regexp.MustCompile(`^\[.+\]`)
-	seriesNumberPattern := regexp.MustCompile(`(?i)(?:[vc]\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?)?|#\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?)?|\d+(?:\.\d+)?-\d+(?:\.\d+)?)$`)
+	if regexp.MustCompile(`^\[.+\]`).MatchString(nameWithoutExt) {
+		return true
+	}
 
-	return authorPattern.MatchString(nameWithoutExt) || seriesNumberPattern.MatchString(nameWithoutExt)
+	prefixed := regexp.MustCompile(`(?i)[vc#]\s*(` + seriesRangeRE + `)$`).FindStringSubmatch(nameWithoutExt)
+	if len(prefixed) == 2 {
+		_, _, ok := seriesnum.ParseRange(prefixed[1])
+		return ok
+	}
+	bareRange := regexp.MustCompile(`(` + seriesNumberRE + `\s*[-–—]\s*` + seriesNumberRE + `)$`).FindStringSubmatch(nameWithoutExt)
+	if len(bareRange) == 2 {
+		_, _, ok := seriesnum.ParseRange(bareRange[1])
+		return ok
+	}
+	return false
 }
 
 // seriesNumberPatterns is the regex pattern table used by NormalizeSeriesNumberInTitle.
@@ -148,22 +158,23 @@ func IsOrganizedName(name string) bool {
 // explicit chapter patterns precede explicit volume patterns; ambiguous indicators
 // (#, bare numbers) default to volume to preserve historical behavior.
 const (
-	seriesNumberRE = `\d+(?:\.\d+)?`
+	seriesNumberRE = `[+-]?\d+(?:\.\d+)?`
 	seriesRangeRE  = seriesNumberRE + `(?:\s*[-–—]\s*` + seriesNumberRE + `)?`
+	seriesValueRE  = `([+-]?\d.*?)`
 )
 
 var seriesNumberPatterns = []struct {
 	re   *regexp.Regexp
 	unit string
 }{
-	{regexp.MustCompile(`(?i)\s*chapter\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
-	{regexp.MustCompile(`(?i)\s*ch\.?\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
-	{regexp.MustCompile(`(?i)\s+c\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
-	{regexp.MustCompile(`(?i)\s*#\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
-	{regexp.MustCompile(`(?i)\s+v\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
-	{regexp.MustCompile(`(?i)\s*vol\.?\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
-	{regexp.MustCompile(`(?i)\s*volume\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
-	{regexp.MustCompile(`\s+(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s*chapter\s*` + seriesValueRE + `\s*$`), models.SeriesNumberUnitChapter},
+	{regexp.MustCompile(`(?i)\s*ch\.?\s*` + seriesValueRE + `\s*$`), models.SeriesNumberUnitChapter},
+	{regexp.MustCompile(`(?i)\s+c\s*` + seriesValueRE + `\s*$`), models.SeriesNumberUnitChapter},
+	{regexp.MustCompile(`(?i)\s*#\s*` + seriesValueRE + `\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s+v\s*` + seriesValueRE + `\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s*volume\s*` + seriesValueRE + `\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s*vol\.?\s*` + seriesValueRE + `\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`\s+` + seriesValueRE + `\s*$`), models.SeriesNumberUnitVolume},
 }
 
 // NormalizeSeriesNumberInTitle normalizes volume- or chapter-style number
@@ -186,7 +197,7 @@ func NormalizeSeriesNumberInTitle(title string, fileType string) (string, string
 		}
 		start, end, ok := seriesnum.ParseRange(matches[1])
 		if !ok {
-			continue
+			return title, "", false
 		}
 		baseTitle := strings.TrimSpace(p.re.ReplaceAllString(title, ""))
 		prefix := "v"
@@ -210,14 +221,19 @@ func formatPaddedSeriesRange(start float64, end *float64) string {
 
 func formatPaddedSeriesEndpoint(number float64) string {
 	formatted := seriesnum.FormatRange(number, nil)
+	sign := ""
+	if strings.HasPrefix(formatted, "-") {
+		sign = "-"
+		formatted = strings.TrimPrefix(formatted, "-")
+	}
 	integer, fraction, hasFraction := strings.Cut(formatted, ".")
 	if len(integer) < 3 {
 		integer = strings.Repeat("0", 3-len(integer)) + integer
 	}
 	if hasFraction {
-		return integer + "." + fraction
+		return sign + integer + "." + fraction
 	}
-	return integer
+	return sign + integer
 }
 
 // extractSeriesNumberFromTitle extracts a normalized series number suffix

--- a/pkg/fileutils/naming.go
+++ b/pkg/fileutils/naming.go
@@ -138,7 +138,7 @@ func IsOrganizedName(name string) bool {
 
 	// Basic pattern: starts with [Author] or contains series number indicators
 	authorPattern := regexp.MustCompile(`^\[.+\]`)
-	seriesNumberPattern := regexp.MustCompile(`([vc]\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?)?|#\d+(?:\.\d+)?)$`)
+	seriesNumberPattern := regexp.MustCompile(`(?i)(?:[vc]\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?)?|#\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?)?|\d+(?:\.\d+)?-\d+(?:\.\d+)?)$`)
 
 	return authorPattern.MatchString(nameWithoutExt) || seriesNumberPattern.MatchString(nameWithoutExt)
 }
@@ -158,9 +158,9 @@ var seriesNumberPatterns = []struct {
 }{
 	{regexp.MustCompile(`(?i)\s*chapter\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
 	{regexp.MustCompile(`(?i)\s*ch\.?\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
-	{regexp.MustCompile(`(?i)\s+c(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
-	{regexp.MustCompile(`(?i)\s*#(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
-	{regexp.MustCompile(`(?i)\s+v(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s+c\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitChapter},
+	{regexp.MustCompile(`(?i)\s*#\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
+	{regexp.MustCompile(`(?i)\s+v\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
 	{regexp.MustCompile(`(?i)\s*vol\.?\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
 	{regexp.MustCompile(`(?i)\s*volume\s*(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},
 	{regexp.MustCompile(`\s+(` + seriesRangeRE + `)\s*$`), models.SeriesNumberUnitVolume},

--- a/pkg/fileutils/naming_test.go
+++ b/pkg/fileutils/naming_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNormalizeSeriesNumberInTitle(t *testing.T) {
@@ -29,6 +30,13 @@ func TestNormalizeSeriesNumberInTitle(t *testing.T) {
 		{"ch without dot", "One Piece Ch 42", "cbz", "One Piece c042", "chapter", true},
 		{"c compact", "One Piece c042", "cbz", "One Piece c042", "chapter", true},
 		{"fractional chapter", "One Piece c5.5", "cbz", "One Piece c005.5", "chapter", true},
+		// Omnibus ranges preserve the unit and normalize both endpoints.
+		{"compact volume range", "Naruto v01-03", "cbz", "Naruto v001-003", "volume", true},
+		{"volume word decimal range", "Naruto volume 1.5 — 3.5", "cbz", "Naruto v001.5-003.5", "volume", true},
+		{"chapter abbreviation range", "One Piece ch. 5–8", "cbz", "One Piece c005-008", "chapter", true},
+		{"compact chapter decimal range", "One Piece c05.5 - 08.5", "cbz", "One Piece c005.5-008.5", "chapter", true},
+		{"hash range defaults to volume", "Saga #1 - 3", "cbz", "Saga v001-003", "volume", true},
+		{"bare trailing range defaults to volume", "Saga 1-3", "cbz", "Saga v001-003", "volume", true},
 		// Non-CBZ short-circuits
 		{"epub returns false", "Some Book v3", "epub", "Some Book v3", "", false},
 		{"m4b returns false", "Some Book v3", "m4b", "Some Book v3", "", false},
@@ -37,6 +45,10 @@ func TestNormalizeSeriesNumberInTitle(t *testing.T) {
 		// Compact c/v require leading whitespace — no false positives mid-word
 		{"compact c not eaten mid-word", "Abc123", "cbz", "Abc123", "", false},
 		{"compact v not eaten mid-word", "Marv7", "cbz", "Marv7", "", false},
+		{"reversed range rejected", "Saga v3-1", "cbz", "Saga v3-1", "", false},
+		{"equal range rejected", "Saga chapter 3-3", "cbz", "Saga chapter 3-3", "", false},
+		{"non-contiguous pair rejected", "Saga v1,3", "cbz", "Saga v1,3", "", false},
+		{"more than two endpoints rejected", "Saga v1-3-5", "cbz", "Saga v1-3-5", "", false},
 	}
 
 	for _, tt := range tests {
@@ -115,23 +127,26 @@ func TestSplitNames(t *testing.T) {
 func TestFormatSeriesNumber(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name     string
-		number   float64
-		unit     string
-		fileType string
-		want     string
+		name      string
+		number    float64
+		numberEnd *float64
+		unit      string
+		fileType  string
+		want      string
 	}{
-		{"volume integer", 5, "volume", "cbz", "v5"},
-		{"volume empty unit defaults to v", 5, "", "cbz", "v5"},
-		{"chapter integer", 42, "chapter", "cbz", "c42"},
-		{"volume fractional", 7.5, "volume", "cbz", "v7.5"},
-		{"chapter fractional", 7.5, "chapter", "cbz", "c7.5"},
-		{"non-cbz still uses #", 3, "", "epub", "#3"},
+		{"volume integer", 5, nil, "volume", "cbz", "v005"},
+		{"volume empty unit defaults to v", 5, nil, "", "cbz", "v005"},
+		{"chapter integer", 42, nil, "chapter", "cbz", "c042"},
+		{"volume fractional", 7.5, nil, "volume", "cbz", "v007.5"},
+		{"chapter fractional", 7.5, nil, "chapter", "cbz", "c007.5"},
+		{"volume integer range", 1, floatPtr(3), "volume", "cbz", "v001-003"},
+		{"chapter decimal range", 5.5, floatPtr(8.5), "chapter", "cbz", "c005.5-008.5"},
+		{"non-cbz still uses #", 3, nil, "", "epub", "#3"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := formatSeriesNumber(tt.number, tt.unit, tt.fileType)
+			got := formatSeriesNumber(tt.number, tt.numberEnd, tt.unit, tt.fileType)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -143,22 +158,31 @@ func TestExtractSeriesNumberFromTitle(t *testing.T) {
 		name     string
 		title    string
 		wantNum  *float64
+		wantEnd  *float64
 		wantUnit string
 	}{
-		{"volume", "Naruto v003", floatPtr(3), "volume"},
-		{"chapter", "One Piece c042", floatPtr(42), "chapter"},
-		{"none", "No Number Here", nil, ""},
-		{"fractional volume", "Naruto v007.5", floatPtr(7.5), "volume"},
+		{"volume", "Naruto v003", floatPtr(3), nil, "volume"},
+		{"chapter", "One Piece c042", floatPtr(42), nil, "chapter"},
+		{"volume range", "Naruto v001-003", floatPtr(1), floatPtr(3), "volume"},
+		{"chapter decimal range", "One Piece c005.5-008.5", floatPtr(5.5), floatPtr(8.5), "chapter"},
+		{"none", "No Number Here", nil, nil, ""},
+		{"fractional volume", "Naruto v007.5", floatPtr(7.5), nil, "volume"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotNum, gotUnit := extractSeriesNumberFromTitle(tt.title)
+			gotNum, gotEnd, gotUnit := extractSeriesNumberFromTitle(tt.title)
 			if tt.wantNum == nil {
 				assert.Nil(t, gotNum)
 			} else {
-				assert.NotNil(t, gotNum)
-				assert.InEpsilon(t, *tt.wantNum, *gotNum, 0.0001)
+				require.NotNil(t, gotNum)
+				assert.InDelta(t, *tt.wantNum, *gotNum, 0.0001)
+			}
+			if tt.wantEnd == nil {
+				assert.Nil(t, gotEnd)
+			} else {
+				require.NotNil(t, gotEnd)
+				assert.InDelta(t, *tt.wantEnd, *gotEnd, 0.0001)
 			}
 			assert.Equal(t, tt.wantUnit, gotUnit)
 		})
@@ -173,27 +197,75 @@ func TestExtractSeriesFromTitle(t *testing.T) {
 		fileType   string
 		wantSeries string
 		wantNum    *float64
+		wantEnd    *float64
 		wantUnit   string
 		wantOK     bool
 	}{
-		{"volume", "Naruto v003", "cbz", "Naruto", floatPtr(3), "volume", true},
-		{"chapter", "One Piece c042", "cbz", "One Piece", floatPtr(42), "chapter", true},
-		{"non-cbz returns false", "Naruto v003", "epub", "", nil, "", false},
-		{"no number returns false", "Just A Title", "cbz", "", nil, "", false},
+		{"volume", "Naruto v003", "cbz", "Naruto", floatPtr(3), nil, "volume", true},
+		{"chapter", "One Piece c042", "cbz", "One Piece", floatPtr(42), nil, "chapter", true},
+		{"volume range", "Naruto v001-003", "cbz", "Naruto", floatPtr(1), floatPtr(3), "volume", true},
+		{"chapter decimal range", "One Piece c005.5-008.5", "cbz", "One Piece", floatPtr(5.5), floatPtr(8.5), "chapter", true},
+		{"non-cbz returns false", "Naruto v003", "epub", "", nil, nil, "", false},
+		{"no number returns false", "Just A Title", "cbz", "", nil, nil, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			gotSeries, gotNum, gotUnit, gotOK := ExtractSeriesFromTitle(tt.title, tt.fileType)
+			gotSeries, gotNum, gotEnd, gotUnit, gotOK := ExtractSeriesFromTitle(tt.title, tt.fileType)
 			assert.Equal(t, tt.wantSeries, gotSeries)
 			assert.Equal(t, tt.wantUnit, gotUnit)
 			assert.Equal(t, tt.wantOK, gotOK)
 			if tt.wantNum == nil {
 				assert.Nil(t, gotNum)
 			} else {
-				assert.NotNil(t, gotNum)
-				assert.InEpsilon(t, *tt.wantNum, *gotNum, 0.0001)
+				require.NotNil(t, gotNum)
+				assert.InDelta(t, *tt.wantNum, *gotNum, 0.0001)
 			}
+			if tt.wantEnd == nil {
+				assert.Nil(t, gotEnd)
+			} else {
+				require.NotNil(t, gotEnd)
+				assert.InDelta(t, *tt.wantEnd, *gotEnd, 0.0001)
+			}
+		})
+	}
+}
+
+func TestSeriesNumberRangeNamingRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantName string
+		wantUnit string
+		wantFrom float64
+		wantTo   float64
+	}{
+		{"integer volume", "Saga vol. 1-3", "Saga v001-003", "volume", 1, 3},
+		{"decimal volume", "Saga #1.5—3.5", "Saga v001.5-003.5", "volume", 1.5, 3.5},
+		{"integer chapter", "Saga chapter 5 - 8", "Saga c005-008", "chapter", 5, 8},
+		{"decimal chapter", "Saga c05.5–08.5", "Saga c005.5-008.5", "chapter", 5.5, 8.5},
+		{"bare volume", "Saga 10-12", "Saga v010-012", "volume", 10, 12},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			normalized, normalizedUnit, ok := NormalizeSeriesNumberInTitle(tt.input, "cbz")
+			require.True(t, ok)
+			assert.Equal(t, tt.wantName, normalized)
+			assert.Equal(t, tt.wantUnit, normalizedUnit)
+
+			series, start, end, extractedUnit, ok := ExtractSeriesFromTitle(normalized, "cbz")
+			require.True(t, ok)
+			assert.Equal(t, "Saga", series)
+			require.NotNil(t, start)
+			require.NotNil(t, end)
+			assert.InDelta(t, tt.wantFrom, *start, 0.0001)
+			assert.InDelta(t, tt.wantTo, *end, 0.0001)
+			assert.Equal(t, tt.wantUnit, extractedUnit)
+			assert.Equal(t, normalized, series+" "+formatSeriesNumber(*start, end, extractedUnit, "cbz"))
 		})
 	}
 }
@@ -202,6 +274,8 @@ func TestIsOrganizedName_Chapter(t *testing.T) {
 	t.Parallel()
 	assert.True(t, IsOrganizedName("Naruto c042.cbz"))
 	assert.True(t, IsOrganizedName("Naruto v042.cbz"))
+	assert.True(t, IsOrganizedName("Naruto v001-003.cbz"))
+	assert.True(t, IsOrganizedName("Naruto c005.5-008.5.cbz"))
 	assert.True(t, IsOrganizedName("Naruto #042.cbz"))
 	assert.True(t, IsOrganizedName("[Author] Title.cbz"))
 }
@@ -218,7 +292,7 @@ func TestGenerateOrganizedFolderName_ChapterUnit(t *testing.T) {
 		SeriesNumberUnit: &chapterUnit,
 		FileType:         "cbz",
 	})
-	assert.Equal(t, "[Eiichiro Oda] One Piece c42", got)
+	assert.Equal(t, "[Eiichiro Oda] One Piece c042", got)
 }
 
 func TestGenerateOrganizedFolderName_VolumeUnitDefault(t *testing.T) {
@@ -230,7 +304,20 @@ func TestGenerateOrganizedFolderName_VolumeUnitDefault(t *testing.T) {
 		FileType:     "cbz",
 	})
 	// Nil unit on CBZ keeps today's behavior: format as volume.
-	assert.Equal(t, "[Eiichiro Oda] One Piece v42", got)
+	assert.Equal(t, "[Eiichiro Oda] One Piece v042", got)
+}
+
+func TestGenerateOrganizedFolderName_Range(t *testing.T) {
+	t.Parallel()
+	chapterUnit := "chapter"
+	got := GenerateOrganizedFolderName(OrganizedNameOptions{
+		Title:            "One Piece",
+		SeriesNumber:     floatPtr(5),
+		SeriesNumberEnd:  floatPtr(8),
+		SeriesNumberUnit: &chapterUnit,
+		FileType:         "cbz",
+	})
+	assert.Equal(t, "One Piece c005-008", got)
 }
 
 func TestGenerateOrganizedFolderName_TitleAlreadyHasChapter(t *testing.T) {

--- a/pkg/fileutils/naming_test.go
+++ b/pkg/fileutils/naming_test.go
@@ -40,6 +40,11 @@ func TestNormalizeSeriesNumberInTitle(t *testing.T) {
 		{"hash range defaults to volume", "Saga #1 - 3", "cbz", "Saga v001-003", "volume", true},
 		{"spaced hash range defaults to volume", "Saga # 1 - 3", "cbz", "Saga v001-003", "volume", true},
 		{"bare trailing range defaults to volume", "Saga 1-3", "cbz", "Saga v001-003", "volume", true},
+		{"negative single volume", "Saga v-1", "cbz", "Saga v-001", "volume", true},
+		{"negative volume range", "Saga v-3--1", "cbz", "Saga v-003--001", "volume", true},
+		{"spaced reversed range rejected", "Saga v3 - 1", "cbz", "Saga v3 - 1", "", false},
+		{"spaced equal range rejected", "Saga c3 - 3", "cbz", "Saga c3 - 3", "", false},
+		{"spaced extra endpoint rejected", "Saga v1 - 3 - 5", "cbz", "Saga v1 - 3 - 5", "", false},
 		// Non-CBZ short-circuits
 		{"epub returns false", "Some Book v3", "epub", "Some Book v3", "", false},
 		{"m4b returns false", "Some Book v3", "m4b", "Some Book v3", "", false},
@@ -282,6 +287,9 @@ func TestIsOrganizedName_Chapter(t *testing.T) {
 	assert.True(t, IsOrganizedName("Naruto #042.cbz"))
 	assert.True(t, IsOrganizedName("Naruto #001-003.cbz"))
 	assert.True(t, IsOrganizedName("Naruto 001-003.cbz"))
+	assert.True(t, IsOrganizedName("Naruto v-003--001.cbz"))
+	assert.False(t, IsOrganizedName("Naruto v003-001.cbz"))
+	assert.False(t, IsOrganizedName("Naruto c005-005.cbz"))
 	assert.True(t, IsOrganizedName("[Author] Title.cbz"))
 }
 
@@ -323,6 +331,19 @@ func TestGenerateOrganizedFolderName_Range(t *testing.T) {
 		FileType:         "cbz",
 	})
 	assert.Equal(t, "One Piece c005-008", got)
+}
+
+func TestGenerateOrganizedFolderName_ReplacesOrClearsExistingRange(t *testing.T) {
+	t.Parallel()
+	volumeUnit := "volume"
+
+	assert.Equal(t, "Saga v001-004", GenerateOrganizedFolderName(OrganizedNameOptions{
+		Title:            "Saga v001-003",
+		SeriesNumber:     floatPtr(1),
+		SeriesNumberEnd:  floatPtr(4),
+		SeriesNumberUnit: &volumeUnit,
+		FileType:         "cbz",
+	}))
 }
 
 func TestGenerateOrganizedFolderName_TitleAlreadyHasChapter(t *testing.T) {

--- a/pkg/fileutils/naming_test.go
+++ b/pkg/fileutils/naming_test.go
@@ -32,10 +32,13 @@ func TestNormalizeSeriesNumberInTitle(t *testing.T) {
 		{"fractional chapter", "One Piece c5.5", "cbz", "One Piece c005.5", "chapter", true},
 		// Omnibus ranges preserve the unit and normalize both endpoints.
 		{"compact volume range", "Naruto v01-03", "cbz", "Naruto v001-003", "volume", true},
+		{"spaced compact volume range", "Naruto v 01-03", "cbz", "Naruto v001-003", "volume", true},
 		{"volume word decimal range", "Naruto volume 1.5 — 3.5", "cbz", "Naruto v001.5-003.5", "volume", true},
 		{"chapter abbreviation range", "One Piece ch. 5–8", "cbz", "One Piece c005-008", "chapter", true},
 		{"compact chapter decimal range", "One Piece c05.5 - 08.5", "cbz", "One Piece c005.5-008.5", "chapter", true},
+		{"spaced compact chapter range", "One Piece c 05-08", "cbz", "One Piece c005-008", "chapter", true},
 		{"hash range defaults to volume", "Saga #1 - 3", "cbz", "Saga v001-003", "volume", true},
+		{"spaced hash range defaults to volume", "Saga # 1 - 3", "cbz", "Saga v001-003", "volume", true},
 		{"bare trailing range defaults to volume", "Saga 1-3", "cbz", "Saga v001-003", "volume", true},
 		// Non-CBZ short-circuits
 		{"epub returns false", "Some Book v3", "epub", "Some Book v3", "", false},
@@ -277,6 +280,8 @@ func TestIsOrganizedName_Chapter(t *testing.T) {
 	assert.True(t, IsOrganizedName("Naruto v001-003.cbz"))
 	assert.True(t, IsOrganizedName("Naruto c005.5-008.5.cbz"))
 	assert.True(t, IsOrganizedName("Naruto #042.cbz"))
+	assert.True(t, IsOrganizedName("Naruto #001-003.cbz"))
+	assert.True(t, IsOrganizedName("Naruto 001-003.cbz"))
 	assert.True(t, IsOrganizedName("[Author] Title.cbz"))
 }
 

--- a/pkg/worker/scan.go
+++ b/pkg/worker/scan.go
@@ -67,7 +67,11 @@ func generateCBZFileName(metadata *mediafile.ParsedMetadata, filename string) st
 			if metadata.SeriesNumberUnit != nil && *metadata.SeriesNumberUnit == models.SeriesNumberUnitChapter {
 				prefix = "c"
 			}
-			return metadata.Series + " " + prefix + formatSeriesNumber(*metadata.SeriesNumber)
+			formatted := formatSeriesNumber(*metadata.SeriesNumber)
+			if metadata.SeriesNumberEnd != nil {
+				formatted += "-" + formatSeriesNumber(*metadata.SeriesNumberEnd)
+			}
+			return metadata.Series + " " + prefix + formatted
 		}
 		return metadata.Series
 	}

--- a/pkg/worker/scan_helpers_test.go
+++ b/pkg/worker/scan_helpers_test.go
@@ -347,6 +347,17 @@ func TestGenerateCBZFileName(t *testing.T) {
 			want:     "Comic Title v001",
 		},
 		{
+			name: "series range used when title is empty",
+			metadata: &mediafile.ParsedMetadata{
+				Series:           "Demon Slayer",
+				SeriesNumber:     floatPtr(5),
+				SeriesNumberEnd:  floatPtr(8),
+				SeriesNumberUnit: workerStringPtr(models.SeriesNumberUnitChapter),
+			},
+			filename: "Demon Slayer.cbz",
+			want:     "Demon Slayer c005-008",
+		},
+		{
 			name: "series only when no number",
 			metadata: &mediafile.ParsedMetadata{
 				Title:        "",
@@ -405,6 +416,8 @@ func TestGenerateCBZFileName(t *testing.T) {
 		})
 	}
 }
+
+func workerStringPtr(value string) *string { return &value }
 
 func TestCleanCBZFilename(t *testing.T) {
 	t.Parallel()

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -2800,9 +2800,10 @@ func applyFilepathFallbacks(metadata *mediafile.ParsedMetadata, filePath, bookPa
 	// Series fallback from title (e.g., "My Series v3" → series="My Series", number=3)
 	if metadata.Series == "" {
 		title := metadata.Title
-		if seriesName, seriesNumber, unit, ok := fileutils.ExtractSeriesFromTitle(title, fileType); ok {
+		if seriesName, seriesNumber, seriesNumberEnd, unit, ok := fileutils.ExtractSeriesFromTitle(title, fileType); ok {
 			metadata.Series = seriesName
 			metadata.SeriesNumber = seriesNumber
+			metadata.SeriesNumberEnd = seriesNumberEnd
 			if unit != "" && metadata.SeriesNumberUnit == nil {
 				u := unit
 				metadata.SeriesNumberUnit = &u

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -4812,6 +4812,22 @@ func TestApplyFilepathFallbacks_PopulatesSeriesFromTitle(t *testing.T) {
 	assert.NotEmpty(t, metadata.Series)
 }
 
+func TestApplyFilepathFallbacks_PopulatesAtomicSeriesRangeFromTitle(t *testing.T) {
+	t.Parallel()
+
+	metadata := &mediafile.ParsedMetadata{DataSource: models.DataSourceCBZMetadata}
+	applyFilepathFallbacks(metadata, "/library/My Series c005-008.cbz", "/library/My Series c005-008", "cbz", true)
+
+	assert.Equal(t, "My Series", metadata.Series)
+	require.NotNil(t, metadata.SeriesNumber)
+	require.NotNil(t, metadata.SeriesNumberEnd)
+	require.NotNil(t, metadata.SeriesNumberUnit)
+	assert.InDelta(t, 5, *metadata.SeriesNumber, 0.001)
+	assert.InDelta(t, 8, *metadata.SeriesNumberEnd, 0.001)
+	assert.Equal(t, models.SeriesNumberUnitChapter, *metadata.SeriesNumberUnit)
+	assert.Equal(t, models.DataSourceFilepath, metadata.SourceForField("series"))
+}
+
 func TestApplyFilepathFallbacks_DoesNotMixUnitIntoPluginSeriesGroup(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/worker/scan_unified_test.go
+++ b/pkg/worker/scan_unified_test.go
@@ -1252,6 +1252,44 @@ func TestScanFileCore_Series_HigherPriority(t *testing.T) {
 	assert.InDelta(t, 2.0, *updatedBook.BookSeries[0].SeriesNumber, 0.0001)
 }
 
+func TestScanFileCore_CBZSeriesRange_PersistsAtomicGroup(t *testing.T) {
+	t.Parallel()
+	tc := newTestContext(t)
+	libraryPath := testgen.TempLibraryDir(t)
+	tc.createLibrary([]string{libraryPath})
+
+	book := &models.Book{
+		LibraryID: 1, Filepath: libraryPath, Title: "Saga", TitleSource: models.DataSourceFilepath,
+		SortTitle: "Saga", AuthorSource: models.DataSourceFilepath,
+	}
+	require.NoError(t, tc.bookService.CreateBook(tc.ctx, book))
+	file := &models.File{
+		LibraryID: 1, BookID: book.ID, Filepath: filepath.Join(libraryPath, "saga.cbz"),
+		FileType: models.FileTypeCBZ, FilesizeBytes: 1000,
+	}
+	require.NoError(t, tc.bookService.CreateFile(tc.ctx, file))
+	unit := models.SeriesNumberUnitChapter
+	metadata := &mediafile.ParsedMetadata{
+		Series: "Saga", SeriesNumber: seriesFloatPtr(5), SeriesNumberEnd: seriesFloatPtr(8),
+		SeriesNumberUnit: &unit, DataSource: models.DataSourceCBZMetadata,
+	}
+
+	_, err := tc.worker.scanFileCore(tc.ctx, file, book, metadata, false, true, nil, nil)
+	require.NoError(t, err)
+	updatedBook, err := tc.bookService.RetrieveBook(tc.ctx, books.RetrieveBookOptions{ID: &book.ID})
+	require.NoError(t, err)
+	require.Len(t, updatedBook.BookSeries, 1)
+	membership := updatedBook.BookSeries[0]
+	require.NotNil(t, membership.SeriesNumber)
+	require.NotNil(t, membership.SeriesNumberEnd)
+	require.NotNil(t, membership.SeriesNumberUnit)
+	assert.InDelta(t, 5, *membership.SeriesNumber, 0.001)
+	assert.InDelta(t, 8, *membership.SeriesNumberEnd, 0.001)
+	assert.Equal(t, unit, *membership.SeriesNumberUnit)
+	require.NotNil(t, membership.Series)
+	assert.Equal(t, models.DataSourceCBZMetadata, membership.Series.NameSource)
+}
+
 func TestScanFileCore_Genres_HigherPriority(t *testing.T) {
 	t.Parallel()
 	tc := newTestContext(t)

--- a/website/docs/supported-formats.md
+++ b/website/docs/supported-formats.md
@@ -26,7 +26,7 @@ Audiobooks encoded with the newer xHE-AAC codec only play in Safari (and other i
 
 ## Comics
 
-- **CBZ** — Full [metadata extraction](./metadata#cbz) from ComicInfo.xml including title, authors, series, cover art, and language. Omnibus series ranges round-trip through ComicInfo `Number` values such as `1-3` and organized names such as `Title v001-003` or `Title c005-008`. Includes an in-app viewer with fit-width/fit-height modes and auto-hide controls
+- **CBZ** — Full [metadata extraction](./metadata#cbz) from ComicInfo.xml including title, authors, series, cover art, and language. Omnibus series ranges round-trip through ComicInfo `Number` values such as `1-3` and organized folder names such as `Title v001-003` or `Title c005-008`. Includes an in-app viewer with fit-width/fit-height modes and auto-hide controls
 
 ## Downloads
 

--- a/website/docs/supported-formats.md
+++ b/website/docs/supported-formats.md
@@ -26,7 +26,7 @@ Audiobooks encoded with the newer xHE-AAC codec only play in Safari (and other i
 
 ## Comics
 
-- **CBZ** — Full [metadata extraction](./metadata#cbz) from ComicInfo.xml including title, authors, series, cover art, and language. Includes an in-app viewer with fit-width/fit-height modes and auto-hide controls
+- **CBZ** — Full [metadata extraction](./metadata#cbz) from ComicInfo.xml including title, authors, series, cover art, and language. Omnibus series ranges round-trip through ComicInfo `Number` values such as `1-3` and organized names such as `Title v001-003` or `Title c005-008`. Includes an in-app viewer with fit-width/fit-height modes and auto-hide controls
 
 ## Downloads
 


### PR DESCRIPTION
Closes #404

## Summary
- Round-trip CBZ omnibus ranges through ComicInfo, filename parsing, scanner persistence, and organized folder names
- Preserve atomic start, end, and unit metadata while rejecting malformed ranges
- Trigger end-only reorganization and document stable range behavior

## Test plan
- Run `mise check:quiet`
- Verify ComicInfo `Number=1-3` parses and regenerates as `1-3`
- Verify supported volume and chapter filename ranges normalize to stable plain-hyphen forms
- Verify changing only the range end reorganizes CBZ and hybrid books