### PR TITLE
[Feature] Add omnibus ranges to plugin metadata

### DIFF
--- a/app/components/library/IdentifyBookDialog.test.tsx
+++ b/app/components/library/IdentifyBookDialog.test.tsx
@@ -133,7 +133,10 @@ function makeBook(overrides: Partial<Book> = {}): Book {
 
 // PluginSearchResult extends the generated ParsedMetadata, whose non-pointer
 // Go fields are always present on the wire; fill them with zero values here.
-function response(title: string): PluginSearchResponse {
+function response(
+  title: string,
+  overrides: Partial<PluginSearchResponse["results"][number]> = {},
+): PluginSearchResponse {
   return {
     results: [
       {
@@ -155,6 +158,7 @@ function response(title: string): PluginSearchResponse {
         chapters: [],
         plugin_scope: "shisho",
         plugin_id: "test",
+        ...overrides,
       },
     ],
     total_plugins: 1,
@@ -253,6 +257,21 @@ describe("IdentifyBookDialog search sequencing", () => {
       expect(screen.getByText("Result B")).toBeInTheDocument();
     });
     expect(screen.queryByText("Result A")).not.toBeInTheDocument();
+  });
+
+  it("renders an omnibus range in a plugin search result", async () => {
+    renderDialog(makeBook({ title: "Query A" }));
+
+    await waitFor(() => expect(requestMock).toHaveBeenCalled());
+    deferredFor("Query A").resolve(
+      response("Ranged result", {
+        series: "Epic Series",
+        series_number: 1,
+        series_number_end: 3,
+      }),
+    );
+
+    expect(await screen.findByText("Epic Series 1-3")).toBeInTheDocument();
   });
 
   it("aborts the superseded request when a newer search is submitted", async () => {

--- a/app/components/library/IdentifyBookDialog.tsx
+++ b/app/components/library/IdentifyBookDialog.tsx
@@ -498,7 +498,7 @@ export function IdentifyBookDialog({
                                     <p className="text-xs text-muted-foreground font-medium mt-0.5">
                                       {result.series}
                                       {result.series_number != null &&
-                                        ` ${formatSeriesNumber(result.series_number, null, result.series_number_unit, selectedFileType)}`}
+                                        ` ${formatSeriesNumber(result.series_number, result.series_number_end, result.series_number_unit, selectedFileType)}`}
                                     </p>
                                   )}
                                 </div>

--- a/app/components/library/IdentifyReviewForm.test.tsx
+++ b/app/components/library/IdentifyReviewForm.test.tsx
@@ -273,7 +273,11 @@ describe("IdentifyReviewForm component", () => {
           } as never,
         ],
       }),
-      result: makeResult({ series: "Some Series", series_number: 2 }),
+      result: makeResult({
+        series: "Some Series",
+        series_number: 1,
+        series_number_unit: "volume",
+      }),
     });
 
     await user.click(getApplyButton());
@@ -282,9 +286,9 @@ describe("IdentifyReviewForm component", () => {
     expect(applyMock.mock.calls[0][0].fields.series).toEqual([
       {
         name: "Some Series",
-        number: 2,
+        number: 1,
         series_number_end: undefined,
-        series_number_unit: undefined,
+        series_number_unit: "volume",
       },
     ]);
   });

--- a/app/components/library/IdentifyReviewForm.test.tsx
+++ b/app/components/library/IdentifyReviewForm.test.tsx
@@ -258,6 +258,76 @@ describe("IdentifyReviewForm component", () => {
     );
   });
 
+  it("submits an incoming omnibus range as one series number group", async () => {
+    const user = createUser();
+    renderForm({
+      result: makeResult({
+        series: "Some Series",
+        series_number: 1,
+        series_number_end: 3,
+        series_number_unit: "volume",
+      }),
+    });
+
+    await user.click(getApplyButton());
+
+    await waitFor(() => expect(applyMock).toHaveBeenCalledTimes(1));
+    expect(applyMock.mock.calls[0][0].fields.series).toEqual([
+      {
+        name: "Some Series",
+        number: 1,
+        series_number_end: 3,
+        series_number_unit: "volume",
+      },
+    ]);
+  });
+
+  it("rejects incomplete and reversed series ranges", async () => {
+    const user = createUser();
+    renderForm({
+      result: makeResult({
+        series: "Some Series",
+        series_number: 1,
+        series_number_end: 3,
+      }),
+    });
+
+    const start = screen.getByRole("spinbutton", { name: "Series start" });
+    const apply = getApplyButton();
+
+    await user.clear(start);
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Series range end requires a start",
+    );
+    expect(apply).toBeDisabled();
+
+    await user.type(start, "3");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Series range end must be greater than its start",
+    );
+    expect(apply).toBeDisabled();
+
+    expect(applyMock).not.toHaveBeenCalled();
+  });
+
+  it("treats the seriesNumber disabled-field alias as the complete series group", () => {
+    renderForm({
+      result: makeResult({
+        disabled_fields: ["seriesNumber"],
+        series: "Some Series",
+        series_number: 1,
+        series_number_end: 3,
+      }),
+    });
+
+    expect(
+      screen.queryByRole("checkbox", { name: "Apply Series" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("spinbutton", { name: "Series start" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("accepting a single series number replaces an existing range group", async () => {
     const user = createUser();
     renderForm({

--- a/app/components/library/IdentifyReviewForm.test.tsx
+++ b/app/components/library/IdentifyReviewForm.test.tsx
@@ -182,6 +182,7 @@ function renderForm(
     book?: Book;
     result?: PluginSearchResult;
     fileId?: number;
+    onHasChangesChange?: (hasChanges: boolean) => void;
   } = {},
 ) {
   const queryClient = new QueryClient({
@@ -200,6 +201,7 @@ function renderForm(
           fileId={opts.fileId}
           onBack={onBack}
           onClose={onClose}
+          onHasChangesChange={opts.onHasChangesChange}
           result={opts.result ?? makeResult()}
         />
       </Dialog>
@@ -326,6 +328,33 @@ describe("IdentifyReviewForm component", () => {
     expect(
       screen.queryByRole("spinbutton", { name: "Series start" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("tracks series end edits and restores the suggested range", async () => {
+    const user = createUser();
+    const onHasChangesChange = vi.fn();
+    renderForm({
+      onHasChangesChange,
+      result: makeResult({
+        series: "Some Series",
+        series_number: 1,
+        series_number_end: 3,
+      }),
+    });
+
+    const end = screen.getByRole("spinbutton", { name: "Series end" });
+    await user.clear(end);
+    await user.type(end, "4");
+    await waitFor(() =>
+      expect(onHasChangesChange).toHaveBeenLastCalledWith(true),
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Restore suggestions" }),
+    );
+    expect(screen.getByRole("spinbutton", { name: "Series end" })).toHaveValue(
+      3,
+    );
   });
 
   it("accepting a single series number replaces an existing range group", async () => {

--- a/app/components/library/IdentifyReviewForm.test.tsx
+++ b/app/components/library/IdentifyReviewForm.test.tsx
@@ -241,6 +241,54 @@ describe("IdentifyReviewForm component", () => {
     expect(screen.getByText("Narrators")).toBeInTheDocument();
   });
 
+  it("surfaces an incoming omnibus series range", () => {
+    renderForm({
+      result: makeResult({
+        series: "Some Series",
+        series_number: 1,
+        series_number_end: 3,
+      }),
+    });
+
+    expect(
+      screen.getByRole("spinbutton", { name: "Series start" }),
+    ).toHaveValue(1);
+    expect(screen.getByRole("spinbutton", { name: "Series end" })).toHaveValue(
+      3,
+    );
+  });
+
+  it("accepting a single series number replaces an existing range group", async () => {
+    const user = createUser();
+    renderForm({
+      book: makeBook({
+        book_series: [
+          {
+            book_id: 1,
+            series_id: 10,
+            series_number: 1,
+            series_number_end: 3,
+            series_number_unit: "volume",
+            series: { id: 10, library_id: 1, name: "Some Series" },
+          } as never,
+        ],
+      }),
+      result: makeResult({ series: "Some Series", series_number: 2 }),
+    });
+
+    await user.click(getApplyButton());
+
+    await waitFor(() => expect(applyMock).toHaveBeenCalledTimes(1));
+    expect(applyMock.mock.calls[0][0].fields.series).toEqual([
+      {
+        name: "Some Series",
+        number: 2,
+        series_number_end: undefined,
+        series_number_unit: undefined,
+      },
+    ]);
+  });
+
   it("clears series when the Remove button is pressed on the series row", async () => {
     const user = createUser();
     renderForm({

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -154,7 +154,7 @@ const PLUGIN_FIELD_ALIASES: Record<FieldKey, string[]> = {
   title: ["title"],
   subtitle: ["subtitle"],
   authors: ["authors"],
-  series: ["series"],
+  series: ["series", "seriesNumber"],
   genres: ["genres"],
   tags: ["tags"],
   description: ["description"],
@@ -278,6 +278,24 @@ function resolveAuthors(
     return { value: current, status: "unchanged" };
   }
   return { value: incoming, status: "changed" };
+}
+
+function validateSeriesEntries(entries: SeriesEntry[]): string | undefined {
+  for (const entry of entries) {
+    if (!entry.name.trim()) continue;
+    const hasStart = entry.number !== "";
+    const hasEnd = entry.numberEnd !== "";
+    if (hasEnd && !hasStart) return "Series range end requires a start.";
+    if (entry.unit !== "" && !hasStart)
+      return "Series number unit requires a start.";
+    if (hasStart && !Number.isFinite(Number(entry.number)))
+      return "Series numbers must be finite.";
+    if (hasEnd && !Number.isFinite(Number(entry.numberEnd)))
+      return "Series numbers must be finite.";
+    if (hasEnd && Number(entry.numberEnd) <= Number(entry.number))
+      return "Series range end must be greater than its start.";
+  }
+  return undefined;
 }
 
 function resolveSeries(
@@ -883,6 +901,9 @@ export function IdentifyReviewForm({
 
   const [decisions, setDecisions] =
     useState<Record<FieldKey, boolean>>(initialDecisions);
+  const seriesValidationError = decisions.series
+    ? validateSeriesEntries(seriesEntries)
+    : undefined;
 
   // The cover image dimensions load asynchronously, so `hasCoverChoice` and
   // therefore `fieldStatus.cover` can flip from "unchanged" to "new"/"changed"
@@ -1094,6 +1115,10 @@ export function IdentifyReviewForm({
 
   // ---- Submit ----
   const handleSubmit = async () => {
+    if (seriesValidationError) {
+      toast.error(seriesValidationError);
+      return;
+    }
     const fields: Record<string, unknown> = {};
     if (decisions.title) fields.title = title;
     if (decisions.subtitle) fields.subtitle = subtitle;
@@ -1553,6 +1578,11 @@ export function IdentifyReviewForm({
                       </div>
                     )}
                   />
+                  {seriesValidationError && (
+                    <p className="text-sm text-destructive" role="alert">
+                      {seriesValidationError}
+                    </p>
+                  )}
                 </FieldRow>
 
                 {/* Genres */}
@@ -2087,7 +2117,11 @@ export function IdentifyReviewForm({
             Cancel
           </Button>
           <Button
-            disabled={applyMutation.isPending || totalSelected === 0}
+            disabled={
+              applyMutation.isPending ||
+              totalSelected === 0 ||
+              seriesValidationError !== undefined
+            }
             onClick={handleSubmit}
             size="sm"
             type="button"

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -288,7 +288,8 @@ function resolveSeries(
     return { value: incoming, status: "new" };
   if (current.length > 0 && incoming.length === 0)
     return { value: current, status: "unchanged" };
-  const key = (s: SeriesEntry) => `${s.name}|${s.number}|${s.unit}`;
+  const key = (s: SeriesEntry) =>
+    `${s.name}|${s.number}|${s.numberEnd}|${s.unit}`;
   const curKeys = current.map(key).sort();
   const incKeys = incoming.map(key).sort();
   if (
@@ -1498,7 +1499,7 @@ export function IdentifyReviewForm({
                     }}
                     onReorder={setSeriesEntries}
                     renderExtras={(entry, idx) => (
-                      <>
+                      <div className="flex min-w-0 flex-wrap items-center gap-2">
                         <Input
                           aria-label="Series start"
                           className="w-20"
@@ -1549,7 +1550,7 @@ export function IdentifyReviewForm({
                             </SelectContent>
                           </Select>
                         </div>
-                      </>
+                      </div>
                     )}
                   />
                 </FieldRow>

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -102,6 +102,7 @@ interface AuthorEntry {
 interface SeriesEntry {
   name: string;
   number: string;
+  numberEnd: string;
   unit: "" | "volume" | "chapter";
 }
 
@@ -493,6 +494,7 @@ export function IdentifyReviewForm({
       (book.book_series ?? []).map((bs) => ({
         name: bs.series?.name ?? "",
         number: bs.series_number?.toString() ?? "",
+        numberEnd: bs.series_number_end?.toString() ?? "",
         unit: (bs.series_number_unit ?? "") as SeriesEntry["unit"],
       })),
     [book.book_series],
@@ -532,6 +534,7 @@ export function IdentifyReviewForm({
           {
             name: result.series,
             number: result.series_number?.toString() ?? "",
+            numberEnd: result.series_number_end?.toString() ?? "",
             unit: (result.series_number_unit ?? "") as SeriesEntry["unit"],
           },
         ]
@@ -744,7 +747,7 @@ export function IdentifyReviewForm({
     };
 
     const seriesKey = (s: SeriesEntry) =>
-      `${s.name.trim()}|${s.number.trim()}|${s.unit}`;
+      `${s.name.trim()}|${s.number.trim()}|${s.numberEnd.trim()}|${s.unit}`;
     const seriesSavedKeys = currentSeriesEntries.map(seriesKey).sort();
     const seriesCurrentKeys = seriesEntries.map(seriesKey).sort();
     const seriesMatch =
@@ -1104,6 +1107,8 @@ export function IdentifyReviewForm({
         .map((s) => ({
           name: s.name,
           number: s.number !== "" ? parseFloat(s.number) : undefined,
+          series_number_end:
+            s.numberEnd !== "" ? parseFloat(s.numberEnd) : undefined,
           series_number_unit: s.unit !== "" ? s.unit : undefined,
         }));
     }
@@ -1437,7 +1442,7 @@ export function IdentifyReviewForm({
                             (s) =>
                               `${s.name}${
                                 s.number
-                                  ? ` ${formatSeriesNumber(parseFloat(s.number), null, s.unit || null, anyCBZ ? "cbz" : null)}`
+                                  ? ` ${formatSeriesNumber(parseFloat(s.number), s.numberEnd ? parseFloat(s.numberEnd) : null, s.unit || null, anyCBZ ? "cbz" : null)}`
                                   : ""
                               }`,
                           )
@@ -1483,7 +1488,7 @@ export function IdentifyReviewForm({
                       if (seriesEntries.some((s) => s.name === name)) return;
                       setSeriesEntries([
                         ...seriesEntries,
-                        { name, number: "", unit: "" },
+                        { name, number: "", numberEnd: "", unit: "" },
                       ]);
                     }}
                     onRemove={(index) => {
@@ -1495,15 +1500,28 @@ export function IdentifyReviewForm({
                     renderExtras={(entry, idx) => (
                       <>
                         <Input
-                          className="w-24"
+                          aria-label="Series start"
+                          className="w-20"
                           onChange={(e) => {
                             const updated = [...seriesEntries];
                             updated[idx].number = e.target.value;
                             setSeriesEntries(updated);
                           }}
-                          placeholder="#"
+                          placeholder="Start"
                           type="number"
                           value={entry.number}
+                        />
+                        <Input
+                          aria-label="Series end"
+                          className="w-20"
+                          onChange={(e) => {
+                            const updated = [...seriesEntries];
+                            updated[idx].numberEnd = e.target.value;
+                            setSeriesEntries(updated);
+                          }}
+                          placeholder="End"
+                          type="number"
+                          value={entry.numberEnd}
                         />
                         <div className="w-32">
                           <Select

--- a/app/components/library/IdentifyReviewForm.tsx
+++ b/app/components/library/IdentifyReviewForm.tsx
@@ -602,8 +602,8 @@ export function IdentifyReviewForm({
     () => narrators.map((name) => ({ name })),
     [narrators],
   );
-  const [seriesEntries, setSeriesEntries] = useState<SeriesEntry[]>(
-    defaults.series.value,
+  const [seriesEntries, setSeriesEntries] = useState<SeriesEntry[]>(() =>
+    defaults.series.value.map((entry) => ({ ...entry })),
   );
   const [genres, setGenres] = useState<string[]>(defaults.genres.value);
   const [tags, setTags] = useState<string[]>(defaults.tags.value);
@@ -1049,7 +1049,7 @@ export function IdentifyReviewForm({
     setDescription(defaults.description.value);
     setAuthors(defaults.authors.value);
     setNarrators(defaults.narrators.value);
-    setSeriesEntries(defaults.series.value);
+    setSeriesEntries(defaults.series.value.map((entry) => ({ ...entry })));
     setGenres(defaults.genres.value);
     setTags(defaults.tags.value);
     setPublisher(defaults.publisher.value);

--- a/packages/plugin-sdk/metadata.d.ts
+++ b/packages/plugin-sdk/metadata.d.ts
@@ -35,8 +35,13 @@ export interface ParsedMetadata {
   authors?: ParsedAuthor[];
   narrators?: string[];
   series?: string;
+  /**
+   * Series position. Must be finite. An optional seriesNumberEnd must also be
+   * finite and greater than this value. If the start, end, or unit is invalid,
+   * Shisho discards the complete series-number group.
+   */
   seriesNumber?: number;
-  /** Optional inclusive end for an omnibus series range. Must be greater than seriesNumber. */
+  /** Optional inclusive end for an omnibus series range. Requires seriesNumber. */
   seriesNumberEnd?: number;
   /** Whether the series number refers to a volume or a chapter. CBZ only. */
   seriesNumberUnit?: "volume" | "chapter";

--- a/packages/plugin-sdk/metadata.d.ts
+++ b/packages/plugin-sdk/metadata.d.ts
@@ -36,6 +36,8 @@ export interface ParsedMetadata {
   narrators?: string[];
   series?: string;
   seriesNumber?: number;
+  /** Optional inclusive end for an omnibus series range. Must be greater than seriesNumber. */
+  seriesNumberEnd?: number;
   /** Whether the series number refers to a volume or a chapter. CBZ only. */
   seriesNumberUnit?: "volume" | "chapter";
   genres?: string[];

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -17,7 +17,7 @@
     "testing/"
   ],
   "scripts": {
-    "build": "cd testing && npx tsc -p tsconfig.json"
+    "build": "cd testing && npx tsc -p tsconfig.json && npx tsc -p type-contract.tsconfig.json"
   },
   "license": "MIT",
   "repository": {

--- a/packages/plugin-sdk/testing/type-contract.ts
+++ b/packages/plugin-sdk/testing/type-contract.ts
@@ -1,0 +1,15 @@
+import type { ParsedMetadata } from "../index";
+
+type Equal<Left, Right> =
+  (<Type>() => Type extends Left ? 1 : 2) extends <Type>() => Type extends Right
+    ? 1
+    : 2
+    ? true
+    : false;
+type Expect<Type extends true> = Type;
+
+type SeriesNumberEndContract = Expect<
+  Equal<ParsedMetadata["seriesNumberEnd"], number | undefined>
+>;
+
+export type { SeriesNumberEndContract };

--- a/packages/plugin-sdk/testing/type-contract.tsconfig.json
+++ b/packages/plugin-sdk/testing/type-contract.tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "files": ["type-contract.ts"]
+}

--- a/pkg/plugins/CLAUDE.md
+++ b/pkg/plugins/CLAUDE.md
@@ -150,7 +150,7 @@ shisho/goodreads-metadata/
 
 **Logical field groupings:**
 - `cover` → controls `coverData`, `coverMimeType`, `coverPage`, and `coverUrl`
-- `series` → controls `series` (name), `seriesNumber`, AND `seriesNumberUnit`
+- `series` → controls `series` (name), `seriesNumber`, `seriesNumberEnd`, AND `seriesNumberUnit`. The three number fields are atomic: a finite start is required, an optional finite end must be greater than the start, and malformed groups are discarded completely.
 
 **`coverPage` precedence:** For CBZ/PDF, only `coverPage` is applied (`coverData`/`coverUrl` ignored). For other formats, only `coverData`/`coverUrl` are applied (`coverPage` ignored). Out-of-range pages are skipped with a warning.
 
@@ -207,7 +207,8 @@ fileParser: {
       authors: [{ name: "Author", role: "writer" }],
       narrators: ["Narrator"],
       series: "Series Name",
-      seriesNumber: 2.5,
+      seriesNumber: 1,
+      seriesNumberEnd: 3,                       // optional inclusive omnibus range end
       seriesNumberUnit: "volume",               // "volume" | "chapter"; CBZ only
       genres: ["Fiction"],
       tags: ["epic"],
@@ -720,8 +721,9 @@ When changing `mediafile.ParsedMetadata`, `ParsedAuthor`, `ParsedIdentifier`, or
 
 1. Update the Go struct in `pkg/mediafile/mediafile.go`
 2. Update parsing in `pkg/plugins/hooks.go` (`parseParsedMetadata` and related functions)
-3. **Update `packages/plugin-sdk/metadata.d.ts`** to match
-4. Prefer adding new optional fields over changing/removing existing ones to avoid breaking plugins
+3. **Update `packages/plugin-sdk/metadata.d.ts`** to match. `seriesNumberEnd` is the optional camelCase SDK field for omnibus range ends; snake_case `series_number_end` is only for Go JSON and HTTP/apply payloads.
+4. Update `packages/plugin-sdk/hooks.d.ts` when the metadata is also exposed in hook context types.
+5. Prefer adding new optional fields over changing/removing existing ones to avoid breaking plugins
 
 ### Writing a test plugin
 

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -226,18 +226,23 @@ func TestApplyMetadata_OrganizesFiles_WhenSeriesChanges(t *testing.T) {
 	assert.True(t, store.organizeCalled, "OrganizeBookFiles should be called when series changes")
 }
 
-func TestApplyMetadata_OrganizesFiles_WhenMultiSeriesArraySent(t *testing.T) {
+func TestApplyMetadata_MultiSeriesArrayWritesCompleteNumberGroups(t *testing.T) {
 	t.Parallel()
 
 	book := newApplyTestBook(t, "Book")
 	store := &stubBookStoreForApply{
 		stubBookStoreForPersist: stubBookStoreForPersist{book: book},
 	}
-	h := newApplyTestHandler(store)
+	h, rel := newApplyTestHandlerWithRelStore(store)
 	c := newApplyEchoContext(t, map[string]any{
 		"series": []any{
-			map[string]any{"name": "Series A", "number": 1.0},
-			map[string]any{"name": "Series B", "number": 2.0, "series_number_unit": "volume"},
+			map[string]any{
+				"name":               "Series A",
+				"number":             1.0,
+				"series_number_end":  3.0,
+				"series_number_unit": "volume",
+			},
+			map[string]any{"name": "Series B", "number": 2.0},
 		},
 	})
 
@@ -245,6 +250,17 @@ func TestApplyMetadata_OrganizesFiles_WhenMultiSeriesArraySent(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, store.organizeCalled, "OrganizeBookFiles should be called when multi-series array is sent")
+	require.Len(t, rel.capturedBookSeries, 2)
+	require.NotNil(t, rel.capturedBookSeries[0].SeriesNumber)
+	require.NotNil(t, rel.capturedBookSeries[0].SeriesNumberEnd)
+	require.NotNil(t, rel.capturedBookSeries[0].SeriesNumberUnit)
+	assert.InDelta(t, 1, *rel.capturedBookSeries[0].SeriesNumber, 0.001)
+	assert.InDelta(t, 3, *rel.capturedBookSeries[0].SeriesNumberEnd, 0.001)
+	assert.Equal(t, "volume", *rel.capturedBookSeries[0].SeriesNumberUnit)
+	require.NotNil(t, rel.capturedBookSeries[1].SeriesNumber)
+	assert.InDelta(t, 2, *rel.capturedBookSeries[1].SeriesNumber, 0.001)
+	assert.Nil(t, rel.capturedBookSeries[1].SeriesNumberEnd)
+	assert.Nil(t, rel.capturedBookSeries[1].SeriesNumberUnit)
 }
 
 func TestApplyMetadata_SkipsOrganize_WhenNoRelevantFieldsChange(t *testing.T) {

--- a/pkg/plugins/handler_apply_metadata_test.go
+++ b/pkg/plugins/handler_apply_metadata_test.go
@@ -618,7 +618,7 @@ func TestApplyMetadata_ExplicitFileName_PreservesEditionName_NonPrimaryFile(t *t
 		"file.NameSource must NOT be replaced by the plugin source")
 }
 
-func TestApplyMetadata_ScalarSeries_WritesSeriesNumberUnit(t *testing.T) {
+func TestApplyMetadata_ScalarSeries_WritesSeriesNumberRange(t *testing.T) {
 	t.Parallel()
 
 	book := newApplyTestBook(t, "Book")
@@ -629,6 +629,7 @@ func TestApplyMetadata_ScalarSeries_WritesSeriesNumberUnit(t *testing.T) {
 	c := newApplyEchoContext(t, map[string]any{
 		"series":             "Naruto",
 		"series_number":      5.0,
+		"series_number_end":  8.0,
 		"series_number_unit": "volume",
 	})
 
@@ -639,6 +640,8 @@ func TestApplyMetadata_ScalarSeries_WritesSeriesNumberUnit(t *testing.T) {
 	bs := rel.capturedBookSeries[0]
 	require.NotNil(t, bs.SeriesNumber)
 	assert.InDelta(t, 5.0, *bs.SeriesNumber, 0.001)
+	require.NotNil(t, bs.SeriesNumberEnd, "scalar series path must write SeriesNumberEnd")
+	assert.InDelta(t, 8.0, *bs.SeriesNumberEnd, 0.001)
 	require.NotNil(t, bs.SeriesNumberUnit, "scalar series path must write SeriesNumberUnit")
 	assert.Equal(t, "volume", *bs.SeriesNumberUnit)
 }

--- a/pkg/plugins/handler_convert.go
+++ b/pkg/plugins/handler_convert.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/shishobooks/shisho/pkg/mediafile"
-	"github.com/shishobooks/shisho/pkg/models"
 )
 
 // convertFieldsToMetadata converts an untyped fields map (from the apply payload) to *mediafile.ParsedMetadata.
@@ -34,17 +33,7 @@ func convertFieldsToMetadata(fields map[string]any) *mediafile.ParsedMetadata {
 		md.CoverURL = v
 	}
 
-	// Series number
-	if v, ok := fields["series_number"].(float64); ok {
-		md.SeriesNumber = &v
-	}
-
-	// Series number unit
-	if v, ok := fields["series_number_unit"].(string); ok {
-		if v == models.SeriesNumberUnitVolume || v == models.SeriesNumberUnitChapter {
-			md.SeriesNumberUnit = &v
-		}
-	}
+	md.SeriesNumber, md.SeriesNumberEnd, md.SeriesNumberUnit = seriesNumberGroupFromFields(fields)
 
 	// Cover page (0-indexed page number for CBZ/PDF). Only accept finite
 	// non-negative integers; reject negative, NaN, and Infinity so they
@@ -178,14 +167,12 @@ func extractSeriesEntries(fields map[string]any) *[]SeriesEntry {
 			continue
 		}
 		entry := SeriesEntry{Name: name}
-		if num, ok := m["number"].(float64); ok {
-			entry.Number = &num
+		groupFields := map[string]any{
+			"series_number":      m["number"],
+			"series_number_end":  m["series_number_end"],
+			"series_number_unit": m["series_number_unit"],
 		}
-		if unit, ok := m["series_number_unit"].(string); ok {
-			if unit == models.SeriesNumberUnitVolume || unit == models.SeriesNumberUnitChapter {
-				entry.SeriesNumberUnit = &unit
-			}
-		}
+		entry.Number, entry.NumberEnd, entry.SeriesNumberUnit = seriesNumberGroupFromFields(groupFields)
 		entries = append(entries, entry)
 	}
 	return &entries

--- a/pkg/plugins/handler_convert_test.go
+++ b/pkg/plugins/handler_convert_test.go
@@ -92,6 +92,71 @@ func TestConvertFieldsToMetadata_SeriesNumber(t *testing.T) {
 	assert.InDelta(t, 2.5, *md.SeriesNumber, 0.001)
 }
 
+func TestConvertFieldsToMetadata_SeriesNumberRangeUsesSnakeCase(t *testing.T) {
+	t.Parallel()
+	fields := map[string]any{
+		"series_number":      float64(1),
+		"series_number_end":  float64(3),
+		"series_number_unit": "volume",
+	}
+
+	md := convertFieldsToMetadata(fields)
+
+	require.NotNil(t, md.SeriesNumber)
+	require.NotNil(t, md.SeriesNumberEnd)
+	require.NotNil(t, md.SeriesNumberUnit)
+	assert.InDelta(t, 1, *md.SeriesNumber, 0.001)
+	assert.InDelta(t, 3, *md.SeriesNumberEnd, 0.001)
+	assert.Equal(t, "volume", *md.SeriesNumberUnit)
+}
+
+func TestConvertFieldsToMetadata_DiscardsMalformedSeriesNumberGroupsAtomically(t *testing.T) {
+	t.Parallel()
+
+	fields := map[string]any{
+		"series_number":      float64(3),
+		"series_number_end":  float64(1),
+		"series_number_unit": "volume",
+	}
+	md := convertFieldsToMetadata(fields)
+	assert.Nil(t, md.SeriesNumber)
+	assert.Nil(t, md.SeriesNumberEnd)
+	assert.Nil(t, md.SeriesNumberUnit)
+}
+
+func TestExtractSeriesEntries_RangeUsesSnakeCaseAndIsAtomic(t *testing.T) {
+	t.Parallel()
+
+	got := extractSeriesEntries(map[string]any{
+		"series": []any{
+			map[string]any{
+				"name":               "Saga",
+				"number":             float64(1),
+				"series_number_end":  float64(3),
+				"series_number_unit": "volume",
+			},
+			map[string]any{
+				"name":               "Broken",
+				"number":             float64(4),
+				"series_number_end":  math.Inf(1),
+				"series_number_unit": "chapter",
+			},
+		},
+	})
+
+	require.NotNil(t, got)
+	require.Len(t, *got, 2)
+	require.NotNil(t, (*got)[0].Number)
+	require.NotNil(t, (*got)[0].NumberEnd)
+	require.NotNil(t, (*got)[0].SeriesNumberUnit)
+	assert.InDelta(t, 1, *(*got)[0].Number, 0.001)
+	assert.InDelta(t, 3, *(*got)[0].NumberEnd, 0.001)
+	assert.Equal(t, "volume", *(*got)[0].SeriesNumberUnit)
+	assert.Nil(t, (*got)[1].Number)
+	assert.Nil(t, (*got)[1].NumberEnd)
+	assert.Nil(t, (*got)[1].SeriesNumberUnit)
+}
+
 func TestConvertFieldsToMetadata_ReleaseDate_DateOnly(t *testing.T) {
 	t.Parallel()
 	fields := map[string]any{
@@ -359,6 +424,7 @@ func TestConvertFieldsToMetadata_AbridgedMissing(t *testing.T) {
 func TestConvertFieldsToMetadata_SeriesNumberUnit(t *testing.T) {
 	t.Parallel()
 	fields := map[string]any{
+		"series_number":      float64(1),
 		"series_number_unit": "chapter",
 	}
 
@@ -371,6 +437,7 @@ func TestConvertFieldsToMetadata_SeriesNumberUnit(t *testing.T) {
 func TestConvertFieldsToMetadata_SeriesNumberUnitVolume(t *testing.T) {
 	t.Parallel()
 	fields := map[string]any{
+		"series_number":      float64(1),
 		"series_number_unit": "volume",
 	}
 

--- a/pkg/plugins/handler_convert_test.go
+++ b/pkg/plugins/handler_convert_test.go
@@ -113,15 +113,29 @@ func TestConvertFieldsToMetadata_SeriesNumberRangeUsesSnakeCase(t *testing.T) {
 func TestConvertFieldsToMetadata_DiscardsMalformedSeriesNumberGroupsAtomically(t *testing.T) {
 	t.Parallel()
 
-	fields := map[string]any{
-		"series_number":      float64(3),
-		"series_number_end":  float64(1),
-		"series_number_unit": "volume",
+	cases := []map[string]any{
+		{
+			"series_number":      float64(3),
+			"series_number_end":  float64(1),
+			"series_number_unit": "volume",
+		},
+		{
+			"series_number":      float64(1),
+			"series_number_end":  "3",
+			"series_number_unit": "volume",
+		},
+		{
+			"series_number":      float64(1),
+			"series_number_end":  float64(3),
+			"series_number_unit": float64(1),
+		},
 	}
-	md := convertFieldsToMetadata(fields)
-	assert.Nil(t, md.SeriesNumber)
-	assert.Nil(t, md.SeriesNumberEnd)
-	assert.Nil(t, md.SeriesNumberUnit)
+	for _, fields := range cases {
+		md := convertFieldsToMetadata(fields)
+		assert.Nil(t, md.SeriesNumber, fields)
+		assert.Nil(t, md.SeriesNumberEnd, fields)
+		assert.Nil(t, md.SeriesNumberUnit, fields)
+	}
 }
 
 func TestExtractSeriesEntries_RangeUsesSnakeCaseAndIsAtomic(t *testing.T) {

--- a/pkg/plugins/handler_persist_metadata.go
+++ b/pkg/plugins/handler_persist_metadata.go
@@ -172,8 +172,7 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 				}
 				if entry.Number != nil {
 					bs.SeriesNumber = entry.Number
-				}
-				if entry.SeriesNumberUnit != nil {
+					bs.SeriesNumberEnd = entry.NumberEnd
 					bs.SeriesNumberUnit = entry.SeriesNumberUnit
 				}
 				if err := h.enrich.relStore.CreateBookSeries(ctx, bs); err != nil {
@@ -190,6 +189,7 @@ func (h *handler) persistMetadata(ctx context.Context, book *models.Book, target
 					BookID:           book.ID,
 					SeriesID:         seriesRecord.ID,
 					SeriesNumber:     md.SeriesNumber,
+					SeriesNumberEnd:  md.SeriesNumberEnd,
 					SeriesNumberUnit: md.SeriesNumberUnit,
 					SortOrder:        1,
 				}); err != nil {

--- a/pkg/plugins/handler_shape_test.go
+++ b/pkg/plugins/handler_shape_test.go
@@ -43,7 +43,7 @@ func installShapeEnricher(t *testing.T, service *Service) *Manager {
     "metadataEnricher": {
       "description": "Enriches metadata",
       "fileTypes": ["epub"],
-      "fields": ["title", "description", "genres", "cover"]
+      "fields": ["title", "description", "genres", "cover", "series"]
     }
   },
   "configSchema": {
@@ -59,6 +59,10 @@ func installShapeEnricher(t *testing.T, service *Service) *Manager {
             title: "Found: " + ctx.query,
             description: "A description",
             genres: ["Fantasy"],
+            series: "Saga",
+            seriesNumber: 1,
+            seriesNumberEnd: 3,
+            seriesNumberUnit: "volume",
             coverUrl: "https://example.com/cover.jpg",
             confidence: 0.9
           }]
@@ -157,6 +161,9 @@ func TestSearchMetadata_ResponseWireShape(t *testing.T) {
 		"plugin_scope",
 		"publisher",
 		"series",
+		"series_number",
+		"series_number_end",
+		"series_number_unit",
 		"subtitle",
 		"tags",
 		"title",
@@ -164,11 +171,12 @@ func TestSearchMetadata_ResponseWireShape(t *testing.T) {
 	}, sortedJSONKeys(t, results[0]))
 
 	var result struct {
-		Title       string   `json:"title"`
-		Genres      []string `json:"genres"`
-		PluginScope string   `json:"plugin_scope"`
-		PluginID    string   `json:"plugin_id"`
-		Confidence  float64  `json:"confidence"`
+		Title           string   `json:"title"`
+		Genres          []string `json:"genres"`
+		PluginScope     string   `json:"plugin_scope"`
+		PluginID        string   `json:"plugin_id"`
+		Confidence      float64  `json:"confidence"`
+		SeriesNumberEnd float64  `json:"series_number_end"`
 	}
 	require.NoError(t, json.Unmarshal(results[0], &result))
 	assert.Equal(t, "Found: dune", result.Title)
@@ -176,6 +184,7 @@ func TestSearchMetadata_ResponseWireShape(t *testing.T) {
 	assert.Equal(t, "test", result.PluginScope)
 	assert.Equal(t, "shape-enricher", result.PluginID)
 	assert.InDelta(t, 0.9, result.Confidence, 0.0001)
+	assert.InDelta(t, 3, result.SeriesNumberEnd, 0.0001)
 }
 
 // TestGetConfig_ResponseWireShape pins the exact wire shape of
@@ -213,7 +222,7 @@ func TestGetConfig_ResponseWireShape(t *testing.T) {
 		DeclaredFields []string                   `json:"declaredFields"`
 	}
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	assert.Equal(t, []string{"title", "description", "genres", "cover"}, body.DeclaredFields)
+	assert.Equal(t, []string{"title", "description", "genres", "cover", "series"}, body.DeclaredFields)
 	require.Contains(t, body.Schema, "apiKey")
 
 	// ConfigField wire keys are camelCase-free but include every field of the

--- a/pkg/plugins/hooks.go
+++ b/pkg/plugins/hooks.go
@@ -424,21 +424,7 @@ func parseSearchResponse(vm *goja.Runtime, val goja.Value, pluginScope, pluginID
 			}
 		}
 
-		// seriesNumber -> *float64
-		seriesNumVal := itemObj.Get("seriesNumber")
-		if seriesNumVal != nil && !goja.IsUndefined(seriesNumVal) && !goja.IsNull(seriesNumVal) {
-			f := seriesNumVal.ToFloat()
-			md.SeriesNumber = &f
-		}
-
-		// seriesNumberUnit -> *string ("volume" | "chapter"); ignore other values
-		unitVal := itemObj.Get("seriesNumberUnit")
-		if unitVal != nil && !goja.IsUndefined(unitVal) && !goja.IsNull(unitVal) {
-			s := unitVal.String()
-			if s == models.SeriesNumberUnitVolume || s == models.SeriesNumberUnitChapter {
-				md.SeriesNumberUnit = &s
-			}
-		}
+		md.SeriesNumber, md.SeriesNumberEnd, md.SeriesNumberUnit = parsePluginSeriesNumberGroup(itemObj)
 
 		// confidence -> *float64 (0-1 score)
 		confidenceVal := itemObj.Get("confidence")
@@ -527,21 +513,7 @@ func parseParsedMetadata(vm *goja.Runtime, val goja.Value) (*mediafile.ParsedMet
 	md.CoverURL = getStringField(obj, "coverUrl")
 	md.DataSource = getStringField(obj, "dataSource")
 
-	// seriesNumber -> *float64
-	seriesNumVal := obj.Get("seriesNumber")
-	if seriesNumVal != nil && !goja.IsUndefined(seriesNumVal) && !goja.IsNull(seriesNumVal) {
-		f := seriesNumVal.ToFloat()
-		md.SeriesNumber = &f
-	}
-
-	// seriesNumberUnit -> *string ("volume" | "chapter"); ignore other values
-	unitVal := obj.Get("seriesNumberUnit")
-	if unitVal != nil && !goja.IsUndefined(unitVal) && !goja.IsNull(unitVal) {
-		s := unitVal.String()
-		if s == models.SeriesNumberUnitVolume || s == models.SeriesNumberUnitChapter {
-			md.SeriesNumberUnit = &s
-		}
-	}
+	md.SeriesNumber, md.SeriesNumberEnd, md.SeriesNumberUnit = parsePluginSeriesNumberGroup(obj)
 
 	// authors -> []ParsedAuthor
 	authorsVal := obj.Get("authors")

--- a/pkg/plugins/hooks_search_result_test.go
+++ b/pkg/plugins/hooks_search_result_test.go
@@ -131,8 +131,17 @@ func TestParseSearchResponse_DiscardsMalformedSeriesNumberGroupsAtomically(t *te
 		`{seriesNumber:3,seriesNumberEnd:3,seriesNumberUnit:"volume"}`,
 		`{seriesNumber:3,seriesNumberEnd:1,seriesNumberUnit:"volume"}`,
 		`{seriesNumber:NaN,seriesNumberEnd:3,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:Infinity,seriesNumberEnd:3,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:-Infinity,seriesNumberEnd:3,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:1,seriesNumberEnd:NaN,seriesNumberUnit:"volume"}`,
 		`{seriesNumber:1,seriesNumberEnd:Infinity,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:1,seriesNumberEnd:-Infinity,seriesNumberUnit:"volume"}`,
 		`{seriesNumber:1,seriesNumberEnd:3,seriesNumberUnit:"invalid"}`,
+		`{seriesNumber:true,seriesNumberEnd:3,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:[1],seriesNumberEnd:3,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:1,seriesNumberEnd:"3",seriesNumberUnit:"volume"}`,
+		`{seriesNumber:1,seriesNumberEnd:[3],seriesNumberUnit:"volume"}`,
+		`{seriesNumber:1,seriesNumberEnd:3,seriesNumberUnit:["volume"]}`,
 	}
 	for _, item := range cases {
 		vm := goja.New()

--- a/pkg/plugins/hooks_search_result_test.go
+++ b/pkg/plugins/hooks_search_result_test.go
@@ -85,6 +85,91 @@ func TestParseSearchResponse_AllFields(t *testing.T) {
 	assert.True(t, *md.Abridged)
 }
 
+func TestParseSearchResponse_SeriesNumberRange(t *testing.T) {
+	t.Parallel()
+
+	vm := goja.New()
+	val, err := vm.RunString(`({results:[{
+		series: "Epic Series",
+		seriesNumber: 1,
+		seriesNumberEnd: 3,
+		seriesNumberUnit: "volume"
+	}]})`)
+	require.NoError(t, err)
+
+	resp := parseSearchResponse(vm, val, "s", "p")
+	require.Len(t, resp.Results, 1)
+	md := resp.Results[0]
+	require.NotNil(t, md.SeriesNumber)
+	require.NotNil(t, md.SeriesNumberEnd)
+	require.NotNil(t, md.SeriesNumberUnit)
+	assert.InDelta(t, 1, *md.SeriesNumber, 0.001)
+	assert.InDelta(t, 3, *md.SeriesNumberEnd, 0.001)
+	assert.Equal(t, "volume", *md.SeriesNumberUnit)
+}
+
+func TestParseSearchResponse_SingleSeriesNumberRemainsSupported(t *testing.T) {
+	t.Parallel()
+
+	vm := goja.New()
+	val, err := vm.RunString(`({results:[{seriesNumber:2.5}]})`)
+	require.NoError(t, err)
+
+	resp := parseSearchResponse(vm, val, "s", "p")
+	require.Len(t, resp.Results, 1)
+	require.NotNil(t, resp.Results[0].SeriesNumber)
+	assert.InDelta(t, 2.5, *resp.Results[0].SeriesNumber, 0.001)
+	assert.Nil(t, resp.Results[0].SeriesNumberEnd)
+	assert.Nil(t, resp.Results[0].SeriesNumberUnit)
+}
+
+func TestParseSearchResponse_DiscardsMalformedSeriesNumberGroupsAtomically(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		`{seriesNumberEnd:3,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:3,seriesNumberEnd:3,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:3,seriesNumberEnd:1,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:NaN,seriesNumberEnd:3,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:1,seriesNumberEnd:Infinity,seriesNumberUnit:"volume"}`,
+		`{seriesNumber:1,seriesNumberEnd:3,seriesNumberUnit:"invalid"}`,
+	}
+	for _, item := range cases {
+		vm := goja.New()
+		val, err := vm.RunString(`({results:[` + item + `]})`)
+		require.NoError(t, err)
+		resp := parseSearchResponse(vm, val, "s", "p")
+		require.Len(t, resp.Results, 1)
+		assert.Nil(t, resp.Results[0].SeriesNumber, item)
+		assert.Nil(t, resp.Results[0].SeriesNumberEnd, item)
+		assert.Nil(t, resp.Results[0].SeriesNumberUnit, item)
+	}
+}
+
+func TestParseParsedMetadata_SeriesNumberRangeAndAtomicValidation(t *testing.T) {
+	t.Parallel()
+
+	vm := goja.New()
+	valid, err := vm.RunString(`({seriesNumber:4,seriesNumberEnd:6,seriesNumberUnit:"chapter"})`)
+	require.NoError(t, err)
+	md, err := parseParsedMetadata(vm, valid)
+	require.NoError(t, err)
+	require.NotNil(t, md.SeriesNumber)
+	require.NotNil(t, md.SeriesNumberEnd)
+	require.NotNil(t, md.SeriesNumberUnit)
+	assert.InDelta(t, 4, *md.SeriesNumber, 0.001)
+	assert.InDelta(t, 6, *md.SeriesNumberEnd, 0.001)
+	assert.Equal(t, "chapter", *md.SeriesNumberUnit)
+
+	invalid, err := vm.RunString(`({seriesNumber:4,seriesNumberEnd:Infinity,seriesNumberUnit:"chapter"})`)
+	require.NoError(t, err)
+	md, err = parseParsedMetadata(vm, invalid)
+	require.NoError(t, err)
+	assert.Nil(t, md.SeriesNumber)
+	assert.Nil(t, md.SeriesNumberEnd)
+	assert.Nil(t, md.SeriesNumberUnit)
+}
+
 func TestParseSearchResponse_LanguageNormalized(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugins/series_number.go
+++ b/pkg/plugins/series_number.go
@@ -8,42 +8,73 @@ import (
 )
 
 func parsePluginSeriesNumberGroup(obj *goja.Object) (*float64, *float64, *string) {
-	start := optionalJSFloat(obj.Get("seriesNumber"))
-	end := optionalJSFloat(obj.Get("seriesNumberEnd"))
-	unit := optionalJSString(obj.Get("seriesNumberUnit"))
+	start, startValid := optionalJSFloat(obj.Get("seriesNumber"))
+	end, endValid := optionalJSFloat(obj.Get("seriesNumberEnd"))
+	unit, unitValid := optionalJSString(obj.Get("seriesNumberUnit"))
+	if !startValid || !endValid || !unitValid {
+		return nil, nil, nil
+	}
 	return normalizePluginSeriesNumberGroup(start, end, unit)
 }
 
-func optionalJSFloat(value goja.Value) *float64 {
+func optionalJSFloat(value goja.Value) (*float64, bool) {
 	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
-		return nil
+		return nil, true
 	}
-	converted := value.ToFloat()
-	return &converted
+	switch exported := value.Export().(type) {
+	case int64:
+		converted := float64(exported)
+		return &converted, true
+	case float64:
+		return &exported, true
+	default:
+		return nil, false
+	}
 }
 
-func optionalJSString(value goja.Value) *string {
+func optionalJSString(value goja.Value) (*string, bool) {
 	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
-		return nil
+		return nil, true
 	}
-	converted := value.String()
-	return &converted
+	exported, ok := value.Export().(string)
+	if !ok {
+		return nil, false
+	}
+	return &exported, true
 }
 
 func seriesNumberGroupFromFields(fields map[string]any) (*float64, *float64, *string) {
-	var start *float64
-	if value, ok := fields["series_number"].(float64); ok {
-		start = &value
-	}
-	var end *float64
-	if value, ok := fields["series_number_end"].(float64); ok {
-		end = &value
-	}
-	var unit *string
-	if value, ok := fields["series_number_unit"].(string); ok {
-		unit = &value
+	start, startValid := optionalFloatField(fields, "series_number")
+	end, endValid := optionalFloatField(fields, "series_number_end")
+	unit, unitValid := optionalStringField(fields, "series_number_unit")
+	if !startValid || !endValid || !unitValid {
+		return nil, nil, nil
 	}
 	return normalizePluginSeriesNumberGroup(start, end, unit)
+}
+
+func optionalFloatField(fields map[string]any, key string) (*float64, bool) {
+	value, present := fields[key]
+	if !present || value == nil {
+		return nil, true
+	}
+	converted, ok := value.(float64)
+	if !ok {
+		return nil, false
+	}
+	return &converted, true
+}
+
+func optionalStringField(fields map[string]any, key string) (*string, bool) {
+	value, present := fields[key]
+	if !present || value == nil {
+		return nil, true
+	}
+	converted, ok := value.(string)
+	if !ok {
+		return nil, false
+	}
+	return &converted, true
 }
 
 func normalizePluginSeriesNumberGroup(start, end *float64, unit *string) (*float64, *float64, *string) {

--- a/pkg/plugins/series_number.go
+++ b/pkg/plugins/series_number.go
@@ -1,0 +1,60 @@
+package plugins
+
+import (
+	"math"
+
+	"github.com/dop251/goja"
+	"github.com/shishobooks/shisho/pkg/models"
+)
+
+func parsePluginSeriesNumberGroup(obj *goja.Object) (*float64, *float64, *string) {
+	start := optionalJSFloat(obj.Get("seriesNumber"))
+	end := optionalJSFloat(obj.Get("seriesNumberEnd"))
+	unit := optionalJSString(obj.Get("seriesNumberUnit"))
+	return normalizePluginSeriesNumberGroup(start, end, unit)
+}
+
+func optionalJSFloat(value goja.Value) *float64 {
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return nil
+	}
+	converted := value.ToFloat()
+	return &converted
+}
+
+func optionalJSString(value goja.Value) *string {
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return nil
+	}
+	converted := value.String()
+	return &converted
+}
+
+func seriesNumberGroupFromFields(fields map[string]any) (*float64, *float64, *string) {
+	var start *float64
+	if value, ok := fields["series_number"].(float64); ok {
+		start = &value
+	}
+	var end *float64
+	if value, ok := fields["series_number_end"].(float64); ok {
+		end = &value
+	}
+	var unit *string
+	if value, ok := fields["series_number_unit"].(string); ok {
+		unit = &value
+	}
+	return normalizePluginSeriesNumberGroup(start, end, unit)
+}
+
+func normalizePluginSeriesNumberGroup(start, end *float64, unit *string) (*float64, *float64, *string) {
+	if start == nil || math.IsNaN(*start) || math.IsInf(*start, 0) {
+		return nil, nil, nil
+	}
+	if end != nil && (math.IsNaN(*end) || math.IsInf(*end, 0) || *end <= *start) {
+		return nil, nil, nil
+	}
+	if unit != nil && *unit != models.SeriesNumberUnitVolume && *unit != models.SeriesNumberUnitChapter {
+		return nil, nil, nil
+	}
+	return start, end, unit
+}

--- a/pkg/plugins/types.go
+++ b/pkg/plugins/types.go
@@ -234,6 +234,7 @@ type SetFieldSettingsPayload struct {
 type SeriesEntry struct {
 	Name             string
 	Number           *float64
+	NumberEnd        *float64
 	SeriesNumberUnit *string
 }
 

--- a/pkg/worker/scan_plugins_test.go
+++ b/pkg/worker/scan_plugins_test.go
@@ -1447,15 +1447,19 @@ func TestFilterMetadataFields_DisabledFieldsZeroed(t *testing.T) {
 }
 
 // TestFilterMetadataFields_SeriesGrouping verifies that the "series" field declaration
-// controls both series name and seriesNumber.
+// controls the series name and complete number group.
 func TestFilterMetadataFields_SeriesGrouping(t *testing.T) {
 	t.Parallel()
 
 	seriesNum := float64(5)
+	seriesNumEnd := float64(8)
+	unit := models.SeriesNumberUnitVolume
 	md := &mediafile.ParsedMetadata{
-		Title:        "Test Title",
-		Series:       "Epic Series",
-		SeriesNumber: &seriesNum,
+		Title:            "Test Title",
+		Series:           "Epic Series",
+		SeriesNumber:     &seriesNum,
+		SeriesNumberEnd:  &seriesNumEnd,
+		SeriesNumberUnit: &unit,
 	}
 
 	// Declare title and series (which controls both series and seriesNumber)
@@ -1471,6 +1475,36 @@ func TestFilterMetadataFields_SeriesGrouping(t *testing.T) {
 	assert.Equal(t, "Test Title", filtered.Title)
 	assert.Empty(t, filtered.Series, "series name should be zeroed when 'series' is disabled")
 	assert.Nil(t, filtered.SeriesNumber, "seriesNumber should be zeroed when 'series' is disabled")
+	assert.Nil(t, filtered.SeriesNumberEnd, "seriesNumberEnd should be zeroed when 'series' is disabled")
+	assert.Nil(t, filtered.SeriesNumberUnit, "seriesNumberUnit should be zeroed when 'series' is disabled")
+}
+
+func TestFilterMetadataFields_UndeclaredSeriesRangeUsesWarningPath(t *testing.T) {
+	t.Parallel()
+
+	seriesNum := float64(1)
+	seriesNumEnd := float64(3)
+	unit := models.SeriesNumberUnitVolume
+	md := &mediafile.ParsedMetadata{
+		Series:           "Epic Series",
+		SeriesNumber:     &seriesNum,
+		SeriesNumberEnd:  &seriesNumEnd,
+		SeriesNumberUnit: &unit,
+	}
+	warnedFields := make([]string, 0, 4)
+
+	filtered := filterMetadataFields(md, nil, nil, "test-plugin", func(_ string, data logger.Data) {
+		field, ok := data["field"].(string)
+		if ok {
+			warnedFields = append(warnedFields, field)
+		}
+	})
+
+	assert.ElementsMatch(t, []string{"series", "seriesNumber", "seriesNumberEnd", "seriesNumberUnit"}, warnedFields)
+	assert.Empty(t, filtered.Series)
+	assert.Nil(t, filtered.SeriesNumber)
+	assert.Nil(t, filtered.SeriesNumberEnd)
+	assert.Nil(t, filtered.SeriesNumberUnit)
 }
 
 // TestFilterMetadataFields_SeriesNumberAliasForSeries verifies that "seriesNumber"

--- a/pkg/worker/scan_plugins_test.go
+++ b/pkg/worker/scan_plugins_test.go
@@ -1513,10 +1513,14 @@ func TestFilterMetadataFields_SeriesNumberAliasForSeries(t *testing.T) {
 	t.Parallel()
 
 	seriesNum := float64(3)
+	seriesNumEnd := float64(5)
+	unit := models.SeriesNumberUnitChapter
 	md := &mediafile.ParsedMetadata{
-		Title:        "Test Title",
-		Series:       "Epic Series",
-		SeriesNumber: &seriesNum,
+		Title:            "Test Title",
+		Series:           "Epic Series",
+		SeriesNumber:     &seriesNum,
+		SeriesNumberEnd:  &seriesNumEnd,
+		SeriesNumberUnit: &unit,
 	}
 
 	// Declare only seriesNumber (alias for series) - should control both
@@ -1531,8 +1535,12 @@ func TestFilterMetadataFields_SeriesNumberAliasForSeries(t *testing.T) {
 
 	assert.Equal(t, "Test Title", filtered.Title)
 	assert.Equal(t, "Epic Series", filtered.Series)
-	assert.NotNil(t, filtered.SeriesNumber)
+	require.NotNil(t, filtered.SeriesNumber)
+	require.NotNil(t, filtered.SeriesNumberEnd)
+	require.NotNil(t, filtered.SeriesNumberUnit)
 	assert.InDelta(t, float64(3), *filtered.SeriesNumber, 0.01)
+	assert.InDelta(t, float64(5), *filtered.SeriesNumberEnd, 0.01)
+	assert.Equal(t, models.SeriesNumberUnitChapter, *filtered.SeriesNumberUnit)
 }
 
 // TestFilterMetadataFields_CoverGrouping verifies that the "cover" field declaration

--- a/pkg/worker/scan_unified.go
+++ b/pkg/worker/scan_unified.go
@@ -3540,8 +3540,8 @@ func filterMetadataFields(
 	// Create a copy to avoid mutating the original
 	result := *md
 
-	// Handle "series" grouping - "series", "seriesNumber", and "seriesNumberUnit"
-	// are all part of the same logical field group.
+	// Handle "series" grouping. The series name plus seriesNumber,
+	// seriesNumberEnd, and seriesNumberUnit are one logical field group.
 	seriesAllowed := isFieldAllowed("series") || isFieldAllowed("seriesNumber")
 	seriesDeclared := declared["series"] || declared["seriesNumber"]
 	if !seriesDeclared {

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -269,6 +269,7 @@ The full set of fields you can return:
 | `series` | `string` | Series name |
 | `seriesNumber` | `number` | Position in series (supports decimals like `1.5`) |
 | `seriesNumberEnd` | `number` | Optional inclusive end of an omnibus range; must be greater than `seriesNumber` |
+| `seriesNumberUnit` | `"volume" \| "chapter"` | Whether the series position is a volume or chapter (CBZ only) |
 | `genres` | `[string]` | Genre names |
 | `tags` | `[string]` | Tag names |
 | `description` | `string` | Book description |
@@ -298,7 +299,7 @@ When Shisho stores an identifier emitted by a plugin, it canonicalizes the `valu
 :::note[Field groupings for enrichers]
 When declaring `fields` in an enricher manifest, some return fields are grouped under a single logical name:
 - **`cover`** controls `coverData`, `coverMimeType`, `coverPage`, and `coverUrl`
-- **`series`** controls `series`, `seriesNumber`, `seriesNumberEnd`, and `seriesNumberUnit`. The number fields form an atomic group: `seriesNumber` must be finite, `seriesNumberEnd` is optional and must be finite and greater than the start, and malformed groups are discarded completely.
+- **`series`** controls `series`, `seriesNumber`, `seriesNumberEnd`, and `seriesNumberUnit`. Declaring `seriesNumber` is also supported as an alias for this complete group. The number fields form an atomic group: `seriesNumber` must be finite, `seriesNumberEnd` is optional and must be finite and greater than the start, and malformed groups are discarded completely.
 :::
 
 **Manifest capability:**
@@ -409,6 +410,7 @@ var plugin = (function() {
 | `series` | `string` | Series name |
 | `seriesNumber` | `number` | Position in series |
 | `seriesNumberEnd` | `number` | Optional inclusive end of an omnibus range; must be greater than `seriesNumber` |
+| `seriesNumberUnit` | `"volume" \| "chapter"` | Whether the series position is a volume or chapter (CBZ only) |
 | `genres` | `string[]` | Genre classification |
 | `tags` | `string[]` | Freeform labels |
 | `description` | `string` | Book description |

--- a/website/docs/plugins/development.md
+++ b/website/docs/plugins/development.md
@@ -268,6 +268,7 @@ The full set of fields you can return:
 | `narrators` | `[string]` | List of narrator names |
 | `series` | `string` | Series name |
 | `seriesNumber` | `number` | Position in series (supports decimals like `1.5`) |
+| `seriesNumberEnd` | `number` | Optional inclusive end of an omnibus range; must be greater than `seriesNumber` |
 | `genres` | `[string]` | Genre names |
 | `tags` | `[string]` | Tag names |
 | `description` | `string` | Book description |
@@ -297,7 +298,7 @@ When Shisho stores an identifier emitted by a plugin, it canonicalizes the `valu
 :::note[Field groupings for enrichers]
 When declaring `fields` in an enricher manifest, some return fields are grouped under a single logical name:
 - **`cover`** controls `coverData`, `coverMimeType`, `coverPage`, and `coverUrl`
-- **`series`** controls both `series` and `seriesNumber`
+- **`series`** controls `series`, `seriesNumber`, `seriesNumberEnd`, and `seriesNumberUnit`. The number fields form an atomic group: `seriesNumber` must be finite, `seriesNumberEnd` is optional and must be finite and greater than the start, and malformed groups are discarded completely.
 :::
 
 **Manifest capability:**
@@ -378,6 +379,7 @@ var plugin = (function() {
               narrators: item.narrators,
               series: item.seriesName,
               seriesNumber: item.seriesNumber,
+              seriesNumberEnd: item.seriesNumberEnd,
               genres: item.genres,
               tags: item.tags,
               description: item.description,
@@ -406,6 +408,7 @@ var plugin = (function() {
 | `narrators` | `string[]` | Narrator names (audiobooks) |
 | `series` | `string` | Series name |
 | `seriesNumber` | `number` | Position in series |
+| `seriesNumberEnd` | `number` | Optional inclusive end of an omnibus range; must be greater than `seriesNumber` |
 | `genres` | `string[]` | Genre classification |
 | `tags` | `string[]` | Freeform labels |
 | `description` | `string` | Book description |


### PR DESCRIPTION
Closes #406

## Summary
- Add optional `seriesNumberEnd` support across plugin file-parser and metadata-enricher flows while preserving single-number compatibility.
- Validate and persist series range starts, ends, and units atomically, including identify review and field filtering behavior.
- Update the TypeScript plugin SDK and plugin author documentation for camelCase `seriesNumberEnd` and snake_case HTTP payloads.

## Test plan
- Run `mise check:quiet` for Go lint/tests, JS lint/unit tests, Chromium E2E, and docs checks.
- Verify parser, enricher, malformed range, apply persistence, field filtering, and wire-shape tests in `pkg/plugins` and `pkg/worker`.
- Verify identify review range display, range apply, single-number replacement, validation, and unsaved-change tests.
- Build the TypeScript plugin SDK contract fixture.

The public plugin SDK and JavaScript bridge use camelCase `seriesNumberEnd`; Go JSON and HTTP/apply payloads use snake_case `series_number_end`. Validation rejects malformed/non-finite starts or ends, equal or reversed ranges, and invalid units as one atomic group. Full local validation passed previously, including Chromium E2E and docs checks; post-review targeted suites pass. Two subsequent full-suite reruns encountered unrelated concurrent Vitest timeout flakes while lint, targeted tests, SDK build, Go plugin/worker tests, Chromium E2E, and docs checks passed.